### PR TITLE
SC: fix networkid and bootnodes for scn, spn and sen

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -723,8 +723,10 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 	case cfg.BootstrapNodes != nil:
 		return // already set, don't apply defaults.
 	case !ctx.GlobalIsSet(NetworkIdFlag.Name):
-		logger.Info("Cypress bootnodes are set")
-		urls = params.MainnetBootnodes[cfg.ConnectionType].Addrs
+		if NodeTypeFlag.Value != "scn" && NodeTypeFlag.Value != "spn" && NodeTypeFlag.Value != "sen" {
+			logger.Info("Cypress bootnodes are set")
+			urls = params.MainnetBootnodes[cfg.ConnectionType].Addrs
+		}
 	}
 
 	cfg.BootstrapNodes = make([]*discover.Node, 0, len(urls))
@@ -955,13 +957,6 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 			log.Fatalf("Option %q: %v", NetrestrictFlag.Name, err)
 		}
 		cfg.NetRestrict = list
-	}
-
-	if ctx.GlobalIsSet(ListenPortFlag.Name) && (NodeTypeFlag.Value == "spn" || NodeTypeFlag.Value == "sen") {
-		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
-			log.Fatalf("Missing network id for the nodetype: %v", NodeTypeFlag.Value)
-		}
-		cfg.NoDiscovery = true
 	}
 
 	cfg.NetworkID, _ = getNetworkId(ctx)
@@ -1326,6 +1321,10 @@ func getNetworkId(ctx *cli.Context) (uint64, bool) {
 		logger.Info("A private network ID is set", "networkid", networkId)
 		return networkId, true
 	default:
+		if NodeTypeFlag.Value == "scn" || NodeTypeFlag.Value == "spn" || NodeTypeFlag.Value == "sen" {
+			logger.Info("A Service Chain default network ID is set", "networkid", params.ServiceChainDefaultNetworkId)
+			return params.ServiceChainDefaultNetworkId, true
+		}
 		logger.Info("Cypress network ID is set", "networkid", params.CypressNetworkId)
 		return params.CypressNetworkId, false
 	}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -114,10 +114,11 @@ const (
 	TxGasCancel                uint64 = 21000
 
 	// Network Id
-	UnusedNetworkId  uint64 = 0
-	AspenNetworkId   uint64 = 1000
-	BaobabNetworkId  uint64 = 1001
-	CypressNetworkId uint64 = 8217
+	UnusedNetworkId              uint64 = 0
+	AspenNetworkId               uint64 = 1000
+	BaobabNetworkId              uint64 = 1001
+	CypressNetworkId             uint64 = 8217
+	ServiceChainDefaultNetworkId uint64 = 3000
 
 	TxGasValueTransfer     uint64 = 21000
 	TxGasContractExecution uint64 = 21000


### PR DESCRIPTION
## Proposed changes

- This PR changes default values of networkid and bootnodes for Service Chain.
- If we run ksen without options, default configuration for networkid and bootnodes is `Cypress`. To prevent the problem, we remove default bootnodes and set default networkid to 3000 for service chain binaries.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
