### PR TITLE
Terminate the queue loop when insert fails

### DIFF
--- a/datasync/fetcher/fetcher.go
+++ b/datasync/fetcher/fetcher.go
@@ -331,6 +331,7 @@ func (f *Fetcher) loop() {
 
 			block := op.block
 			peer := op.origin
+			insertFailed := false
 			select {
 			case f.insertTasks <- insertTask{peer, block}:
 				logger.Debug("Importing propagated block", "peer", peer, "number", number, "hash", hash)
@@ -340,6 +341,9 @@ func (f *Fetcher) loop() {
 				if f.queueChangeHook != nil {
 					f.queueChangeHook(hash, true)
 				}
+				insertFailed = true
+			}
+			if insertFailed {
 				break
 			}
 		}

--- a/datasync/fetcher/fetcher.go
+++ b/datasync/fetcher/fetcher.go
@@ -725,6 +725,7 @@ func (f *Fetcher) insertWorker() {
 		case task := <-f.insertTasks:
 			f.insertWork(task.peer, task.block)
 		case <-f.quit:
+			logger.Info("Terminated insertWorker")
 			return
 		}
 	}


### PR DESCRIPTION
## Proposed changes

- It is intended to terminate the queue loop when the insertion to the fetcher fails.
- However, the change was not implemented as it was intended.
- Therefore, terminate the queue loop as intended.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
