### PR TITLE
SC: Support a non-echo prompt for subbridge operator unlock API.

### DIFF
--- a/console/bridge.go
+++ b/console/bridge.go
@@ -173,10 +173,8 @@ func (b *bridge) UnlockAccount(call otto.FunctionCall) (response otto.Value) {
 }
 
 // passwdByPrompt returns the password from a non-echoing password prompt.
-func (b *bridge) passwdByPrompt(call otto.FunctionCall, msg string) otto.Value {
-	// If password is not given or is the null value, prompt the user for it
-	var passwd otto.Value
-
+func (b *bridge) passwdByPrompt(call otto.FunctionCall, msg string) (passwd otto.Value) {
+	// If password is not given or is the null value, prompt the user for i
 	if call.Argument(1).IsUndefined() || call.Argument(1).IsNull() {
 		fmt.Fprintln(b.printer, msg)
 		if input, err := b.prompter.PromptPassword("Passphrase: "); err != nil {
@@ -190,7 +188,7 @@ func (b *bridge) passwdByPrompt(call otto.FunctionCall, msg string) otto.Value {
 		}
 		passwd = call.Argument(1)
 	}
-	return passwd
+	return
 }
 
 // UnlockParentOperator is a wrapper around the subbridge.unlockParentOperator RPC method that
@@ -199,11 +197,11 @@ func (b *bridge) passwdByPrompt(call otto.FunctionCall, msg string) otto.Value {
 // the RPC call.
 func (b *bridge) UnlockParentOperator(call otto.FunctionCall) (response otto.Value) {
 	// Send the request to the backend and return
-	val, err := call.Otto.Call("jeth.unlockParentOperator", nil, b.passwdByPrompt(call, "Unlock parent operator account"))
+	response, err := call.Otto.Call("jeth.unlockParentOperator", nil, b.passwdByPrompt(call, "Unlock parent operator account"))
 	if err != nil {
 		throwJSException(err.Error())
 	}
-	return val
+	return
 }
 
 // UnlockChildOperator is a wrapper around the subbridge.unlockChildOperator RPC method that
@@ -212,11 +210,11 @@ func (b *bridge) UnlockParentOperator(call otto.FunctionCall) (response otto.Val
 // the RPC call.
 func (b *bridge) UnlockChildOperator(call otto.FunctionCall) (response otto.Value) {
 	// Send the request to the backend and return
-	val, err := call.Otto.Call("jeth.unlockChildOperator", nil, b.passwdByPrompt(call, "Unlock child operator account"))
+	response, err := call.Otto.Call("jeth.unlockChildOperator", nil, b.passwdByPrompt(call, "Unlock child operator account"))
 	if err != nil {
 		throwJSException(err.Error())
 	}
-	return val
+	return
 }
 
 // Sign is a wrapper around the personal.sign RPC method that uses a non-echoing password

--- a/console/console.go
+++ b/console/console.go
@@ -206,11 +206,10 @@ func (c *Console) init(preload []string) error {
 			if _, err = c.jsre.Run(`jeth.unlockParentOperator = subbridge.unlockParentOperator;`); err != nil {
 				return fmt.Errorf("subBridge.unlockParentOperator: %v", err)
 			}
-			obj.Set("unlockParentOperator", bridge.UnlockParentOperator)
-
 			if _, err = c.jsre.Run(`jeth.unlockChildOperator = subbridge.unlockChildOperator;`); err != nil {
 				return fmt.Errorf("subBridge.unlockChildOperator: %v", err)
 			}
+			obj.Set("unlockParentOperator", bridge.UnlockParentOperator)
 			obj.Set("unlockChildOperator", bridge.UnlockChildOperator)
 		}
 	}


### PR DESCRIPTION
## Proposed changes
This PR enabled users to type their password in interactive mode of `subbridge.unlockParent/ChildOperator` APIs without echoing the password like below.

```
> subbridge.unlock
subbridge.unlockChildOperator subbridge.unlockParentOperator 

> subbridge.unlockChildOperator()
Unlock child operator account
Passphrase: 
Error: could not decrypt key with given passphrase

> subbridge.unlockChildOperator()
Unlock child operator account
Passphrase: 
null

```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues
#143 
