### PR TITLE
SC: change the max peer of the main and sub bridges to one

### DIFF
--- a/cmd/utils/nodecmd/dumpconfigcmd.go
+++ b/cmd/utils/nodecmd/dumpconfigcmd.go
@@ -210,11 +210,7 @@ func makeDBSyncerConfig(ctx *cli.Context) dbsyncer.DBConfig {
 }
 
 func makeServiceChainConfig(ctx *cli.Context) (config sc.SCConfig) {
-	cfg := sc.SCConfig{
-		// TODO-Klaytn this value is temp for test
-		NetworkId: 1,
-		MaxPeer:   1, // Only a single main-bridge and sub-bridge pair is allowed.
-	}
+	cfg := sc.DefaultConfig
 
 	// bridge service
 	if ctx.GlobalBool(utils.MainBridgeFlag.Name) {

--- a/cmd/utils/nodecmd/dumpconfigcmd.go
+++ b/cmd/utils/nodecmd/dumpconfigcmd.go
@@ -213,7 +213,7 @@ func makeServiceChainConfig(ctx *cli.Context) (config sc.SCConfig) {
 	cfg := sc.SCConfig{
 		// TODO-Klaytn this value is temp for test
 		NetworkId: 1,
-		MaxPeer:   50,
+		MaxPeer:   1, // Only a single main-bridge and sub-bridge pair is allowed.
 	}
 
 	// bridge service

--- a/node/sc/config.go
+++ b/node/sc/config.go
@@ -43,12 +43,6 @@ const (
 
 var logger = log.NewModuleLogger(log.ServiceChain)
 
-// DefaultConfig contains default settings for use on the Klaytn main net.
-var DefaultConfig = SCConfig{
-	NetworkId: 1,
-	MaxPeer:   1, // Only a single main-bridge and sub-bridge pair is allowed.
-}
-
 func init() {
 	home := os.Getenv("HOME")
 	if home == "" {

--- a/node/sc/config.go
+++ b/node/sc/config.go
@@ -43,6 +43,12 @@ const (
 
 var logger = log.NewModuleLogger(log.ServiceChain)
 
+// DefaultConfig contains default settings for use on the Klaytn main net.
+var DefaultConfig = SCConfig{
+	NetworkId: 1,
+	MaxPeer:   1, // Only a single main-bridge and sub-bridge pair is allowed.
+}
+
 func init() {
 	home := os.Getenv("HOME")
 	if home == "" {

--- a/node/sc/config.go
+++ b/node/sc/config.go
@@ -46,7 +46,7 @@ var logger = log.NewModuleLogger(log.ServiceChain)
 // DefaultConfig contains default settings for use on the Klaytn main net.
 var DefaultConfig = SCConfig{
 	NetworkId: 1,
-	MaxPeer:   50,
+	MaxPeer:   1, // Only a single main-bridge and sub-bridge pair is allowed.
 }
 
 func init() {


### PR DESCRIPTION
## Proposed changes

- When configuring the service chain, main-bridge and sub-bridge are limited to single pair only.
- This is to simplify HA implementation.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

n/a

## Further comments

n/a