### PR TITLE
#8 Compact docker image for circleci jobs for klaytn build and test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,17 +11,16 @@ jobs:
       - run:
           name: "Build"
           command: |
-            cd $HOME
-            wget https://s3.ap-northeast-2.amazonaws.com/klaytn-ops-stuff/circle-ci/go1.11.2.tar.gz
-            tar xfz go1.11.2.tar.gz
-            export PATH=$HOME/go-go1.11.2/bin:$PATH
-            cd -
+            curl -O https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz
+            mkdir $HOME/go1.12.5
+            tar -C $HOME/go1.12.5 -xzf go1.12.5.linux-amd64.tar.gz
+            export PATH=$HOME/go1.12.5/go/bin:$PATH
             make fmt
             make all
 
   test-datasync:
     docker:
-      - image: kjhman21/dev:go1.11.2-solc0.4.24
+      - image: klaytn/build_base:1.0
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -32,7 +31,7 @@ jobs:
 
   test-networks:
     docker:
-      - image: kjhman21/dev:go1.11.2-solc0.4.24
+      - image: klaytn/build_base:1.0
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -43,7 +42,7 @@ jobs:
 
   test-tests:
     docker:
-      - image: kjhman21/dev:go1.11.2-solc0.4.24
+      - image: klaytn/build_base:1.0
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -55,7 +54,7 @@ jobs:
 
   test-others:
     docker:
-      - image: kjhman21/dev:go1.11.2-solc0.4.24
+      - image: klaytn/build_base:1.0
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -66,7 +65,7 @@ jobs:
 
   coverage:
     docker:
-      - image: kjhman21/dev:go1.11.2-solc0.4.24
+      - image: klaytn/build_base:1.0
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout

--- a/build/Dockerfile-go1.12.5-solc0.4.24-alpine
+++ b/build/Dockerfile-go1.12.5-solc0.4.24-alpine
@@ -1,0 +1,28 @@
+FROM alpine as solc_builder
+RUN \
+  apk --no-cache --update add build-base cmake boost-dev git; \
+  sed -i -E -e 's/include <sys\/poll.h>/include <poll.h>/' /usr/include/boost/asio/detail/socket_types.hpp; \
+  git clone --depth 1 --recursive -b v0.4.24 https://github.com/ethereum/solidity; \
+  cd /solidity && cmake -DCMAKE_BUILD_TYPE=Release -DTESTS=0 -DSTATIC_LINKING=1 && \
+  touch prerelease.txt && make -j8 solc && install -s solc/solc /usr/bin; \
+  cd / && rm -rf solidity; \
+  apk del sed build-base git make cmake gcc g++ musl-dev curl-dev boost-dev; \
+  rm -rf /var/cache/apk/*
+
+FROM alpine as go_builder
+RUN \
+  apk add --no-cache --virtual .build-deps bash gcc musl-dev openssl go; \
+  wget -O go.src.tar.gz https://dl.google.com/go/go1.12.5.src.tar.gz; \
+  tar -C /usr/local -xzf go.src.tar.gz; \
+  cd /usr/local/go/src/ && ./make.bash; \
+  apk del .build-deps
+
+FROM alpine
+
+RUN apk add --no-cache ca-certificates boost git make gcc libc-dev
+COPY --from=solc_builder /usr/bin/solc /usr/bin/solc
+COPY --from=go_builder /usr/local/go /usr/local
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"


### PR DESCRIPTION
## Proposed changes

(#8) Some circleci jobs in klaytn use private docker images (kjhman21). It needs to change the official docker image of klaytn. and current docker image which used to build klaytn uses go1.11.2. It needs to be changed to go 1.12.5.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
