### PR TITLE
 Fix server address parsing errors

### DIFF
--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -516,7 +516,7 @@ func (srv *MultiChannelServer) SetupConn(fd net.Conn, flags connFlag, dialDest *
 		c.portOrder = PortOrder(dialDest.PortOrder)
 	} else {
 		for i, addr := range srv.ListenAddrs {
-			s1 := strings.Split(addr, ":")                    // string format example, [::]:30303
+			s1 := strings.Split(addr, ":")                    // string format example, [::]:30303 or 123.123.123.123:30303
 			s2 := strings.Split(fd.LocalAddr().String(), ":") // string format example, 123.123.123.123:30303
 			if s1[len(s1)-1] == s2[len(s2)-1] {
 				c.portOrder = PortOrder(i)

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -520,6 +520,7 @@ func (srv *MultiChannelServer) SetupConn(fd net.Conn, flags connFlag, dialDest *
 			s2 := strings.Split(fd.LocalAddr().String(), ":") // string format example, 123.123.123.123:30303
 			if s1[len(s1)-1] == s2[len(s2)-1] {
 				c.portOrder = PortOrder(i)
+				break
 			}
 		}
 	}

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -518,11 +518,7 @@ func (srv *MultiChannelServer) SetupConn(fd net.Conn, flags connFlag, dialDest *
 		for i, addr := range srv.ListenAddrs {
 			s1 := strings.Split(addr, ":")                    // string format example, [::]:30303
 			s2 := strings.Split(fd.LocalAddr().String(), ":") // string format example, 123.123.123.123:30303
-			if len(s1) != 4 || len(s2) != 2 {
-				srv.logger.Error("Address format is incorrect", "srv.ListenAddr", addr, "fd.LocalAddr().String()", fd.LocalAddr().String())
-				return errors.New("incorrect Address")
-			}
-			if s1[3] == s2[1] {
+			if s1[len(s1)-1] == s2[len(s2)-1] {
 				c.portOrder = PortOrder(i)
 			}
 		}


### PR DESCRIPTION
## Proposed changes

- There is a problem parsing the server address to check the port number. The address information can be divided into ipv4 and ipv6 depending on the network adapter. However, the current implementation implements only parsing correctly for ipv6, so this has been fixed.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
