### PR TITLE
account: add optional block number for contract calls

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -39,10 +39,10 @@ type SignerFn func(types.Signer, common.Address, *types.Transaction) (*types.Tra
 
 // CallOpts is the collection of options to fine tune a contract call request.
 type CallOpts struct {
-	Pending bool           // Whether to operate on the pending state or the last known one
-	From    common.Address // Optional the sender address, otherwise the first account is used
-
-	Context context.Context // Network context to support cancellation and timeouts (nil = no timeout)
+	Pending     bool            // Whether to operate on the pending state or the last known one
+	From        common.Address  // Optional the sender address, otherwise the first account is used
+	BlockNumber *big.Int        // Optional the block number on which the call should be performed
+	Context     context.Context // Network context to support cancellation and timeouts (nil = no timeout)
 }
 
 // TransactOpts is the collection of authorization data required to create a
@@ -151,10 +151,10 @@ func (c *BoundContract) Call(opts *CallOpts, result interface{}, method string, 
 			}
 		}
 	} else {
-		output, err = c.caller.CallContract(ctx, msg, nil)
+		output, err = c.caller.CallContract(ctx, msg, opts.BlockNumber)
 		if err == nil && len(output) == 0 {
 			// Make sure we have a contract to operate on, and bail out otherwise.
-			if code, err = c.caller.CodeAt(ctx, c.address, nil); err != nil {
+			if code, err = c.caller.CodeAt(ctx, c.address, opts.BlockNumber); err != nil {
 				return err
 			} else if len(code) == 0 {
 				return ErrNoCode

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -1,0 +1,84 @@
+// Modifications Copyright 2019 The klaytn Authors
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from accounts/abi/bind/base_test.go (2019/07/22).
+// Modified and improved for the klaytn development.
+
+package bind_test
+
+import (
+	"context"
+	"github.com/klaytn/klaytn"
+	"math/big"
+	"testing"
+
+	"github.com/klaytn/klaytn/accounts/abi"
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/common"
+)
+
+type mockCaller struct {
+	codeAtBlockNumber       *big.Int
+	callContractBlockNumber *big.Int
+}
+
+func (mc *mockCaller) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	mc.codeAtBlockNumber = blockNumber
+	return []byte{1, 2, 3}, nil
+}
+
+func (mc *mockCaller) CallContract(ctx context.Context, call klaytn.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	mc.callContractBlockNumber = blockNumber
+	return nil, nil
+}
+
+func TestPassingBlockNumber(t *testing.T) {
+
+	mc := &mockCaller{}
+
+	bc := bind.NewBoundContract(common.HexToAddress("0x0"), abi.ABI{
+		Methods: map[string]abi.Method{
+			"something": {
+				Name:    "something",
+				Outputs: abi.Arguments{},
+			},
+		},
+	}, mc, nil, nil)
+	var ret string
+
+	blockNumber := big.NewInt(42)
+
+	bc.Call(&bind.CallOpts{BlockNumber: blockNumber}, &ret, "something")
+
+	if mc.callContractBlockNumber != blockNumber {
+		t.Fatalf("CallContract() was not passed the block number")
+	}
+
+	if mc.codeAtBlockNumber != blockNumber {
+		t.Fatalf("CodeAt() was not passed the block number")
+	}
+
+	bc.Call(&bind.CallOpts{}, &ret, "something")
+
+	if mc.callContractBlockNumber != nil {
+		t.Fatalf("CallContract() was passed a block number when it should not have been")
+	}
+
+	if mc.codeAtBlockNumber != nil {
+		t.Fatalf("CodeAt() was passed a block number when it should not have been")
+	}
+}

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -23,12 +23,11 @@ package bind_test
 import (
 	"context"
 	"github.com/klaytn/klaytn"
-	"math/big"
-	"testing"
-
 	"github.com/klaytn/klaytn/accounts/abi"
 	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/common"
+	"math/big"
+	"testing"
 )
 
 type mockCaller struct {


### PR DESCRIPTION
## Proposed changes

- Update for contract call with block number.
- From https://github.com/ethereum/go-ethereum/pull/17942

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/ethereum/go-ethereum/pull/17942

## Further comments

n/a
