### PR TITLE
SC: move bridge tests to the sc directory

### DIFF
--- a/node/sc/bridge_test.go
+++ b/node/sc/bridge_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
 
-package contracts
+package sc
 
 import (
 	"context"
@@ -28,7 +28,6 @@ import (
 	"github.com/klaytn/klaytn/contracts/extbridge"
 	sctoken "github.com/klaytn/klaytn/contracts/sc_erc20"
 	"github.com/klaytn/klaytn/crypto"
-	"github.com/klaytn/klaytn/node/sc"
 	"github.com/klaytn/klaytn/params"
 	"github.com/stretchr/testify/assert"
 	"log"
@@ -460,7 +459,7 @@ func TestExtendedBridgeAndCallback(t *testing.T) {
 		assert.Equal(t, amount.String(), ev.ValueOrTokenId.String())
 		assert.Equal(t, rNonce, ev.HandleNonce)
 		assert.Equal(t, erc20Addr, ev.TokenAddress)
-		assert.Equal(t, sc.ERC20, ev.TokenType)
+		assert.Equal(t, ERC20, ev.TokenType)
 		assert.Equal(t, callbackAddr, ev.To)
 
 	case <-time.After(time.Second):


### PR DESCRIPTION
## Proposed changes

- Simply move `bridge_test.go` in the `contract` to the `node/sc` directory.
- `multi_bridge_test.go` will be added in future PR.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
