### PR TITLE
Fix wrong governance cache behavior

### DIFF
--- a/governance/default.go
+++ b/governance/default.go
@@ -608,7 +608,7 @@ func newGovernanceCache() common.Cache {
 
 func (g *Governance) initializeCache() error {
 	// get last n governance change block number
-	indices, err := g.db.ReadRecentGovernanceIdx(params.GovernanceCacheLimit)
+	indices, err := g.db.ReadRecentGovernanceIdx(params.GovernanceIdxCacheLimit)
 	if err != nil {
 		return ErrNotInitialized
 	}
@@ -616,9 +616,10 @@ func (g *Governance) initializeCache() error {
 
 	// Put governance items into the itemCache
 	for _, v := range indices {
-		if num, data, err := g.ReadGovernance(v); err == nil {
-			g.itemCache.Add(getGovernanceCacheKey(num), data)
-			atomic.StoreUint64(&g.actualGovernanceBlock, num)
+		if data, err := g.db.ReadGovernance(v); err == nil {
+			data = adjustDecodedSet(data)
+			g.itemCache.Add(getGovernanceCacheKey(v), data)
+			atomic.StoreUint64(&g.actualGovernanceBlock, v)
 		} else {
 			logger.Crit("Couldn't read governance cache from database. Check database consistency", "index", v, "err", err)
 		}
@@ -665,6 +666,14 @@ func getGovernanceCacheKey(num uint64) common.GovernanceCacheKey {
 
 // Store new governance data on DB. This updates Governance cache too.
 func (g *Governance) WriteGovernance(num uint64, data GovernanceSet, delta GovernanceSet) error {
+	g.idxCacheLock.RLock()
+	idx := make([]uint64, 0, len(g.idxCache))
+	copy(idx, g.idxCache)
+	g.idxCacheLock.RUnlock()
+
+	if len(idx) > 0 && num <= idx[len(idx)-1] {
+		return nil
+	}
 
 	new := NewGovernanceSet()
 	new.Import(data.Items())
@@ -770,7 +779,7 @@ func (gov *Governance) UpdateCurrentGovernance(num uint64) {
 	newNumber, newGovernanceSet, _ := gov.ReadGovernance(num)
 
 	// Do the change only when the governance actually changed
-	if newGovernanceSet != nil && newNumber != atomic.LoadUint64(&gov.actualGovernanceBlock) {
+	if newGovernanceSet != nil && newNumber > atomic.LoadUint64(&gov.actualGovernanceBlock) {
 		atomic.StoreUint64(&gov.actualGovernanceBlock, newNumber)
 		gov.currentSet.Import(newGovernanceSet)
 		gov.triggerChange(newGovernanceSet)

--- a/governance/default.go
+++ b/governance/default.go
@@ -667,11 +667,11 @@ func getGovernanceCacheKey(num uint64) common.GovernanceCacheKey {
 // Store new governance data on DB. This updates Governance cache too.
 func (g *Governance) WriteGovernance(num uint64, data GovernanceSet, delta GovernanceSet) error {
 	g.idxCacheLock.RLock()
-	idx := make([]uint64, 0, len(g.idxCache))
-	copy(idx, g.idxCache)
+	indices := make([]uint64, 0, len(g.idxCache))
+	copy(indices, g.idxCache)
 	g.idxCacheLock.RUnlock()
 
-	if len(idx) > 0 && num <= idx[len(idx)-1] {
+	if len(indices) > 0 && num <= indices[len(indices)-1] {
 		return nil
 	}
 

--- a/params/governance_params.go
+++ b/params/governance_params.go
@@ -54,7 +54,7 @@ const (
 	// Block reward will be separated by three pieces and distributed
 	RewardSliceCount = 3
 	// GovernanceConfig is stored in a cache which has below capacity
-	GovernanceCacheLimit    = 3
+	GovernanceCacheLimit    = 512
 	GovernanceIdxCacheLimit = 1000
 	// The prefix for governance cache
 	GovernanceCachePrefix = "governance"


### PR DESCRIPTION
## Proposed changes

- Governance manages its own cache for faster retrieval of recent change history
- There was two issues in managing cache
- 1. Duplicated block number could be written in idxCache if a node stop and run repeatedly. In this case same number was appended at the end of idxCache
- 2. itemCache may have different block's governance information and it makes a node to retrieve database directly though it should be retrieved from the cache
- To solve above issues, check routines were refined. And use `g.db.ReadGovernance` in initializing cache.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
