### PR TITLE
[Reward] calculate gini with stakingAmounts of nodes which deployed staking contracts

### DIFF
--- a/consensus/istanbul/validator/multi_staking_test.go
+++ b/consensus/istanbul/validator/multi_staking_test.go
@@ -114,6 +114,7 @@ func TestWeightedCouncil_getStakingAmountsOfValidators(t *testing.T) {
 // if UseGini is true, gini is calculated and reflected to stakingAmounts.
 func TestCalcTotalAmount(t *testing.T) {
 	testCases := []struct {
+		weightedValidators     []*weightedValidator
 		stakingInfo            *reward.StakingInfo
 		stakingAmounts         []float64
 		expectedGini           float64
@@ -121,6 +122,9 @@ func TestCalcTotalAmount(t *testing.T) {
 		expectedStakingAmounts []float64
 	}{
 		{
+			[]*weightedValidator{
+				{address: common.StringToAddress("101")}, {address: common.StringToAddress("102")}, {address: common.StringToAddress("103")},
+			},
 			&reward.StakingInfo{
 				CouncilNodeAddrs: []common.Address{common.StringToAddress("101"), common.StringToAddress("102"), common.StringToAddress("103")},
 				UseGini:          false,
@@ -132,6 +136,9 @@ func TestCalcTotalAmount(t *testing.T) {
 			[]float64{5000000, 5000000, 5000000},
 		},
 		{
+			[]*weightedValidator{
+				{address: common.StringToAddress("101")}, {address: common.StringToAddress("102")}, {address: common.StringToAddress("103")},
+			},
 			&reward.StakingInfo{
 				CouncilNodeAddrs: []common.Address{common.StringToAddress("101"), common.StringToAddress("102"), common.StringToAddress("103")},
 				UseGini:          true,
@@ -144,6 +151,9 @@ func TestCalcTotalAmount(t *testing.T) {
 		},
 
 		{
+			[]*weightedValidator{
+				{address: common.StringToAddress("101")}, {address: common.StringToAddress("102")}, {address: common.StringToAddress("103")}, {address: common.StringToAddress("104")}, {address: common.StringToAddress("105")},
+			},
 			&reward.StakingInfo{
 				CouncilNodeAddrs: []common.Address{common.StringToAddress("101"), common.StringToAddress("102"), common.StringToAddress("103"), common.StringToAddress("104"), common.StringToAddress("105")},
 				UseGini:          true,
@@ -157,7 +167,7 @@ func TestCalcTotalAmount(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		stakingAmounts := testCase.stakingAmounts
-		totalAmount := calcTotalAmount(testCase.stakingInfo, stakingAmounts)
+		totalAmount := calcTotalAmount(testCase.weightedValidators, testCase.stakingInfo, stakingAmounts)
 
 		assert.Equal(t, testCase.expectedGini, testCase.stakingInfo.Gini)
 		assert.Equal(t, testCase.expectedTotalAmount, totalAmount)
@@ -291,7 +301,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 				UseGini:               true,
 				CouncilStakingAmounts: []uint64{10000000, 5000000, 20000000, 5000000, 5000000, 5000000},
 			},
-			[]int64{29, 22, 36, 13, 1},
+			[]int64{29, 21, 37, 12, 1},
 		},
 	}
 	for _, testCase := range testCases {
@@ -299,7 +309,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 
 		weightedValidators, stakingAmounts, err := council.getStakingAmountsOfValidators(testCase.stakingInfo)
 		assert.NoError(t, err)
-		totalStaking := calcTotalAmount(testCase.stakingInfo, stakingAmounts)
+		totalStaking := calcTotalAmount(weightedValidators, testCase.stakingInfo, stakingAmounts)
 		calcWeight(weightedValidators, stakingAmounts, totalStaking)
 
 		for i, weight := range testCase.expectedWeights {

--- a/reward/staking_info.go
+++ b/reward/staking_info.go
@@ -141,21 +141,19 @@ func (p float64Slice) Less(i, j int) bool { return p[i] < p[j] }
 func (p float64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 func CalcGiniCoefficient(stakingAmount float64Slice) float64 {
-	tempStakingAmount := make(float64Slice, len(stakingAmount))
-	copy(tempStakingAmount, stakingAmount)
-	sort.Sort(tempStakingAmount)
+	sort.Sort(stakingAmount)
 
 	// calculate gini coefficient
 	sumOfAbsoluteDifferences := float64(0)
 	subSum := float64(0)
 
-	for i, x := range tempStakingAmount {
+	for i, x := range stakingAmount {
 		temp := x*float64(i) - subSum
 		sumOfAbsoluteDifferences = sumOfAbsoluteDifferences + temp
 		subSum = subSum + x
 	}
 
-	result := sumOfAbsoluteDifferences / subSum / float64(len(tempStakingAmount))
+	result := sumOfAbsoluteDifferences / subSum / float64(len(stakingAmount))
 	result = math.Round(result*100) / 100
 
 	return result


### PR DESCRIPTION
## Proposed changes

gini coefficient should is calculated by stakingAmounts of node.
if a node doesn't have a staking contract, the stakingAmounts of node will be 0.
but the value 0 shouldn't be included when calculating gini coefficient.

This pr is for excluding 0 stakingAmount value by checking if a node deployed a staking contract or not

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
