### PR TITLE
SC: Rename main/service->parent/child, bridge account -> operator

### DIFF
--- a/client/bridge_client.go
+++ b/client/bridge_client.go
@@ -216,7 +216,7 @@ func (ec *Client) BridgeListBridge(ctx context.Context) ([]*BridgeJournal, error
 	return result, err
 }
 
-// BridgeSubscribeBridge can enable for service chain bridge to subscribe the event of given child/parent chain bridges.
+// BridgeSubscribeBridge can enable for subbridge to subscribe the event of given child/parent chain bridges.
 // If the subscribing is failed, it returns an error.
 func (ec *Client) BridgeSubscribeBridge(ctx context.Context, cBridge common.Address, pBridge common.Address) error {
 	return ec.c.CallContext(ctx, nil, "subbridge_subscribeBridge", cBridge, pBridge)

--- a/client/bridge_client.go
+++ b/client/bridge_client.go
@@ -80,11 +80,11 @@ func (ec *Client) BridgeGetChildChainIndexingEnabled(ctx context.Context) (bool,
 	return result, err
 }
 
-// BridgeConvertServiceChainBlockHashToMainChainTxHash can convert service chain block hash to
+// BridgeConvertChildChainBlockHashToParentChainTxHash can convert child chain block hash to
 // anchoring tx hash which contains anchored data.
-func (ec *Client) BridgeConvertServiceChainBlockHashToMainChainTxHash(ctx context.Context, scBlockHash common.Hash) (common.Hash, error) {
+func (ec *Client) BridgeConvertChildChainBlockHashToParentChainTxHash(ctx context.Context, scBlockHash common.Hash) (common.Hash, error) {
 	var txHash common.Hash
-	err := ec.c.CallContext(ctx, &txHash, "mainbridge_convertServiceChainBlockHashToMainChainTxHash", scBlockHash)
+	err := ec.c.CallContext(ctx, &txHash, "mainbridge_convertChildChainBlockHashToParentChainTxHash", scBlockHash)
 	return txHash, err
 }
 
@@ -106,31 +106,31 @@ func (ec *Client) BridgeGetReceiptFromParentChain(ctx context.Context, hash comm
 	return result, err
 }
 
-// BridgeGetMainChainAccountAddr can get a main chain bridge account address.
-func (ec *Client) BridgeGetMainChainAccountAddr(ctx context.Context) (common.Address, error) {
+// BridgeGetParentOperatorAddr can get a parent chain operator address.
+func (ec *Client) BridgeGetParentOperatorAddr(ctx context.Context) (common.Address, error) {
 	var result common.Address
-	err := ec.c.CallContext(ctx, &result, "subbridge_getMainChainAccountAddr")
+	err := ec.c.CallContext(ctx, &result, "subbridge_getParentOperatorAddr")
 	return result, err
 }
 
-// BridgeGetServiceChainAccountAddr can get a service chain bridge account address.
-func (ec *Client) BridgeGetServiceChainAccountAddr(ctx context.Context) (common.Address, error) {
+// BridgeGetChildOperatorAddr can get a child chain operator address.
+func (ec *Client) BridgeGetChildOperatorAddr(ctx context.Context) (common.Address, error) {
 	var result common.Address
-	err := ec.c.CallContext(ctx, &result, "subbridge_getServiceChainAccountAddr")
+	err := ec.c.CallContext(ctx, &result, "subbridge_getChildOperatorAddr")
 	return result, err
 }
 
-// BridgeGetMainChainAccountNonce can get a main chain bridge account nonce.
-func (ec *Client) BridgeGetMainChainAccountNonce(ctx context.Context) (uint64, error) {
+// BridgeGetParentOperatorNonce can get a parent chain operator nonce.
+func (ec *Client) BridgeGetParentOperatorNonce(ctx context.Context) (uint64, error) {
 	var result uint64
-	err := ec.c.CallContext(ctx, &result, "subbridge_getMainChainAccountNonce")
+	err := ec.c.CallContext(ctx, &result, "subbridge_getParentOperatorNonce")
 	return result, err
 }
 
-// BridgeGetServiceChainAccountAddr can get a service chain bridge account nonce.
-func (ec *Client) BridgeGetServiceChainAccountNonce(ctx context.Context) (uint64, error) {
+// BridgeGetChildOperatorAddr can get a child chain operator nonce.
+func (ec *Client) BridgeGetChildOperatorNonce(ctx context.Context) (uint64, error) {
 	var result uint64
-	err := ec.c.CallContext(ctx, &result, "subbridge_getServiceChainAccountNonce")
+	err := ec.c.CallContext(ctx, &result, "subbridge_getChildOperatorNonce")
 	return result, err
 }
 
@@ -189,23 +189,23 @@ func (ec *Client) BridgeDeployBridge(ctx context.Context) (common.Address, commo
 }
 
 // BridgeRegisterBridge can register the given pair of deployed child/parent bridges.
-func (ec *Client) BridgeRegisterBridge(ctx context.Context, scBridge common.Address, mcBridge common.Address) (bool, error) {
+func (ec *Client) BridgeRegisterBridge(ctx context.Context, cBridge common.Address, pBridge common.Address) (bool, error) {
 	var result bool
-	err := ec.c.CallContext(ctx, &result, "subbridge_registerBridge", scBridge, mcBridge)
+	err := ec.c.CallContext(ctx, &result, "subbridge_registerBridge", cBridge, pBridge)
 	return result, err
 }
 
 // BridgeDeregisterBridge can deregister the given pair of deployed child/parent bridges.
-func (ec *Client) BridgeDeregisterBridge(ctx context.Context, scBridge common.Address, mcBridge common.Address) (bool, error) {
+func (ec *Client) BridgeDeregisterBridge(ctx context.Context, cBridge common.Address, pBridge common.Address) (bool, error) {
 	var result bool
-	err := ec.c.CallContext(ctx, &result, "subbridge_deregisterBridge", scBridge, mcBridge)
+	err := ec.c.CallContext(ctx, &result, "subbridge_deregisterBridge", cBridge, pBridge)
 	return result, err
 }
 
 // TODO-Klaytn if client pkg is removed in sc pkg, this will be replaced origin struct.
 type BridgeJournal struct {
-	LocalAddress  common.Address `json:"localAddress"`
-	RemoteAddress common.Address `json:"remoteAddress"`
+	ChildAddress  common.Address `json:"childAddress"`
+	ParentAddress common.Address `json:"parentAddress"`
 	Subscribed    bool           `json:"subscribed"`
 }
 
@@ -216,28 +216,28 @@ func (ec *Client) BridgeListBridge(ctx context.Context) ([]*BridgeJournal, error
 	return result, err
 }
 
-// BridgeSubscribeBridge can enable for service chain bridge to subscribe the event of given service/main chain bridges.
+// BridgeSubscribeBridge can enable for service chain bridge to subscribe the event of given child/parent chain bridges.
 // If the subscribing is failed, it returns an error.
-func (ec *Client) BridgeSubscribeBridge(ctx context.Context, scBridge common.Address, mcBridge common.Address) error {
-	return ec.c.CallContext(ctx, nil, "subbridge_subscribeBridge", scBridge, mcBridge)
+func (ec *Client) BridgeSubscribeBridge(ctx context.Context, cBridge common.Address, pBridge common.Address) error {
+	return ec.c.CallContext(ctx, nil, "subbridge_subscribeBridge", cBridge, pBridge)
 }
 
-// BridgeUnsubscribeBridge disables the event subscription of the given service/main chain bridges.
+// BridgeUnsubscribeBridge disables the event subscription of the given child/parent chain bridges.
 // If the unsubscribing is failed, it returns an error.
-func (ec *Client) BridgeUnsubscribeBridge(ctx context.Context, scBridge common.Address, mcBridge common.Address) error {
-	return ec.c.CallContext(ctx, nil, "subbridge_unsubscribeBridge", scBridge, mcBridge)
+func (ec *Client) BridgeUnsubscribeBridge(ctx context.Context, cBridge common.Address, pBridge common.Address) error {
+	return ec.c.CallContext(ctx, nil, "subbridge_unsubscribeBridge", cBridge, pBridge)
 }
 
-// BridgeRegisterTokenContract can register the given pair of deployed service/main chain token contracts.
+// BridgeRegisterTokenContract can register the given pair of deployed child/parent chain token contracts.
 // If the registering is failed, it returns an error.
-func (ec *Client) BridgeRegisterTokenContract(ctx context.Context, scBridge, mcBridge, scToken, mcToken common.Address) error {
-	return ec.c.CallContext(ctx, nil, "subbridge_registerToken", scBridge, mcBridge, scToken, mcToken)
+func (ec *Client) BridgeRegisterTokenContract(ctx context.Context, cBridge, pBridge, cToken, pToken common.Address) error {
+	return ec.c.CallContext(ctx, nil, "subbridge_registerToken", cBridge, pBridge, cToken, pToken)
 }
 
-// BridgeDeregisterTokenContract can deregister the given pair of deployed service/main chain token contracts.
+// BridgeDeregisterTokenContract can deregister the given pair of deployed child/parent chain token contracts.
 // If the registering is failed, it returns an error.
-func (ec *Client) BridgeDeregisterTokenContract(ctx context.Context, scBridge, mcBridge, scToken, mcToken common.Address) error {
-	return ec.c.CallContext(ctx, nil, "subbridge_deregisterToken", scBridge, mcBridge, scToken, mcToken)
+func (ec *Client) BridgeDeregisterTokenContract(ctx context.Context, cBridge, pBridge, cToken, pToken common.Address) error {
+	return ec.c.CallContext(ctx, nil, "subbridge_deregisterToken", cBridge, pBridge, cToken, pToken)
 }
 
 // BridgeTxPendingCount can return the count of the pend tx in bridge txpool.

--- a/cmd/homi/docker/service/validator.go
+++ b/cmd/homi/docker/service/validator.go
@@ -115,7 +115,7 @@ var validatorTemplate = `{{ .Name }}:
 {{- end }}
         echo '{{ .StaticNodes }}' > /klaytn/static-nodes.json
 {{- if .BridgeNodes }}
-        echo '{{ .BridgeNodes }}' > /klaytn/mainchain-bridges.json
+        echo '{{ .BridgeNodes }}' > /klaytn/parentchain-bridges.json
 {{- end }}
         k{{ .NodeType }} --datadir "/klaytn" init "/klaytn/genesis.json"
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -477,7 +477,7 @@ var (
 	}
 	AnchoringPeriodFlag = cli.Uint64Flag{
 		Name:  "chaintxperiod",
-		Usage: "The period to make and send a chain transaction to the main chain",
+		Usage: "The period to make and send a chain transaction to the parent chain",
 		Value: 1,
 	}
 	SentChainTxsLimit = cli.Uint64Flag{
@@ -566,7 +566,7 @@ var (
 	}
 	ServiceChainNewAccountFlag = cli.BoolFlag{
 		Name:  "scnewaccount",
-		Usage: "Enable account creation for the service chain (default: false). If set true, generated account can't be synced with the main chain.",
+		Usage: "Enable account creation for the service chain (default: false). If set true, generated account can't be synced with the parent chain.",
 	}
 	ServiceChainConsensusFlag = cli.StringFlag{
 		Name:  "scconsensus",

--- a/cmd/utils/nodecmd/dumpconfigcmd.go
+++ b/cmd/utils/nodecmd/dumpconfigcmd.go
@@ -243,7 +243,7 @@ func MakeFullNode(ctx *cli.Context) *node.Node {
 	if utils.NetworkTypeFlag.Value == SCNNetworkType && scfg.EnabledSubBridge {
 		cfg.CN.NoAccountCreation = !ctx.GlobalBool(utils.ServiceChainNewAccountFlag.Name)
 		if !cfg.CN.NoAccountCreation {
-			logger.Warn("generated accounts can't be synced with the main chain since account creation is enabled")
+			logger.Warn("generated accounts can't be synced with the parent chain since account creation is enabled")
 		}
 
 		switch scfg.ServiceChainConsensus {

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -926,8 +926,8 @@ web3._extend({
 			call: 'mainbridge_getChildChainIndexingEnabled'
 		}),
 		new web3._extend.Method({
-			name: 'convertServiceChainBlockHashToMainChainTxHash',
-			call: 'mainbridge_convertServiceChainBlockHashToMainChainTxHash',
+			name: 'convertChildChainBlockHashToParentChainTxHash',
+			call: 'mainbridge_convertChildChainBlockHashToParentChainTxHash',
 			params: 1
 		}),
 	],
@@ -1077,12 +1077,12 @@ web3._extend({
 			getter: 'subbridge_peers'
 		}),
 		new web3._extend.Property({
-			name: 'mainChainAccount',
-			getter: 'subbridge_getMainChainAccountAddr'
+			name: 'parentOperator',
+			getter: 'subbridge_getParentOperatorAddr'
 		}),
 			new web3._extend.Property({
-			name: 'serviceChainAccount',
-			getter: 'subbridge_getServiceChainAccountAddr'
+			name: 'childOperator',
+			getter: 'subbridge_getChildOperatorAddr'
 		}),
 		new web3._extend.Property({
 			name: 'operators',
@@ -1097,12 +1097,12 @@ web3._extend({
 			getter: 'subbridge_getSentChainTxsLimit'
 		}),
 		new web3._extend.Property({
-			name: 'mainChainAccountNonce',
-			getter: 'subbridge_getMainChainAccountNonce'
+			name: 'parentOperatorNonce',
+			getter: 'subbridge_getParentOperatorNonce'
 		}),
 		new web3._extend.Property({
-			name: 'serviceChainAccountNonce',
-			getter: 'subbridge_getServiceChainAccountNonce'
+			name: 'childOperatorNonce',
+			getter: 'subbridge_getChildOperatorNonce'
 		}),
 		new web3._extend.Property({
 			name: 'listBridge',

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -80,9 +80,9 @@ type Config struct {
 	NoPruning bool
 
 	// Service chain options
-	MainChainAccountAddr *common.Address `toml:",omitempty"` // A hex account address in the main chain used to sign a service chain transaction.
-	AnchoringPeriod      uint64          // Period when child chain sends an anchoring transaction to the main chain. Default value is 1.
-	SentChainTxsLimit    uint64          // Number of chain transactions stored for resending. Default value is 1000.
+	ParentOperatorAddr *common.Address `toml:",omitempty"` // A hex account address in the parent chain used to sign a child chain transaction.
+	AnchoringPeriod    uint64          // Period when child chain sends an anchoring transaction to the parent chain. Default value is 1.
+	SentChainTxsLimit  uint64          // Number of chain transactions stored for resending. Default value is 1000.
 
 	// Light client options
 	//LightServ  int `toml:",omitempty"` // Maximum percentage of time allowed for serving LES requests

--- a/node/cn/gen_config.go
+++ b/node/cn/gen_config.go
@@ -24,7 +24,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		NetworkId               uint64
 		SyncMode                downloader.SyncMode
 		NoPruning               bool
-		MainChainAccountAddr    *common.Address `toml:",omitempty"`
+		ParentOperatorAddr      *common.Address `toml:",omitempty"`
 		AnchoringPeriod         uint64
 		SentChainTxsLimit       uint64
 		SkipBcVersionCheck      bool `toml:"-"`
@@ -61,7 +61,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.NetworkId = c.NetworkId
 	enc.SyncMode = c.SyncMode
 	enc.NoPruning = c.NoPruning
-	enc.MainChainAccountAddr = c.MainChainAccountAddr
+	enc.ParentOperatorAddr = c.ParentOperatorAddr
 	enc.AnchoringPeriod = c.AnchoringPeriod
 	enc.SentChainTxsLimit = c.SentChainTxsLimit
 	enc.SkipBcVersionCheck = c.SkipBcVersionCheck
@@ -102,7 +102,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		NetworkId               *uint64
 		SyncMode                *downloader.SyncMode
 		NoPruning               *bool
-		MainChainAccountAddr    *common.Address `toml:",omitempty"`
+		ParentOperatorAddr      *common.Address `toml:",omitempty"`
 		AnchoringPeriod         *uint64
 		SentChainTxsLimit       *uint64
 		SkipBcVersionCheck      *bool `toml:"-"`
@@ -150,8 +150,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.NoPruning != nil {
 		c.NoPruning = *dec.NoPruning
 	}
-	if dec.MainChainAccountAddr != nil {
-		c.MainChainAccountAddr = dec.MainChainAccountAddr
+	if dec.ParentOperatorAddr != nil {
+		c.ParentOperatorAddr = dec.ParentOperatorAddr
 	}
 	if dec.AnchoringPeriod != nil {
 		c.AnchoringPeriod = *dec.AnchoringPeriod

--- a/node/sc/bridge_accounts.go
+++ b/node/sc/bridge_accounts.go
@@ -47,7 +47,7 @@ type accountInfo struct {
 	mu            sync.RWMutex
 }
 
-// BridgeAccounts manages bridge account for main/service chain.
+// BridgeAccounts manages bridge account for parent/child chain.
 type BridgeAccounts struct {
 	pAccount *accountInfo
 	cAccount *accountInfo

--- a/node/sc/bridge_addr_journal_test.go
+++ b/node/sc/bridge_addr_journal_test.go
@@ -34,8 +34,8 @@ func TestBridgeJournal(t *testing.T) {
 
 	journal := newBridgeAddrJournal(path.Join(os.TempDir(), "test.rlp"))
 	if err := journal.load(func(journal BridgeJournal) error {
-		t.Log("Local address ", journal.LocalAddress.Hex())
-		t.Log("Remote address ", journal.RemoteAddress.Hex())
+		t.Log("Local address ", journal.ChildAddress.Hex())
+		t.Log("Remote address ", journal.ParentAddress.Hex())
 		t.Log("Subscribed", journal.Subscribed)
 		return nil
 	}); err != nil {
@@ -65,17 +65,17 @@ func TestBridgeJournal(t *testing.T) {
 	journal = newBridgeAddrJournal(path.Join(os.TempDir(), "test.rlp"))
 
 	if err := journal.load(func(journal BridgeJournal) error {
-		switch address := journal.LocalAddress.Hex(); address {
+		switch address := journal.ChildAddress.Hex(); address {
 		case "0x0000000000000000000000000000007465737431":
-			if journal.RemoteAddress.Hex() != "0x0000000000000000000000000000007465737432" {
+			if journal.ParentAddress.Hex() != "0x0000000000000000000000000000007465737432" {
 				t.Fatalf("unknown remoteAddress")
 			}
 		case "0x0000000000000000000000000000007465737432":
-			if journal.RemoteAddress.Hex() != "0x0000000000000000000000000000007465737433" {
+			if journal.ParentAddress.Hex() != "0x0000000000000000000000000000007465737433" {
 				t.Fatalf("unknown remoteAddress")
 			}
 		case "0x0000000000000000000000000000007465737433":
-			if journal.RemoteAddress.Hex() != "0x0000000000000000000000000000007465737431" {
+			if journal.ParentAddress.Hex() != "0x0000000000000000000000000000007465737431" {
 				t.Fatalf("unknown remoteAddress")
 			}
 		default:
@@ -115,7 +115,7 @@ func TestBridgeJournalCache(t *testing.T) {
 
 	assert.Equal(t, 1, len(journals.cache))
 	for _, journal := range journals.cache {
-		assert.Equal(t, localAddr, journal.LocalAddress)
-		assert.Equal(t, remoteAddr, journal.RemoteAddress)
+		assert.Equal(t, localAddr, journal.ChildAddress)
+		assert.Equal(t, remoteAddr, journal.ParentAddress)
 	}
 }

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -67,7 +67,7 @@ func CheckReceipt(b bind.DeployBackend, tx *types.Transaction, duration time.Dur
 
 // TestBridgeManager tests the event/method of Token/NFT/Bridge contracts.
 // TODO-Klaytn-Servicechain needs to refine this test.
-// - consider main/service chain simulated backend.
+// - consider parent/child chain simulated backend.
 // - separate each test
 func TestBridgeManager(t *testing.T) {
 	tempDir := os.TempDir() + "sc"

--- a/node/sc/config.go
+++ b/node/sc/config.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	datadirMainChainBridgeNodes = "parentchain-bridges.json" // Path within the datadir to the static node list
+	datadirMainChainBridgeNodes = "main-bridges.json" // Path within the datadir to the static node list
 )
 
 var logger = log.NewModuleLogger(log.ServiceChain)

--- a/node/sc/config.go
+++ b/node/sc/config.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	datadirMainChainBridgeNodes = "mainchain-bridges.json" // Path within the datadir to the static node list
+	datadirMainChainBridgeNodes = "parentchain-bridges.json" // Path within the datadir to the static node list
 )
 
 var logger = log.NewModuleLogger(log.ServiceChain)

--- a/node/sc/main_bridge_handler.go
+++ b/node/sc/main_bridge_handler.go
@@ -134,7 +134,7 @@ func (mbh *MainBridgeHandler) handleServiceChainParentChainInfoRequestMsg(p Brid
 	nonce := mbh.mainbridge.txPool.GetPendingNonce(addr)
 	pcInfo := parentChainInfo{nonce, mbh.mainbridge.blockchain.Config().UnitPrice}
 	p.SendServiceChainInfoResponse(&pcInfo)
-	logger.Info("SendServiceChainInfoResponse", "mcBridgeAccoount", addr, "nonce", pcInfo.Nonce, "gasPrice", pcInfo.GasPrice)
+	logger.Info("SendServiceChainInfoResponse", "pBridgeAccoount", addr, "nonce", pcInfo.Nonce, "gasPrice", pcInfo.GasPrice)
 	return nil
 }
 

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -74,7 +74,7 @@ func (mce *MainChainEventHandler) WriteLastIndexedBlockNumber(blockNum uint64) {
 }
 
 // ConvertChildChainBlockHashToParentChainTxHash returns a transaction hash of a transaction which contains
-// ChainHashes, with the key made with given service chain block hash.
+// ChainHashes, with the key made with given child chain block hash.
 // Index is built when service chain indexing is enabled.
 func (mce *MainChainEventHandler) ConvertChildChainBlockHashToParentChainTxHash(scBlockHash common.Hash) common.Hash {
 	return mce.mainbridge.chainDB.ConvertChildChainBlockHashToParentChainTxHash(scBlockHash)

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -73,11 +73,11 @@ func (mce *MainChainEventHandler) WriteLastIndexedBlockNumber(blockNum uint64) {
 	mce.mainbridge.chainDB.WriteLastIndexedBlockNumber(blockNum)
 }
 
-// ConvertServiceChainBlockHashToMainChainTxHash returns a transaction hash of a transaction which contains
+// ConvertChildChainBlockHashToParentChainTxHash returns a transaction hash of a transaction which contains
 // ChainHashes, with the key made with given service chain block hash.
 // Index is built when service chain indexing is enabled.
-func (mce *MainChainEventHandler) ConvertServiceChainBlockHashToMainChainTxHash(scBlockHash common.Hash) common.Hash {
-	return mce.mainbridge.chainDB.ConvertServiceChainBlockHashToMainChainTxHash(scBlockHash)
+func (mce *MainChainEventHandler) ConvertChildChainBlockHashToParentChainTxHash(scBlockHash common.Hash) common.Hash {
+	return mce.mainbridge.chainDB.ConvertChildChainBlockHashToParentChainTxHash(scBlockHash)
 }
 
 // WriteChildChainTxHash stores a transaction hash of a transaction which contains

--- a/node/sc/sub_event_handler.go
+++ b/node/sc/sub_event_handler.go
@@ -101,9 +101,9 @@ func (cce *ChildChainEventHandler) ProcessHandleEvent(ev *HandleValueTransferEve
 	return nil
 }
 
-// ConvertServiceChainBlockHashToMainChainTxHash returns a transaction hash of a transaction which contains
-// ChainHashes, with the key made with given service chain block hash.
-// Index is built when service chain indexing is enabled.
-func (cce *ChildChainEventHandler) ConvertServiceChainBlockHashToMainChainTxHash(scBlockHash common.Hash) common.Hash {
-	return cce.subbridge.chainDB.ConvertServiceChainBlockHashToMainChainTxHash(scBlockHash)
+// ConvertChildChainBlockHashToParentChainTxHash returns a transaction hash of a transaction which contains
+// ChainHashes, with the key made with given child chain block hash.
+// Index is built when child chain indexing is enabled.
+func (cce *ChildChainEventHandler) ConvertChildChainBlockHashToParentChainTxHash(scBlockHash common.Hash) common.Hash {
+	return cce.subbridge.chainDB.ConvertChildChainBlockHashToParentChainTxHash(scBlockHash)
 }

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -545,7 +545,7 @@ func (sc *SubBridge) resetBridgeLoop() {
 			peerCount--
 			if peerCount == 0 {
 				needResetSubscription = true
-				sc.handler.setMainChainAccountNonceSynced(false)
+				sc.handler.setParentOperatorNonceSynced(false)
 			}
 		case <-ticker.C:
 			if needResetSubscription && peerCount > 0 {

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -364,7 +364,7 @@ func TestAlreadyStartedVTRecovery(t *testing.T) {
 	vtr.Stop()
 }
 
-// TestScenarioMainChainRecovery tests the value transfer recovery of the parent chain to service chain value transfers.
+// TestScenarioMainChainRecovery tests the value transfer recovery of the parent chain to child chain value transfers.
 func TestScenarioMainChainRecovery(t *testing.T) {
 	tempDir := os.TempDir() + "sc"
 	os.MkdirAll(tempDir, os.ModePerm)
@@ -719,7 +719,7 @@ func requestNFTTransfer(info *testInfo, bi *BridgeInfo) {
 	defer bi.account.UnLock()
 
 	opts := bi.account.GetTransactOpts()
-	// TODO-Klaytn need to separate service / parent chain nftIndex.
+	// TODO-Klaytn need to separate child / parent chain nftIndex.
 	nftIndex := new(big.Int).SetInt64(info.nftIndex)
 
 	var err error

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -120,9 +120,9 @@ func TestBasicKLAYTransferRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update value transfer hint")
 	}
-	t.Log("value transfer hint", vtr.service2mainHint)
-	assert.Equal(t, uint64(testTxCount), vtr.service2mainHint.requestNonce)
-	assert.Equal(t, uint64(testTxCount-testPendingCount), vtr.service2mainHint.handleNonce)
+	t.Log("value transfer hint", vtr.child2parentHint)
+	assert.Equal(t, uint64(testTxCount), vtr.child2parentHint.requestNonce)
+	assert.Equal(t, uint64(testTxCount-testPendingCount), vtr.child2parentHint.handleNonce)
 
 	// 3. Request events by using the hint.
 	err = vtr.retrievePendingEvents()
@@ -131,9 +131,9 @@ func TestBasicKLAYTransferRecovery(t *testing.T) {
 	}
 
 	// 4. Check pending events.
-	t.Log("check pending tx", "len", len(vtr.serviceChainEvents))
+	t.Log("check pending tx", "len", len(vtr.childEvents))
 	var count = 0
-	for _, ev := range vtr.serviceChainEvents {
+	for _, ev := range vtr.childEvents {
 		assert.Equal(t, info.nodeAuth.From, ev.From)
 		assert.Equal(t, info.aliceAuth.From, ev.To)
 		assert.Equal(t, big.NewInt(testAmount), ev.ValueOrTokenId)
@@ -158,7 +158,7 @@ func TestBasicKLAYTransferRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to retrieve pending events from the bridge contract")
 	}
-	assert.Equal(t, 0, len(vtr.serviceChainEvents))
+	assert.Equal(t, 0, len(vtr.childEvents))
 
 	assert.Equal(t, nil, vtr.Recover()) // nothing to recover
 }
@@ -184,8 +184,8 @@ func TestBasicTokenTransferRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.NotEqual(t, vtr.service2mainHint.requestNonce, vtr.service2mainHint.handleNonce)
-	t.Log("token transfer hint", vtr.service2mainHint)
+	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
+	t.Log("token transfer hint", vtr.child2parentHint)
 
 	info.recoveryCh <- true
 	err = vtr.Recover()
@@ -198,7 +198,7 @@ func TestBasicTokenTransferRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.Equal(t, vtr.service2mainHint.requestNonce, vtr.service2mainHint.handleNonce)
+	assert.Equal(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
 }
 
 // TestBasicNFTTransferRecovery tests the NFT transfer recovery.
@@ -223,8 +223,8 @@ func TestBasicNFTTransferRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.NotEqual(t, vtr.service2mainHint.requestNonce, vtr.service2mainHint.handleNonce)
-	t.Log("token transfer hint", vtr.service2mainHint)
+	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
+	t.Log("token transfer hint", vtr.child2parentHint)
 
 	info.recoveryCh <- true
 	err = vtr.Recover()
@@ -237,7 +237,7 @@ func TestBasicNFTTransferRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.Equal(t, vtr.service2mainHint.requestNonce, vtr.service2mainHint.handleNonce)
+	assert.Equal(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
 }
 
 // TestMethodRecover tests the valueTransferRecovery.Recover() method.
@@ -260,7 +260,7 @@ func TestMethodRecover(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.NotEqual(t, vtr.service2mainHint.requestNonce, vtr.service2mainHint.handleNonce)
+	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
 
 	info.recoveryCh <- true
 	err = vtr.Recover()
@@ -273,7 +273,7 @@ func TestMethodRecover(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.Equal(t, vtr.service2mainHint.requestNonce, vtr.service2mainHint.handleNonce)
+	assert.Equal(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
 }
 
 // TestMethodStop tests the Stop method for stop the internal goroutine.
@@ -296,7 +296,7 @@ func TestMethodStop(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.NotEqual(t, vtr.service2mainHint.requestNonce, vtr.service2mainHint.handleNonce)
+	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
 
 	info.recoveryCh <- true
 	err = vtr.Start()
@@ -364,7 +364,7 @@ func TestAlreadyStartedVTRecovery(t *testing.T) {
 	vtr.Stop()
 }
 
-// TestScenarioMainChainRecovery tests the value transfer recovery of the main chain to service chain value transfers.
+// TestScenarioMainChainRecovery tests the value transfer recovery of the parent chain to service chain value transfers.
 func TestScenarioMainChainRecovery(t *testing.T) {
 	tempDir := os.TempDir() + "sc"
 	os.MkdirAll(tempDir, os.ModePerm)
@@ -385,7 +385,7 @@ func TestScenarioMainChainRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.NotEqual(t, vtr.main2serviceHint.requestNonce, vtr.main2serviceHint.handleNonce)
+	assert.NotEqual(t, vtr.parent2childHint.requestNonce, vtr.parent2childHint.handleNonce)
 
 	info.recoveryCh <- true
 	err = vtr.Recover()
@@ -398,7 +398,7 @@ func TestScenarioMainChainRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.Equal(t, vtr.main2serviceHint.requestNonce, vtr.main2serviceHint.handleNonce)
+	assert.Equal(t, vtr.parent2childHint.requestNonce, vtr.parent2childHint.handleNonce)
 }
 
 // TestScenarioAutomaticRecovery tests the recovery of the internal goroutine.
@@ -421,7 +421,7 @@ func TestScenarioAutomaticRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
-	assert.NotEqual(t, vtr.service2mainHint.requestNonce, vtr.service2mainHint.handleNonce)
+	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
 
 	info.recoveryCh <- true
 	err = vtr.Start()
@@ -436,7 +436,7 @@ func TestScenarioAutomaticRecovery(t *testing.T) {
 		t.Fatal("fail to update a value transfer hint")
 	}
 	vtr.Stop()
-	assert.Equal(t, vtr.service2mainHint.requestNonce, vtr.service2mainHint.handleNonce)
+	assert.Equal(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
 }
 
 // prepare generates dummy blocks for testing value transfer recovery.
@@ -681,7 +681,7 @@ func requestTokenTransfer(info *testInfo, bi *BridgeInfo) {
 	opts := bi.account.GetTransactOpts()
 
 	var err error
-	if bi.onServiceChain {
+	if bi.onChildChain {
 		_, err = info.tokenLocalBridge.RequestValueTransfer(opts, testToken, info.chainAuth.From, big.NewInt(0), nil)
 	} else {
 		_, err = info.tokenRemoteBridge.RequestValueTransfer(opts, testToken, info.nodeAuth.From, big.NewInt(0), nil)
@@ -719,11 +719,11 @@ func requestNFTTransfer(info *testInfo, bi *BridgeInfo) {
 	defer bi.account.UnLock()
 
 	opts := bi.account.GetTransactOpts()
-	// TODO-Klaytn need to separate service / main chain nftIndex.
+	// TODO-Klaytn need to separate service / parent chain nftIndex.
 	nftIndex := new(big.Int).SetInt64(info.nftIndex)
 
 	var err error
-	if bi.onServiceChain {
+	if bi.onChildChain {
 		_, err = info.nftLocalBridge.RequestValueTransfer(opts, nftIndex, info.aliceAuth.From, nil)
 	} else {
 		_, err = info.nftRemoteBridge.RequestValueTransfer(opts, nftIndex, info.aliceAuth.From, nil)
@@ -742,7 +742,7 @@ func handleNFTTransfer(info *testInfo, bi *BridgeInfo, ev *RequestValueTransferE
 
 	var nftAddr common.Address
 
-	if bi.onServiceChain {
+	if bi.onChildChain {
 		nftAddr = info.nftLocalAddr
 	} else {
 		nftAddr = info.nftRemoteAddr

--- a/storage/database/child_chain_data_test.go
+++ b/storage/database/child_chain_data_test.go
@@ -41,18 +41,18 @@ func TestChildChainData_ReadAndWrite_ChildChainTxHash(t *testing.T) {
 	ccTxHash := common.HexToHash("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f")
 
 	// Before writing the data into DB, nil should be returned.
-	ccTxHashFromDB := dbm.ConvertServiceChainBlockHashToMainChainTxHash(ccBlockHash)
+	ccTxHashFromDB := dbm.ConvertChildChainBlockHashToParentChainTxHash(ccBlockHash)
 	assert.Equal(t, common.Hash{}, ccTxHashFromDB)
 
 	// After writing the data into DB, data should be returned.
 	dbm.WriteChildChainTxHash(ccBlockHash, ccTxHash)
-	ccTxHashFromDB = dbm.ConvertServiceChainBlockHashToMainChainTxHash(ccBlockHash)
+	ccTxHashFromDB = dbm.ConvertChildChainBlockHashToParentChainTxHash(ccBlockHash)
 	assert.NotNil(t, ccTxHashFromDB)
 	assert.Equal(t, ccTxHash, ccTxHashFromDB)
 
 	ccBlockHashFake := common.HexToHash("0x0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a")
 	// Invalid information should not return the data.
-	ccTxHashFromDB = dbm.ConvertServiceChainBlockHashToMainChainTxHash(ccBlockHashFake)
+	ccTxHashFromDB = dbm.ConvertChildChainBlockHashToParentChainTxHash(ccBlockHashFake)
 	assert.Equal(t, common.Hash{}, ccTxHashFromDB)
 }
 

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -137,9 +137,9 @@ type DBManager interface {
 	ReadPreimage(hash common.Hash) []byte
 	WritePreimages(number uint64, preimages map[common.Hash][]byte)
 
-	// below operations are used in main chain side, not service chain side.
+	// below operations are used in parent chain side, not child chain side.
 	WriteChildChainTxHash(ccBlockHash common.Hash, ccTxHash common.Hash)
-	ConvertServiceChainBlockHashToMainChainTxHash(scBlockHash common.Hash) common.Hash
+	ConvertChildChainBlockHashToParentChainTxHash(scBlockHash common.Hash) common.Hash
 
 	WriteLastIndexedBlockNumber(blockNum uint64)
 	GetLastIndexedBlockNumber() uint64
@@ -1328,9 +1328,9 @@ func (dbm *databaseManager) WriteChildChainTxHash(ccBlockHash common.Hash, ccTxH
 	}
 }
 
-// ConvertServiceChainBlockHashToMainChainTxHash returns a transaction hash of a transaction which contains
+// ConvertChildChainBlockHashToParentChainTxHash returns a transaction hash of a transaction which contains
 // ChainHashes, with the key made with given child chain block hash.
-func (dbm *databaseManager) ConvertServiceChainBlockHashToMainChainTxHash(scBlockHash common.Hash) common.Hash {
+func (dbm *databaseManager) ConvertChildChainBlockHashToParentChainTxHash(scBlockHash common.Hash) common.Hash {
 	key := childChainTxHashKey(scBlockHash)
 	db := dbm.getDatabase(bridgeServiceDB)
 	data, _ := db.Get(key)

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -557,13 +557,13 @@ func TestDBManager_Preimage(t *testing.T) {
 func TestDBManager_ParentChain(t *testing.T) {
 	for _, dbm := range dbManagers {
 		// 1. Read/Write SerivceChainTxHash
-		assert.Equal(t, common.Hash{}, dbm.ConvertServiceChainBlockHashToMainChainTxHash(hash1))
+		assert.Equal(t, common.Hash{}, dbm.ConvertChildChainBlockHashToParentChainTxHash(hash1))
 
 		dbm.WriteChildChainTxHash(hash1, hash1)
-		assert.Equal(t, hash1, dbm.ConvertServiceChainBlockHashToMainChainTxHash(hash1))
+		assert.Equal(t, hash1, dbm.ConvertChildChainBlockHashToParentChainTxHash(hash1))
 
 		dbm.WriteChildChainTxHash(hash1, hash2)
-		assert.Equal(t, hash2, dbm.ConvertServiceChainBlockHashToMainChainTxHash(hash1))
+		assert.Equal(t, hash2, dbm.ConvertChildChainBlockHashToParentChainTxHash(hash1))
 
 		// 2. Read/Write LastIndexedBlockNumber
 		assert.Equal(t, uint64(0), dbm.GetLastIndexedBlockNumber())


### PR DESCRIPTION
## Proposed changes
Service chain can be composed for multiple layer chains like below.
- main net <-> 1st service chain <-> 2nd service chain <-> ... <-> Nth service chain

For this multiple layer service chains, main/service chain words are not exact.
So this PR renamed some words like below.
- main/service->parent/child

And we renamed bridge account to operator which sign the handled transaction for bridge contract. This will be expected to help to understand well of bridge contract structure.
- bridge account -> operator

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
