### PR TITLE
Fix bug in making slice. It blocked copying the slice properly

### DIFF
--- a/governance/default.go
+++ b/governance/default.go
@@ -668,7 +668,7 @@ func getGovernanceCacheKey(num uint64) common.GovernanceCacheKey {
 // Store new governance data on DB. This updates Governance cache too.
 func (g *Governance) WriteGovernance(num uint64, data GovernanceSet, delta GovernanceSet) error {
 	g.idxCacheLock.RLock()
-	indices := make([]uint64, 0, len(g.idxCache))
+	indices := make([]uint64, len(g.idxCache))
 	copy(indices, g.idxCache)
 	g.idxCacheLock.RUnlock()
 

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -547,11 +547,13 @@ func TestWriteGovernance_idxCache(t *testing.T) {
 	delta := NewGovernanceSet()
 	src.Import(tstMap)
 
-	gov.WriteGovernance(30, src, delta)
-	gov.WriteGovernance(30, src, delta)
-	gov.WriteGovernance(60, src, delta)
-	gov.WriteGovernance(60, src, delta)
-	gov.WriteGovernance(50, src, delta)
+	blockNum := []uint64{30, 30, 60, 60, 50}
+
+	for _, num := range blockNum {
+		if ret := gov.WriteGovernance(num, src, delta); ret != nil {
+			t.Errorf("Error in testing WriteGovernance, %v", ret)
+		}
+	}
 
 	// idxCache should have 0, 30 and 60
 	if len(gov.idxCache) != 3 && gov.idxCache[len(gov.idxCache)-1] != 60 {

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -537,3 +537,24 @@ func TestCypressGenesisHash(t *testing.T) {
 		t.Errorf("Generated hash is not equal to Cypress's hash. Want %v, Have %v", cypressHash.String(), block.Hash().String())
 	}
 }
+
+func TestWriteGovernance_idxCache(t *testing.T) {
+	gov := getGovernance()
+
+	tstMap := copyMap(testGovernanceMap)
+
+	src := NewGovernanceSet()
+	delta := NewGovernanceSet()
+	src.Import(tstMap)
+
+	gov.WriteGovernance(30, src, delta)
+	gov.WriteGovernance(30, src, delta)
+	gov.WriteGovernance(60, src, delta)
+	gov.WriteGovernance(60, src, delta)
+	gov.WriteGovernance(50, src, delta)
+
+	// idxCache should have 0, 30 and 60
+	if len(gov.idxCache) != 3 && gov.idxCache[len(gov.idxCache)-1] != 60 {
+		t.Errorf("idxCache has wrong value")
+	}
+}


### PR DESCRIPTION
## Proposed changes

- This PR is to fix a bug in writing governance change.
- While transferring commits from the former repository, the code changed as below
```go
idx := []uint64{}
```
to
```go
indices := make([]uint64, 0,  len(g.idxCache))
```
- But because indices has zero length, nothing could be copied to indices so it passed the check routine because its size is zero
```go
	if len(indices) > 0 && num <= indices[len(indices)-1] {
		return nil
	}
```
- It made idxCache have duplicated block numbers in it when node stopped and restarted

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules