### PR TITLE
database: add more tests to db_manager_test.go

### DIFF
--- a/storage/database/cache_manager.go
+++ b/storage/database/cache_manager.go
@@ -229,7 +229,7 @@ func (cm *cacheManager) deleteHeaderCache(hash common.Hash) {
 
 // hasHeaderInCache returns if a cachedHeader exists with given headerHash.
 func (cm *cacheManager) hasHeaderInCache(hash common.Hash) bool {
-	if cm.blockNumberCache.Contains(hash) || cm.headerCache.Contains(hash) {
+	if cached, ok := cm.headerCache.Get(hash); ok && cached != nil {
 		return true
 	}
 	return false
@@ -352,7 +352,10 @@ func (cm *cacheManager) readBlockCache(hash common.Hash) *types.Block {
 
 // hasBlockInCache returns if given hash exists in blockCache.
 func (cm *cacheManager) hasBlockInCache(hash common.Hash) bool {
-	return cm.blockCache.Contains(hash)
+	if cachedBlock, ok := cm.blockCache.Get(hash); ok && cachedBlock != nil {
+		return true
+	}
+	return false
 }
 
 // writeBlockCache writes block as a value, blockHash as a key.

--- a/storage/database/cache_manager.go
+++ b/storage/database/cache_manager.go
@@ -263,7 +263,7 @@ func (cm *cacheManager) deleteTdCache(hash common.Hash) {
 // readBlockNumberCache looks for cached headerNumber in blockNumberCache.
 // It returns nil if not found.
 func (cm *cacheManager) readBlockNumberCache(hash common.Hash) *uint64 {
-	if cached, ok := cm.blockNumberCache.Get(hash); ok {
+	if cached, ok := cm.blockNumberCache.Get(hash); ok && cached != nil {
 		cacheGetBlockNumberHitMeter.Mark(1)
 		blockNumber := cached.(uint64)
 		return &blockNumber
@@ -275,6 +275,11 @@ func (cm *cacheManager) readBlockNumberCache(hash common.Hash) *uint64 {
 // writeHeaderCache writes headerNumber as a value, headerHash as a key.
 func (cm *cacheManager) writeBlockNumberCache(hash common.Hash, number uint64) {
 	cm.blockNumberCache.Add(hash, number)
+}
+
+// deleteBlockNumberCache deletes headerNumber with a headerHash as a key.
+func (cm *cacheManager) deleteBlockNumberCache(hash common.Hash) {
+	cm.blockNumberCache.Add(hash, nil)
 }
 
 // readCanonicalHashCache looks for cached canonical hash in canonicalHashCache.

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -446,25 +446,6 @@ func (dbm *databaseManager) DeleteCanonicalHash(number uint64) {
 	dbm.cm.writeCanonicalHashCache(number, common.Hash{})
 }
 
-// Head Number operations.
-// ReadHeaderNumber returns the header number assigned to a hash.
-func (dbm *databaseManager) ReadHeaderNumber(hash common.Hash) *uint64 {
-	if cachedHeaderNumber := dbm.cm.readBlockNumberCache(hash); cachedHeaderNumber != nil {
-		return cachedHeaderNumber
-	}
-
-	db := dbm.getDatabase(headerDB)
-	data, _ := db.Get(headerNumberKey(hash))
-	if len(data) != 8 {
-		return nil
-	}
-	number := binary.BigEndian.Uint64(data)
-
-	// Write to cache before returning found value.
-	dbm.cm.writeBlockNumberCache(hash, number)
-	return &number
-}
-
 // Head Header Hash operations.
 // ReadHeadHeaderHash retrieves the hash of the current canonical head header.
 func (dbm *databaseManager) ReadHeadHeaderHash() common.Hash {
@@ -625,6 +606,25 @@ func (dbm *databaseManager) DeleteHeader(hash common.Hash, number uint64) {
 
 	// Delete cache at the end of successful delete.
 	dbm.cm.deleteHeaderCache(hash)
+}
+
+// Head Number operations.
+// ReadHeaderNumber returns the header number assigned to a hash.
+func (dbm *databaseManager) ReadHeaderNumber(hash common.Hash) *uint64 {
+	if cachedHeaderNumber := dbm.cm.readBlockNumberCache(hash); cachedHeaderNumber != nil {
+		return cachedHeaderNumber
+	}
+
+	db := dbm.getDatabase(headerDB)
+	data, _ := db.Get(headerNumberKey(hash))
+	if len(data) != 8 {
+		return nil
+	}
+	number := binary.BigEndian.Uint64(data)
+
+	// Write to cache before returning found value.
+	dbm.cm.writeBlockNumberCache(hash, number)
+	return &number
 }
 
 // (Block)Body operations.

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -606,6 +606,7 @@ func (dbm *databaseManager) DeleteHeader(hash common.Hash, number uint64) {
 
 	// Delete cache at the end of successful delete.
 	dbm.cm.deleteHeaderCache(hash)
+	dbm.cm.deleteBlockNumberCache(hash)
 }
 
 // Head Number operations.

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -198,7 +198,7 @@ func TestDBManager_Header(t *testing.T) {
 	}
 }
 
-// TestDBManager_Header tests read, write and delete operations of blockchain bodies.
+// TestDBManager_Body tests read, write and delete operations of blockchain bodies.
 func TestDBManager_Body(t *testing.T) {
 	body := &types.Body{Transactions: types.Transactions{}}
 	encodedBody, err := rlp.EncodeToBytes(body)

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -17,11 +17,15 @@
 package database
 
 import (
+	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/ser/rlp"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+	"math/big"
 	"os"
+	"strconv"
 	"testing"
 )
 
@@ -161,28 +165,177 @@ func TestDBManager_FastTrieProgress(t *testing.T) {
 	}
 }
 
+// TestDBManager_Header tests read, write and delete operations of blockchain headers.
 func TestDBManager_Header(t *testing.T) {
-	// TODO-Klaytn-Database Implement this!
+	header := &types.Header{Number: big.NewInt(int64(num1))}
+	headerHash := header.Hash()
+
+	encodedHeader, err := rlp.EncodeToBytes(header)
+	if err != nil {
+		t.Fatal("Failed to encode header!", "err", err)
+	}
+
+	for _, dbm := range dbManagers {
+		assert.False(t, dbm.HasHeader(headerHash, num1))
+		assert.Nil(t, dbm.ReadHeader(headerHash, num1))
+		assert.Nil(t, dbm.ReadHeaderNumber(headerHash))
+
+		dbm.WriteHeader(header)
+
+		assert.True(t, dbm.HasHeader(headerHash, num1))
+		assert.Equal(t, header, dbm.ReadHeader(headerHash, num1))
+		assert.Equal(t, rlp.RawValue(encodedHeader), dbm.ReadHeaderRLP(headerHash, num1))
+		assert.Equal(t, num1, *dbm.ReadHeaderNumber(headerHash))
+
+		dbm.DeleteHeader(headerHash, num1)
+
+		assert.False(t, dbm.HasHeader(headerHash, num1))
+		assert.Nil(t, dbm.ReadHeader(headerHash, num1))
+		assert.Equal(t, num1, *dbm.ReadHeaderNumber(headerHash)) // headerNumber still exists in the cache
+	}
 }
 
+// TestDBManager_Header tests read, write and delete operations of blockchain bodies.
 func TestDBManager_Body(t *testing.T) {
-	// TODO-Klaytn-Database Implement this!
+	body := &types.Body{Transactions:types.Transactions{}}
+	encodedBody, err := rlp.EncodeToBytes(body)
+	if err != nil {
+		t.Fatal("Failed to encode body!", "err", err)
+	}
+
+	for _, dbm := range dbManagers {
+		assert.False(t, dbm.HasBody(hash1, num1))
+		assert.Nil(t, dbm.ReadBody(hash1, num1))
+		assert.Nil(t, dbm.ReadBodyInCache(hash1))
+		assert.Nil(t, dbm.ReadBodyRLP(hash1, num1))
+		assert.Nil(t, dbm.ReadBodyRLPByHash(hash1))
+
+		dbm.WriteBody(hash1, num1, body)
+
+		assert.True(t, dbm.HasBody(hash1, num1))
+		assert.Equal(t, body, dbm.ReadBody(hash1, num1))
+		assert.Equal(t, body, dbm.ReadBodyInCache(hash1))
+		assert.Equal(t, rlp.RawValue(encodedBody), dbm.ReadBodyRLP(hash1, num1))
+		assert.Equal(t, rlp.RawValue(encodedBody), dbm.ReadBodyRLPByHash(hash1))
+
+		dbm.DeleteBody(hash1, num1)
+
+		assert.False(t, dbm.HasBody(hash1, num1))
+		assert.Nil(t, dbm.ReadBody(hash1, num1))
+		assert.Nil(t, dbm.ReadBodyInCache(hash1))
+		assert.Nil(t, dbm.ReadBodyRLP(hash1, num1))
+		assert.Nil(t, dbm.ReadBodyRLPByHash(hash1))
+
+		dbm.WriteBodyRLP(hash1, num1, encodedBody)
+
+		assert.True(t, dbm.HasBody(hash1, num1))
+		assert.Equal(t, body, dbm.ReadBody(hash1, num1))
+		assert.Equal(t, body, dbm.ReadBodyInCache(hash1))
+		assert.Equal(t, rlp.RawValue(encodedBody), dbm.ReadBodyRLP(hash1, num1))
+		assert.Equal(t, rlp.RawValue(encodedBody), dbm.ReadBodyRLPByHash(hash1))
+
+		bodyBatch := dbm.NewBatch(BodyDB)
+		dbm.PutBodyToBatch(bodyBatch, hash2, num2, body)
+		if err := bodyBatch.Write(); err != nil {
+			t.Fatal("Failed to write batch!", "err", err)
+		}
+
+		assert.True(t, dbm.HasBody(hash2, num2))
+		assert.Equal(t, body, dbm.ReadBody(hash2, num2))
+		assert.Equal(t, body, dbm.ReadBodyInCache(hash2))
+		assert.Equal(t, rlp.RawValue(encodedBody), dbm.ReadBodyRLP(hash2, num2))
+		assert.Equal(t, rlp.RawValue(encodedBody), dbm.ReadBodyRLPByHash(hash2))
+	}
 }
 
+// TestDBManager_Td tests read, write and delete operations of blockchain headers' total difficulty.
 func TestDBManager_Td(t *testing.T) {
-	// TODO-Klaytn-Database Implement this!
+	for _, dbm := range dbManagers {
+		assert.Nil(t, dbm.ReadTd(hash1, num1))
+
+		dbm.WriteTd(hash1, num1, big.NewInt(12345))
+		assert.Equal(t, big.NewInt(12345), dbm.ReadTd(hash1, num1))
+
+		dbm.WriteTd(hash1, num1, big.NewInt(54321))
+		assert.Equal(t, big.NewInt(54321), dbm.ReadTd(hash1, num1))
+
+		dbm.DeleteTd(hash1, num1)
+		assert.Nil(t, dbm.ReadTd(hash1, num1))
+	}
 }
 
+// TestDBManager_Receipts read, write and delete operations of blockchain receipts.
 func TestDBManager_Receipts(t *testing.T) {
-	// TODO-Klaytn-Database Implement this!
+	header := &types.Header{Number: big.NewInt(int64(num1))}
+	headerHash := header.Hash()
+	receipts := types.Receipts{generateReceipt(111)}
+
+	for _, dbm := range dbManagers {
+		assert.Nil(t, dbm.ReadReceipts(headerHash, num1))
+		assert.Nil(t, dbm.ReadReceiptsByBlockHash(headerHash))
+
+		dbm.WriteReceipts(headerHash, num1, receipts)
+		dbm.WriteHeader(header)
+
+		assert.Equal(t, receipts, dbm.ReadReceipts(headerHash, num1))
+		assert.Equal(t, receipts, dbm.ReadReceiptsByBlockHash(headerHash))
+
+		dbm.DeleteReceipts(headerHash, num1)
+
+		assert.Nil(t, dbm.ReadReceipts(headerHash, num1))
+		assert.Nil(t, dbm.ReadReceiptsByBlockHash(headerHash))
+	}
 }
 
+// TestDBManager_Block read, write and delete operations of blockchain blocks.
 func TestDBManager_Block(t *testing.T) {
-	// TODO-Klaytn-Database Implement this!
+	header := &types.Header{Number: big.NewInt(int64(num1))}
+	headerHash := header.Hash()
+	block := types.NewBlockWithHeader(header)
+
+	for _, dbm := range dbManagers {
+		assert.False(t, dbm.HasBlock(headerHash, num1))
+		assert.Nil(t, dbm.ReadBlock(headerHash, num1))
+		assert.Nil(t, dbm.ReadBlockByHash(headerHash))
+		assert.Nil(t, dbm.ReadBlockByNumber(num1))
+
+		dbm.WriteBlock(block)
+		dbm.WriteCanonicalHash(headerHash, num1)
+
+		assert.True(t, dbm.HasBlock(headerHash, num1))
+
+		blockFromDB1 := dbm.ReadBlock(headerHash, num1)
+		blockFromDB2 := dbm.ReadBlockByHash(headerHash)
+		blockFromDB3 := dbm.ReadBlockByNumber(num1)
+
+		assert.Equal(t, headerHash, blockFromDB1.Hash())
+		assert.Equal(t, headerHash, blockFromDB2.Hash())
+		assert.Equal(t, headerHash, blockFromDB3.Hash())
+
+		dbm.DeleteBlock(headerHash, num1)
+		dbm.DeleteCanonicalHash(num1)
+
+		assert.False(t, dbm.HasBlock(headerHash, num1))
+		assert.Nil(t, dbm.ReadBlock(headerHash, num1))
+		assert.Nil(t, dbm.ReadBlockByHash(headerHash))
+		assert.Nil(t, dbm.ReadBlockByNumber(num1))
+	}
 }
 
+// TestDBManager_IstanbulSnapshot tests read and write operations of istanbul snapshots.
 func TestDBManager_IstanbulSnapshot(t *testing.T) {
-	// TODO-Klaytn-Database Implement this!
+	for _, dbm := range dbManagers {
+		snapshot, _ := dbm.ReadIstanbulSnapshot(hash1)
+		assert.Nil(t, snapshot)
+
+		dbm.WriteIstanbulSnapshot(hash1, hash2[:])
+		snapshot, _ = dbm.ReadIstanbulSnapshot(hash1)
+		assert.Equal(t, hash2[:], snapshot)
+
+		dbm.WriteIstanbulSnapshot(hash1, hash1[:])
+		snapshot, _ = dbm.ReadIstanbulSnapshot(hash1)
+		assert.Equal(t, hash1[:], snapshot)
+	}
 }
 
 // TestDBManager_DatabaseVersion tests read/write operations of database version.
@@ -310,4 +463,15 @@ func TestDBManager_CliqueSnapshot(t *testing.T) {
 
 func TestDBManager_Governance(t *testing.T) {
 	// TODO-Klaytn-Database Implement this!
+}
+
+func generateReceipt(gasUsed int) *types.Receipt {
+	log := &types.Log{Topics: []common.Hash{}, Data: []uint8{}, BlockNumber: uint64(gasUsed)}
+	log.Topics = append(log.Topics, common.HexToHash(strconv.Itoa(gasUsed)))
+	return &types.Receipt{
+		TxHash:  common.HexToHash(strconv.Itoa(gasUsed)),
+		GasUsed: uint64(gasUsed),
+		Status:  types.ReceiptStatusSuccessful,
+		Logs:    []*types.Log{log},
+	}
 }

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -45,8 +45,11 @@ var baseConfigs = []*DBConfig{
 
 var num1 = uint64(20190815)
 var num2 = uint64(20199999)
+var num3 = uint64(12345678)
+
 var hash1 = common.HexToHash("1341655") // 20190805 in hexadecimal
 var hash2 = common.HexToHash("1343A3F") // 20199999 in hexadecimal
+var hash3 = common.HexToHash("BC614E") // 12345678 in hexadecimal
 
 func init() {
 	for _, bc := range baseConfigs {
@@ -197,7 +200,7 @@ func TestDBManager_Header(t *testing.T) {
 
 // TestDBManager_Header tests read, write and delete operations of blockchain bodies.
 func TestDBManager_Body(t *testing.T) {
-	body := &types.Body{Transactions:types.Transactions{}}
+	body := &types.Body{Transactions: types.Transactions{}}
 	encodedBody, err := rlp.EncodeToBytes(body)
 	if err != nil {
 		t.Fatal("Failed to encode body!", "err", err)
@@ -325,15 +328,15 @@ func TestDBManager_Block(t *testing.T) {
 // TestDBManager_IstanbulSnapshot tests read and write operations of istanbul snapshots.
 func TestDBManager_IstanbulSnapshot(t *testing.T) {
 	for _, dbm := range dbManagers {
-		snapshot, _ := dbm.ReadIstanbulSnapshot(hash1)
+		snapshot, _ := dbm.ReadIstanbulSnapshot(hash3)
 		assert.Nil(t, snapshot)
 
-		dbm.WriteIstanbulSnapshot(hash1, hash2[:])
-		snapshot, _ = dbm.ReadIstanbulSnapshot(hash1)
+		dbm.WriteIstanbulSnapshot(hash3, hash2[:])
+		snapshot, _ = dbm.ReadIstanbulSnapshot(hash3)
 		assert.Equal(t, hash2[:], snapshot)
 
-		dbm.WriteIstanbulSnapshot(hash1, hash1[:])
-		snapshot, _ = dbm.ReadIstanbulSnapshot(hash1)
+		dbm.WriteIstanbulSnapshot(hash3, hash1[:])
+		snapshot, _ = dbm.ReadIstanbulSnapshot(hash3)
 		assert.Equal(t, hash1[:], snapshot)
 	}
 }

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -194,7 +194,7 @@ func TestDBManager_Header(t *testing.T) {
 
 		assert.False(t, dbm.HasHeader(headerHash, num1))
 		assert.Nil(t, dbm.ReadHeader(headerHash, num1))
-		assert.Equal(t, num1, *dbm.ReadHeaderNumber(headerHash)) // headerNumber still exists in the cache
+		assert.Nil(t, dbm.ReadHeaderNumber(headerHash))
 	}
 }
 

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -49,7 +49,7 @@ var num3 = uint64(12345678)
 
 var hash1 = common.HexToHash("1341655") // 20190805 in hexadecimal
 var hash2 = common.HexToHash("1343A3F") // 20199999 in hexadecimal
-var hash3 = common.HexToHash("BC614E") // 12345678 in hexadecimal
+var hash3 = common.HexToHash("BC614E")  // 12345678 in hexadecimal
 
 func init() {
 	for _, bc := range baseConfigs {


### PR DESCRIPTION
## Proposed changes

- Added more tests to db_manager_test.go to increase the coverage of database pkg
- `hasHeaderInCache` and `hasBlockInCache` are changed since stored `nil` indicates that the corresponding value is removed.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...