### PR TITLE
Fix roundchange behavior when the number of nodes are less than 4.

### DIFF
--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -110,7 +110,8 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 				numCatchUp = n - 1
 	} else {
 		f := int(c.valSet.F())
-		numStartNewRound = int(2*fValue + 1)
+		// 2*f + 1 ROUND CHANGE messages can start new round.	
+		numStartNewRound = 2*f + 1
 		numCatchUp = int(fValue + 1)
 	}
 

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -106,7 +106,8 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 		n := c.valSet.Size()
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n
-		numCatchUp = numStartNewRound - 1
+				// N - 1 ROUND CHANGE messages can catch up the round.
+				numCatchUp = n - 1
 	} else {
 		fValue := c.valSet.F()
 		numStartNewRound = int(2*fValue + 1)

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -103,14 +103,14 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 
 	var numCatchUp, numStartNewRound int
 	if c.valSet.Size() < 4 {
-		n := c.valSet.Size()
+		n := int(c.valSet.Size())
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n
-				// N - 1 ROUND CHANGE messages can catch up the round.
-				numCatchUp = n - 1
+		// N - 1 ROUND CHANGE messages can catch up the round.
+		numCatchUp = n - 1
 	} else {
 		f := int(c.valSet.F())
-		// 2*f + 1 ROUND CHANGE messages can start new round.	
+		// 2*f + 1 ROUND CHANGE messages can start new round.
 		numStartNewRound = 2*f + 1
 		// F + 1 ROUND CHANGE messages can start catch up the round.
 		numCatchUp = f + 1

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -112,7 +112,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 	}
 
 	if num == numStartNewRound && (c.waitingForRoundChange || cv.Round.Cmp(roundView.Round) < 0) {
-		// We've received 2f+1 ROUND CHANGE messages, start a new round immediately.
+		// We've received enough ROUND CHANGE messages, start a new round immediately.
 		logger.Warn("[RC] Received 2f+1 Round Change Messages. Starting new round")
 		c.startNewRound(roundView.Round)
 		return nil

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -103,7 +103,9 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 
 	var numCatchUp, numStartNewRound int
 	if c.valSet.Size() < 4 {
-		numStartNewRound = int(c.valSet.Size())
+		n := c.valSet.Size()
+		// N ROUND CHANGE messages can start new round.
+		numStartNewRound = n
 		numCatchUp = numStartNewRound - 1
 	} else {
 		fValue := c.valSet.F()

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -104,16 +104,16 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 	// Once we received f+1 ROUND CHANGE messages, those messages form a weak certificate.
 	// If our round number is smaller than the certificate's round number, we would
 	// try to catch up the round number.
-	if c.waitingForRoundChange && num == int(c.valSet.F()+1) {
+	if num == int(2*c.valSet.F()+1) && (c.waitingForRoundChange || cv.Round.Cmp(roundView.Round) < 0) {
+		// We've received 2f+1 ROUND CHANGE messages, start a new round immediately.
+		logger.Warn("[RC] Received 2f+1 Round Change Messages. Starting new round")
+		c.startNewRound(roundView.Round)
+		return nil
+	} else if c.waitingForRoundChange && num == int(c.valSet.F()+1) {
 		if cv.Round.Cmp(roundView.Round) < 0 {
 			logger.Warn("[RC] Send round change because we have F+1 roundchange messages")
 			c.sendRoundChange(roundView.Round)
 		}
-		return nil
-	} else if num == int(2*c.valSet.F()+1) && (c.waitingForRoundChange || cv.Round.Cmp(roundView.Round) < 0) {
-		// We've received 2f+1 ROUND CHANGE messages, start a new round immediately.
-		logger.Warn("[RC] Received 2f+1 Round Change Messages. Starting new round")
-		c.startNewRound(roundView.Round)
 		return nil
 	} else if cv.Round.Cmp(roundView.Round) < 0 {
 		// Only gossip the message with current round to other validators.

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -112,7 +112,8 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 		f := int(c.valSet.F())
 		// 2*f + 1 ROUND CHANGE messages can start new round.	
 		numStartNewRound = 2*f + 1
-		numCatchUp = int(fValue + 1)
+		// F + 1 ROUND CHANGE messages can start catch up the round.
+		numCatchUp = f + 1
 	}
 
 	if num == numStartNewRound && (c.waitingForRoundChange || cv.Round.Cmp(roundView.Round) < 0) {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -117,7 +117,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 		c.startNewRound(roundView.Round)
 		return nil
 	} else if c.waitingForRoundChange && num == numCatchUp {
-		// Once we received f+1 ROUND CHANGE messages, those messages form a weak certificate.
+		// Once we received enough ROUND CHANGE messages, those messages form a weak certificate.
 		// If our round number is smaller than the certificate's round number, we would
 		// try to catch up the round number.
 		if cv.Round.Cmp(roundView.Round) < 0 {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -110,7 +110,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 		numCatchUp = n - 1
 	} else {
 		f := int(c.valSet.F())
-		// 2*f + 1 ROUND CHANGE messages can start new round.
+		// 2*F + 1 ROUND CHANGE messages can start new round.
 		numStartNewRound = 2*f + 1
 		// F + 1 ROUND CHANGE messages can start catch up the round.
 		numCatchUp = f + 1

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -109,7 +109,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 				// N - 1 ROUND CHANGE messages can catch up the round.
 				numCatchUp = n - 1
 	} else {
-		fValue := c.valSet.F()
+		f := int(c.valSet.F())
 		numStartNewRound = int(2*fValue + 1)
 		numCatchUp = int(fValue + 1)
 	}


### PR DESCRIPTION
## Proposed changes

- This PR is to solve an issue of block generation when F() is 0 (meaning that the number of nodes are less than 4)
- When a roundchange happened, the required number of messages are calculated differently based on the number of nodes

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules