### PR TITLE
Add governance API for debugging

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -128,6 +128,12 @@ web3._extend({
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
+		new web3._extend.Method({
+			name: 'itemCacheFromDb',
+			call: 'governance_itemCacheFromDb',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		})
 	],
 	properties: [
 		new web3._extend.Property({
@@ -154,6 +160,22 @@ web3._extend({
 			name: 'nodeAddress',
 			getter: 'governance_nodeAddress',
 		}),
+		new web3._extend.Property({
+			name: 'pendingChanges',
+			getter: 'governance_pendingChanges',
+		}),
+		new web3._extend.Property({
+			name: 'votes',
+			getter: 'governance_votes',
+		}),
+		new web3._extend.Property({
+			name: 'idxCache',
+			getter: 'governance_idxCache',
+		}),
+		new web3._extend.Property({
+			name: 'idxCacheFromDb',
+			getter: 'governance_idxCacheFromDb',
+		})
 	]
 });
 `

--- a/governance/api.go
+++ b/governance/api.go
@@ -157,6 +157,33 @@ func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interf
 	}
 }
 
+func (api *PublicGovernanceAPI) PendingChanges() map[string]interface{} {
+	return api.governance.PendingChanges()
+}
+
+func (api *PublicGovernanceAPI) Votes() []GovernanceVote {
+	return api.governance.Votes()
+}
+
+func (api *PublicGovernanceAPI) IdxCache() []uint64 {
+	return api.governance.IdxCache()
+}
+
+func (api *PublicGovernanceAPI) IdxCacheFromDb() []uint64 {
+	return api.governance.IdxCacheFromDb()
+}
+
+func (api *PublicGovernanceAPI) ItemCacheFromDb(num *rpc.BlockNumber) map[string]interface{} {
+	blockNumber := uint64(0)
+	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
+		blockNumber = api.governance.blockChain.CurrentHeader().Number.Uint64()
+	} else {
+		blockNumber = uint64(num.Int64())
+	}
+	ret, _ := api.governance.db.ReadGovernance(blockNumber)
+	return ret
+}
+
 type VoteList struct {
 	Key      string
 	Value    interface{}

--- a/governance/default.go
+++ b/governance/default.go
@@ -1045,3 +1045,23 @@ func (gov *Governance) UseGiniCoeff() bool {
 func (gov *Governance) ChainId() uint64 {
 	return gov.ChainConfig.ChainID.Uint64()
 }
+
+func (gov *Governance) PendingChanges() map[string]interface{} {
+	return gov.changeSet.Items()
+}
+
+func (gov *Governance) Votes() []GovernanceVote {
+	return gov.GovernanceVotes.Copy()
+}
+
+func (gov *Governance) IdxCache() []uint64 {
+	gov.idxCacheLock.RLock()
+	defer gov.idxCacheLock.RUnlock()
+
+	return gov.idxCache
+}
+
+func (gov *Governance) IdxCacheFromDb() []uint64 {
+	res, _ := gov.db.ReadRecentGovernanceIdx(0)
+	return res
+}

--- a/governance/default.go
+++ b/governance/default.go
@@ -1058,7 +1058,9 @@ func (gov *Governance) IdxCache() []uint64 {
 	gov.idxCacheLock.RLock()
 	defer gov.idxCacheLock.RUnlock()
 
-	return gov.idxCache
+	copiedCache := make([]uint64, 0, len(gov.idxCache))
+	copy(copiedCache, gov.idxCache)
+	return copiedCache
 }
 
 func (gov *Governance) IdxCacheFromDb() []uint64 {


### PR DESCRIPTION
## Proposed changes

- This PR adds APIs to check / debug current status of governance object
- Following APIs are added
- itemCacheFromDb() : Returns governance information stored at given block
- pendingChanges() : Returns `changeSet` of the governance object
- idxCache(): Returns in-memory idxCache that a node has
- idxCacheFromDb(): Returns idxCache which holds all historical change from database
- votes(): Returns a list of governance votes in this epoch

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
