### PR TITLE
circleci: upgrade nightly-coverage resource_type to xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,6 +504,8 @@ workflows:
                 - master
     jobs:
       - coverage
+      - build:
+          resource_class: xlarge
 
   nightly-linters:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
     docker:
       - image: klaytn/build_base:1.0
     working_directory: /go/src/github.com/klaytn/klaytn
+    resource_class: xlarge
     steps:
       - checkout
       - run:
@@ -504,8 +505,6 @@ workflows:
                 - master
     jobs:
       - coverage
-      - build:
-          resource_class: xlarge
 
   nightly-linters:
     triggers:


### PR DESCRIPTION
## Proposed changes

- To avoid OOM during nightly-coverage, upgrade its resource_type to xlarge

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...