### PR TITLE
Remove direct access to governance.ChainConfig

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -139,7 +139,7 @@ func (sb *backend) GetRewardBase() common.Address {
 }
 
 func (sb *backend) GetSubGroupSize() uint64 {
-	return sb.governance.ChainConfig.Istanbul.SubGroupSize
+	return sb.governance.CommitteeSize()
 }
 
 func (sb *backend) SetCurrentView(view *istanbul.View) {
@@ -360,14 +360,14 @@ func (sb *backend) ParentValidators(proposal istanbul.Proposal) istanbul.Validat
 		return sb.getValidators(block.Number().Uint64()-1, block.ParentHash())
 	}
 
-	return validator.NewValidatorSet(nil, istanbul.ProposerPolicy(sb.governance.ChainConfig.Istanbul.ProposerPolicy), sb.governance.ChainConfig.Istanbul.SubGroupSize, sb.chain)
+	return validator.NewValidatorSet(nil, istanbul.ProposerPolicy(sb.governance.ProposerPolicy()), sb.governance.CommitteeSize(), sb.chain)
 }
 
 func (sb *backend) getValidators(number uint64, hash common.Hash) istanbul.ValidatorSet {
 	snap, err := sb.snapshot(sb.chain, number, hash, nil)
 	if err != nil {
 		logger.Error("Snapshot not found.", "err", err)
-		return validator.NewValidatorSet(nil, istanbul.ProposerPolicy(sb.governance.ChainConfig.Istanbul.ProposerPolicy), sb.governance.ChainConfig.Istanbul.SubGroupSize, sb.chain)
+		return validator.NewValidatorSet(nil, istanbul.ProposerPolicy(sb.governance.ProposerPolicy()), sb.governance.CommitteeSize(), sb.chain)
 	}
 	return snap.ValSet
 }

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -22,7 +22,6 @@ package istanbul
 
 import (
 	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/params"
 	"strings"
 )
 
@@ -93,7 +92,7 @@ type ValidatorSet interface {
 	IsSubSet() bool
 
 	// Refreshes a list of candidate proposers with given hash and blockNum
-	Refresh(hash common.Hash, blockNum uint64, config *params.ChainConfig) error
+	Refresh(hash common.Hash, blockNum uint64, chainId uint64) error
 
 	SetBlockNum(blockNum uint64)
 

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/istanbul"
-	"github.com/klaytn/klaytn/params"
 	"math"
 	"math/rand"
 	"reflect"
@@ -396,7 +395,7 @@ func (valSet *defaultSet) F() int {
 
 func (valSet *defaultSet) Policy() istanbul.ProposerPolicy { return valSet.policy }
 
-func (valSet *defaultSet) Refresh(hash common.Hash, blockNum uint64, config *params.ChainConfig) error {
+func (valSet *defaultSet) Refresh(hash common.Hash, blockNum uint64, chainId uint64) error {
 	return nil
 }
 func (valSet *defaultSet) SetBlockNum(blockNum uint64)     { /* Do nothing */ }

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -554,7 +554,7 @@ func (valSet *weightedCouncil) Policy() istanbul.ProposerPolicy { return valSet.
 // It return no error when weightedCouncil
 //   (1) already has up-do-date proposers
 //   (2) successfully calculated up-do-date proposers
-func (valSet *weightedCouncil) Refresh(hash common.Hash, blockNum uint64, config *params.ChainConfig) error {
+func (valSet *weightedCouncil) Refresh(hash common.Hash, blockNum uint64, chainId uint64) error {
 	valSet.validatorMu.Lock()
 	defer valSet.validatorMu.Unlock()
 

--- a/consensus/istanbul/validator/weighted_random_test.go
+++ b/consensus/istanbul/validator/weighted_random_test.go
@@ -348,7 +348,7 @@ func TestWeightedCouncil_RemoveValidator(t *testing.T) {
 	config := &params.ChainConfig{Governance: governance.GetDefaultGovernanceConfig(params.UseIstanbul)}
 	config.ChainID = big.NewInt(1)
 	config.Governance.Reward.UseGiniCoeff = false
-	valSet.Refresh(testPrevHash, 1, config)
+	valSet.Refresh(testPrevHash, 1, config.ChainID.Uint64())
 
 	for _, val := range validators {
 
@@ -386,7 +386,7 @@ func TestWeightedCouncil_RefreshAfterRemoveValidator(t *testing.T) {
 	config := &params.ChainConfig{Governance: governance.GetDefaultGovernanceConfig(params.UseIstanbul)}
 	config.Governance.Reward.UseGiniCoeff = false
 	config.ChainID = big.NewInt(1)
-	valSet.Refresh(testPrevHash, 1, config)
+	valSet.Refresh(testPrevHash, 1, config.ChainID.Uint64())
 
 	for _, val := range validators {
 
@@ -406,7 +406,7 @@ func TestWeightedCouncil_RefreshAfterRemoveValidator(t *testing.T) {
 			}
 		}
 
-		valSet.Refresh(testPrevHash, 1, config)
+		valSet.Refresh(testPrevHash, 1, config.ChainID.Uint64())
 
 		// check whether removedVal is excluded as expected when refreshing proposers
 		for _, p := range valSet.proposers {

--- a/governance/api.go
+++ b/governance/api.go
@@ -62,7 +62,7 @@ var (
 
 func (api *GovernanceKlayAPI) GasPriceAt(num *rpc.BlockNumber) (*big.Int, error) {
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		ret := api.governance.GetGovernanceValue(params.UnitPrice).(uint64)
+		ret := api.governance.UnitPrice()
 		return big.NewInt(0).SetUint64(ret), nil
 	} else {
 		blockNum := num.Int64()
@@ -80,14 +80,14 @@ func (api *GovernanceKlayAPI) GasPriceAt(num *rpc.BlockNumber) (*big.Int, error)
 }
 
 func (api *GovernanceKlayAPI) GasPrice() *big.Int {
-	ret := api.governance.GetGovernanceValue(params.UnitPrice).(uint64)
+	ret := api.governance.UnitPrice()
 	return big.NewInt(0).SetUint64(ret)
 }
 
 // Vote injects a new vote for governance targets such as unitprice and governingnode.
 func (api *PublicGovernanceAPI) Vote(key string, val interface{}) (string, error) {
-	gMode := api.governance.ChainConfig.Governance.GovernanceMode
-	gNode := api.governance.ChainConfig.Governance.GoverningNode
+	gMode := api.governance.GovernanceMode()
+	gNode := api.governance.GoverningNode()
 
 	if GovernanceModeMap[gMode] == params.GovernanceMode_Single && gNode != api.governance.nodeAddress.Load().(common.Address) {
 		return "", errPermissionDenied
@@ -198,7 +198,7 @@ func (api *PublicGovernanceAPI) NodeAddress() common.Address {
 }
 
 func (api *PublicGovernanceAPI) isGovernanceModeBallot() bool {
-	if GovernanceModeMap[api.governance.ChainConfig.Governance.GovernanceMode] == params.GovernanceMode_Ballot {
+	if GovernanceModeMap[api.governance.GovernanceMode()] == params.GovernanceMode_Ballot {
 		return true
 	}
 	return false

--- a/governance/default.go
+++ b/governance/default.go
@@ -991,57 +991,57 @@ func (gov *Governance) GovernanceMode() string {
 }
 
 func (gov *Governance) GoverningNode() common.Address {
-   return gov.GetGovernanceValue(params.GoverningNode).(common.Address)
+	return gov.GetGovernanceValue(params.GoverningNode).(common.Address)
 }
 
 func (gov *Governance) UnitPrice() uint64 {
-   return gov.GetGovernanceValue(params.UnitPrice).(uint64)
+	return gov.GetGovernanceValue(params.UnitPrice).(uint64)
 }
 
 func (gov *Governance) CommitteeSize() uint64 {
-   return gov.GetGovernanceValue(params.CommitteeSize).(uint64)
+	return gov.GetGovernanceValue(params.CommitteeSize).(uint64)
 }
 
 func (gov *Governance) Epoch() uint64 {
-   if ret := gov.GetGovernanceValue(params.Epoch); ret == nil {
-       // When a node is initializing, value can be nil
-       return gov.ChainConfig.Istanbul.Epoch
-   }
-   return gov.GetGovernanceValue(params.Epoch).(uint64)
+	if ret := gov.GetGovernanceValue(params.Epoch); ret == nil {
+		// When a node is initializing, value can be nil
+		return gov.ChainConfig.Istanbul.Epoch
+	}
+	return gov.GetGovernanceValue(params.Epoch).(uint64)
 }
 
 func (gov *Governance) ProposerPolicy() uint64 {
-   return gov.GetGovernanceValue(params.Policy).(uint64)
+	return gov.GetGovernanceValue(params.Policy).(uint64)
 }
 
 func (gov *Governance) DeferredTxFee() bool {
-   return gov.GetGovernanceValue(params.DeferredTxFee).(bool)
+	return gov.GetGovernanceValue(params.DeferredTxFee).(bool)
 }
 
 func (gov *Governance) MinimumStake() string {
-   return gov.GetGovernanceValue(params.MinimumStake).(string)
+	return gov.GetGovernanceValue(params.MinimumStake).(string)
 }
 
 func (gov *Governance) MintingAmount() string {
-   return gov.GetGovernanceValue(params.MintingAmount).(string)
+	return gov.GetGovernanceValue(params.MintingAmount).(string)
 }
 
 func (gov *Governance) ProposerUpdateInterval() uint64 {
-   return gov.GetGovernanceValue(params.ProposerRefreshInterval).(uint64)
+	return gov.GetGovernanceValue(params.ProposerRefreshInterval).(uint64)
 }
 
 func (gov *Governance) Ratio() string {
-   return gov.GetGovernanceValue(params.Ratio).(string)
+	return gov.GetGovernanceValue(params.Ratio).(string)
 }
 
 func (gov *Governance) StakingUpdateInterval() uint64 {
-   return gov.GetGovernanceValue(params.StakeUpdateInterval).(uint64)
+	return gov.GetGovernanceValue(params.StakeUpdateInterval).(uint64)
 }
 
 func (gov *Governance) UseGiniCoeff() bool {
-   return gov.GetGovernanceValue(params.UseGiniCoeff).(bool)
+	return gov.GetGovernanceValue(params.UseGiniCoeff).(bool)
 }
 
 func (gov *Governance) ChainId() uint64 {
-   return gov.ChainConfig.ChainID.Uint64()
+	return gov.ChainConfig.ChainID.Uint64()
 }

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -121,15 +121,6 @@ func getGovernance() *Governance {
 	return NewGovernance(config, dbm)
 }
 
-func TestNewGovernance(t *testing.T) {
-	config := getTestConfig()
-	tstGovernance := NewGovernance(config, nil)
-
-	if !reflect.DeepEqual(tstGovernance.ChainConfig, config) {
-		t.Errorf("New governance's config is not same as the given one")
-	}
-}
-
 func TestGetDefaultGovernanceConfig(t *testing.T) {
 	tstGovernance := GetDefaultGovernanceConfig(params.UseIstanbul)
 
@@ -543,6 +534,6 @@ func TestCypressGenesisHash(t *testing.T) {
 	db := database.NewMemoryDBManager()
 	block, _ := genesis.Commit(db)
 	if block.Hash() != cypressHash {
-		t.Errorf("Generated hash is not equal to Baobab's hash. Want %v, Have %v", cypressHash.String(), block.Hash().String())
+		t.Errorf("Generated hash is not equal to Cypress's hash. Want %v, Have %v", cypressHash.String(), block.Hash().String())
 	}
 }

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -32,7 +32,7 @@ import (
 type check struct {
 	t         reflect.Type
 	validator func(k string, v interface{}) bool
-	trigger   func(g *Governance, k string, v interface{}) bool
+	trigger   func(g *Governance, k string, v interface{})
 }
 
 var (
@@ -62,42 +62,36 @@ var GovernanceItems = map[int]check{
 	params.ConstTxGasHumanReadable: {uint64T, checkUint64andBool, updateTxGasHumanReadable},
 }
 
-func updateTxGasHumanReadable(g *Governance, k string, v interface{}) bool {
+func updateTxGasHumanReadable(g *Governance, k string, v interface{}) {
 	params.TxGasHumanReadable = v.(uint64)
 	logger.Info("TxGasHumanReadable changed", "New value", params.TxGasHumanReadable)
-	return true
 }
 
-func updateUnitPrice(g *Governance, k string, v interface{}) bool {
+func updateUnitPrice(g *Governance, k string, v interface{}) {
 	newPrice := v.(uint64)
 	if g.TxPool != nil {
 		g.TxPool.SetGasPrice(big.NewInt(0).SetUint64(newPrice))
 	}
-	return true
 }
 
-func updateUseGiniCoeff(g *Governance, k string, v interface{}) bool {
+func updateUseGiniCoeff(g *Governance, k string, v interface{}) {
 	if g.blockChain != nil {
 		g.blockChain.SetUseGiniCoeff(g.UseGiniCoeff())
 	}
-	return true
 }
 
-func updateStakingUpdateInterval(g *Governance, k string, v interface{}) bool {
+func updateStakingUpdateInterval(g *Governance, k string, v interface{}) {
 	params.SetStakingUpdateInterval(g.StakingUpdateInterval())
-	return true
 }
 
-func updateProposerUpdateInterval(g *Governance, k string, v interface{}) bool {
+func updateProposerUpdateInterval(g *Governance, k string, v interface{}) {
 	params.SetProposerUpdateInterval(g.ProposerUpdateInterval())
-	return true
 }
 
-func updateProposerPolicy(g *Governance, k string, v interface{}) bool {
+func updateProposerPolicy(g *Governance, k string, v interface{}) {
 	if g.blockChain != nil {
 		g.blockChain.SetProposerPolicy(g.ProposerPolicy())
 	}
-	return true
 }
 
 // AddVote adds a vote to the voteMap

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -219,10 +219,10 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	governance.SetBlockchain(cn.blockchain)
 	// Synchronize proposerpolicy & useGiniCoeff
 	if cn.blockchain.Config().Istanbul != nil {
-		cn.blockchain.Config().Istanbul.ProposerPolicy = governance.ChainConfig.Istanbul.ProposerPolicy
+		cn.blockchain.Config().Istanbul.ProposerPolicy = governance.ProposerPolicy()
 	}
 	if cn.blockchain.Config().Governance.Reward != nil {
-		cn.blockchain.Config().Governance.Reward.UseGiniCoeff = governance.ChainConfig.Governance.Reward.UseGiniCoeff
+		cn.blockchain.Config().Governance.Reward.UseGiniCoeff = governance.UseGiniCoeff()
 	}
 
 	if config.SenderTxHashIndexing {
@@ -247,7 +247,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	cn.txPool = blockchain.NewTxPool(config.TxPool, cn.chainConfig, cn.blockchain)
 	governance.SetTxPool(cn.txPool)
 	// Synchronize unitprice
-	cn.txPool.SetGasPrice(big.NewInt(0).SetUint64(governance.ChainConfig.UnitPrice))
+	cn.txPool.SetGasPrice(big.NewInt(0).SetUint64(governance.UnitPrice()))
 
 	if cn.protocolManager, err = NewProtocolManager(cn.chainConfig, config.SyncMode, config.NetworkId, cn.eventMux, cn.txPool, cn.engine, cn.blockchain, chainDB, ctx.NodeType(), config); err != nil {
 		return nil, err

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -478,6 +478,8 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 
 // generateGovernaceDataForTest returns *governance.Governance for test.
 func generateGovernaceDataForTest() *governance.Governance {
+	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
+
 	return governance.NewGovernance(&params.ChainConfig{
 		ChainID:       big.NewInt(2018),
 		UnitPrice:     25000000000,
@@ -488,7 +490,7 @@ func generateGovernaceDataForTest() *governance.Governance {
 			SubGroupSize:   istanbul.DefaultConfig.SubGroupSize,
 		},
 		Governance: governance.GetDefaultGovernanceConfig(params.UseIstanbul),
-	}, nil)
+	}, dbm)
 }
 
 // setUpTest sets up test data directory, verbosity and profile file.


### PR DESCRIPTION
## Proposed changes

- This PR has following changes and formerly reviewed at https://github.com/ground-x/klaytn/pull/3682
- Added getters for each filed of chain config
- Replace direct access to chainConfig with newly added getters
- From this PR, ChainConfig is not updated. governance.currentSet holds all current governance information and provides it if requested.
- blockchain has its own chainConfig and It should be updated when there is a change. A getter and setter for `UseGiniCoeff` and `ProposerPolicy` are added and those are called by governance when there is a change

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
