### PR TITLE
SC: add unit tests for multi operator vt recovery

### DIFF
--- a/node/sc/multi_bridge_test.go
+++ b/node/sc/multi_bridge_test.go
@@ -712,7 +712,8 @@ func TestMultiBridgeErrOverSign(t *testing.T) {
 // TestMultiOperatorKLAYTransferDup checks the following:
 // - set threshold to 1.
 // - an operator succeed to handle value transfer.
-// - the operator fails to handle value transfer because of vote closing (duplicated).
+// - the operator (same auth) fails to handle value transfer because of vote closing (duplicated).
+// - another operator (different auth) fails to handle value transfer because of vote closing (duplicated).
 func TestMultiOperatorKLAYTransferDup(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
 	to := common.Address{100}
@@ -733,6 +734,11 @@ func TestMultiOperatorKLAYTransferDup(t *testing.T) {
 	info.sim.Commit()
 	assert.NoError(t, bind.CheckWaitMined(info.sim, tx))
 
+	tx = SendHandleKLAYTransfer(info.b, acc, to, transferAmount, sentNonce, sentBlockNumber, t)
+	info.sim.Commit()
+	assert.Error(t, bind.CheckWaitMined(info.sim, tx))
+
+	acc = info.accounts[1]
 	tx = SendHandleKLAYTransfer(info.b, acc, to, transferAmount, sentNonce, sentBlockNumber, t)
 	info.sim.Commit()
 	assert.Error(t, bind.CheckWaitMined(info.sim, tx))


### PR DESCRIPTION
## Proposed changes

- Add following unit tests
    - value transfer recovery for multi-operator
    - a failure case for duplicated handle transfer that is already handled.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules