### PR TITLE
SC: fix a mainbridge port mapping of docker compose

### DIFF
--- a/cmd/homi/docker/service/validator.go
+++ b/cmd/homi/docker/service/validator.go
@@ -92,8 +92,9 @@ var validatorTemplate = `{{ .Name }}:
       - '{{ .Port }}:32323'
       - '{{ .RPCPort }}:8551'
       - '{{ .PrometheusPort }}:61001'
-{{- if eq .Name "SCN-0" }}
+{{- if eq .Name "EN-0" }}
       - '50505:50505'
+{{- else if eq .Name "SCN-0" }}
       - '50506:50506'
 {{- end }}
     entrypoint:


### PR DESCRIPTION
## Proposed changes

- Fixed external port mapping of main-bridge in homi docker-compose.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

n/a

## Further comments

n/a
