### PR TITLE
SC : Make homi to generate testkey's keystore file

### DIFF
--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -276,7 +276,7 @@ func genValidatorKeystore(privKeys []*ecdsa.PrivateKey) {
 	ks := keystore.NewKeyStore(path, keystore.StandardScryptN, keystore.StandardScryptP)
 
 	for i, pk := range privKeys {
-		pwdStr := RandStringRunes(10)
+		pwdStr := RandStringRunes(16)
 		ks.ImportECDSA(pk, pwdStr)
 		WriteFile([]byte(pwdStr), DirKeys, "passwd"+strconv.Itoa(i+1))
 	}
@@ -902,7 +902,7 @@ func writeTestKeys(parentDir string, privKeys []*ecdsa.PrivateKey, keys []string
 		pk := privKeys[i]
 		ksPath := path.Join(parentPath, "keystore"+strconv.Itoa(i+1))
 		ks := keystore.NewKeyStore(ksPath, keystore.StandardScryptN, keystore.StandardScryptP)
-		pwdStr := RandStringRunes(10)
+		pwdStr := RandStringRunes(16)
 		ks.ImportECDSA(pk, pwdStr)
 		WriteFile([]byte(pwdStr), path.Join(parentDir, "keystore"+strconv.Itoa(i+1)), crypto.PubkeyToAddress(pk.PublicKey).String())
 	}

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -276,7 +276,7 @@ func genValidatorKeystore(privKeys []*ecdsa.PrivateKey) {
 	ks := keystore.NewKeyStore(path, keystore.StandardScryptN, keystore.StandardScryptP)
 
 	for i, pk := range privKeys {
-		pwdStr := RandStringRunes(100)
+		pwdStr := RandStringRunes(10)
 		ks.ImportECDSA(pk, pwdStr)
 		WriteFile([]byte(pwdStr), DirKeys, "passwd"+strconv.Itoa(i+1))
 	}
@@ -902,7 +902,7 @@ func writeTestKeys(parentDir string, privKeys []*ecdsa.PrivateKey, keys []string
 		pk := privKeys[i]
 		ksPath := path.Join(parentPath, "keystore"+strconv.Itoa(i+1))
 		ks := keystore.NewKeyStore(ksPath, keystore.StandardScryptN, keystore.StandardScryptP)
-		pwdStr := RandStringRunes(32)
+		pwdStr := RandStringRunes(10)
 		ks.ImportECDSA(pk, pwdStr)
 		WriteFile([]byte(pwdStr), path.Join(parentDir, "keystore"+strconv.Itoa(i+1)), crypto.PubkeyToAddress(pk.PublicKey).String())
 	}

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -427,7 +427,7 @@ func gen(ctx *cli.Context) error {
 		numValidators = cnNum
 	}
 	if numValidators > cnNum {
-		return fmt.Errorf("num-validators(%d) cannot be greater than num(%d)", numValidators, cnNum)
+		return fmt.Errorf("validators-num(%d) cannot be greater than num(%d)", numValidators, cnNum)
 	}
 
 	privKeys, nodeKeys, nodeAddrs := istcommon.GenerateKeys(cnNum)

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -902,7 +902,7 @@ func writeTestKeys(parentDir string, privKeys []*ecdsa.PrivateKey, keys []string
 		pk := privKeys[i]
 		ksPath := path.Join(parentPath, "keystore"+strconv.Itoa(i+1))
 		ks := keystore.NewKeyStore(ksPath, keystore.StandardScryptN, keystore.StandardScryptP)
-		pwdStr := RandStringRunes(10)
+		pwdStr := RandStringRunes(32)
 		ks.ImportECDSA(pk, pwdStr)
 		WriteFile([]byte(pwdStr), path.Join(parentDir, "keystore"+strconv.Itoa(i+1)), crypto.PubkeyToAddress(pk.PublicKey).String())
 	}

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -276,7 +276,7 @@ func genValidatorKeystore(privKeys []*ecdsa.PrivateKey) {
 	ks := keystore.NewKeyStore(path, keystore.StandardScryptN, keystore.StandardScryptP)
 
 	for i, pk := range privKeys {
-		pwdStr := RandStringRunes(16)
+		pwdStr := RandStringRunes(params.PasswordLength)
 		ks.ImportECDSA(pk, pwdStr)
 		WriteFile([]byte(pwdStr), DirKeys, "passwd"+strconv.Itoa(i+1))
 	}
@@ -902,7 +902,7 @@ func writeTestKeys(parentDir string, privKeys []*ecdsa.PrivateKey, keys []string
 		pk := privKeys[i]
 		ksPath := path.Join(parentPath, "keystore"+strconv.Itoa(i+1))
 		ks := keystore.NewKeyStore(ksPath, keystore.StandardScryptN, keystore.StandardScryptP)
-		pwdStr := RandStringRunes(16)
+		pwdStr := RandStringRunes(params.PasswordLength)
 		ks.ImportECDSA(pk, pwdStr)
 		WriteFile([]byte(pwdStr), path.Join(parentDir, "keystore"+strconv.Itoa(i+1)), crypto.PubkeyToAddress(pk.PublicKey).String())
 	}

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -53,14 +53,14 @@ var (
 	}
 
 	numOfCNsFlag = cli.IntFlag{
-		Name:  "num",
+		Name:  "cn-num",
 		Usage: "Number of consensus nodes",
 		Value: 4,
 	}
 
 	numOfValidatorsFlag = cli.IntFlag{
 		Name:  "num-validators",
-		Usage: "Number of validators. If not set, it will be set the number of option num",
+		Usage: "Number of validators. If not set, it will be set the number of option cn-num",
 		Value: 0,
 	}
 

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -59,7 +59,7 @@ var (
 	}
 
 	numOfValidatorsFlag = cli.IntFlag{
-		Name:  "num-validators",
+		Name:  "validators-num",
 		Usage: "Number of validators. If not set, it will be set the number of option cn-num",
 		Value: 0,
 	}

--- a/node/sc/bridge_accounts.go
+++ b/node/sc/bridge_accounts.go
@@ -104,7 +104,7 @@ func InitializeBridgeAccountKeystore(keystorePath string) (accounts.Wallet, comm
 	// If there is no keystore file, this creates a random account and the corresponded password file.
 	// TODO-Klaytn-Servicechain A test-option will be added and this routine will be only executed with it.
 	if len(ks.Accounts()) == 0 {
-		password := setup.RandStringRunes(10)
+		password := setup.RandStringRunes(16)
 		acc, err := ks.NewAccount(password)
 		if err != nil {
 			return nil, common.Address{}, true, err

--- a/node/sc/bridge_accounts.go
+++ b/node/sc/bridge_accounts.go
@@ -23,6 +23,7 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/cmd/homi/setup"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/params"
 	"io/ioutil"
 	"math/big"
 	"os"
@@ -104,7 +105,7 @@ func InitializeBridgeAccountKeystore(keystorePath string) (accounts.Wallet, comm
 	// If there is no keystore file, this creates a random account and the corresponded password file.
 	// TODO-Klaytn-Servicechain A test-option will be added and this routine will be only executed with it.
 	if len(ks.Accounts()) == 0 {
-		password := setup.RandStringRunes(16)
+		password := setup.RandStringRunes(params.PasswordLength)
 		acc, err := ks.NewAccount(password)
 		if err != nil {
 			return nil, common.Address{}, true, err

--- a/node/sc/bridge_accounts.go
+++ b/node/sc/bridge_accounts.go
@@ -104,7 +104,7 @@ func InitializeBridgeAccountKeystore(keystorePath string) (accounts.Wallet, comm
 	// If there is no keystore file, this creates a random account and the corresponded password file.
 	// TODO-Klaytn-Servicechain A test-option will be added and this routine will be only executed with it.
 	if len(ks.Accounts()) == 0 {
-		password := setup.RandStringRunes(32)
+		password := setup.RandStringRunes(10)
 		acc, err := ks.NewAccount(password)
 		if err != nil {
 			return nil, common.Address{}, true, err

--- a/params/config.go
+++ b/params/config.go
@@ -107,7 +107,7 @@ const (
 )
 
 const (
-	ChainIDBaobab = 1001
+	PasswordLength = 16
 )
 
 // ChainConfig is the blockchain config which determines the blockchain settings.


### PR DESCRIPTION
## Proposed changes
This PR makes homi to generate testkey's keystore file and validator's keystore files.

- testkey's keystore files for service chain operator's keystore
- validator's keystore files for service chain's test account to generate transactions.

This PR is for https://github.com/ground-x/klaytn-node-tests/pull/83.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
