### PR TITLE
edit type of weight to uint64

### DIFF
--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -259,7 +259,7 @@ type snapshotJSON struct {
 	// for weighted validator
 	RewardAddrs       []common.Address `json:"rewardAddrs"`
 	VotingPowers      []uint64         `json:"votingPower"`
-	Weights           []int64          `json:"weight"`
+	Weights           []uint64         `json:"weight"`
 	Proposers         []common.Address `json:"proposers"`
 	ProposersBlockNum uint64           `json:"proposersBlockNum"`
 }
@@ -267,7 +267,7 @@ type snapshotJSON struct {
 func (s *Snapshot) toJSONStruct() *snapshotJSON {
 	var rewardAddrs []common.Address
 	var votingPowers []uint64
-	var weights []int64
+	var weights []uint64
 	var proposers []common.Address
 	var proposersBlockNum uint64
 	var validators []common.Address

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -35,7 +35,7 @@ type Validator interface {
 
 	RewardAddress() common.Address
 	VotingPower() uint64
-	Weight() int64
+	Weight() uint64
 }
 
 // ----------------------------------------------------------------------------

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -60,7 +60,7 @@ func (val *defaultValidator) Hash() int64 {
 
 func (val *defaultValidator) RewardAddress() common.Address { return common.Address{} }
 func (val *defaultValidator) VotingPower() uint64           { return 1000 }
-func (val *defaultValidator) Weight() int64                 { return 0 }
+func (val *defaultValidator) Weight() uint64                { return 0 }
 
 type defaultSet struct {
 	subSize uint64

--- a/consensus/istanbul/validator/multi_staking_test.go
+++ b/consensus/istanbul/validator/multi_staking_test.go
@@ -182,7 +182,7 @@ func TestCalcWeight(t *testing.T) {
 		weightedValidators []*weightedValidator
 		stakingAmounts     []float64
 		totalStaking       float64
-		expectedWeights    []int64
+		expectedWeights    []uint64
 	}{
 		{
 			[]*weightedValidator{
@@ -190,7 +190,7 @@ func TestCalcWeight(t *testing.T) {
 			},
 			[]float64{0, 0, 0},
 			0,
-			[]int64{0, 0, 0},
+			[]uint64{0, 0, 0},
 		},
 		{
 			[]*weightedValidator{
@@ -198,7 +198,7 @@ func TestCalcWeight(t *testing.T) {
 			},
 			[]float64{5000000, 5000000, 5000000},
 			15000000,
-			[]int64{33, 33, 33},
+			[]uint64{33, 33, 33},
 		},
 		{
 			[]*weightedValidator{
@@ -206,7 +206,7 @@ func TestCalcWeight(t *testing.T) {
 			},
 			[]float64{5000000, 10000000, 5000000, 5000000},
 			25000000,
-			[]int64{20, 40, 20, 20},
+			[]uint64{20, 40, 20, 20},
 		},
 		{
 			[]*weightedValidator{
@@ -214,7 +214,7 @@ func TestCalcWeight(t *testing.T) {
 			},
 			[]float64{324946, 560845, 771786, 967997, 1153934},
 			3779508,
-			[]int64{9, 15, 20, 26, 31},
+			[]uint64{9, 15, 20, 26, 31},
 		},
 	}
 	for _, testCase := range testCases {
@@ -231,7 +231,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 	testCases := []struct {
 		validators      []common.Address
 		stakingInfo     *reward.StakingInfo
-		expectedWeights []int64
+		expectedWeights []uint64
 	}{
 		{
 			[]common.Address{common.StringToAddress("101"), common.StringToAddress("102"), common.StringToAddress("103")},
@@ -241,7 +241,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 				UseGini:               false,
 				CouncilStakingAmounts: []uint64{0, 0, 0},
 			},
-			[]int64{0, 0, 0},
+			[]uint64{0, 0, 0},
 		},
 		{
 			[]common.Address{common.StringToAddress("101"), common.StringToAddress("102"), common.StringToAddress("103"), common.StringToAddress("104")},
@@ -251,7 +251,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 				UseGini:               true,
 				CouncilStakingAmounts: []uint64{5000000, 5000000, 5000000, 5000000},
 			},
-			[]int64{25, 25, 25, 25},
+			[]uint64{25, 25, 25, 25},
 		},
 		{
 			[]common.Address{common.StringToAddress("101"), common.StringToAddress("102"), common.StringToAddress("103"), common.StringToAddress("104"), common.StringToAddress("105")},
@@ -261,7 +261,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 				UseGini:               true,
 				CouncilStakingAmounts: []uint64{10000000, 20000000, 30000000, 40000000, 50000000},
 			},
-			[]int64{9, 15, 20, 26, 31},
+			[]uint64{9, 15, 20, 26, 31},
 		},
 		{
 			[]common.Address{common.StringToAddress("101"), common.StringToAddress("102"), common.StringToAddress("103"), common.StringToAddress("104")},
@@ -271,7 +271,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 				UseGini:               false,
 				CouncilStakingAmounts: []uint64{5000000, 5000000, 5000000, 5000000, 5000000},
 			},
-			[]int64{40, 20, 20, 20},
+			[]uint64{40, 20, 20, 20},
 		},
 		{
 			[]common.Address{common.StringToAddress("101"), common.StringToAddress("102"), common.StringToAddress("103"), common.StringToAddress("104")},
@@ -281,7 +281,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 				UseGini:               true,
 				CouncilStakingAmounts: []uint64{5000000, 5000000, 5000000, 5000000, 5000000},
 			},
-			[]int64{38, 21, 21, 21},
+			[]uint64{38, 21, 21, 21},
 		},
 		{
 			[]common.Address{common.StringToAddress("104"), common.StringToAddress("103"), common.StringToAddress("102"), common.StringToAddress("101")},
@@ -291,7 +291,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 				UseGini:               true,
 				CouncilStakingAmounts: []uint64{10000000, 5000000, 20000000, 5000000, 5000000, 5000000},
 			},
-			[]int64{29, 21, 37, 12},
+			[]uint64{29, 21, 37, 12},
 		},
 		{
 			[]common.Address{common.StringToAddress("101"), common.StringToAddress("102"), common.StringToAddress("103"), common.StringToAddress("104"), common.StringToAddress("105")},
@@ -301,7 +301,7 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 				UseGini:               true,
 				CouncilStakingAmounts: []uint64{10000000, 5000000, 20000000, 5000000, 5000000, 5000000},
 			},
-			[]int64{29, 21, 37, 12, 1},
+			[]uint64{29, 21, 37, 12, 1},
 		},
 	}
 	for _, testCase := range testCases {

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -43,7 +43,7 @@ type weightedValidator struct {
 
 	rewardAddress atomic.Value
 	votingPower   uint64 // TODO-Klaytn-Issue1336 This should be updated for governance implementation
-	weight        int64
+	weight        uint64
 }
 
 func (val *weightedValidator) Address() common.Address {
@@ -78,11 +78,11 @@ func (val *weightedValidator) VotingPower() uint64 {
 	return val.votingPower
 }
 
-func (val *weightedValidator) Weight() int64 {
-	return atomic.LoadInt64(&val.weight)
+func (val *weightedValidator) Weight() uint64 {
+	return atomic.LoadUint64(&val.weight)
 }
 
-func newWeightedValidator(addr common.Address, reward common.Address, votingpower uint64, weight int64) istanbul.Validator {
+func newWeightedValidator(addr common.Address, reward common.Address, votingpower uint64, weight uint64) istanbul.Validator {
 	weightedValidator := &weightedValidator{
 		address:     addr,
 		votingPower: votingpower,
@@ -131,7 +131,7 @@ func RecoverWeightedCouncilProposer(valSet istanbul.ValidatorSet, proposerAddrs 
 	weightedCouncil.proposers = proposers
 }
 
-func NewWeightedCouncil(addrs []common.Address, rewards []common.Address, votingPowers []uint64, weights []int64, policy istanbul.ProposerPolicy, committeeSize uint64, blockNum uint64, proposersBlockNum uint64, chain consensus.ChainReader) *weightedCouncil {
+func NewWeightedCouncil(addrs []common.Address, rewards []common.Address, votingPowers []uint64, weights []uint64, policy istanbul.ProposerPolicy, committeeSize uint64, blockNum uint64, proposersBlockNum uint64, chain consensus.ChainReader) *weightedCouncil {
 
 	if policy != istanbul.WeightedRandom {
 		logger.Error("unsupported proposer policy for weighted council", "policy", policy)
@@ -153,7 +153,7 @@ func NewWeightedCouncil(addrs []common.Address, rewards []common.Address, voting
 	// prepare weights if necessary
 	if weights == nil {
 		// initialize with 0 weight.
-		weights = make([]int64, len(addrs))
+		weights = make([]uint64, len(addrs))
 	}
 
 	// prepare votingPowers if necessary
@@ -212,7 +212,7 @@ func NewWeightedCouncil(addrs []common.Address, rewards []common.Address, voting
 	return valSet
 }
 
-func GetWeightedCouncilData(valSet istanbul.ValidatorSet) (validators []common.Address, rewardAddrs []common.Address, votingPowers []uint64, weights []int64, proposers []common.Address, proposersBlockNum uint64) {
+func GetWeightedCouncilData(valSet istanbul.ValidatorSet) (validators []common.Address, rewardAddrs []common.Address, votingPowers []uint64, weights []uint64, proposers []common.Address, proposersBlockNum uint64) {
 
 	weightedCouncil, ok := valSet.(*weightedCouncil)
 	if !ok {
@@ -225,13 +225,13 @@ func GetWeightedCouncilData(valSet istanbul.ValidatorSet) (validators []common.A
 		validators = make([]common.Address, numVals)
 		rewardAddrs = make([]common.Address, numVals)
 		votingPowers = make([]uint64, numVals)
-		weights = make([]int64, numVals)
+		weights = make([]uint64, numVals)
 		for i, val := range weightedCouncil.List() {
 			weightedVal := val.(*weightedValidator)
 			validators[i] = weightedVal.address
 			rewardAddrs[i] = weightedVal.RewardAddress()
 			votingPowers[i] = weightedVal.votingPower
-			weights[i] = atomic.LoadInt64(&weightedVal.weight)
+			weights[i] = atomic.LoadUint64(&weightedVal.weight)
 		}
 
 		proposers = make([]common.Address, len(weightedCouncil.proposers))
@@ -681,17 +681,17 @@ func calcWeight(weightedValidators []*weightedValidator, stakingAmounts []float6
 	localLogger := logger.NewWith()
 	if totalStaking > 0 {
 		for i, weightedVal := range weightedValidators {
-			weight := int64(math.Round(stakingAmounts[i] * 100 / totalStaking))
+			weight := uint64(math.Round(stakingAmounts[i] * 100 / totalStaking))
 			if weight <= 0 {
 				// A validator, who holds zero or small stake, has minimum weight, 1.
 				weight = 1
 			}
-			atomic.StoreInt64(&weightedVal.weight, weight)
+			atomic.StoreUint64(&weightedVal.weight, weight)
 			localLogger = localLogger.NewWith(weightedVal.String(), weight)
 		}
 	} else {
 		for _, weightedVal := range weightedValidators {
-			atomic.StoreInt64(&weightedVal.weight, 0)
+			atomic.StoreUint64(&weightedVal.weight, 0)
 			localLogger = localLogger.NewWith(weightedVal.String(), 0)
 		}
 	}
@@ -703,7 +703,7 @@ func (valSet *weightedCouncil) refreshProposers(seed int64, blockNum uint64) {
 
 	for index, val := range valSet.validators {
 		weight := val.Weight()
-		for i := int64(0); i < weight; i++ {
+		for i := uint64(0); i < weight; i++ {
 			candidateValsIdx = append(candidateValsIdx, index)
 		}
 	}

--- a/consensus/istanbul/validator/weighted_random_test.go
+++ b/consensus/istanbul/validator/weighted_random_test.go
@@ -82,7 +82,7 @@ var (
 		1, 1, 1, 1, 1,
 		1, 1, 1,
 	}
-	testZeroWeights = []int64{
+	testZeroWeights = []uint64{
 		0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0,
 		0, 0, 0,
@@ -105,14 +105,14 @@ var (
 		common.HexToAddress("0x9a049EefC01aAE911F2B6F19d724dF9d3ca5cAe6"),
 	}
 
-	testNonZeroWeights = []int64{
+	testNonZeroWeights = []uint64{
 		1, 1, 2, 1, 1,
 		1, 0, 3, 2, 1,
 		0, 1, 5,
 	}
 )
 
-func makeTestValidators(weights []int64) (validators istanbul.Validators) {
+func makeTestValidators(weights []uint64) (validators istanbul.Validators) {
 	validators = make([]istanbul.Validator, len(testAddrs))
 	for i := range testAddrs {
 		validators[i] = newWeightedValidator(testAddrs[i], testRewardAddrs[i], testVotingPowers[i], weights[i])
@@ -122,7 +122,7 @@ func makeTestValidators(weights []int64) (validators istanbul.Validators) {
 	return
 }
 
-func makeTestWeightedCouncil(weights []int64) (valSet *weightedCouncil) {
+func makeTestWeightedCouncil(weights []uint64) (valSet *weightedCouncil) {
 	// prepare weighted council
 	valSet = NewWeightedCouncil(testAddrs, testRewardAddrs, testVotingPowers, weights, istanbul.WeightedRandom, 21, 0, 0, nil)
 	return
@@ -321,16 +321,16 @@ func TestWeightedCouncil_RefreshWithNonZeroWeight(t *testing.T) {
 	// Run tests
 
 	// 1. number of proposers
-	totalWeights := int64(0)
+	totalWeights := uint64(0)
 	for _, v := range validators {
 		totalWeights += v.Weight()
 	}
-	assert.Equal(t, totalWeights, int64(len(valSet.proposers)))
+	assert.Equal(t, totalWeights, uint64(len(valSet.proposers)))
 
 	// 2. weight and appearance frequency
 	for _, v := range validators {
 		weight := v.Weight()
-		appearance := int64(0)
+		appearance := uint64(0)
 		for _, p := range valSet.proposers {
 			if v.Address() == p.Address() {
 				appearance++

--- a/consensus/istanbul/validator/weighted_test.go
+++ b/consensus/istanbul/validator/weighted_test.go
@@ -81,13 +81,13 @@ func TestNormalWeightedCouncil(t *testing.T) {
 	votingPower1 := uint64(1)
 	votingPower2 := uint64(2)
 
-	weight1 := int64(1)
-	weight2 := int64(2)
+	weight1 := uint64(1)
+	weight2 := uint64(2)
 
 	val1 := newWeightedValidator(addr1, rewardAddr1, votingPower1, weight1)
 	val2 := newWeightedValidator(addr2, rewardAddr2, votingPower2, weight2)
 
-	valSet := NewWeightedCouncil([]common.Address{addr1, addr2}, []common.Address{rewardAddr1, rewardAddr2}, []uint64{votingPower1, votingPower2}, []int64{weight1, weight2}, istanbul.WeightedRandom, 21, 0, 0, nil)
+	valSet := NewWeightedCouncil([]common.Address{addr1, addr2}, []common.Address{rewardAddr1, rewardAddr2}, []uint64{votingPower1, votingPower2}, []uint64{weight1, weight2}, istanbul.WeightedRandom, 21, 0, 0, nil)
 	if valSet == nil {
 		t.Errorf("the format of validator set is invalid")
 		t.FailNow()
@@ -180,7 +180,7 @@ func TestNewWeightedCouncil_IncompleteParams(t *testing.T) {
 	var validators []istanbul.Validator
 	var rewardAddrs []common.Address
 	var votingPowers []uint64
-	var weights []int64
+	var weights []uint64
 
 	// Create 3 validators with random addresses
 	b := []byte{}
@@ -196,7 +196,7 @@ func TestNewWeightedCouncil_IncompleteParams(t *testing.T) {
 		rewardAddrs = append(rewardAddrs, rewardAddr)
 
 		votingPowers = append(votingPowers, uint64(1))
-		weights = append(weights, int64(1))
+		weights = append(weights, uint64(1))
 	}
 
 	// No validator address
@@ -214,7 +214,7 @@ func TestNewWeightedCouncil_IncompleteParams(t *testing.T) {
 	assert.Equal(t, (*weightedCouncil)(nil), valSet)
 
 	// Incomplete rewardAddrs
-	incompleteWeights := make([]int64, 1)
+	incompleteWeights := make([]uint64, 1)
 	valSet = NewWeightedCouncil(ExtractValidators(b), nil, nil, incompleteWeights, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
 	assert.Equal(t, (*weightedCouncil)(nil), valSet)
 }


### PR DESCRIPTION
## Proposed changes

- change type of weight to unit64.
weight is the count how much each validator is included to proposer list.
As weight should not be less than 0, using unit64 type is safe.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
