### PR TITLE
add stakingInfo.String()

### DIFF
--- a/reward/staking_info.go
+++ b/reward/staking_info.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"math/big"
 	"sort"
+	"strings"
 )
 
 const (
@@ -132,6 +133,58 @@ func (s *StakingInfo) GetStakingAmountByNodeId(nodeAddress common.Address) (uint
 		return 0, err
 	}
 	return s.CouncilStakingAmounts[i], nil
+}
+
+func (s *StakingInfo) String() string {
+	str := make([]string, 0)
+
+	header := fmt.Sprintf("StakingInfo:{BlockNum:%v", s.BlockNum)
+	str = append(str, header)
+
+	// nodeIds
+	nodeIdsHeader := fmt.Sprintf(" CouncilNodeIds:[")
+	str = append(str, nodeIdsHeader)
+	nodeIds := make([]string, 0)
+	for _, nodeId := range s.CouncilNodeAddrs {
+		nodeIds = append(nodeIds, nodeId.String())
+	}
+	str = append(str, strings.Join(nodeIds, " "))
+	str = append(str, "]")
+
+	// stakingAddrs
+	stakingAddrsHeader := fmt.Sprintf(", CouncilStakingAddrs:[")
+	str = append(str, stakingAddrsHeader)
+	stakingAddrs := make([]string, 0)
+	for _, stakingAddr := range s.CouncilStakingAddrs {
+		stakingAddrs = append(stakingAddrs, stakingAddr.String())
+	}
+	str = append(str, strings.Join(stakingAddrs, " "))
+	str = append(str, "]")
+
+	// rewardAddrs
+	rewardAddrsHeader := fmt.Sprintf(", CouncilRewardAddrs:[")
+	str = append(str, rewardAddrsHeader)
+	rewardAddrs := make([]string, 0)
+	for _, rewardAddr := range s.CouncilRewardAddrs {
+		rewardAddrs = append(rewardAddrs, rewardAddr.String())
+	}
+	str = append(str, strings.Join(rewardAddrs, " "))
+	str = append(str, "]")
+
+	// pocAddr and kirAddr
+	pocAddr := fmt.Sprintf(", PoCAddr:%v", s.PoCAddr.String())
+	str = append(str, pocAddr)
+	kirAddr := fmt.Sprintf(", KIRAddr:%v", s.KIRAddr.String())
+	str = append(str, kirAddr)
+
+	useGini := fmt.Sprintf(", UseGini:%v ", s.UseGini)
+	str = append(str, useGini)
+
+	// stakingAmounts
+	stakingAmounts := fmt.Sprintf(", CouncilStakingAmounts:%v }", s.CouncilStakingAmounts)
+	str = append(str, stakingAmounts)
+
+	return strings.Join(str, " ")
 }
 
 type float64Slice []float64


### PR DESCRIPTION
## Proposed changes

- This pr is to change log message of stakingInfo

before
`
INFO[08/26,11:24:10 +09] [44] Add a new stakingInfo to the stakingInfoCache  stakingInfo="&{BlockNum:2160 CouncilNodeAddrs:[[38 176 59 237 109 175 199 233 24 223 2 201 46 250 65 19 55 11 49 255] [210 249 234 186 81 235 209 253 115 100 184 130 235 210 182 45 233 69 230 211] [99 88 84 20 248 181 67 169 179 1 179 221 87 216 89 29 104 62 74 249] [77 152 32 65 147 132 4 62 194 104 2 158 74 167 8 95 78 185 130 231]] CouncilStakingAddrs:[[112 224 81 196 110 167 107 154 249 151 116 7 187 50 25 35 25 144 127 158] [228 160 195 130 26 39 17 117 131 6 237 87 194 244 144 10 169 221 187 61] [243 186 58 51 179 191 124 242 8 88 144 49 91 65 204 120 135 112 254 179] [146 133 168 87 119 208 174 126 18 190 227 255 215 132 41 8 178 41 95 69]] CouncilRewardAddrs:[[187 173 90 4 27 47 53 30 63 8 164 146 31 85 24 220 117 209 37 64] [233 44 140 234 107 161 87 150 179 43 225 69 183 98 43 31 86 171 239 142] [88 41 49 179 63 71 44 153 40 214 57 53 191 65 141 253 141 142 127 25] [152 171 4 238 189 210 218 87 94 166 76 114 113 148 218 11 50 255 138 1]] KIRAddr:[103 48 3 229 249 168 82 211 220 133 184 61 22 239 98 212 84 151 251 150] PoCAddr:[87 109 192 194 175 235 22 97 218 60 245 58 96 231 109 212 227 44 122 177] UseGini:true Gini:-1 CouncilStakingAmounts:[10000000 15000000 5000000 5000000]}"
`

after
`
INFO[08/26,14:25:27 +09] [44] Add a new stakingInfo to the stakingInfoCache  stakingInfo="StakingInfo:{BlockNum:600  CouncilNodeIds:[ 0xe1f3295a957EC2d1f1e6Ca5ED46A41eF2A3Ce87A 0x164866E1a5b4F8185473934f81f0c96286f48F4E 0x024f5CBd985441690E57ED192A9C0a75e84c211E 0xE1a3829527cBEf9AA17e527CAe5C3802Ad450DA8 ] , CouncilStakingAddrs:[ 0x70e051C46eA76b9aF9977407Bb32192319907f9e 0xe4a0c3821a2711758306Ed57c2f4900AA9Ddbb3d 0xF3Ba3A33B3BF7CF2085890315b41cC788770FeB3 0x9285a85777d0Ae7e12BEE3ffd7842908b2295F45 ] , CouncilRewardAddrs:[ 0x25F23a7fFb2255EDfa4eA26D9b924438317564c7 0xd760414D490CD2ED8d999444633ADEbe7357CB77 0x65c5031EAfC46deee9B7d7a109B5B556671AD123 0x293143C498a53B7E56252ae0d79c86E38Ba3BB81 ] , PoCAddr:0x576dc0C2afEB1661da3CF53a60e76DD4E32c7Ab1 , KIRAddr:0x673003e5F9A852d3Dc85b83d16EF62D45497fB96 , UseGini:true  , CouncilStakingAmounts:[5000000 5000000 5000000 5000000] }"
`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
