### PR TITLE
Deepcopy for weightedValidator when refreshing proposer list

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -354,7 +354,6 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 		kirAddr := common.Address{}
 		lastHeader := chain.CurrentHeader()
 		valSet := sb.getValidators(lastHeader.Number.Uint64(), lastHeader.Hash())
-		proposer := valSet.GetProposer()
 
 		// Determine and update Rewardbase when mining. When mining, state root is not yet determined and will be determined at the end of this Finalize below.
 		if common.EmptyHash(header.Root) {
@@ -373,12 +372,10 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 			logger.Trace(logMsg, "header.Number", header.Number.Uint64(), "node address", sb.address, "rewardbase", header.Rewardbase)
 		}
 
-		if proposer.Weight() != 0 {
-			stakingInfo := sb.GetStakingManager().GetStakingInfo(header.Number.Uint64())
-			if stakingInfo != nil {
-				kirAddr = stakingInfo.KIRAddr
-				pocAddr = stakingInfo.PoCAddr
-			}
+		stakingInfo := sb.GetStakingManager().GetStakingInfo(header.Number.Uint64())
+		if stakingInfo != nil {
+			kirAddr = stakingInfo.KIRAddr
+			pocAddr = stakingInfo.PoCAddr
 		}
 
 		if err := sb.rewardDistributor.DistributeBlockReward(state, header, pocAddr, kirAddr); err != nil {

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -36,6 +36,7 @@ type Validator interface {
 	RewardAddress() common.Address
 	VotingPower() uint64
 	Weight() uint64
+	Copy() Validator
 }
 
 // ----------------------------------------------------------------------------

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -62,6 +62,12 @@ func (val *defaultValidator) RewardAddress() common.Address { return common.Addr
 func (val *defaultValidator) VotingPower() uint64           { return 1000 }
 func (val *defaultValidator) Weight() uint64                { return 0 }
 
+func (val *defaultValidator) Copy() istanbul.Validator {
+	return &defaultValidator{
+		address: val.address,
+	}
+}
+
 type defaultSet struct {
 	subSize uint64
 

--- a/consensus/istanbul/validator/default_test.go
+++ b/consensus/istanbul/validator/default_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/crypto"
+	"github.com/stretchr/testify/assert"
 	"math/big"
 	"reflect"
 	"strings"
@@ -38,6 +39,20 @@ var (
 	testAddress4 = "b37866a925bccd69cfa98d43b510f1d23d78a853"
 	testAddress5 = "b37866a925bccd69cfa98d43b510f1d23d78a854"
 )
+
+func TestDefaultValidator_Copy(t *testing.T) {
+	testAddresses := []common.Address{
+		common.Address{},
+		common.StringToAddress("address"),
+	}
+	for _, testAddress := range testAddresses {
+		validator := &defaultValidator{testAddress}
+		copiedValidator := validator.Copy()
+
+		assert.Equal(t, validator, copiedValidator)
+		assert.NotEqual(t, fmt.Sprintf("%p", &validator), fmt.Sprintf("%p", &copiedValidator))
+	}
+}
 
 func TestNewValidatorSet(t *testing.T) {
 	var validators []istanbul.Validator

--- a/consensus/istanbul/validator/default_test.go
+++ b/consensus/istanbul/validator/default_test.go
@@ -42,7 +42,7 @@ var (
 
 func TestDefaultValidator_Copy(t *testing.T) {
 	testAddresses := []common.Address{
-		common.Address{},
+		{},
 		common.StringToAddress("address"),
 	}
 	for _, testAddress := range testAddresses {

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -82,6 +82,16 @@ func (val *weightedValidator) Weight() uint64 {
 	return atomic.LoadUint64(&val.weight)
 }
 
+func (val *weightedValidator) Copy() istanbul.Validator {
+	weightedValidator := &weightedValidator{
+		address:     val.address,
+		votingPower: val.votingPower,
+		weight:      val.weight,
+	}
+	weightedValidator.SetRewardAddress(val.RewardAddress())
+	return weightedValidator
+}
+
 func newWeightedValidator(addr common.Address, reward common.Address, votingpower uint64, weight uint64) istanbul.Validator {
 	weightedValidator := &weightedValidator{
 		address:     addr,
@@ -529,7 +539,9 @@ func (valSet *weightedCouncil) Copy() istanbul.ValidatorSet {
 		blockNum:          valSet.blockNum,
 	}
 	newWeightedCouncil.validators = make([]istanbul.Validator, len(valSet.validators))
-	copy(newWeightedCouncil.validators, valSet.validators)
+	for i := 0; i < len(valSet.validators); i++ {
+		newWeightedCouncil.validators[i] = valSet.validators[i].Copy()
+	}
 
 	newWeightedCouncil.proposers = make([]istanbul.Validator, len(valSet.proposers))
 	copy(newWeightedCouncil.proposers, valSet.proposers)

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -539,9 +539,7 @@ func (valSet *weightedCouncil) Copy() istanbul.ValidatorSet {
 		blockNum:          valSet.blockNum,
 	}
 	newWeightedCouncil.validators = make([]istanbul.Validator, len(valSet.validators))
-	for i := 0; i < len(valSet.validators); i++ {
-		newWeightedCouncil.validators[i] = valSet.validators[i].Copy()
-	}
+	copy(newWeightedCouncil.validators, valSet.validators)
 
 	newWeightedCouncil.proposers = make([]istanbul.Validator, len(valSet.proposers))
 	copy(newWeightedCouncil.proposers, valSet.proposers)
@@ -597,6 +595,12 @@ func (valSet *weightedCouncil) Refresh(hash common.Hash, blockNum uint64, stakin
 		// Just return without updating proposer
 		return errors.New("skip refreshing proposers due to no staking info")
 	}
+
+	validators := make([]istanbul.Validator, len(valSet.validators))
+	for i := 0; i < len(valSet.validators); i++ {
+		validators[i] = valSet.validators[i].Copy()
+	}
+	valSet.validators = validators
 
 	weightedValidators, stakingAmounts, err := valSet.getStakingAmountsOfValidators(newStakingInfo)
 	if err != nil {

--- a/consensus/istanbul/validator/weighted_random_test.go
+++ b/consensus/istanbul/validator/weighted_random_test.go
@@ -17,6 +17,7 @@
 package validator
 
 import (
+	"fmt"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/crypto"
@@ -126,6 +127,35 @@ func makeTestWeightedCouncil(weights []uint64) (valSet *weightedCouncil) {
 	// prepare weighted council
 	valSet = NewWeightedCouncil(testAddrs, testRewardAddrs, testVotingPowers, weights, istanbul.WeightedRandom, 21, 0, 0, nil)
 	return
+}
+
+func TestWeightedValidator_Copy(t *testing.T) {
+	testCases := []struct {
+		addr        common.Address
+		reward      common.Address
+		votingpower uint64
+		weight      int64
+	}{
+		{
+			common.Address{},
+			common.Address{},
+			1000,
+			0,
+		},
+		{
+			common.StringToAddress("address"),
+			common.StringToAddress("reward address"),
+			1000,
+			10,
+		},
+	}
+	for _, testCase := range testCases {
+		validator := newWeightedValidator(testCase.addr, testCase.reward, testCase.votingpower, testCase.weight)
+		copiedValidator := validator.Copy()
+
+		assert.Equal(t, validator, copiedValidator)
+		assert.NotEqual(t, fmt.Sprintf("%p", &validator), fmt.Sprintf("%p", &copiedValidator))
+	}
 }
 
 func TestWeightedCouncil_List(t *testing.T) {

--- a/consensus/istanbul/validator/weighted_random_test.go
+++ b/consensus/istanbul/validator/weighted_random_test.go
@@ -134,7 +134,7 @@ func TestWeightedValidator_Copy(t *testing.T) {
 		addr        common.Address
 		reward      common.Address
 		votingpower uint64
-		weight      int64
+		weight      uint64
 	}{
 		{
 			common.Address{},


### PR DESCRIPTION
## Proposed changes

- deep copy for weightedValidator when refreshing proposer list

### Problem
calling istanbul.getSnapshot api for a past block sometimes returns validator information of current block.

### reason
A snapshot is made by copying the previous snapshot.
weightedCouncil is a structure in a snapshot.
weightedCouncil has a validator list and a proposer list. They are lists of weightedValidators.
As weightedCouncil is in a snapshot, it is also copied from the previous weightedCouncil.
but the problem is when weightedCouncil is copied, 
a validator list and a proposer list is not deep copied but shallow copied.
so validator object is just one and used for every block.
It is the reason why the snapshot of a past block has current validator information.


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments
```
func TestWeightedValidator_Copy(t *testing.T) {
	valSet := makeTestWeightedCouncil(testNonZeroWeights)
	copiedValSet := valSet.Copy().(*weightedCouncil)

	t.Logf("valSet.weight : %v copiedValSet.weight : %v",valSet.validators[0].Weight(), copiedValSet.validators[0].Weight())
	atomic.StoreInt64(&(copiedValSet.validators[0].(*weightedValidator).weight),30)
	t.Logf("valSet.weight : %v copiedValSet.weight : %v",valSet.validators[0].Weight(), copiedValSet.validators[0].Weight())
}
```
```
=== RUN   TestWeightedValidator_Copy
--- PASS: TestWeightedValidator_Copy (0.00s)
    weighted_random_test.go:501: valSet.weight : 1 copiedValSet.weight : 1
    weighted_random_test.go:503: valSet.weight : 30 copiedValSet.weight : 30
PASS
```