### PR TITLE
Remove unnecessary legacy Ethereum code about StorageBlock

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -735,25 +735,6 @@ func (bc *BlockChain) GetLogsByHash(hash common.Hash) [][]*types.Log {
 	return logs
 }
 
-// GetBlocksFromHash returns the block corresponding to hash and up to n-1 ancestors.
-// [deprecated by klay/62]
-func (bc *BlockChain) GetBlocksFromHash(hash common.Hash, n int) (blocks []*types.Block) {
-	number := bc.GetBlockNumber(hash)
-	if number == nil {
-		return nil
-	}
-	for i := 0; i < n; i++ {
-		block := bc.GetBlock(hash, *number)
-		if block == nil {
-			break
-		}
-		blocks = append(blocks, block)
-		hash = block.ParentHash()
-		*number--
-	}
-	return
-}
-
 // TrieNode retrieves a blob of data associated with a trie node (or code hash)
 // either from ephemeral in-memory cache, or from persistent storage.
 func (bc *BlockChain) TrieNode(hash common.Hash) ([]byte, error) {

--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -153,7 +153,7 @@ type Result struct {
 	Round int64
 }
 
-// "external" block encoding. used for Klaytn protocol, etc.
+// extblock represents external block encoding used for Klaytn protocol, etc.
 type extblock struct {
 	Header *Header
 	Txs    []*Transaction

--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -153,31 +153,10 @@ type Result struct {
 	Round int64
 }
 
-// DeprecatedTd is an old relic for extracting the TD of a block. It is in the
-// code solely to facilitate upgrading the database from the old format to the
-// new, after which it should be deleted. Do not use!
-func (b *Block) DeprecatedTd() *big.Int {
-	return b.td
-}
-
-// [deprecated by klay/63]
-// StorageBlock defines the RLP encoding of a Block stored in the
-// state database. The StorageBlock encoding contains fields that
-// would otherwise need to be recomputed.
-type StorageBlock Block
-
 // "external" block encoding. used for Klaytn protocol, etc.
 type extblock struct {
 	Header *Header
 	Txs    []*Transaction
-}
-
-// [deprecated by klay/63]
-// "storage" block encoding. used for database.
-type storageblock struct {
-	Header *Header
-	Txs    []*Transaction
-	TD     *big.Int
 }
 
 // NewBlock creates a new block. The input data is copied,
@@ -262,18 +241,6 @@ func (b *Block) EncodeRLP(w io.Writer) error {
 		Txs:    b.transactions,
 	})
 }
-
-// [deprecated by klay/63]
-func (b *StorageBlock) DecodeRLP(s *rlp.Stream) error {
-	var sb storageblock
-	if err := s.Decode(&sb); err != nil {
-		return err
-	}
-	b.header, b.transactions, b.td = sb.Header, sb.Txs, sb.TD
-	return nil
-}
-
-// TODO: copies
 
 func (b *Block) Transactions() Transactions { return b.transactions }
 


### PR DESCRIPTION
## Proposed changes

1. Klaytn doesn't use StorageBlock which had been used in the old version of Ethereum. 
2. Even though Klaytn still has total difficulty in a block, Klaytn has not used it anywhere from the genesis. Therefore, the old getter function of td, `DeprecatedTd()`, is not required. 
3. `GetBlocksFromHash()` is also legacy code which had used in Ethereum's old block storing process. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules


