### PR TITLE
SC: Add APIs for lock/unlock bridge operators

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -62,9 +62,9 @@ func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
 	}
 }
 
-// NewKeyedTransactorWithWallet is a utility method to easily create a transaction signer
+// NewKeyedTransactorWithKeystore is a utility method to easily create a transaction signer
 // from a keystore wallet.
-func NewKeyedTransactorWithWallet(address common.Address, wallet accounts.Wallet, chainID *big.Int) *TransactOpts {
+func NewKeyedTransactorWithKeystore(address common.Address, ks *keystore.KeyStore, chainID *big.Int) *TransactOpts {
 	keyAddr := address
 	return &TransactOpts{
 		From: keyAddr,
@@ -73,7 +73,7 @@ func NewKeyedTransactorWithWallet(address common.Address, wallet accounts.Wallet
 				return nil, errors.New("not authorized to sign this account")
 			}
 			account := accounts.Account{Address: address}
-			return wallet.SignTx(account, tx, chainID)
+			return ks.SignTx(account, tx, chainID)
 		},
 	}
 }
@@ -91,12 +91,12 @@ func MakeTransactOpts(accountKey *ecdsa.PrivateKey, nonce *big.Int, gasLimit uin
 }
 
 // MakeTransactOptsWithKeystore creates a transaction signer with nonce, gasLimit, and gasPrice from a keystore wallet.
-func MakeTransactOptsWithKeystore(wallet accounts.Wallet, from common.Address, nonce *big.Int, chainID *big.Int, gasLimit uint64, gasPrice *big.Int) *TransactOpts {
-	if wallet == nil {
+func MakeTransactOptsWithKeystore(ks *keystore.KeyStore, from common.Address, nonce *big.Int, chainID *big.Int, gasLimit uint64, gasPrice *big.Int) *TransactOpts {
+	if ks == nil {
 		return nil
 	}
 
-	auth := NewKeyedTransactorWithWallet(from, wallet, chainID)
+	auth := NewKeyedTransactorWithKeystore(from, ks, chainID)
 	auth.GasLimit = gasLimit
 	auth.GasPrice = gasPrice
 	auth.Nonce = nonce

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -329,6 +329,16 @@ func (ks *KeyStore) Lock(addr common.Address) error {
 	return nil
 }
 
+// IsLock returns if the account is locked or not.
+func (ks *KeyStore) IsLock(addr common.Address) bool {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	if _, found := ks.unlocked[addr]; found {
+		return false
+	}
+	return true
+}
+
 // TimedUnlock unlocks the given account with the passphrase. The account
 // stays unlocked for the duration of timeout. A timeout of 0 unlocks the account
 // until the program exits. The account must match a unique key file.

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -329,14 +329,12 @@ func (ks *KeyStore) Lock(addr common.Address) error {
 	return nil
 }
 
-// IsLocked returns if the account is locked or not.
-func (ks *KeyStore) IsLocked(addr common.Address) bool {
+// IsUnlocked returns if the account is unlocked or not.
+func (ks *KeyStore) IsUnlocked(addr common.Address) bool {
 	ks.mu.RLock()
 	defer ks.mu.RUnlock()
-	if _, found := ks.unlocked[addr]; found {
-		return false
-	}
-	return true
+	_, found := ks.unlocked[addr]
+	return found
 }
 
 // TimedUnlock unlocks the given account with the passphrase. The account

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -329,8 +329,8 @@ func (ks *KeyStore) Lock(addr common.Address) error {
 	return nil
 }
 
-// IsLock returns if the account is locked or not.
-func (ks *KeyStore) IsLock(addr common.Address) bool {
+// IsLocked returns if the account is locked or not.
+func (ks *KeyStore) IsLocked(addr common.Address) bool {
 	ks.mu.RLock()
 	defer ks.mu.RUnlock()
 	if _, found := ks.unlocked[addr]; found {

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -1048,6 +1048,24 @@ web3._extend({
 			call: 'subbridge_getFeeReceiver',
 			params: 1
 		}),
+		new web3._extend.Method({
+			name: 'lockParentOperator',
+			call: 'subbridge_lockParentOperator'
+		}),
+		new web3._extend.Method({
+			name: 'lockChildOperator',
+			call: 'subbridge_lockChildOperator'
+		}),
+		new web3._extend.Method({
+			name: 'unlockParentOperator',
+			call: 'subbridge_unlockParentOperator',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'unlockChildOperator',
+			call: 'subbridge_unlockChildOperator',
+			params: 1
+		}),
 	],
     properties: [
 		new web3._extend.Property({
@@ -1065,6 +1083,10 @@ web3._extend({
 			new web3._extend.Property({
 			name: 'serviceChainAccount',
 			getter: 'subbridge_getServiceChainAccountAddr'
+		}),
+		new web3._extend.Property({
+			name: 'operators',
+			getter: 'subbridge_getOperators'
 		}),
 		new web3._extend.Property({
 			name: 'anchoringPeriod',

--- a/node/sc/api_bridge.go
+++ b/node/sc/api_bridge.go
@@ -464,6 +464,31 @@ func (sbapi *SubBridgeAPI) GetServiceChainAccountNonce() uint64 {
 	return sbapi.sc.handler.getServiceChainAccountNonce()
 }
 
+// GetBridgeOperators returns the information of bridge operators.
+func (sbapi *SubBridgeAPI) GetOperators() map[string]interface{} {
+	return sbapi.sc.bridgeAccounts.GetBridgeOperators()
+}
+
+// LockParentOperator can lock the parent bridge operator.
+func (sbapi *SubBridgeAPI) LockParentOperator() error {
+	return sbapi.sc.bridgeAccounts.pAccount.LockAccount()
+}
+
+// LockParentOperator can lock the child bridge operator.
+func (sbapi *SubBridgeAPI) LockChildOperator() error {
+	return sbapi.sc.bridgeAccounts.cAccount.LockAccount()
+}
+
+// LockParentOperator can unlock the parent bridge operator.
+func (sbapi *SubBridgeAPI) UnlockParentOperator(passphrase string) error {
+	return sbapi.sc.bridgeAccounts.pAccount.UnLockAccount(passphrase)
+}
+
+// LockParentOperator can unlock the child bridge operator.
+func (sbapi *SubBridgeAPI) UnlockChildOperator(passphrase string) error {
+	return sbapi.sc.bridgeAccounts.cAccount.UnLockAccount(passphrase)
+}
+
 func (sbapi *SubBridgeAPI) GetAnchoringPeriod() uint64 {
 	return sbapi.sc.config.AnchoringPeriod
 }

--- a/node/sc/api_bridge.go
+++ b/node/sc/api_bridge.go
@@ -464,7 +464,7 @@ func (sbapi *SubBridgeAPI) GetServiceChainAccountNonce() uint64 {
 	return sbapi.sc.handler.getServiceChainAccountNonce()
 }
 
-// GetBridgeOperators returns the information of bridge operators.
+// GetOperators returns the information of bridge operators.
 func (sbapi *SubBridgeAPI) GetOperators() map[string]interface{} {
 	return sbapi.sc.bridgeAccounts.GetBridgeOperators()
 }
@@ -474,17 +474,17 @@ func (sbapi *SubBridgeAPI) LockParentOperator() error {
 	return sbapi.sc.bridgeAccounts.pAccount.LockAccount()
 }
 
-// LockParentOperator can lock the child bridge operator.
+// LockChildOperator can lock the child bridge operator.
 func (sbapi *SubBridgeAPI) LockChildOperator() error {
 	return sbapi.sc.bridgeAccounts.cAccount.LockAccount()
 }
 
-// LockParentOperator can unlock the parent bridge operator.
+// UnlockParentOperator can unlock the parent bridge operator.
 func (sbapi *SubBridgeAPI) UnlockParentOperator(passphrase string) error {
 	return sbapi.sc.bridgeAccounts.pAccount.UnLockAccount(passphrase)
 }
 
-// LockParentOperator can unlock the child bridge operator.
+// UnlockChildOperator can unlock the child bridge operator.
 func (sbapi *SubBridgeAPI) UnlockChildOperator(passphrase string) error {
 	return sbapi.sc.bridgeAccounts.cAccount.UnLockAccount(passphrase)
 }

--- a/node/sc/bridge_account_test.go
+++ b/node/sc/bridge_account_test.go
@@ -41,8 +41,8 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 	config.DataDir = tempDir
 	bAcc, err := NewBridgeAccounts(config.DataDir)
 	assert.NoError(t, err)
-	assert.Equal(t, false, bAcc.cAccount.IsLockedAccount())
-	assert.Equal(t, false, bAcc.pAccount.IsLockedAccount())
+	assert.Equal(t, false, bAcc.cAccount.IsUnlockedAccount())
+	assert.Equal(t, false, bAcc.pAccount.IsUnlockedAccount())
 
 	pPwdFilePath := path.Join(tempDir, "parent_bridge_account", bAcc.pAccount.address.String())
 	pPwdStr, err := ioutil.ReadFile(pPwdFilePath)
@@ -56,36 +56,36 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 	{
 		err := bAcc.cAccount.LockAccount()
 		assert.NoError(t, err)
-		assert.Equal(t, true, bAcc.cAccount.IsLockedAccount())
+		assert.Equal(t, true, bAcc.cAccount.IsUnlockedAccount())
 	}
 	{
 		err := bAcc.pAccount.LockAccount()
 		assert.NoError(t, err)
-		assert.Equal(t, true, bAcc.pAccount.IsLockedAccount())
+		assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
 	}
 
 	// Fail to UnLock Account
 	{
 		err := bAcc.cAccount.UnLockAccount(string(cPwdStr)[3:])
 		assert.EqualError(t, err, keystore.ErrDecrypt.Error())
-		assert.Equal(t, true, bAcc.cAccount.IsLockedAccount())
+		assert.Equal(t, true, bAcc.cAccount.IsUnlockedAccount())
 	}
 	{
 		err := bAcc.pAccount.UnLockAccount(string(pPwdStr)[3:])
 		assert.EqualError(t, err, keystore.ErrDecrypt.Error())
-		assert.Equal(t, true, bAcc.pAccount.IsLockedAccount())
+		assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
 	}
 
 	// Succeed to UnLock Account
 	{
 		err := bAcc.cAccount.UnLockAccount(string(cPwdStr))
 		assert.NoError(t, err)
-		assert.Equal(t, false, bAcc.cAccount.IsLockedAccount())
+		assert.Equal(t, false, bAcc.cAccount.IsUnlockedAccount())
 	}
 	{
 		err := bAcc.pAccount.UnLockAccount(string(pPwdStr))
 		assert.NoError(t, err)
-		assert.Equal(t, false, bAcc.pAccount.IsLockedAccount())
+		assert.Equal(t, false, bAcc.pAccount.IsUnlockedAccount())
 	}
 }
 
@@ -104,8 +104,8 @@ func TestBridgeAccountInformation(t *testing.T) {
 	config.DataDir = tempDir
 	bAcc, err := NewBridgeAccounts(config.DataDir)
 	assert.NoError(t, err)
-	assert.Equal(t, false, bAcc.cAccount.IsLockedAccount())
-	assert.Equal(t, false, bAcc.pAccount.IsLockedAccount())
+	assert.Equal(t, false, bAcc.cAccount.IsUnlockedAccount())
+	assert.Equal(t, false, bAcc.pAccount.IsUnlockedAccount())
 
 	bAcc.pAccount.gasPrice = big.NewInt(100)
 	bAcc.pAccount.nonce = 10
@@ -127,12 +127,12 @@ func TestBridgeAccountInformation(t *testing.T) {
 	assert.Equal(t, pRes["chainID"].(*big.Int).String(), bAcc.pAccount.chainID.String())
 	assert.Equal(t, pRes["gasPrice"].(*big.Int).String(), bAcc.pAccount.gasPrice.String())
 	assert.Equal(t, pRes["isNonceSynced"], bAcc.pAccount.isNonceSynced)
-	assert.Equal(t, pRes["isLocked"], bAcc.pAccount.IsLockedAccount())
+	assert.Equal(t, pRes["isUnlocked"], bAcc.pAccount.IsUnlockedAccount())
 
 	assert.Equal(t, cRes["address"], bAcc.cAccount.address)
 	assert.Equal(t, cRes["nonce"], bAcc.cAccount.nonce)
 	assert.Equal(t, cRes["chainID"].(*big.Int).String(), bAcc.cAccount.chainID.String())
 	assert.Equal(t, cRes["gasPrice"].(*big.Int).String(), bAcc.cAccount.gasPrice.String())
 	assert.Equal(t, cRes["isNonceSynced"], bAcc.cAccount.isNonceSynced)
-	assert.Equal(t, cRes["isLocked"], bAcc.cAccount.IsLockedAccount())
+	assert.Equal(t, cRes["isUnlocked"], bAcc.cAccount.IsUnlockedAccount())
 }

--- a/node/sc/bridge_account_test.go
+++ b/node/sc/bridge_account_test.go
@@ -1,0 +1,138 @@
+// Copyright 2019 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package sc
+
+import (
+	"github.com/klaytn/klaytn/accounts/keystore"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path"
+	"testing"
+)
+
+// TestBridgeAccountLockUnlock checks the lock/unlock functionality.
+func TestBridgeAccountLockUnlock(t *testing.T) {
+	tempDir := os.TempDir() + "sc"
+	os.MkdirAll(tempDir, os.ModePerm)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("fail to delete file %v", err)
+		}
+	}()
+
+	// Config Bridge Account Manager
+	config := &SCConfig{}
+	config.DataDir = tempDir
+	bAcc, err := NewBridgeAccounts(config.DataDir)
+	assert.NoError(t, err)
+	assert.Equal(t, false, bAcc.cAccount.IsLockAccount())
+	assert.Equal(t, false, bAcc.pAccount.IsLockAccount())
+
+	pPwdFilePath := path.Join(tempDir, "parent_bridge_account", bAcc.pAccount.address.String())
+	pPwdStr, err := ioutil.ReadFile(pPwdFilePath)
+	assert.NoError(t, err)
+
+	cPwdFilePath := path.Join(tempDir, "child_bridge_account", bAcc.cAccount.address.String())
+	cPwdStr, err := ioutil.ReadFile(cPwdFilePath)
+	assert.NoError(t, err)
+
+	// Lock Account
+	{
+		err := bAcc.cAccount.LockAccount()
+		assert.NoError(t, err)
+		assert.Equal(t, true, bAcc.cAccount.IsLockAccount())
+	}
+	{
+		err := bAcc.pAccount.LockAccount()
+		assert.NoError(t, err)
+		assert.Equal(t, true, bAcc.pAccount.IsLockAccount())
+	}
+
+	// Fail to UnLock Account
+	{
+		err := bAcc.cAccount.UnLockAccount(string(cPwdStr)[3:])
+		assert.EqualError(t, err, keystore.ErrDecrypt.Error())
+		assert.Equal(t, true, bAcc.cAccount.IsLockAccount())
+	}
+	{
+		err := bAcc.pAccount.UnLockAccount(string(pPwdStr)[3:])
+		assert.EqualError(t, err, keystore.ErrDecrypt.Error())
+		assert.Equal(t, true, bAcc.pAccount.IsLockAccount())
+	}
+
+	// Succeed to UnLock Account
+	{
+		err := bAcc.cAccount.UnLockAccount(string(cPwdStr))
+		assert.NoError(t, err)
+		assert.Equal(t, false, bAcc.cAccount.IsLockAccount())
+	}
+	{
+		err := bAcc.pAccount.UnLockAccount(string(pPwdStr))
+		assert.NoError(t, err)
+		assert.Equal(t, false, bAcc.pAccount.IsLockAccount())
+	}
+}
+
+// TestBridgeAccountInformation checks if the information result is right or not.
+func TestBridgeAccountInformation(t *testing.T) {
+	tempDir := os.TempDir() + "sc"
+	os.MkdirAll(tempDir, os.ModePerm)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("fail to delete file %v", err)
+		}
+	}()
+
+	// Config Bridge Account Manager
+	config := &SCConfig{}
+	config.DataDir = tempDir
+	bAcc, err := NewBridgeAccounts(config.DataDir)
+	assert.NoError(t, err)
+	assert.Equal(t, false, bAcc.cAccount.IsLockAccount())
+	assert.Equal(t, false, bAcc.pAccount.IsLockAccount())
+
+	bAcc.pAccount.gasPrice = big.NewInt(100)
+	bAcc.pAccount.nonce = 10
+	bAcc.pAccount.chainID = big.NewInt(200)
+	bAcc.pAccount.isNonceSynced = true
+	err = bAcc.pAccount.LockAccount()
+	assert.NoError(t, err)
+
+	res := bAcc.GetBridgeOperators()
+	assert.Equal(t, 2, len(res))
+
+	pRes := (res["parentOperator"]).(map[string]interface{})
+	cRes := res["childOperator"].(map[string]interface{})
+	assert.Equal(t, 6, len(pRes))
+	assert.Equal(t, 6, len(cRes))
+
+	assert.Equal(t, pRes["address"], bAcc.pAccount.address)
+	assert.Equal(t, pRes["nonce"], bAcc.pAccount.nonce)
+	assert.Equal(t, pRes["chainID"].(*big.Int).String(), bAcc.pAccount.chainID.String())
+	assert.Equal(t, pRes["gasPrice"].(*big.Int).String(), bAcc.pAccount.gasPrice.String())
+	assert.Equal(t, pRes["isNonceSynced"], bAcc.pAccount.isNonceSynced)
+	assert.Equal(t, pRes["isLocked"], bAcc.pAccount.IsLockAccount())
+
+	assert.Equal(t, cRes["address"], bAcc.cAccount.address)
+	assert.Equal(t, cRes["nonce"], bAcc.cAccount.nonce)
+	assert.Equal(t, cRes["chainID"].(*big.Int).String(), bAcc.cAccount.chainID.String())
+	assert.Equal(t, cRes["gasPrice"].(*big.Int).String(), bAcc.cAccount.gasPrice.String())
+	assert.Equal(t, cRes["isNonceSynced"], bAcc.cAccount.isNonceSynced)
+	assert.Equal(t, cRes["isLocked"], bAcc.cAccount.IsLockAccount())
+}

--- a/node/sc/bridge_account_test.go
+++ b/node/sc/bridge_account_test.go
@@ -41,8 +41,8 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 	config.DataDir = tempDir
 	bAcc, err := NewBridgeAccounts(config.DataDir)
 	assert.NoError(t, err)
-	assert.Equal(t, false, bAcc.cAccount.IsUnlockedAccount())
-	assert.Equal(t, false, bAcc.pAccount.IsUnlockedAccount())
+	assert.Equal(t, true, bAcc.cAccount.IsUnlockedAccount())
+	assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
 
 	pPwdFilePath := path.Join(tempDir, "parent_bridge_account", bAcc.pAccount.address.String())
 	pPwdStr, err := ioutil.ReadFile(pPwdFilePath)
@@ -56,36 +56,36 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 	{
 		err := bAcc.cAccount.LockAccount()
 		assert.NoError(t, err)
-		assert.Equal(t, true, bAcc.cAccount.IsUnlockedAccount())
+		assert.Equal(t, false, bAcc.cAccount.IsUnlockedAccount())
 	}
 	{
 		err := bAcc.pAccount.LockAccount()
 		assert.NoError(t, err)
-		assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
+		assert.Equal(t, false, bAcc.pAccount.IsUnlockedAccount())
 	}
 
 	// Fail to UnLock Account
 	{
 		err := bAcc.cAccount.UnLockAccount(string(cPwdStr)[3:])
 		assert.EqualError(t, err, keystore.ErrDecrypt.Error())
-		assert.Equal(t, true, bAcc.cAccount.IsUnlockedAccount())
+		assert.Equal(t, false, bAcc.cAccount.IsUnlockedAccount())
 	}
 	{
 		err := bAcc.pAccount.UnLockAccount(string(pPwdStr)[3:])
 		assert.EqualError(t, err, keystore.ErrDecrypt.Error())
-		assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
+		assert.Equal(t, false, bAcc.pAccount.IsUnlockedAccount())
 	}
 
 	// Succeed to UnLock Account
 	{
 		err := bAcc.cAccount.UnLockAccount(string(cPwdStr))
 		assert.NoError(t, err)
-		assert.Equal(t, false, bAcc.cAccount.IsUnlockedAccount())
+		assert.Equal(t, true, bAcc.cAccount.IsUnlockedAccount())
 	}
 	{
 		err := bAcc.pAccount.UnLockAccount(string(pPwdStr))
 		assert.NoError(t, err)
-		assert.Equal(t, false, bAcc.pAccount.IsUnlockedAccount())
+		assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
 	}
 }
 
@@ -104,8 +104,8 @@ func TestBridgeAccountInformation(t *testing.T) {
 	config.DataDir = tempDir
 	bAcc, err := NewBridgeAccounts(config.DataDir)
 	assert.NoError(t, err)
-	assert.Equal(t, false, bAcc.cAccount.IsUnlockedAccount())
-	assert.Equal(t, false, bAcc.pAccount.IsUnlockedAccount())
+	assert.Equal(t, true, bAcc.cAccount.IsUnlockedAccount())
+	assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
 
 	bAcc.pAccount.gasPrice = big.NewInt(100)
 	bAcc.pAccount.nonce = 10

--- a/node/sc/bridge_account_test.go
+++ b/node/sc/bridge_account_test.go
@@ -117,7 +117,7 @@ func TestBridgeAccountInformation(t *testing.T) {
 	res := bAcc.GetBridgeOperators()
 	assert.Equal(t, 2, len(res))
 
-	pRes := (res["parentOperator"]).(map[string]interface{})
+	pRes := res["parentOperator"].(map[string]interface{})
 	cRes := res["childOperator"].(map[string]interface{})
 	assert.Equal(t, 6, len(pRes))
 	assert.Equal(t, 6, len(cRes))

--- a/node/sc/bridge_account_test.go
+++ b/node/sc/bridge_account_test.go
@@ -41,8 +41,8 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 	config.DataDir = tempDir
 	bAcc, err := NewBridgeAccounts(config.DataDir)
 	assert.NoError(t, err)
-	assert.Equal(t, false, bAcc.cAccount.IsLockAccount())
-	assert.Equal(t, false, bAcc.pAccount.IsLockAccount())
+	assert.Equal(t, false, bAcc.cAccount.IsLockedAccount())
+	assert.Equal(t, false, bAcc.pAccount.IsLockedAccount())
 
 	pPwdFilePath := path.Join(tempDir, "parent_bridge_account", bAcc.pAccount.address.String())
 	pPwdStr, err := ioutil.ReadFile(pPwdFilePath)
@@ -56,36 +56,36 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 	{
 		err := bAcc.cAccount.LockAccount()
 		assert.NoError(t, err)
-		assert.Equal(t, true, bAcc.cAccount.IsLockAccount())
+		assert.Equal(t, true, bAcc.cAccount.IsLockedAccount())
 	}
 	{
 		err := bAcc.pAccount.LockAccount()
 		assert.NoError(t, err)
-		assert.Equal(t, true, bAcc.pAccount.IsLockAccount())
+		assert.Equal(t, true, bAcc.pAccount.IsLockedAccount())
 	}
 
 	// Fail to UnLock Account
 	{
 		err := bAcc.cAccount.UnLockAccount(string(cPwdStr)[3:])
 		assert.EqualError(t, err, keystore.ErrDecrypt.Error())
-		assert.Equal(t, true, bAcc.cAccount.IsLockAccount())
+		assert.Equal(t, true, bAcc.cAccount.IsLockedAccount())
 	}
 	{
 		err := bAcc.pAccount.UnLockAccount(string(pPwdStr)[3:])
 		assert.EqualError(t, err, keystore.ErrDecrypt.Error())
-		assert.Equal(t, true, bAcc.pAccount.IsLockAccount())
+		assert.Equal(t, true, bAcc.pAccount.IsLockedAccount())
 	}
 
 	// Succeed to UnLock Account
 	{
 		err := bAcc.cAccount.UnLockAccount(string(cPwdStr))
 		assert.NoError(t, err)
-		assert.Equal(t, false, bAcc.cAccount.IsLockAccount())
+		assert.Equal(t, false, bAcc.cAccount.IsLockedAccount())
 	}
 	{
 		err := bAcc.pAccount.UnLockAccount(string(pPwdStr))
 		assert.NoError(t, err)
-		assert.Equal(t, false, bAcc.pAccount.IsLockAccount())
+		assert.Equal(t, false, bAcc.pAccount.IsLockedAccount())
 	}
 }
 
@@ -104,8 +104,8 @@ func TestBridgeAccountInformation(t *testing.T) {
 	config.DataDir = tempDir
 	bAcc, err := NewBridgeAccounts(config.DataDir)
 	assert.NoError(t, err)
-	assert.Equal(t, false, bAcc.cAccount.IsLockAccount())
-	assert.Equal(t, false, bAcc.pAccount.IsLockAccount())
+	assert.Equal(t, false, bAcc.cAccount.IsLockedAccount())
+	assert.Equal(t, false, bAcc.pAccount.IsLockedAccount())
 
 	bAcc.pAccount.gasPrice = big.NewInt(100)
 	bAcc.pAccount.nonce = 10
@@ -127,12 +127,12 @@ func TestBridgeAccountInformation(t *testing.T) {
 	assert.Equal(t, pRes["chainID"].(*big.Int).String(), bAcc.pAccount.chainID.String())
 	assert.Equal(t, pRes["gasPrice"].(*big.Int).String(), bAcc.pAccount.gasPrice.String())
 	assert.Equal(t, pRes["isNonceSynced"], bAcc.pAccount.isNonceSynced)
-	assert.Equal(t, pRes["isLocked"], bAcc.pAccount.IsLockAccount())
+	assert.Equal(t, pRes["isLocked"], bAcc.pAccount.IsLockedAccount())
 
 	assert.Equal(t, cRes["address"], bAcc.cAccount.address)
 	assert.Equal(t, cRes["nonce"], bAcc.cAccount.nonce)
 	assert.Equal(t, cRes["chainID"].(*big.Int).String(), bAcc.cAccount.chainID.String())
 	assert.Equal(t, cRes["gasPrice"].(*big.Int).String(), bAcc.cAccount.gasPrice.String())
 	assert.Equal(t, cRes["isNonceSynced"], bAcc.cAccount.isNonceSynced)
-	assert.Equal(t, cRes["isLocked"], bAcc.cAccount.IsLockAccount())
+	assert.Equal(t, cRes["isLocked"], bAcc.cAccount.IsLockedAccount())
 }

--- a/node/sc/bridge_accounts.go
+++ b/node/sc/bridge_accounts.go
@@ -154,7 +154,7 @@ func (acc *accountInfo) GetAccountInfo() map[string]interface{} {
 	res["address"] = acc.address
 	res["nonce"] = acc.nonce
 	res["isNonceSynced"] = acc.isNonceSynced
-	res["isLocked"] = acc.IsLockAccount()
+	res["isLocked"] = acc.IsLockedAccount()
 	res["chainID"] = acc.chainID
 	res["gasPrice"] = acc.gasPrice
 
@@ -241,8 +241,8 @@ func (acc *accountInfo) UnLockAccount(passphrase string) error {
 	return nil
 }
 
-// IsLockAccount can return if the account is lock or not.
-func (acc *accountInfo) IsLockAccount() bool {
+// IsLockedAccount can return if the account is lock or not.
+func (acc *accountInfo) IsLockedAccount() bool {
 	acc.mu.Lock()
 	defer acc.mu.Unlock()
 	return acc.keystore.IsLocked(acc.address)

--- a/node/sc/bridge_accounts.go
+++ b/node/sc/bridge_accounts.go
@@ -245,5 +245,5 @@ func (acc *accountInfo) UnLockAccount(passphrase string) error {
 func (acc *accountInfo) IsLockAccount() bool {
 	acc.mu.Lock()
 	defer acc.mu.Unlock()
-	return acc.keystore.IsLock(acc.address)
+	return acc.keystore.IsLocked(acc.address)
 }

--- a/node/sc/bridge_accounts.go
+++ b/node/sc/bridge_accounts.go
@@ -154,7 +154,7 @@ func (acc *accountInfo) GetAccountInfo() map[string]interface{} {
 	res["address"] = acc.address
 	res["nonce"] = acc.nonce
 	res["isNonceSynced"] = acc.isNonceSynced
-	res["isLocked"] = acc.IsLockedAccount()
+	res["isUnlocked"] = acc.IsUnlockedAccount()
 	res["chainID"] = acc.chainID
 	res["gasPrice"] = acc.gasPrice
 
@@ -241,9 +241,9 @@ func (acc *accountInfo) UnLockAccount(passphrase string) error {
 	return nil
 }
 
-// IsLockedAccount can return if the account is lock or not.
-func (acc *accountInfo) IsLockedAccount() bool {
+// IsUnlockedAccount can return if the account is unlocked or not.
+func (acc *accountInfo) IsUnlockedAccount() bool {
 	acc.mu.Lock()
 	defer acc.mu.Unlock()
-	return acc.keystore.IsLocked(acc.address)
+	return acc.keystore.IsUnlocked(acc.address)
 }


### PR DESCRIPTION
## Proposed changes
This PR added APIs to lock/unlock bridge operators and return the information of operators.

```
> subbridge.lockChildOperator()
null
> subbridge.unlockParentOperator("+YkO]0US3$P(XV|R")
null
> subbridge.operators
{
  childOperator: {
    address: "0x8060fe1d0b81face0bb0537f50600c34d644cd3c",
    chainID: 1000,
    gasPrice: null,
    isLocked: true,
    isNonceSynced: true,
    nonce: 0
  },
  parentOperator: {
    address: "0x564d9e40e6b1bd0c62d7d931d3e468ed094a38bb",
    chainID: 10000,
    gasPrice: null,
    isLocked: false,
    isNonceSynced: false,
    nonce: 0
  }
}

```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

After this PR, I will implementate prompting to enter a password without showing the password in console like `person.unlockAccount()`.
```
> personal.unlockAccount("0x564d9e40e6b1bd0c62d7d931d3e468ed094a38bb")
Unlock account 0x564d9e40e6b1bd0c62d7d931d3e468ed094a38bb
Passphrase: 
Error: no key for given address or file
```
