### PR TITLE
In a test case, move 'txpool' declaration logic to mitigate a test fail issue

### DIFF
--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -1880,9 +1880,6 @@ func TestValidationPoolResetAfterFeePayerKeyChange(t *testing.T) {
 		reservoir.AddNonce()
 	}
 
-	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc)
-
 	// transfer KLAY to fee payer
 	{
 		var txs types.Transactions
@@ -1909,6 +1906,9 @@ func TestValidationPoolResetAfterFeePayerKeyChange(t *testing.T) {
 		}
 		reservoir.AddNonce()
 	}
+
+	// make TxPool to test validation in 'TxPool add' process
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc)
 
 	// state changing tx which will invalidate other txs when it is contained in a block.
 	var txs types.Transactions


### PR DESCRIPTION
## Proposed changes
The test case occasionally fails since some part of the code cause a race condition issue.
In the test code, `txpool` is declared before the execution of `bcdata.GenABlockWithTransaction()` which resets the status of `txpool` through go-routine. 

The problem can be mitigated by moving the `txpool` declaration logic to the next line of `bcdata.GenABlockWithTransaction()`. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
