### PR TITLE
Add nil checks for the wrong genesis configuration

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -200,7 +200,7 @@ func SetupGenesisBlock(db database.DBManager, genesis *Genesis, networkId uint64
 		return newcfg, stored, nil
 	} else {
 		if storedcfg.Governance == nil {
-			logger.Crit("Governance field is missing")
+			logger.Crit("Failed to read governance. storedcfg.Governance == nil")
 		}
 		if storedcfg.Governance.Reward.StakingUpdateInterval != 0 {
 			params.SetStakingUpdateInterval(storedcfg.Governance.Reward.StakingUpdateInterval)

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -199,6 +199,9 @@ func SetupGenesisBlock(db database.DBManager, genesis *Genesis, networkId uint64
 		db.WriteChainConfig(stored, newcfg)
 		return newcfg, stored, nil
 	} else {
+		if storedcfg.Governance == nil {
+			logger.Crit("Governance field is missing")
+		}
 		if storedcfg.Governance.Reward.StakingUpdateInterval != 0 {
 			params.SetStakingUpdateInterval(storedcfg.Governance.Reward.StakingUpdateInterval)
 		}

--- a/governance/default.go
+++ b/governance/default.go
@@ -520,6 +520,9 @@ func (g *Governance) searchCache(num uint64) (uint64, bool) {
 }
 
 func (g *Governance) ReadGovernance(num uint64) (uint64, GovernanceSet, error) {
+	if g.ChainConfig.Istanbul == nil {
+		logger.Crit("Failed to read governance. ChainConfig.Istanbul == nil")
+	}
 	blockNum := CalcGovernanceInfoBlock(num, g.ChainConfig.Istanbul.Epoch)
 	// Check cache first
 	if gBlockNum, ok := g.searchCache(blockNum); ok {


### PR DESCRIPTION
## Proposed changes

- Bug fix for #39 
- If the chain config is invalid, this patch gracefully prints a log message and exits instead of SIGSEGV.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #39

## Further comments

- We manually test this patch but it will be nice if we add unit tests for error cases in the future PR.
