### PR TITLE
Make governance variables to be atomic

### DIFF
--- a/governance/api.go
+++ b/governance/api.go
@@ -89,7 +89,7 @@ func (api *PublicGovernanceAPI) Vote(key string, val interface{}) (string, error
 	gMode := api.governance.ChainConfig.Governance.GovernanceMode
 	gNode := api.governance.ChainConfig.Governance.GoverningNode
 
-	if GovernanceModeMap[gMode] == params.GovernanceMode_Single && gNode != api.governance.nodeAddress {
+	if GovernanceModeMap[gMode] == params.GovernanceMode_Single && gNode != api.governance.nodeAddress.Load().(common.Address) {
 		return "", errPermissionDenied
 	}
 	if strings.ToLower(key) == "governance.removevalidator" {
@@ -113,7 +113,7 @@ func (api *PublicGovernanceAPI) Vote(key string, val interface{}) (string, error
 func (api *PublicGovernanceAPI) isRemovingSelf(val interface{}) bool {
 	target := val.(string)
 
-	if common.HexToAddress(target) == api.governance.nodeAddress {
+	if common.HexToAddress(target) == api.governance.nodeAddress.Load().(common.Address) {
 		return true
 	} else {
 		return false
@@ -195,7 +195,7 @@ func (api *PublicGovernanceAPI) ChainConfig() *params.ChainConfig {
 }
 
 func (api *PublicGovernanceAPI) NodeAddress() common.Address {
-	return api.governance.nodeAddress
+	return api.governance.nodeAddress.Load().(common.Address)
 }
 
 func (api *PublicGovernanceAPI) isGovernanceModeBallot() bool {

--- a/governance/default.go
+++ b/governance/default.go
@@ -564,9 +564,7 @@ func (g *Governance) initializeCache() error {
 	if err != nil {
 		return ErrNotInitialized
 	}
-	g.idxCacheLock.Lock()
 	g.idxCache = indices
-	g.idxCacheLock.Unlock()
 
 	// Put governance items into the itemCache
 	for _, v := range indices {

--- a/governance/default.go
+++ b/governance/default.go
@@ -604,17 +604,20 @@ func (g *Governance) addGovernanceCache(num uint64, data GovernanceSet) {
 	}
 	cKey := getGovernanceCacheKey(num)
 	g.itemCache.Add(cKey, data.Items())
-
-	g.idxCache = append(g.idxCache, num)
-	if len(g.idxCache) > params.GovernanceIdxCacheLimit {
-		g.idxCache = g.idxCache[len(g.idxCache)-params.GovernanceIdxCacheLimit:]
-	}
+	g.addIdxCache(num)
 }
 
 // getGovernanceCacheKey returns cache key of the given block number
 func getGovernanceCacheKey(num uint64) common.GovernanceCacheKey {
 	v := fmt.Sprintf("%v", num)
 	return common.GovernanceCacheKey(params.GovernanceCachePrefix + "_" + v)
+}
+
+func (g *Governance) addIdxCache(num uint64) {
+	g.idxCache = append(g.idxCache, num)
+	if len(g.idxCache) > params.GovernanceIdxCacheLimit {
+		g.idxCache = g.idxCache[len(g.idxCache)-params.GovernanceIdxCacheLimit:]
+	}
 }
 
 // Store new governance data on DB. This updates Governance cache too.
@@ -935,14 +938,5 @@ func AddGovernanceCacheForTest(g *Governance, num uint64, config *params.ChainCo
 	// Don't update cache if num (block number) is smaller than the biggest number of cached block number
 
 	data := getGovernanceItemsFromChainConfig(config)
-	cKey := getGovernanceCacheKey(num)
-	g.itemCache.Add(cKey, data.Items())
-
-	g.idxCacheLock.Lock()
-	defer g.idxCacheLock.Unlock()
-
-	g.idxCache = append(g.idxCache, num)
-	if len(g.idxCache) > params.GovernanceIdxCacheLimit {
-		g.idxCache = g.idxCache[len(g.idxCache)-params.GovernanceIdxCacheLimit:]
-	}
+	g.addGovernanceCache(num, data)
 }

--- a/governance/default.go
+++ b/governance/default.go
@@ -604,20 +604,17 @@ func (g *Governance) addGovernanceCache(num uint64, data GovernanceSet) {
 	}
 	cKey := getGovernanceCacheKey(num)
 	g.itemCache.Add(cKey, data.Items())
-	g.addIdxCache(num)
+
+	g.idxCache = append(g.idxCache, num)
+	if len(g.idxCache) > params.GovernanceIdxCacheLimit {
+		g.idxCache = g.idxCache[len(g.idxCache)-params.GovernanceIdxCacheLimit:]
+	}
 }
 
 // getGovernanceCacheKey returns cache key of the given block number
 func getGovernanceCacheKey(num uint64) common.GovernanceCacheKey {
 	v := fmt.Sprintf("%v", num)
 	return common.GovernanceCacheKey(params.GovernanceCachePrefix + "_" + v)
-}
-
-func (g *Governance) addIdxCache(num uint64) {
-	g.idxCache = append(g.idxCache, num)
-	if len(g.idxCache) > params.GovernanceIdxCacheLimit {
-		g.idxCache = g.idxCache[len(g.idxCache)-params.GovernanceIdxCacheLimit:]
-	}
 }
 
 // Store new governance data on DB. This updates Governance cache too.


### PR DESCRIPTION
## Proposed changes
- This PR includes following PRs which were reverted before. To remove data race, several variables in the governance object have been changed to be atomic.
- Add missing atomic operation for lastGovernanceStateBlock https://github.com/ground-x/klaytn/pull/3517
- Make nodeAddress as an atomic.Value https://github.com/ground-x/klaytn/pull/3524
- Add idxCacheLock to protect idxCache https://github.com/ground-x/klaytn/pull/3526

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

