### PR TITLE
SC: add a test case for contract start and stop method

### DIFF
--- a/node/sc/multi_bridge_test.go
+++ b/node/sc/multi_bridge_test.go
@@ -91,7 +91,7 @@ func TestStartStop(t *testing.T) {
 
 	isRunning, err := info.b.IsRunning(nil)
 	assert.NoError(t, err)
-	assert.Equal(t, isRunning, true)
+	assert.Equal(t, true, isRunning)
 
 	opts = &bind.TransactOpts{From: info.acc.From, Signer: info.acc.Signer, GasLimit: gasLimit}
 	tx, err = info.b.Start(opts, false)
@@ -101,5 +101,5 @@ func TestStartStop(t *testing.T) {
 
 	isRunning, err = info.b.IsRunning(nil)
 	assert.NoError(t, err)
-	assert.Equal(t, isRunning, false)
+	assert.Equal(t, false, isRunning)
 }

--- a/node/sc/multi_bridge_test.go
+++ b/node/sc/multi_bridge_test.go
@@ -76,3 +76,30 @@ func TestRegisterDeregisterOperator(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, false, isOperator)
 }
+
+// TestStartStop checks the following:
+// - the bridge contract method Start.
+// - the bridge contract method Stop.
+func TestStartStop(t *testing.T) {
+	info := prepareMultiBridgeTest(t)
+
+	opts := &bind.TransactOpts{From: info.acc.From, Signer: info.acc.Signer, GasLimit: gasLimit}
+	tx, err := info.b.Start(opts, true)
+	assert.NoError(t, err)
+	info.sim.Commit()
+	assert.Nil(t, bind.CheckWaitMined(info.sim, tx))
+
+	isRunning, err := info.b.IsRunning(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, isRunning, true)
+
+	opts = &bind.TransactOpts{From: info.acc.From, Signer: info.acc.Signer, GasLimit: gasLimit}
+	tx, err = info.b.Start(opts, false)
+	assert.NoError(t, err)
+	info.sim.Commit()
+	assert.Nil(t, bind.CheckWaitMined(info.sim, tx))
+
+	isRunning, err = info.b.IsRunning(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, isRunning, false)
+}


### PR DESCRIPTION
## Proposed changes

- Add a test case for start and stop bridge with onlyOwner.

## Types of changes

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

This test case is based on the following document: https://docs.google.com/spreadsheets/d/1aQZVWTNGs6KLHKXUPxHDX5akGUBiGDS9xAexLG6zMfE/edit?pli=1#gid=2142770539
