### PR TITLE
Refactor voteMap to avoid data race

### DIFF
--- a/governance/api.go
+++ b/governance/api.go
@@ -167,10 +167,8 @@ type VoteList struct {
 func (api *PublicGovernanceAPI) MyVotes() []*VoteList {
 
 	ret := []*VoteList{}
-	api.governance.voteMapLock.RLock()
-	defer api.governance.voteMapLock.RUnlock()
 
-	for k, v := range api.governance.voteMap {
+	for k, v := range api.governance.voteMap.Copy() {
 		item := &VoteList{
 			Key:      k,
 			Value:    v.Value,

--- a/governance/api.go
+++ b/governance/api.go
@@ -166,7 +166,8 @@ type VoteList struct {
 
 func (api *PublicGovernanceAPI) MyVotes() []*VoteList {
 
-	ret := []*VoteList{}
+	ret := make([]*VoteList, 0, api.governance.voteMap.Size())
+	//ret := []*VoteList{}
 
 	for k, v := range api.governance.voteMap.Copy() {
 		item := &VoteList{

--- a/governance/default.go
+++ b/governance/default.go
@@ -146,7 +146,7 @@ type VoteStatus struct {
 	Num    uint64      `json:"num"`
 }
 
-type VoteSet struct {
+type VoteMap struct {
 	items map[string]VoteStatus
 	mu    *sync.RWMutex
 }
@@ -155,7 +155,7 @@ type Governance struct {
 	ChainConfig *params.ChainConfig
 
 	// Map used to keep multiple types of votes
-	voteMap VoteSet
+	voteMap VoteMap
 
 	nodeAddress      atomic.Value //common.Address
 	totalVotingPower uint64
@@ -183,8 +183,8 @@ type Governance struct {
 	blockChain *blockchain.BlockChain
 }
 
-func NewVoteMap() VoteSet {
-	return VoteSet{
+func NewVoteMap() VoteMap {
+	return VoteMap{
 		items: make(map[string]VoteStatus),
 		mu:    new(sync.RWMutex),
 	}
@@ -211,7 +211,7 @@ func (gt *GovernanceTallyList) Clear() {
 	gt.items = make([]GovernanceTallyItem, 0)
 }
 
-func (vl *VoteSet) Copy() map[string]VoteStatus {
+func (vl *VoteMap) Copy() map[string]VoteStatus {
 	vl.mu.RLock()
 	defer vl.mu.RUnlock()
 
@@ -223,21 +223,21 @@ func (vl *VoteSet) Copy() map[string]VoteStatus {
 	return ret
 }
 
-func (vl *VoteSet) GetValue(key string) VoteStatus {
+func (vl *VoteMap) GetValue(key string) VoteStatus {
 	vl.mu.RLock()
 	defer vl.mu.RUnlock()
 
 	return vl.items[key]
 }
 
-func (vl *VoteSet) SetValue(key string, val VoteStatus) {
+func (vl *VoteMap) SetValue(key string, val VoteStatus) {
 	vl.mu.Lock()
 	defer vl.mu.Unlock()
 
 	vl.items[key] = val
 }
 
-func (vl *VoteSet) Import(src map[string]VoteStatus) {
+func (vl *VoteMap) Import(src map[string]VoteStatus) {
 	vl.mu.Lock()
 	defer vl.mu.Unlock()
 
@@ -246,14 +246,14 @@ func (vl *VoteSet) Import(src map[string]VoteStatus) {
 	}
 }
 
-func (vl *VoteSet) Clear() {
+func (vl *VoteMap) Clear() {
 	vl.mu.Lock()
 	defer vl.mu.Unlock()
 
 	vl.items = make(map[string]VoteStatus)
 }
 
-func (vl *VoteSet) Size() int {
+func (vl *VoteMap) Size() int {
 	vl.mu.RLock()
 	defer vl.mu.RUnlock()
 

--- a/governance/default.go
+++ b/governance/default.go
@@ -146,12 +146,16 @@ type VoteStatus struct {
 	Num    uint64      `json:"num"`
 }
 
+type VoteSet struct {
+	items map[string]VoteStatus
+	mu    *sync.RWMutex
+}
+
 type Governance struct {
 	ChainConfig *params.ChainConfig
 
 	// Map used to keep multiple types of votes
-	voteMap     map[string]VoteStatus
-	voteMapLock sync.RWMutex
+	voteMap VoteSet
 
 	nodeAddress      atomic.Value //common.Address
 	totalVotingPower uint64
@@ -179,6 +183,13 @@ type Governance struct {
 	blockChain *blockchain.BlockChain
 }
 
+func NewVoteMap() VoteSet {
+	return VoteSet{
+		items: make(map[string]VoteStatus),
+		mu:    new(sync.RWMutex),
+	}
+}
+
 func NewGovernanceTallies() GovernanceTallyList {
 	return GovernanceTallyList{
 		items: []GovernanceTallyItem{},
@@ -198,6 +209,55 @@ func (gt *GovernanceTallyList) Clear() {
 	defer gt.mu.Unlock()
 
 	gt.items = make([]GovernanceTallyItem, 0)
+}
+
+func (vl *VoteSet) Copy() map[string]VoteStatus {
+	vl.mu.RLock()
+	defer vl.mu.RUnlock()
+
+	ret := make(map[string]VoteStatus)
+	for k, v := range vl.items {
+		ret[k] = v
+	}
+
+	return ret
+}
+
+func (vl *VoteSet) GetValue(key string) VoteStatus {
+	vl.mu.RLock()
+	defer vl.mu.RUnlock()
+
+	return vl.items[key]
+}
+
+func (vl *VoteSet) SetValue(key string, val VoteStatus) {
+	vl.mu.Lock()
+	defer vl.mu.Unlock()
+
+	vl.items[key] = val
+}
+
+func (vl *VoteSet) Import(src map[string]VoteStatus) {
+	vl.mu.Lock()
+	defer vl.mu.Unlock()
+
+	for k, v := range src {
+		vl.items[k] = v
+	}
+}
+
+func (vl *VoteSet) Clear() {
+	vl.mu.Lock()
+	defer vl.mu.Unlock()
+
+	vl.items = make(map[string]VoteStatus)
+}
+
+func (vl *VoteSet) Size() int {
+	vl.mu.RLock()
+	defer vl.mu.RUnlock()
+
+	return len(vl.items)
 }
 
 func (gt *GovernanceTallyList) Copy() []GovernanceTallyItem {
@@ -328,7 +388,7 @@ func (gs *GovernanceSet) Merge(change map[string]interface{}) {
 func NewGovernance(chainConfig *params.ChainConfig, dbm database.DBManager) *Governance {
 	ret := Governance{
 		ChainConfig:              chainConfig,
-		voteMap:                  make(map[string]VoteStatus),
+		voteMap:                  NewVoteMap(),
 		db:                       dbm,
 		itemCache:                newGovernanceCache(),
 		currentSet:               NewGovernanceSet(),
@@ -370,24 +430,19 @@ func (g *Governance) SetMyVotingPower(t uint64) {
 
 func (g *Governance) GetEncodedVote(addr common.Address, number uint64) []byte {
 	// TODO-Klaytn-Governance Change this part to add all votes to the header at once
-	g.voteMapLock.RLock()
-	defer g.voteMapLock.RUnlock()
-
-	if len(g.voteMap) > 0 {
-		for key, val := range g.voteMap {
-			if val.Casted == false {
-				vote := new(GovernanceVote)
-				vote.Validator = addr
-				vote.Key = key
-				vote.Value = val.Value
-				encoded, err := rlp.EncodeToBytes(vote)
-				if err != nil {
-					logger.Error("Failed to RLP Encode a vote", "vote", vote)
-					g.RemoveVote(key, val, number)
-					continue
-				}
-				return encoded
+	for key, val := range g.voteMap.Copy() {
+		if val.Casted == false {
+			vote := new(GovernanceVote)
+			vote.Validator = addr
+			vote.Key = key
+			vote.Value = val.Value
+			encoded, err := rlp.EncodeToBytes(vote)
+			if err != nil {
+				logger.Error("Failed to RLP Encode a vote", "vote", vote)
+				g.RemoveVote(key, val, number)
+				continue
 			}
+			return encoded
 		}
 	}
 	return nil
@@ -399,16 +454,12 @@ func (g *Governance) getKey(k string) string {
 
 // RemoveVote remove a vote from the voteMap to prevent repetitive addition of same vote
 func (g *Governance) RemoveVote(key string, value interface{}, number uint64) {
-	g.voteMapLock.Lock()
-	defer g.voteMapLock.Unlock()
-
-	key = g.getKey(key)
-	if g.voteMap[key].Value == value {
-		g.voteMap[key] = VoteStatus{
+	if g.voteMap.GetValue(key).Value == value {
+		g.voteMap.SetValue(key, VoteStatus{
 			Value:  value,
 			Casted: true,
 			Num:    number,
-		}
+		})
 	}
 	if g.CanWriteGovernanceState(number) {
 		g.WriteGovernanceState(number, false)
@@ -416,13 +467,10 @@ func (g *Governance) RemoveVote(key string, value interface{}, number uint64) {
 }
 
 func (g *Governance) ClearVotes(num uint64) {
-	g.voteMapLock.Lock()
-	defer g.voteMapLock.Unlock()
-
 	g.GovernanceVotes.Clear()
 	g.GovernanceTallies.Clear()
 	g.changeSet.Clear()
-	g.voteMap = make(map[string]VoteStatus)
+	g.voteMap.Clear()
 	logger.Info("Governance votes are cleared", "num", num)
 }
 
@@ -805,7 +853,7 @@ func (gov *Governance) toJSON(num uint64) ([]byte, error) {
 	ret := &governanceJSON{
 		BlockNumber:     num,
 		ChainConfig:     gov.ChainConfig,
-		VoteMap:         gov.voteMap,
+		VoteMap:         gov.voteMap.Copy(),
 		NodeAddress:     gov.nodeAddress.Load().(common.Address),
 		GovernanceVotes: gov.GovernanceVotes.Copy(),
 		GovernanceTally: gov.GovernanceTallies.Copy(),
@@ -822,7 +870,7 @@ func (gov *Governance) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	gov.ChainConfig = j.ChainConfig
-	gov.voteMap = j.VoteMap
+	gov.voteMap.Import(j.VoteMap)
 	gov.nodeAddress.Store(j.NodeAddress)
 	gov.GovernanceVotes.Import(j.GovernanceVotes)
 	gov.GovernanceTallies.Import(j.GovernanceTally)

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -220,7 +220,7 @@ func TestGovernance_RemoveVote(t *testing.T) {
 	}
 }
 
-func countUncastedVote(data VoteSet) int {
+func countUncastedVote(data VoteMap) int {
 	size := 0
 
 	for _, v := range data.Copy() {

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -111,9 +111,6 @@ func updateGovernanceConfig(g *Governance, k string, v interface{}) bool {
 
 // AddVote adds a vote to the voteMap
 func (g *Governance) AddVote(key string, val interface{}) bool {
-	g.voteMapLock.Lock()
-	defer g.voteMapLock.Unlock()
-
 	key = g.getKey(key)
 
 	// If the key is forbidden, stop processing it
@@ -124,11 +121,11 @@ func (g *Governance) AddVote(key string, val interface{}) bool {
 	vote := &GovernanceVote{Key: key, Value: val}
 	var ok bool
 	if vote, ok = g.ValidateVote(vote); ok {
-		g.voteMap[key] = VoteStatus{
+		g.voteMap.SetValue(key, VoteStatus{
 			Value:  vote.Value,
 			Casted: false,
 			Num:    0,
-		}
+		})
 		return true
 	}
 	return false


### PR DESCRIPTION
## Proposed changes

- This PR changes the data structure of voteMap which stores a node's vote status from a normal map into a struct with its own lock
- And this struct has its own methods to Copy, Clear, Get/SetValue, Size and Import. Each methods lock the mutex as it needs
- The original PR is https://github.com/ground-x/klaytn/pull/3525 which was reverted

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules