### PR TITLE
Add curl to build image for coverage tests

### DIFF
--- a/build/Dockerfile-go1.12.5-solc0.4.24-alpine
+++ b/build/Dockerfile-go1.12.5-solc0.4.24-alpine
@@ -1,4 +1,4 @@
-FROM alpine as solc_builder
+FROM alpine:3.8 as solc_builder
 RUN \
   apk --no-cache --update add build-base cmake boost-dev git; \
   sed -i -E -e 's/include <sys\/poll.h>/include <poll.h>/' /usr/include/boost/asio/detail/socket_types.hpp; \
@@ -9,7 +9,7 @@ RUN \
   apk del sed build-base git make cmake gcc g++ musl-dev curl-dev boost-dev; \
   rm -rf /var/cache/apk/*
 
-FROM alpine as go_builder
+FROM alpine:3.8 as go_builder
 RUN \
   apk add --no-cache --virtual .build-deps bash gcc musl-dev openssl go; \
   wget -O go.src.tar.gz https://dl.google.com/go/go1.12.5.src.tar.gz; \
@@ -17,9 +17,9 @@ RUN \
   cd /usr/local/go/src/ && ./make.bash; \
   apk del .build-deps
 
-FROM alpine
+FROM alpine:3.8
 
-RUN apk add --no-cache ca-certificates boost git make gcc libc-dev
+RUN apk add --no-cache ca-certificates boost git make gcc libc-dev curl bash
 COPY --from=solc_builder /usr/bin/solc /usr/bin/solc
 COPY --from=go_builder /usr/local/go /usr/local
 


### PR DESCRIPTION
## Proposed changes

- Add `curl` to the Docker image used for builds
- Pin the Alpine version to 3.8 for compatibility with Solidity 0.4.24 (Solidity 0.5.6 results in Klaytn test failures, newer Alpine results in Solidity 0.4.x failing to build).
- This fixes the missing coverage reports

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
