### PR TITLE
 SC: add transaction count for anchoring

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -83,6 +83,10 @@ func NewSimulatedBackend(alloc blockchain.GenesisAlloc) *SimulatedBackend {
 	return backend
 }
 
+func (b *SimulatedBackend) BlockChain() *blockchain.BlockChain {
+	return b.blockchain
+}
+
 // Commit imports all the pending transactions as a single block and starts a
 // fresh new state.
 func (b *SimulatedBackend) Commit() {

--- a/blockchain/types/anchoring_data.go
+++ b/blockchain/types/anchoring_data.go
@@ -35,13 +35,13 @@ type AnchoringDataInternalType0 struct {
 	StateRootHash common.Hash
 	BlockNumber   *big.Int
 	Period        *big.Int
-	TxCounts      *big.Int
+	TxCount       *big.Int
 }
 
-func NewAnchoringDataType0(block *Block, period *big.Int, txCounts *big.Int) (*AnchoringData, error) {
+func NewAnchoringDataType0(block *Block, period *big.Int, txCount *big.Int) (*AnchoringData, error) {
 	data := &AnchoringDataInternalType0{block.Hash(), block.Header().TxHash,
 		block.Header().ParentHash, block.Header().ReceiptHash,
-		block.Header().Root, block.Header().Number, period, txCounts}
+		block.Header().Root, block.Header().Number, period, txCount}
 	encodedCCTxData, err := rlp.EncodeToBytes(data)
 	if err != nil {
 		return nil, err

--- a/blockchain/types/anchoring_data.go
+++ b/blockchain/types/anchoring_data.go
@@ -22,6 +22,10 @@ import (
 	"math/big"
 )
 
+const (
+	AnchoringDataType0 uint8 = 0
+)
+
 type AnchoringData struct {
 	Type uint8
 	Data []byte
@@ -46,5 +50,5 @@ func NewAnchoringDataType0(block *Block, period *big.Int, txCount *big.Int) (*An
 	if err != nil {
 		return nil, err
 	}
-	return &AnchoringData{0, encodedCCTxData}, nil
+	return &AnchoringData{AnchoringDataType0, encodedCCTxData}, nil
 }

--- a/blockchain/types/anchoring_data.go
+++ b/blockchain/types/anchoring_data.go
@@ -38,7 +38,7 @@ type AnchoringDataInternalType0 struct {
 	TxCounts      *big.Int
 }
 
-func NewChainHashesType0(block *Block, period *big.Int, txCounts *big.Int) (*AnchoringData, error) {
+func NewAnchoringDataType0(block *Block, period *big.Int, txCounts *big.Int) (*AnchoringData, error) {
 	data := &AnchoringDataInternalType0{block.Hash(), block.Header().TxHash,
 		block.Header().ParentHash, block.Header().ReceiptHash,
 		block.Header().Root, block.Header().Number, period, txCounts}

--- a/blockchain/types/chain_hashes.go
+++ b/blockchain/types/chain_hashes.go
@@ -22,12 +22,12 @@ import (
 	"math/big"
 )
 
-type ChainHashes struct {
+type AnchoringData struct {
 	Type uint8
 	Data []byte
 }
 
-type ChainHashesInternalType0 struct {
+type AnchoringDataInternalType0 struct {
 	BlockHash     common.Hash
 	TxHash        common.Hash
 	ParentHash    common.Hash
@@ -38,13 +38,13 @@ type ChainHashesInternalType0 struct {
 	TxCounts      *big.Int
 }
 
-func NewChainHashesType0(block *Block, period *big.Int, txCounts *big.Int) (*ChainHashes, error) {
-	data := &ChainHashesInternalType0{block.Hash(), block.Header().TxHash,
+func NewChainHashesType0(block *Block, period *big.Int, txCounts *big.Int) (*AnchoringData, error) {
+	data := &AnchoringDataInternalType0{block.Hash(), block.Header().TxHash,
 		block.Header().ParentHash, block.Header().ReceiptHash,
 		block.Header().Root, block.Header().Number, period, txCounts}
 	encodedCCTxData, err := rlp.EncodeToBytes(data)
 	if err != nil {
 		return nil, err
 	}
-	return &ChainHashes{0, encodedCCTxData}, nil
+	return &AnchoringData{0, encodedCCTxData}, nil
 }

--- a/blockchain/types/chain_hashes.go
+++ b/blockchain/types/chain_hashes.go
@@ -34,13 +34,14 @@ type ChainHashesInternalType0 struct {
 	ReceiptHash   common.Hash
 	StateRootHash common.Hash
 	BlockNumber   *big.Int
+	Period        *big.Int
 	TxCounts      *big.Int
 }
 
-func NewChainHashesType0(block *Block, txCounts *big.Int) (*ChainHashes, error) {
+func NewChainHashesType0(block *Block, period *big.Int, txCounts *big.Int) (*ChainHashes, error) {
 	data := &ChainHashesInternalType0{block.Hash(), block.Header().TxHash,
 		block.Header().ParentHash, block.Header().ReceiptHash,
-		block.Header().Root, block.Header().Number, txCounts}
+		block.Header().Root, block.Header().Number, period, txCounts}
 	encodedCCTxData, err := rlp.EncodeToBytes(data)
 	if err != nil {
 		return nil, err

--- a/blockchain/types/chain_hashes.go
+++ b/blockchain/types/chain_hashes.go
@@ -18,20 +18,32 @@ package types
 
 import (
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/ser/rlp"
 	"math/big"
 )
 
 type ChainHashes struct {
+	Type uint8
+	Data []byte
+}
+
+type ChainHashesInternalType0 struct {
 	BlockHash     common.Hash
 	TxHash        common.Hash
 	ParentHash    common.Hash
 	ReceiptHash   common.Hash
 	StateRootHash common.Hash
 	BlockNumber   *big.Int
+	TxCounts      *big.Int
 }
 
-func NewChainHashes(block *Block) *ChainHashes {
-	return &ChainHashes{block.Hash(), block.Header().TxHash,
+func NewChainHashesType0(block *Block, txCounts *big.Int) (*ChainHashes, error) {
+	data := &ChainHashesInternalType0{block.Hash(), block.Header().TxHash,
 		block.Header().ParentHash, block.Header().ReceiptHash,
-		block.Header().Root, block.Header().Number}
+		block.Header().Root, block.Header().Number, txCounts}
+	encodedCCTxData, err := rlp.EncodeToBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	return &ChainHashes{0, encodedCCTxData}, nil
 }

--- a/blockchain/types/tx_internal_data_serializer_test.go
+++ b/blockchain/types/tx_internal_data_serializer_test.go
@@ -375,7 +375,7 @@ func genFeeDelegatedSmartContractDeployWithRatioTransaction() TxInternalData {
 func genChainDataTransaction() TxInternalData {
 	data := &ChainHashesInternalType0{common.HexToHash("0"), common.HexToHash("1"),
 		common.HexToHash("2"), common.HexToHash("3"),
-		common.HexToHash("4"), big.NewInt(5), big.NewInt(6)}
+		common.HexToHash("4"), big.NewInt(5), big.NewInt(6), big.NewInt(7)}
 	encodedCCTxData, err := rlp.EncodeToBytes(data)
 	if err != nil {
 		panic(err)

--- a/blockchain/types/tx_internal_data_serializer_test.go
+++ b/blockchain/types/tx_internal_data_serializer_test.go
@@ -373,13 +373,14 @@ func genFeeDelegatedSmartContractDeployWithRatioTransaction() TxInternalData {
 }
 
 func genChainDataTransaction() TxInternalData {
-	blockTxData := &ChainHashes{
-		common.HexToHash("0"),
-		common.HexToHash("1"),
-		common.HexToHash("2"),
-		common.HexToHash("3"),
-		common.HexToHash("4"),
-		big.NewInt(5)}
+	data := &ChainHashesInternalType0{common.HexToHash("0"), common.HexToHash("1"),
+		common.HexToHash("2"), common.HexToHash("3"),
+		common.HexToHash("4"), big.NewInt(5), big.NewInt(6)}
+	encodedCCTxData, err := rlp.EncodeToBytes(data)
+	if err != nil {
+		panic(err)
+	}
+	blockTxData := &ChainHashes{0, encodedCCTxData}
 
 	anchoredData, err := rlp.EncodeToBytes(blockTxData)
 	if err != nil {

--- a/blockchain/types/tx_internal_data_serializer_test.go
+++ b/blockchain/types/tx_internal_data_serializer_test.go
@@ -373,14 +373,14 @@ func genFeeDelegatedSmartContractDeployWithRatioTransaction() TxInternalData {
 }
 
 func genChainDataTransaction() TxInternalData {
-	data := &ChainHashesInternalType0{common.HexToHash("0"), common.HexToHash("1"),
+	data := &AnchoringDataInternalType0{common.HexToHash("0"), common.HexToHash("1"),
 		common.HexToHash("2"), common.HexToHash("3"),
 		common.HexToHash("4"), big.NewInt(5), big.NewInt(6), big.NewInt(7)}
 	encodedCCTxData, err := rlp.EncodeToBytes(data)
 	if err != nil {
 		panic(err)
 	}
-	blockTxData := &ChainHashes{0, encodedCCTxData}
+	blockTxData := &AnchoringData{0, encodedCCTxData}
 
 	anchoredData, err := rlp.EncodeToBytes(blockTxData)
 	if err != nil {

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1324,7 +1324,6 @@ func TestAnchoringBasic(t *testing.T) {
 	sc.handler.txCounts = startTxCounts
 	sc.handler.txCountsEnabledBlockNumber = curBlk.NumberU64()
 	sc.handler.blockAnchoringManager(curBlk)
-	assert.Equal(t, uint64(0), sc.handler.txCounts)
 	pending := sc.GetBridgeTxPool().Pending()
 	assert.Equal(t, 1, len(pending))
 	var tx *types.Transaction
@@ -1498,7 +1497,6 @@ func TestAnchoringPeriod(t *testing.T) {
 	// Generate anchoring tx again for only the curBlk.
 	curBlk = types.NewBlock(&types.Header{Number: big.NewInt(startBlkNum + 1)}, body.Transactions, nil)
 	sc.handler.blockAnchoringManager(curBlk)
-	assert.Equal(t, uint64(0), sc.handler.txCounts)
 	pending = sc.GetBridgeTxPool().Pending()
 	assert.Equal(t, 1, len(pending))
 

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1335,14 +1335,14 @@ func TestAnchoringBasic(t *testing.T) {
 
 	// Decoding the anchoring tx.
 	assert.Equal(t, types.TxTypeChainDataAnchoring, tx.Type())
-	chainHashes := new(types.ChainHashes)
+	chainHashes := new(types.AnchoringData)
 	data, err := tx.AnchoredData()
 	assert.NoError(t, err)
 
 	err = rlp.DecodeBytes(data, chainHashes)
 	assert.NoError(t, err)
 	assert.Equal(t, uint8(0), chainHashes.Type)
-	chainHashesInternal := new(types.ChainHashesInternalType0)
+	chainHashesInternal := new(types.AnchoringDataInternalType0)
 	if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
 		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
 	}
@@ -1510,14 +1510,14 @@ func TestAnchoringPeriod(t *testing.T) {
 
 	// Decoding the anchoring tx.
 	assert.Equal(t, types.TxTypeChainDataAnchoring, tx.Type())
-	chainHashes := new(types.ChainHashes)
+	chainHashes := new(types.AnchoringData)
 	data, err := tx.AnchoredData()
 	assert.NoError(t, err)
 
 	err = rlp.DecodeBytes(data, chainHashes)
 	assert.NoError(t, err)
 	assert.Equal(t, uint8(0), chainHashes.Type)
-	chainHashesInternal := new(types.ChainHashesInternalType0)
+	chainHashesInternal := new(types.AnchoringDataInternalType0)
 	if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
 		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
 	}

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1280,9 +1280,6 @@ func TestAnchoringBasic(t *testing.T) {
 		}
 	}()
 
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-
 	config := &SCConfig{AnchoringPeriod: 1}
 	config.DataDir = tempDir
 	config.VTRecovery = true
@@ -1370,9 +1367,6 @@ func TestAnchoringUpdateTxCount(t *testing.T) {
 		}
 	}()
 
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-
 	config := &SCConfig{AnchoringPeriod: 3}
 	config.DataDir = tempDir
 	config.VTRecovery = true
@@ -1448,9 +1442,6 @@ func TestAnchoringPeriod(t *testing.T) {
 			t.Fatalf("fail to delete file %v", err)
 		}
 	}()
-
-	wg := sync.WaitGroup{}
-	wg.Add(2)
 
 	config := &SCConfig{AnchoringPeriod: 4}
 	config.DataDir = tempDir

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1502,6 +1502,10 @@ func TestAnchoringPeriod(t *testing.T) {
 	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
 	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
 	sim.Commit()
+	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
+	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
+	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
+	sim.Commit()
 	curBlk = sim.BlockChain().CurrentBlock()
 	sc.handler.blockAnchoringManager(curBlk)
 	pending = sc.GetBridgeTxPool().Pending()
@@ -1531,7 +1535,7 @@ func TestAnchoringPeriod(t *testing.T) {
 	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), chainHashesInternal.BlockNumber.String())
 	assert.Equal(t, curBlk.Hash(), chainHashesInternal.BlockHash)
 	assert.Equal(t, big.NewInt(2).String(), chainHashesInternal.Period.String())
-	assert.Equal(t, big.NewInt(startTxCounts+4).String(), chainHashesInternal.TxCounts.String())
+	assert.Equal(t, big.NewInt(startTxCounts+7).String(), chainHashesInternal.TxCounts.String())
 }
 
 func generateBody(t *testing.T) *types.Body {

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1341,7 +1341,7 @@ func TestAnchoringBasic(t *testing.T) {
 
 	err = rlp.DecodeBytes(data, anchoringData)
 	assert.NoError(t, err)
-	assert.Equal(t, uint8(0), anchoringData.Type)
+	assert.Equal(t, types.AnchoringDataType0, anchoringData.Type)
 	anchoringDataInternal := new(types.AnchoringDataInternalType0)
 	if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
 		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
@@ -1519,7 +1519,7 @@ func TestAnchoringPeriod(t *testing.T) {
 
 	err = rlp.DecodeBytes(data, anchoringData)
 	assert.NoError(t, err)
-	assert.Equal(t, uint8(0), anchoringData.Type)
+	assert.Equal(t, types.AnchoringDataType0, anchoringData.Type)
 	anchoringDataInternal := new(types.AnchoringDataInternalType0)
 	if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
 		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1315,6 +1315,7 @@ func TestAnchoringBasic(t *testing.T) {
 	})
 
 	assert.Equal(t, uint64(0), sc.handler.txCountsEnabledBlockNumber)
+	assert.Equal(t, uint64(0), sc.handler.latestTxCountsAddedBlockNumber)
 	assert.Equal(t, uint64(1), sc.handler.chainTxPeriod)
 
 	// Encoding anchoring tx
@@ -1337,23 +1338,24 @@ func TestAnchoringBasic(t *testing.T) {
 
 	// Decoding the anchoring tx.
 	assert.Equal(t, types.TxTypeChainDataAnchoring, tx.Type())
-	chainHashes := new(types.AnchoringData)
+	anchoringData := new(types.AnchoringData)
 	data, err := tx.AnchoredData()
 	assert.NoError(t, err)
 
-	err = rlp.DecodeBytes(data, chainHashes)
+	err = rlp.DecodeBytes(data, anchoringData)
 	assert.NoError(t, err)
-	assert.Equal(t, uint8(0), chainHashes.Type)
-	chainHashesInternal := new(types.AnchoringDataInternalType0)
-	if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
+	assert.Equal(t, uint8(0), anchoringData.Type)
+	anchoringDataInternal := new(types.AnchoringDataInternalType0)
+	if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
 		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
 	}
 
 	// Check the current block is anchored.
-	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), chainHashesInternal.BlockNumber.String())
-	assert.Equal(t, curBlk.Hash(), chainHashesInternal.BlockHash)
-	assert.Equal(t, big.NewInt(1).String(), chainHashesInternal.Period.String())
-	assert.Equal(t, big.NewInt(startTxCounts+1).String(), chainHashesInternal.TxCounts.String())
+	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), anchoringDataInternal.BlockNumber.String())
+	assert.Equal(t, curBlk.NumberU64(), sc.handler.latestTxCountsAddedBlockNumber)
+	assert.Equal(t, curBlk.Hash(), anchoringDataInternal.BlockHash)
+	assert.Equal(t, big.NewInt(1).String(), anchoringDataInternal.Period.String())
+	assert.Equal(t, big.NewInt(startTxCounts+1).String(), anchoringDataInternal.TxCounts.String())
 }
 
 // TestAnchoringPeriod tests the following:
@@ -1519,23 +1521,23 @@ func TestAnchoringPeriod(t *testing.T) {
 
 	// Decoding the anchoring tx.
 	assert.Equal(t, types.TxTypeChainDataAnchoring, tx.Type())
-	chainHashes := new(types.AnchoringData)
+	anchoringData := new(types.AnchoringData)
 	data, err := tx.AnchoredData()
 	assert.NoError(t, err)
 
-	err = rlp.DecodeBytes(data, chainHashes)
+	err = rlp.DecodeBytes(data, anchoringData)
 	assert.NoError(t, err)
-	assert.Equal(t, uint8(0), chainHashes.Type)
-	chainHashesInternal := new(types.AnchoringDataInternalType0)
-	if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
+	assert.Equal(t, uint8(0), anchoringData.Type)
+	anchoringDataInternal := new(types.AnchoringDataInternalType0)
+	if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
 		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
 	}
 
 	// Check the current block is anchored.
-	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), chainHashesInternal.BlockNumber.String())
-	assert.Equal(t, curBlk.Hash(), chainHashesInternal.BlockHash)
-	assert.Equal(t, big.NewInt(4).String(), chainHashesInternal.Period.String())
-	assert.Equal(t, big.NewInt(startTxCounts+7).String(), chainHashesInternal.TxCounts.String())
+	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), anchoringDataInternal.BlockNumber.String())
+	assert.Equal(t, curBlk.Hash(), anchoringDataInternal.BlockHash)
+	assert.Equal(t, big.NewInt(4).String(), anchoringDataInternal.Period.String())
+	assert.Equal(t, big.NewInt(startTxCounts+7).String(), anchoringDataInternal.TxCounts.String())
 }
 
 func generateBody(t *testing.T) *types.Body {

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -28,12 +28,15 @@ import (
 	"github.com/klaytn/klaytn/contracts/sc_erc20"
 	"github.com/klaytn/klaytn/contracts/sc_erc721"
 	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/node/sc/bridgepool"
 	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/ser/rlp"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/stretchr/testify/assert"
 	"log"
 	"math/big"
 	"os"
+	"path"
 	"sync"
 	"testing"
 	"time"
@@ -1257,6 +1260,293 @@ func TestErrorDupSubscription(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 
 	bm.Stop()
+}
+
+// TestAnchoringBasic tests the following:
+// 1. generate anchoring tx
+// 2. decode anchoring tx
+// 3. start anchoring from the current block
+// 4. accumulated tx counts
+func TestAnchoringBasic(t *testing.T) {
+	const (
+		startBlkNum   = 10
+		startTxCounts = 100
+	)
+	tempDir := os.TempDir() + "anchoring"
+	os.MkdirAll(tempDir, os.ModePerm)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("fail to delete file %v", err)
+		}
+	}()
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	config := &SCConfig{AnchoringPeriod: 1}
+	config.DataDir = tempDir
+	config.VTRecovery = true
+
+	bAcc, _ := NewBridgeAccounts(tempDir)
+	bAcc.pAccount.chainID = big.NewInt(0)
+	bAcc.cAccount.chainID = big.NewInt(0)
+
+	alloc := blockchain.GenesisAlloc{}
+	sim := backends.NewSimulatedBackend(alloc)
+
+	sc := &SubBridge{
+		config:         config,
+		peers:          newBridgePeerSet(),
+		localBackend:   sim,
+		remoteBackend:  sim,
+		bridgeAccounts: bAcc,
+	}
+
+	var err error
+	sc.handler, err = NewSubBridgeHandler(sc.config, sc)
+	if err != nil {
+		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
+		return
+	}
+	sc.bridgeTxPool = bridgepool.NewBridgeTxPool(bridgepool.BridgeTxPoolConfig{
+		Journal:     path.Join(tempDir, "bridge_transactions.rlp"),
+		GlobalQueue: 1024,
+	})
+
+	assert.Equal(t, uint64(0), sc.handler.txCountsEnabledBlockNumber)
+	assert.Equal(t, uint64(1), sc.handler.chainTxPeriod)
+
+	// Encoding anchoring tx
+	body := generateBody(t)
+	curBlk := types.NewBlock(&types.Header{Number: big.NewInt(startBlkNum)}, body.Transactions, nil)
+
+	// Generate anchoring tx again for only the curBlk.
+	sc.handler.txCounts = startTxCounts
+	sc.handler.txCountsEnabledBlockNumber = curBlk.NumberU64()
+	sc.handler.blockAnchoringManager(curBlk)
+	assert.Equal(t, uint64(0), sc.handler.txCounts)
+	pending := sc.GetBridgeTxPool().Pending()
+	assert.Equal(t, 1, len(pending))
+	var tx *types.Transaction
+	for _, v := range pending {
+		assert.Equal(t, 1, len(v))
+		tx = v[0]
+	}
+
+	// Decoding the anchoring tx.
+	assert.Equal(t, types.TxTypeChainDataAnchoring, tx.Type())
+	chainHashes := new(types.ChainHashes)
+	data, err := tx.AnchoredData()
+	assert.NoError(t, err)
+
+	err = rlp.DecodeBytes(data, chainHashes)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(0), chainHashes.Type)
+	chainHashesInternal := new(types.ChainHashesInternalType0)
+	if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
+		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
+	}
+
+	// Check the current block is anchored.
+	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), chainHashesInternal.BlockNumber.String())
+	assert.Equal(t, curBlk.Hash(), chainHashesInternal.BlockHash)
+	assert.Equal(t, big.NewInt(startTxCounts+1), chainHashesInternal.TxCounts)
+}
+
+// TestAnchoringPeriod tests the following:
+// 1. set anchoring period to 1, 2, 3 and check txCountsEnabledBlockNumber
+func TestAnchoringUpdateTxCounts(t *testing.T) {
+	const (
+		startBlkNum   = 9
+		startTxCounts = 100
+	)
+	tempDir := os.TempDir() + "anchoring"
+	os.MkdirAll(tempDir, os.ModePerm)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("fail to delete file %v", err)
+		}
+	}()
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	config := &SCConfig{AnchoringPeriod: 3}
+	config.DataDir = tempDir
+	config.VTRecovery = true
+
+	bAcc, _ := NewBridgeAccounts(tempDir)
+	bAcc.pAccount.chainID = big.NewInt(0)
+	bAcc.cAccount.chainID = big.NewInt(0)
+
+	alloc := blockchain.GenesisAlloc{}
+	sim := backends.NewSimulatedBackend(alloc)
+
+	sc := &SubBridge{
+		config:         config,
+		peers:          newBridgePeerSet(),
+		localBackend:   sim,
+		remoteBackend:  sim,
+		bridgeAccounts: bAcc,
+	}
+
+	var err error
+	sc.handler, err = NewSubBridgeHandler(sc.config, sc)
+	if err != nil {
+		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
+		return
+	}
+
+	assert.Equal(t, uint64(0), sc.handler.txCountsEnabledBlockNumber)
+
+	// Check tx counting is started as expected.
+	type testParams struct {
+		period   uint64 // chainTxPeriod
+		enabled  int64  // block number where anchoring is enabled
+		expected uint64 // txCountsEnabledBlockNumber
+	}
+
+	testCases := []testParams{
+		{1, 1, 1},
+		{1, 2, 2},
+		{2, 1, 1},
+		{2, 2, 3},
+		{2, 3, 3},
+		{2, 4, 5},
+		{3, 6, 7},
+		{3, 7, 7},
+		{3, 8, 10},
+		{3, 9, 10},
+		{3, 10, 10},
+	}
+
+	body := generateBody(t)
+
+	for i := 0; i < len(testCases); i++ {
+		curBlk := types.NewBlock(&types.Header{Number: big.NewInt(testCases[i].enabled)}, body.Transactions, nil)
+		sc.handler.txCountsEnabledBlockNumber = 0
+		sc.handler.chainTxPeriod = testCases[i].period
+		sc.handler.updateTxCounts(curBlk)
+		assert.Equal(t, testCases[i].expected, sc.handler.txCountsEnabledBlockNumber)
+	}
+}
+
+// TestAnchoringPeriod tests the following:
+// 1. set anchoring period 2
+// 2. accumulate tx counts
+func TestAnchoringPeriod(t *testing.T) {
+	const (
+		startBlkNum   = 9
+		startTxCounts = 100
+	)
+	tempDir := os.TempDir() + "anchoringPeriod"
+	os.MkdirAll(tempDir, os.ModePerm)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("fail to delete file %v", err)
+		}
+	}()
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	config := &SCConfig{AnchoringPeriod: 2}
+	config.DataDir = tempDir
+	config.VTRecovery = true
+
+	bAcc, _ := NewBridgeAccounts(tempDir)
+	bAcc.pAccount.chainID = big.NewInt(0)
+	bAcc.cAccount.chainID = big.NewInt(0)
+
+	alloc := blockchain.GenesisAlloc{}
+	sim := backends.NewSimulatedBackend(alloc)
+
+	sc := &SubBridge{
+		config:         config,
+		peers:          newBridgePeerSet(),
+		localBackend:   sim,
+		remoteBackend:  sim,
+		bridgeAccounts: bAcc,
+	}
+
+	var err error
+	sc.handler, err = NewSubBridgeHandler(sc.config, sc)
+	if err != nil {
+		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
+		return
+	}
+	sc.bridgeTxPool = bridgepool.NewBridgeTxPool(bridgepool.BridgeTxPoolConfig{
+		Journal:     path.Join(tempDir, "bridge_transactions.rlp"),
+		GlobalQueue: 1024,
+	})
+
+	assert.Equal(t, uint64(0), sc.handler.txCountsEnabledBlockNumber)
+	assert.Equal(t, uint64(2), sc.handler.chainTxPeriod)
+
+	body := generateBody(t)
+
+	// Try to generate anchoring tx again for only the curBlk (but failed)
+	curBlk := types.NewBlock(&types.Header{Number: big.NewInt(startBlkNum)}, body.Transactions, nil)
+	sc.handler.txCounts = startTxCounts
+	sc.handler.txCountsEnabledBlockNumber = curBlk.NumberU64()
+	sc.handler.blockAnchoringManager(curBlk)
+	assert.Equal(t, uint64(startTxCounts+1), sc.handler.txCounts)
+	pending := sc.GetBridgeTxPool().Pending()
+	assert.Equal(t, 0, len(pending))
+
+	// Generate anchoring tx again for only the curBlk.
+	curBlk = types.NewBlock(&types.Header{Number: big.NewInt(startBlkNum + 1)}, body.Transactions, nil)
+	sc.handler.blockAnchoringManager(curBlk)
+	assert.Equal(t, uint64(0), sc.handler.txCounts)
+	pending = sc.GetBridgeTxPool().Pending()
+	assert.Equal(t, 1, len(pending))
+
+	var tx *types.Transaction
+	for _, v := range pending {
+		assert.Equal(t, 1, len(v))
+		tx = v[0]
+	}
+
+	// Decoding the anchoring tx.
+	assert.Equal(t, types.TxTypeChainDataAnchoring, tx.Type())
+	chainHashes := new(types.ChainHashes)
+	data, err := tx.AnchoredData()
+	assert.NoError(t, err)
+
+	err = rlp.DecodeBytes(data, chainHashes)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(0), chainHashes.Type)
+	chainHashesInternal := new(types.ChainHashesInternalType0)
+	if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
+		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
+	}
+
+	// Check the current block is anchored.
+	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), chainHashesInternal.BlockNumber.String())
+	assert.Equal(t, curBlk.Hash(), chainHashesInternal.BlockHash)
+	assert.Equal(t, big.NewInt(startTxCounts+2), chainHashesInternal.TxCounts)
+}
+
+func generateBody(t *testing.T) *types.Body {
+	body := &types.Body{}
+
+	tx := generateTx(t)
+	txs := types.Transactions{tx}
+	body.Transactions = txs
+
+	return body
+}
+
+func generateTx(t *testing.T) *types.Transaction {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	signer := types.NewEIP155Signer(big.NewInt(18))
+	tx1, err := types.SignTx(types.NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil), signer, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tx1
 }
 
 // for TestMethod

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1432,7 +1432,7 @@ func TestAnchoringUpdateTxCounts(t *testing.T) {
 }
 
 // TestAnchoringPeriod tests the following:
-// 1. set anchoring period 2
+// 1. set anchoring period 4
 // 2. accumulate tx counts
 func TestAnchoringPeriod(t *testing.T) {
 	const (
@@ -1449,7 +1449,7 @@ func TestAnchoringPeriod(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	config := &SCConfig{AnchoringPeriod: 2}
+	config := &SCConfig{AnchoringPeriod: 4}
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
@@ -1481,7 +1481,7 @@ func TestAnchoringPeriod(t *testing.T) {
 	})
 
 	assert.Equal(t, uint64(0), sc.handler.txCountsEnabledBlockNumber)
-	assert.Equal(t, uint64(2), sc.handler.chainTxPeriod)
+	assert.Equal(t, uint64(4), sc.handler.chainTxPeriod)
 
 	// Try to generate anchoring tx again for only the curBlk (but failed)
 	auth := bAcc.pAccount.GetTransactOpts()
@@ -1534,7 +1534,7 @@ func TestAnchoringPeriod(t *testing.T) {
 	// Check the current block is anchored.
 	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), chainHashesInternal.BlockNumber.String())
 	assert.Equal(t, curBlk.Hash(), chainHashesInternal.BlockHash)
-	assert.Equal(t, big.NewInt(2).String(), chainHashesInternal.Period.String())
+	assert.Equal(t, big.NewInt(4).String(), chainHashesInternal.Period.String())
 	assert.Equal(t, big.NewInt(startTxCounts+7).String(), chainHashesInternal.TxCounts.String())
 }
 

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1350,7 +1350,8 @@ func TestAnchoringBasic(t *testing.T) {
 	// Check the current block is anchored.
 	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), chainHashesInternal.BlockNumber.String())
 	assert.Equal(t, curBlk.Hash(), chainHashesInternal.BlockHash)
-	assert.Equal(t, big.NewInt(startTxCounts+1), chainHashesInternal.TxCounts)
+	assert.Equal(t, big.NewInt(1).String(), chainHashesInternal.Period.String())
+	assert.Equal(t, big.NewInt(startTxCounts+1).String(), chainHashesInternal.TxCounts.String())
 }
 
 // TestAnchoringPeriod tests the following:
@@ -1524,7 +1525,8 @@ func TestAnchoringPeriod(t *testing.T) {
 	// Check the current block is anchored.
 	assert.Equal(t, new(big.Int).SetUint64(curBlk.NumberU64()).String(), chainHashesInternal.BlockNumber.String())
 	assert.Equal(t, curBlk.Hash(), chainHashesInternal.BlockHash)
-	assert.Equal(t, big.NewInt(startTxCounts+2), chainHashesInternal.TxCounts)
+	assert.Equal(t, big.NewInt(2).String(), chainHashesInternal.Period.String())
+	assert.Equal(t, big.NewInt(startTxCounts+2).String(), chainHashesInternal.TxCounts.String())
 }
 
 func generateBody(t *testing.T) *types.Body {

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -114,19 +114,19 @@ func (mce *MainChainEventHandler) writeChildChainTxHashFromBlock(block *types.Bl
 				continue
 			}
 			if err := rlp.DecodeBytes(data, chainHashes); err != nil {
-				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
+				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
 				continue
 			}
 			if chainHashes.Type == 0 {
 				chainHashesInternal := new(types.AnchoringDataInternalType0)
 				if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
-					logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
+					logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
 					continue
 				}
 				mce.mainbridge.chainDB.WriteChildChainTxHash(chainHashesInternal.BlockHash, tx.Hash())
 				logger.Trace("Write anchoring data on chainDB", "blockHash", chainHashesInternal.BlockHash.String(), "txHash", tx.Hash().String())
 			} else {
-				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data. unknown type", "type", chainHashes.Type)
+				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data. unknown type", "type", chainHashes.Type, "txHash", tx.Hash().String())
 				return
 			}
 		}

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -117,7 +117,7 @@ func (mce *MainChainEventHandler) writeChildChainTxHashFromBlock(block *types.Bl
 				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
 				continue
 			}
-			if anchoringData.Type == 0 {
+			if anchoringData.Type == types.AnchoringDataType0 {
 				anchoringDataInternal := new(types.AnchoringDataInternalType0)
 				if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
 					logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -74,21 +74,21 @@ func (mce *MainChainEventHandler) WriteLastIndexedBlockNumber(blockNum uint64) {
 }
 
 // ConvertChildChainBlockHashToParentChainTxHash returns a transaction hash of a transaction which contains
-// ChainHashes, with the key made with given child chain block hash.
+// AnchoringData, with the key made with given child chain block hash.
 // Index is built when service chain indexing is enabled.
 func (mce *MainChainEventHandler) ConvertChildChainBlockHashToParentChainTxHash(scBlockHash common.Hash) common.Hash {
 	return mce.mainbridge.chainDB.ConvertChildChainBlockHashToParentChainTxHash(scBlockHash)
 }
 
 // WriteChildChainTxHash stores a transaction hash of a transaction which contains
-// ChainHashes, with the key made with given child chain block hash.
+// AnchoringData, with the key made with given child chain block hash.
 // Index is built when child chain indexing is enabled.
 func (mce *MainChainEventHandler) WriteChildChainTxHash(ccBlockHash common.Hash, ccTxHash common.Hash) {
 	mce.mainbridge.chainDB.WriteChildChainTxHash(ccBlockHash, ccTxHash)
 }
 
 // writeChildChainTxHashFromBlock writes transaction hashes of transactions which contain
-// ChainHashes.
+// AnchoringData.
 func (mce *MainChainEventHandler) writeChildChainTxHashFromBlock(block *types.Block) {
 	if !mce.GetChildChainIndexingEnabled() {
 		logger.Trace("ChildChainIndexing is disabled. Skipped to write anchoring data on chainDB", "Head block", block.NumberU64())
@@ -107,7 +107,7 @@ func (mce *MainChainEventHandler) writeChildChainTxHashFromBlock(block *types.Bl
 				continue
 			}
 
-			chainHashes := new(types.ChainHashes)
+			chainHashes := new(types.AnchoringData)
 			data, err := tx.AnchoredData()
 			if err != nil {
 				logger.Error("writeChildChainTxHashFromBlock : failed to get anchoring data from the tx", "txHash", tx.Hash().String())
@@ -118,7 +118,7 @@ func (mce *MainChainEventHandler) writeChildChainTxHashFromBlock(block *types.Bl
 				continue
 			}
 			if chainHashes.Type == 0 {
-				chainHashesInternal := new(types.ChainHashesInternalType0)
+				chainHashesInternal := new(types.AnchoringDataInternalType0)
 				if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
 					logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
 					continue

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -107,26 +107,26 @@ func (mce *MainChainEventHandler) writeChildChainTxHashFromBlock(block *types.Bl
 				continue
 			}
 
-			chainHashes := new(types.AnchoringData)
+			anchoringData := new(types.AnchoringData)
 			data, err := tx.AnchoredData()
 			if err != nil {
 				logger.Error("writeChildChainTxHashFromBlock : failed to get anchoring data from the tx", "txHash", tx.Hash().String())
 				continue
 			}
-			if err := rlp.DecodeBytes(data, chainHashes); err != nil {
+			if err := rlp.DecodeBytes(data, anchoringData); err != nil {
 				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
 				continue
 			}
-			if chainHashes.Type == 0 {
-				chainHashesInternal := new(types.AnchoringDataInternalType0)
-				if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
+			if anchoringData.Type == 0 {
+				anchoringDataInternal := new(types.AnchoringDataInternalType0)
+				if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
 					logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
 					continue
 				}
-				mce.mainbridge.chainDB.WriteChildChainTxHash(chainHashesInternal.BlockHash, tx.Hash())
-				logger.Trace("Write anchoring data on chainDB", "blockHash", chainHashesInternal.BlockHash.String(), "txHash", tx.Hash().String())
+				mce.mainbridge.chainDB.WriteChildChainTxHash(anchoringDataInternal.BlockHash, tx.Hash())
+				logger.Trace("Write anchoring data on chainDB", "blockHash", anchoringDataInternal.BlockHash.String(), "txHash", tx.Hash().String())
 			} else {
-				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data. unknown type", "type", chainHashes.Type, "txHash", tx.Hash().String())
+				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data. unknown type", "type", anchoringData.Type, "txHash", tx.Hash().String())
 				return
 			}
 		}

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -318,18 +318,18 @@ func (sbh *SubBridgeHandler) writeChildChainTxReceipts(bc *blockchain.BlockChain
 		txHash := receipt.TxHash
 		if tx := sbh.subbridge.GetBridgeTxPool().Get(txHash); tx != nil {
 			if tx.Type() == types.TxTypeChainDataAnchoring {
-				chainHashes := new(types.ChainHashes)
+				chainHashes := new(types.AnchoringData)
 				data, err := tx.AnchoredData()
 				if err != nil {
 					logger.Error("failed to get anchoring tx type from the tx", "txHash", txHash.String())
 					return
 				}
 				if err := rlp.DecodeBytes(data, chainHashes); err != nil {
-					logger.Error("failed to RLP decode ChainHashes", "txHash", txHash.String())
+					logger.Error("failed to RLP decode AnchoringData", "txHash", txHash.String())
 					return
 				}
 				if chainHashes.Type == 0 {
-					chainHashesInternal := new(types.ChainHashesInternalType0)
+					chainHashesInternal := new(types.AnchoringDataInternalType0)
 					if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
 						logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
 						continue

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -407,6 +407,7 @@ func (sbh *SubBridgeHandler) updateTxCount(block *types.Block) {
 	}
 }
 
+// blockAnchoringManager generates anchoring transactions and updates transaction count.
 func (sbh *SubBridgeHandler) blockAnchoringManager(block *types.Block) {
 	sbh.updateTxCount(block)
 	if err := sbh.generateAndAddAnchoringTxIntoTxPool(block); err == nil {

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -243,7 +243,7 @@ func (sbh *SubBridgeHandler) handleParentChainReceiptResponseMsg(p BridgePeer, m
 // genUnsignedChainDataAnchoringTx generates an unsigned transaction, which type is TxTypeChainDataAnchoring.
 // Nonce of account used for service chain transaction will be increased after the signing.
 func (sbh *SubBridgeHandler) genUnsignedChainDataAnchoringTx(block *types.Block) (*types.Transaction, error) {
-	chainHashes, err := types.NewChainHashesType0(block, new(big.Int).SetUint64(sbh.txCounts))
+	chainHashes, err := types.NewChainHashesType0(block, new(big.Int).SetUint64(sbh.chainTxPeriod), new(big.Int).SetUint64(sbh.txCounts))
 	if err != nil {
 		return nil, err
 	}

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -459,7 +459,7 @@ func (sbh *SubBridgeHandler) GetLatestAnchoredBlockNumber() uint64 {
 	return sbh.subbridge.ChainDB().ReadAnchoredBlockNumber()
 }
 
-// UpdateLatestTxCountAddedBlockNumber set the latestTxCountAddedBlockNumber to the block number of the last anchoring tx which was added into bridge txPool.
+// UpdateLatestTxCountAddedBlockNumber sets the latestTxCountAddedBlockNumber to the block number of the last anchoring tx which was added into bridge txPool.
 func (sbh *SubBridgeHandler) UpdateLatestTxCountAddedBlockNumber(newLatestAnchoredBN uint64) {
 	if sbh.latestTxCountAddedBlockNumber < newLatestAnchoredBN {
 		sbh.latestTxCountAddedBlockNumber = newLatestAnchoredBN

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -402,9 +402,9 @@ func (sbh *SubBridgeHandler) updateTxCount(block *types.Block) {
 				break
 			}
 			sbh.txCount += uint64(b.Transactions().Len())
+			sbh.UpdateLatestTxCountAddedBlockNumber(i)
 		}
 	}
-	sbh.UpdateLatestTxCountAddedBlockNumber(block.NumberU64())
 }
 
 func (sbh *SubBridgeHandler) blockAnchoringManager(block *types.Block) {

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -247,7 +247,6 @@ func (sbh *SubBridgeHandler) genUnsignedChainDataAnchoringTx(block *types.Block)
 	if err != nil {
 		return nil, err
 	}
-	sbh.txCounts = 0 // reset for the next anchoring period
 	encodedCCTxData, err := rlp.EncodeToBytes(chainHashes)
 	if err != nil {
 		return nil, err
@@ -376,6 +375,7 @@ func (sbh *SubBridgeHandler) broadcastServiceChainReceiptRequest() {
 // updateTxCounts update txCounts to insert into anchoring tx. It skips first remnant txCounts.
 func (sbh *SubBridgeHandler) updateTxCounts(block *types.Block) {
 	if sbh.txCountsEnabledBlockNumber == 0 {
+		sbh.txCounts = 0 // reset for the next anchoring period
 		sbh.txCountsEnabledBlockNumber = block.NumberU64()
 		if sbh.chainTxPeriod > 1 {
 			remnant := block.NumberU64() % sbh.chainTxPeriod

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -311,8 +311,8 @@ func (sbh *SubBridgeHandler) broadcastServiceChainTx() {
 	logger.Debug("broadcastServiceChainTx ServiceChainTxData", "len(txs)", len(txs), "len(peers)", len(peers))
 }
 
-// writeServiceChainTxReceipt writes the received receipts of service chain transactions.
-func (sbh *SubBridgeHandler) writeChildChainTxReceipts(bc *blockchain.BlockChain, receipts []*types.ReceiptForStorage) {
+// writeServiceChainTxReceipts writes the received receipts of service chain transactions.
+func (sbh *SubBridgeHandler) writeServiceChainTxReceipts(bc *blockchain.BlockChain, receipts []*types.ReceiptForStorage) {
 	for _, receipt := range receipts {
 		txHash := receipt.TxHash
 		if tx := sbh.subbridge.GetBridgeTxPool().Get(txHash); tx != nil {
@@ -342,6 +342,7 @@ func (sbh *SubBridgeHandler) writeChildChainTxReceipts(bc *blockchain.BlockChain
 				}
 			}
 
+			// TODO-Klaytn-ServiceChain: implement WriteReceiptFromParentChain if receipt is needed.
 			sbh.subbridge.GetBridgeTxPool().RemoveTx(tx)
 		} else {
 			logger.Trace("received service chain transaction receipt does not exist in sentServiceChainTxs", "txHash", txHash.String())

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -326,7 +326,7 @@ func (sbh *SubBridgeHandler) writeServiceChainTxReceipts(bc *blockchain.BlockCha
 					logger.Error("failed to RLP decode AnchoringData", "txHash", txHash.String())
 					continue
 				}
-				if anchoringData.Type == 0 {
+				if anchoringData.Type == types.AnchoringDataType0 {
 					anchoringDataInternal := new(types.AnchoringDataInternalType0)
 					if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
 						logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", txHash.String())

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -330,14 +330,14 @@ func (sbh *SubBridgeHandler) writeChildChainTxReceipts(bc *blockchain.BlockChain
 				if chainHashes.Type == 0 {
 					chainHashesInternal := new(types.AnchoringDataInternalType0)
 					if err := rlp.DecodeBytes(chainHashes.Data, chainHashesInternal); err != nil {
-						logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data")
+						logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", txHash.String())
 						continue
 					}
 					sbh.WriteReceiptFromParentChain(chainHashesInternal.BlockHash, (*types.Receipt)(receipt))
 					sbh.WriteAnchoredBlockNumber(chainHashesInternal.BlockNumber.Uint64())
 					logger.Trace("received anchoring tx receipt", "blockNum", chainHashesInternal.BlockNumber.String(), "blcokHash", chainHashesInternal.BlockHash.String(), "txHash", txHash.String(), "txCounts", chainHashesInternal.TxCounts)
 				} else {
-					logger.Error("writeChildChainTxReceipts : failed to decode anchoring data. unknown type", "type", chainHashes.Type)
+					logger.Error("writeChildChainTxReceipts : failed to decode anchoring data. unknown type", "type", chainHashes.Type, "txHash", txHash.String())
 					return
 				}
 			}

--- a/node/sc/sub_event_handler.go
+++ b/node/sc/sub_event_handler.go
@@ -102,7 +102,7 @@ func (cce *ChildChainEventHandler) ProcessHandleEvent(ev *HandleValueTransferEve
 }
 
 // ConvertChildChainBlockHashToParentChainTxHash returns a transaction hash of a transaction which contains
-// ChainHashes, with the key made with given child chain block hash.
+// AnchoringData, with the key made with given child chain block hash.
 // Index is built when child chain indexing is enabled.
 func (cce *ChildChainEventHandler) ConvertChildChainBlockHashToParentChainTxHash(scBlockHash common.Hash) common.Hash {
 	return cce.subbridge.chainDB.ConvertChildChainBlockHashToParentChainTxHash(scBlockHash)

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -271,7 +271,7 @@ func (sb *SubBridge) GetAnchoringTx() bool {
 func (sb *SubBridge) SetAnchoringTx(flag bool) bool {
 	sb.onAnchoringTx = flag
 	if !flag {
-		sb.handler.anchoringEnabledBlockNumber = 0
+		sb.handler.txCountsEnabledBlockNumber = 0
 	}
 	return sb.GetAnchoringTx()
 }

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -270,7 +270,7 @@ func (sb *SubBridge) GetAnchoringTx() bool {
 
 func (sb *SubBridge) SetAnchoringTx(flag bool) bool {
 	if sb.onAnchoringTx != flag && flag {
-		sb.handler.txCountsEnabledBlockNumber = 0
+		sb.handler.txCountEnabledBlockNumber = 0
 	}
 	sb.onAnchoringTx = flag
 	return sb.GetAnchoringTx()

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -269,10 +269,10 @@ func (sb *SubBridge) GetAnchoringTx() bool {
 }
 
 func (sb *SubBridge) SetAnchoringTx(flag bool) bool {
-	sb.onAnchoringTx = flag
-	if !flag {
+	if sb.onAnchoringTx != flag && flag {
 		sb.handler.txCountsEnabledBlockNumber = 0
 	}
+	sb.onAnchoringTx = flag
 	return sb.GetAnchoringTx()
 }
 

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -270,6 +270,9 @@ func (sb *SubBridge) GetAnchoringTx() bool {
 
 func (sb *SubBridge) SetAnchoringTx(flag bool) bool {
 	sb.onAnchoringTx = flag
+	if !flag {
+		sb.handler.anchoringEnabledBlockNumber = 0
+	}
 	return sb.GetAnchoringTx()
 }
 

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1319,7 +1319,7 @@ func (dbm *databaseManager) WritePreimages(number uint64, preimages map[common.H
 }
 
 // WriteChildChainTxHash writes stores a transaction hash of a transaction which contains
-// ChainHashes, with the key made with given child chain block hash.
+// AnchoringData, with the key made with given child chain block hash.
 func (dbm *databaseManager) WriteChildChainTxHash(ccBlockHash common.Hash, ccTxHash common.Hash) {
 	key := childChainTxHashKey(ccBlockHash)
 	db := dbm.getDatabase(bridgeServiceDB)
@@ -1329,7 +1329,7 @@ func (dbm *databaseManager) WriteChildChainTxHash(ccBlockHash common.Hash, ccTxH
 }
 
 // ConvertChildChainBlockHashToParentChainTxHash returns a transaction hash of a transaction which contains
-// ChainHashes, with the key made with given child chain block hash.
+// AnchoringData, with the key made with given child chain block hash.
 func (dbm *databaseManager) ConvertChildChainBlockHashToParentChainTxHash(scBlockHash common.Hash) common.Hash {
 	key := childChainTxHashKey(scBlockHash)
 	db := dbm.getDatabase(bridgeServiceDB)

--- a/tests/klay_scenario_test.go
+++ b/tests/klay_scenario_test.go
@@ -1875,7 +1875,7 @@ func TestValidateSender(t *testing.T) {
 	{
 		dummyBlock := types.NewBlock(&types.Header{}, nil, nil)
 
-		scData, err := types.NewChainHashesType0(dummyBlock, big.NewInt(int64(dummyBlock.Transactions().Len())))
+		scData, err := types.NewChainHashesType0(dummyBlock, big.NewInt(0), big.NewInt(int64(dummyBlock.Transactions().Len())))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tests/klay_scenario_test.go
+++ b/tests/klay_scenario_test.go
@@ -1875,7 +1875,10 @@ func TestValidateSender(t *testing.T) {
 	{
 		dummyBlock := types.NewBlock(&types.Header{}, nil, nil)
 
-		scData := types.NewChainHashes(dummyBlock)
+		scData, err := types.NewChainHashesType0(dummyBlock, big.NewInt(int64(dummyBlock.Transactions().Len())))
+		if err != nil {
+			t.Fatal(err)
+		}
 		dataAnchoredRLP, _ := rlp.EncodeToBytes(scData)
 
 		values := map[types.TxValueKeyType]interface{}{

--- a/tests/klay_scenario_test.go
+++ b/tests/klay_scenario_test.go
@@ -1875,7 +1875,7 @@ func TestValidateSender(t *testing.T) {
 	{
 		dummyBlock := types.NewBlock(&types.Header{}, nil, nil)
 
-		scData, err := types.NewChainHashesType0(dummyBlock, big.NewInt(0), big.NewInt(int64(dummyBlock.Transactions().Len())))
+		scData, err := types.NewAnchoringDataType0(dummyBlock, big.NewInt(0), big.NewInt(int64(dummyBlock.Transactions().Len())))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tests/rpc_output_test.go
+++ b/tests/rpc_output_test.go
@@ -658,7 +658,7 @@ func BenchmarkRPCOutput(t *testing.B) {
 			ReceiptHash:   common.HexToHash("3"),
 			StateRootHash: common.HexToHash("4"),
 			BlockNumber:   big.NewInt(5),
-			TxCounts:      big.NewInt(6),
+			TxCount:       big.NewInt(6),
 		}
 		encodedCCTxData, err := rlp.EncodeToBytes(data)
 		if err != nil {

--- a/tests/rpc_output_test.go
+++ b/tests/rpc_output_test.go
@@ -651,7 +651,7 @@ func BenchmarkRPCOutput(t *testing.B) {
 
 	// TxTypeChainDataAnchoring
 	{
-		data := &types.ChainHashesInternalType0{
+		data := &types.AnchoringDataInternalType0{
 			BlockHash:     common.HexToHash("0"),
 			TxHash:        common.HexToHash("1"),
 			ParentHash:    common.HexToHash("2"),
@@ -664,7 +664,7 @@ func BenchmarkRPCOutput(t *testing.B) {
 		if err != nil {
 			panic(err)
 		}
-		blockTxData := &types.ChainHashes{Type: 0, Data: encodedCCTxData}
+		blockTxData := &types.AnchoringData{Type: 0, Data: encodedCCTxData}
 
 		anchoredData, err := rlp.EncodeToBytes(blockTxData)
 		if err != nil {

--- a/tests/rpc_output_test.go
+++ b/tests/rpc_output_test.go
@@ -651,13 +651,20 @@ func BenchmarkRPCOutput(t *testing.B) {
 
 	// TxTypeChainDataAnchoring
 	{
-		blockTxData := &types.ChainHashes{
+		data := &types.ChainHashesInternalType0{
 			BlockHash:     common.HexToHash("0"),
 			TxHash:        common.HexToHash("1"),
 			ParentHash:    common.HexToHash("2"),
 			ReceiptHash:   common.HexToHash("3"),
 			StateRootHash: common.HexToHash("4"),
-			BlockNumber:   big.NewInt(5)}
+			BlockNumber:   big.NewInt(5),
+			TxCounts:      big.NewInt(6),
+		}
+		encodedCCTxData, err := rlp.EncodeToBytes(data)
+		if err != nil {
+			panic(err)
+		}
+		blockTxData := &types.ChainHashes{Type: 0, Data: encodedCCTxData}
 
 		anchoredData, err := rlp.EncodeToBytes(blockTxData)
 		if err != nil {


### PR DESCRIPTION
## Proposed changes

If this PR is merged, the transaction count generated by the service chain is included in the anchoring transaction and transferred to the main chain. It is available as an indicator of the activation of the service chain.

- Modify to include the accumulated transaction counts during anchoring period
- Modify to start anchoring from the current block
- Unit tests

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
