### PR TITLE
SC: add a scconsensus option for kspn and ksen

### DIFF
--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -63,6 +63,7 @@ var senHelpFlagGroups = []utils.FlagGroup{
 	{
 		Name: "SERVICECHAIN",
 		Flags: []cli.Flag{
+			utils.ServiceChainConsensusFlag,
 			utils.ChildChainIndexingFlag,
 			utils.MainBridgeFlag,
 			utils.MainBridgeListenPortFlag,

--- a/cmd/kspn/main.go
+++ b/cmd/kspn/main.go
@@ -69,6 +69,22 @@ var spnHelpFlagGroups = []utils.FlagGroup{
 		},
 	},
 	{
+		Name: "SERVICECHAIN",
+		Flags: []cli.Flag{
+			utils.ServiceChainConsensusFlag,
+			utils.ChildChainIndexingFlag,
+			utils.MainBridgeFlag,
+			utils.MainBridgeListenPortFlag,
+			utils.SubBridgeFlag,
+			utils.SubBridgeListenPortFlag,
+			utils.AnchoringPeriodFlag,
+			utils.SentChainTxsLimit,
+			utils.ParentChainIDFlag,
+			utils.VTRecoveryFlag,
+			utils.VTRecoveryIntervalFlag,
+		},
+	},
+	{
 		Name: "ACCOUNT",
 		Flags: []cli.Flag{
 			utils.UnlockedAccountFlag,

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -172,6 +172,7 @@ var KSPNFlags = []cli.Flag{
 	utils.TxResendIntervalFlag,
 	utils.TxResendCountFlag,
 	utils.TxResendUseLegacyFlag,
+	utils.ServiceChainConsensusFlag,
 }
 
 var KSENFlags = []cli.Flag{
@@ -186,6 +187,7 @@ var KSENFlags = []cli.Flag{
 	utils.ParentChainIDFlag,
 	utils.VTRecoveryFlag,
 	utils.VTRecoveryIntervalFlag,
+	utils.ServiceChainConsensusFlag,
 	// DBSyncer
 	utils.EnableDBSyncerFlag,
 	utils.DBHostFlag,


### PR DESCRIPTION
## Proposed changes

- This PR add a `scconsensus` option support for kspn and ksen.
- The `scconsensus` is used for setting 'istanbul' or 'clique' consensus for the node.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #49 

## Further comments

n/a
