### PR TITLE
homi: update docker compose to use daemon packages

### DIFF
--- a/build/packaging/linux/bin/kscnd
+++ b/build/packaging/linux/bin/kscnd
@@ -55,12 +55,6 @@ start() {
         mkdir -p $LOG_DIR
     fi
 
-    if [ -z $SCSIGNER_PASSWD_FILE ] || [ ! -f $SCSIGNER_PASSWD_FILE ]; then
-        echo
-        echo "  [ERROR] : The service chain signer wallet password file is not exist. [conf/kscnd.conf - SCSIGNER_PASSWD_FILE=$SCSIGNER_PASSWD_FILE ]"
-        exit 1
-    fi
-
     set -f
     OPTIONS="--nodiscover"
 

--- a/build/packaging/linux/conf/kscnd.conf
+++ b/build/packaging/linux/conf/kscnd.conf
@@ -1,6 +1,6 @@
 # Configuration file for the kscnd
 
-SCSIGNER="0x0"
+SCSIGNER=
 SCSIGNER_PASSWD_FILE=   # Need to right password file for the keystore file of the scsigner address
 
 NETWORK_ID=3000

--- a/build/rpm/etc/kscnd/conf/kscnd.conf
+++ b/build/rpm/etc/kscnd/conf/kscnd.conf
@@ -1,6 +1,6 @@
 # Configuration file for the kscnd
 
-SCSIGNER="0x0"
+SCSIGNER=
 SCSIGNER_PASSWD_FILE="/etc/kscnd/conf/kscnd.password"   # Need to right password file for the keystore file of the service chain signer address
 
 NETWORK_ID=3000

--- a/cmd/homi/docker/service/validator.go
+++ b/cmd/homi/docker/service/validator.go
@@ -90,8 +90,6 @@ func (v Validator) String() string {
 var validatorTemplate = `{{ .Name }}:
     hostname: {{ .Name }}
     image: {{ .DockerImageId }}
-    tty: true
-    stdin_open: true
     ports:
       - '{{ .Port }}:32323'
       - '{{ .RPCPort }}:8551'

--- a/cmd/homi/docker/service/validator.go
+++ b/cmd/homi/docker/service/validator.go
@@ -90,6 +90,8 @@ func (v Validator) String() string {
 var validatorTemplate = `{{ .Name }}:
     hostname: {{ .Name }}
     image: {{ .DockerImageId }}
+    tty: true
+    stdin_open: true
     ports:
       - '{{ .Port }}:32323'
       - '{{ .RPCPort }}:8551'
@@ -100,7 +102,7 @@ var validatorTemplate = `{{ .Name }}:
       - '50506:50506'
 {{- end }}
     entrypoint:
-      - /bin/sh
+      - /bin/bash
       - -c
       - |
         mkdir -p /klaytn
@@ -123,51 +125,49 @@ var validatorTemplate = `{{ .Name }}:
         echo '{"address":"75a59b94889a05c03c66c3c84e9d2f8308ca4abd","crypto":{"cipher":"aes-128-ctr","ciphertext":"347fef8ab9aaf9d41b6114dfc0d9fd6ecab9d660fa86f687dc7aa1e094b76184","cipherparams":{"iv":"5070268dfc64ced716cf407bee943def"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"2cf44cb912515c5de2aacf4d133fd97a56efece5a8fc691381296300b42fb6c8"},"mac":"ea20c0019321f2a91f1ca51bc99d58c8f7cf1f37cff5cc47ae17ad747c060046"},"id":"a122a8da-a787-4d3d-a627-02034553e674","version":1}' > /klaytn/keystore/mykey
         echo "SuperSecret1231" > /klaytn/password.txt
 {{- end}}
-        k{{ .NodeType }} \
-        --identity "{{ .Name }}" \
-        --rpc \
-        --rpcaddr "0.0.0.0" \
-        --rpcport "8551" \
-        --rpccorsdomain "*" \
-        --datadir "/klaytn" \
-        --port "32323" \
-        --rpcapi "db,klay,net,web3,miner,personal,txpool,debug,admin,istanbul,mainbridge,subbridge" \
-        --networkid "{{ .NetworkId }}" \
-        --nat "any" \
-        --nodekeyhex "{{ .NodeKey }}" \
-        --nodiscover \
-        --debug \
-        --metrics \
-        --prometheus \
-        --syncmode "full" \
+        echo "# docker-compose" >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'NETWORK=""' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'DATA_DIR="/klaytn"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'LOG_DIR="$$DATA_DIR/log"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'RPC_ENABLE=1' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'RPC_API="db,klay,net,web3,miner,personal,txpool,debug,admin,istanbul,mainbridge,subbridge"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'NETWORK_ID="{{ .NetworkId }}"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'NO_DISCOVER=1' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'SYNCMODE="full"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'ADDITIONAL="$$ADDITIONAL --identity \"{{ .Name }}\""' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'ADDITIONAL="$$ADDITIONAL --nodekeyhex {{ .NodeKey }}"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- if .AddPrivKey}}
-        --unlock "75a59b94889a05c03c66c3c84e9d2f8308ca4abd" \
-        --password "/klaytn/password.txt" \
+        echo 'ADDITIONAL="$$ADDITIONAL --unlock \"75a59b94889a05c03c66c3c84e9d2f8308ca4abd\""' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'ADDITIONAL="$$ADDITIONAL --password "/klaytn/password.txt"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- end}}
 {{- if eq .NodeType "scn" }}
-        --scconsensus "istanbul" \
+        echo 'PORT=32323' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'ADDITIONAL="$$ADDITIONAL --scconsensus "istanbul""' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- else if eq .NodeType "spn" }}
-        --scconsensus "istanbul" \
+        echo 'ADDITIONAL="$$ADDITIONAL --scconsensus "istanbul""' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- else if eq .NodeType "sen" }}
-        --scconsensus "istanbul" \
+        echo 'ADDITIONAL="$$ADDITIONAL --scconsensus "istanbul""' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- end}}
 {{- if .ParentChainId }}
-        --parentchainid {{ .ParentChainId }} \
-        --subbridge \
-        --subbridgeport 50506 \
+        echo 'ADDITIONAL="$$ADDITIONAL --parentchainid {{ .ParentChainId }}"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'SC_SUB_BRIDGE=1' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'SC_SUB_BRIDGE_PORT=50506' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- end}}
 {{- if .UseFastHttp}}
-        --srvtype fasthttp \
+        echo 'SERVER_TYPE=fasthttp' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- end}}
 {{- if eq .NodeType "cn" }}
-        --rewardbase {{ .Address }}
+        echo 'REWARDBASE={{ .Address }}' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- else if eq .NodeType "pn" }}
-        --txpool.nolocals
+        echo 'ADDITIONAL="$$ADDITIONAL --txpool.nolocals"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- else if eq .Name "EN-0" }}
-        --mainbridge \
-        --mainbridgeport 50505
+        echo 'SC_MAIN_BRIDGE=1' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'SC_MAIN_BRIDGE_PORT=50505' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        echo 'SC_MAIN_BRIDGE_INDEXING=1' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
 {{- end }}
-
+        echo 'ADDITIONAL="$$ADDITIONAL --debug --metrics --prometheus"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
+        /klaytn-docker-pkg/bin/k{{ .NodeType }}d start
+        while true; do sleep 1; done
     networks:
       app_net:
         ipv4_address: {{ .IP }}

--- a/cmd/homi/docker/service/validator.go
+++ b/cmd/homi/docker/service/validator.go
@@ -100,7 +100,7 @@ var validatorTemplate = `{{ .Name }}:
       - '50506:50506'
 {{- end }}
     entrypoint:
-      - /bin/bash
+      - /bin/sh
       - -c
       - |
         mkdir -p /klaytn

--- a/governance/default.go
+++ b/governance/default.go
@@ -1067,7 +1067,7 @@ func (gov *Governance) IdxCache() []uint64 {
 	gov.idxCacheLock.RLock()
 	defer gov.idxCacheLock.RUnlock()
 
-	copiedCache := make([]uint64, 0, len(gov.idxCache))
+	copiedCache := make([]uint64, len(gov.idxCache))
 	copy(copiedCache, gov.idxCache)
 	return copiedCache
 }


### PR DESCRIPTION
## Proposed changes

- Update docker compose output of homi.
- After applying this patch, the docker compose uses daemon binaries (kcnd, kpnd, etc.) in packages.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
