### PR TITLE
SC: add subbridge support for ksen

### DIFF
--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -66,6 +66,13 @@ var senHelpFlagGroups = []utils.FlagGroup{
 			utils.ChildChainIndexingFlag,
 			utils.MainBridgeFlag,
 			utils.MainBridgeListenPortFlag,
+			utils.SubBridgeFlag,
+			utils.SubBridgeListenPortFlag,
+			utils.AnchoringPeriodFlag,
+			utils.SentChainTxsLimit,
+			utils.ParentChainIDFlag,
+			utils.VTRecoveryFlag,
+			utils.VTRecoveryIntervalFlag,
 		},
 	},
 	{

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -180,6 +180,13 @@ var KSENFlags = []cli.Flag{
 	utils.ChildChainIndexingFlag,
 	utils.MainBridgeFlag,
 	utils.MainBridgeListenPortFlag,
+	utils.SubBridgeFlag,
+	utils.SubBridgeListenPortFlag,
+	utils.AnchoringPeriodFlag,
+	utils.SentChainTxsLimit,
+	utils.ParentChainIDFlag,
+	utils.VTRecoveryFlag,
+	utils.VTRecoveryIntervalFlag,
 	// DBSyncer
 	utils.EnableDBSyncerFlag,
 	utils.DBHostFlag,


### PR DESCRIPTION
## Proposed changes

- This PR has been modified to allow subbridge to be set in a KSEN binary
- The following options has been added:
    - subbridge, subbridgeport, chaintxperiod, chaintxlimit, parentchainid, vtrecovery, vtrecoveryinterval

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #21

## Further comments

n/a