### PR TITLE
SC: Add an old anchoring tx handling for compatibility

### DIFF
--- a/blockchain/types/anchoring_data.go
+++ b/blockchain/types/anchoring_data.go
@@ -31,8 +31,8 @@ type AnchoringData struct {
 	Data []byte
 }
 
-// AnchoringDataInternalNoType is an old anchoring type that does not support an data type.
-type AnchoringDataInternalNoType struct {
+// AnchoringDataLegacy is an old anchoring type that does not support an data type.
+type AnchoringDataLegacy struct {
 	BlockHash     common.Hash
 	TxHash        common.Hash
 	ParentHash    common.Hash

--- a/blockchain/types/anchoring_data.go
+++ b/blockchain/types/anchoring_data.go
@@ -31,6 +31,16 @@ type AnchoringData struct {
 	Data []byte
 }
 
+// AnchoringDataInternalNoType is an old anchoring type that does not support an data type.
+type AnchoringDataInternalNoType struct {
+	BlockHash     common.Hash
+	TxHash        common.Hash
+	ParentHash    common.Hash
+	ReceiptHash   common.Hash
+	StateRootHash common.Hash
+	BlockNumber   *big.Int
+}
+
 type AnchoringDataInternalType0 struct {
 	BlockHash     common.Hash
 	TxHash        common.Hash

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1532,10 +1532,10 @@ func TestAnchoringPeriod(t *testing.T) {
 	assert.Equal(t, big.NewInt(startTxCount+7).String(), anchoringDataInternal.TxCount.String())
 }
 
-// TestDecodingAnchoringTxWithNoType tests the following:
-// 1. generate AnchoringDataInternalNoType anchoring tx
-// 2. decode AnchoringDataInternalNoType with a decoding method of a sub-bridge handler.
-func TestDecodingAnchoringTxWithNoType(t *testing.T) {
+// TestDecodingLegacyAnchoringTx tests the following:
+// 1. generate AnchoringDataLegacy anchoring tx
+// 2. decode AnchoringDataLegacy with a decoding method of a sub-bridge handler.
+func TestDecodingLegacyAnchoringTx(t *testing.T) {
 	const (
 		startBlkNum  = 10
 		startTxCount = 100
@@ -1581,7 +1581,7 @@ func TestDecodingAnchoringTxWithNoType(t *testing.T) {
 	sim.Commit()
 	curBlk := sim.BlockChain().CurrentBlock()
 
-	anchoringData := &types.AnchoringDataInternalNoType{
+	anchoringData := &types.AnchoringDataLegacy{
 		BlockHash:     curBlk.Hash(),
 		TxHash:        curBlk.Header().TxHash,
 		ParentHash:    curBlk.Header().ParentHash,

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1532,6 +1532,72 @@ func TestAnchoringPeriod(t *testing.T) {
 	assert.Equal(t, big.NewInt(startTxCount+7).String(), anchoringDataInternal.TxCount.String())
 }
 
+// TestDecodingAnchoringTxWithNoType tests the following:
+// 1. generate AnchoringDataInternalNoType anchoring tx
+// 2. decode AnchoringDataInternalNoType with a decoding method of a sub-bridge handler.
+func TestDecodingAnchoringTxWithNoType(t *testing.T) {
+	const (
+		startBlkNum  = 10
+		startTxCount = 100
+	)
+	tempDir := os.TempDir() + "anchoring"
+	os.MkdirAll(tempDir, os.ModePerm)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("fail to delete file %v", err)
+		}
+	}()
+
+	config := &SCConfig{AnchoringPeriod: 1}
+	config.DataDir = tempDir
+	config.VTRecovery = true
+
+	bAcc, _ := NewBridgeAccounts(tempDir)
+	bAcc.pAccount.chainID = big.NewInt(0)
+	bAcc.cAccount.chainID = big.NewInt(0)
+
+	alloc := blockchain.GenesisAlloc{}
+	sim := backends.NewSimulatedBackend(alloc)
+
+	sc := &SubBridge{
+		config:         config,
+		peers:          newBridgePeerSet(),
+		localBackend:   sim,
+		remoteBackend:  sim,
+		bridgeAccounts: bAcc,
+	}
+	sc.blockchain = sim.BlockChain()
+
+	var err error
+	sc.handler, err = NewSubBridgeHandler(sc.config, sc)
+	if err != nil {
+		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
+		return
+	}
+
+	// Encoding anchoring tx.
+	auth := bAcc.pAccount.GetTransactOpts()
+	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
+	sim.Commit()
+	curBlk := sim.BlockChain().CurrentBlock()
+
+	anchoringData := &types.AnchoringDataInternalNoType{
+		BlockHash:     curBlk.Hash(),
+		TxHash:        curBlk.Header().TxHash,
+		ParentHash:    curBlk.Header().ParentHash,
+		ReceiptHash:   curBlk.Header().ReceiptHash,
+		StateRootHash: curBlk.Header().Root,
+		BlockNumber:   curBlk.Header().Number,
+	}
+	data, err := rlp.EncodeToBytes(anchoringData)
+	assert.NoError(t, err)
+
+	// Decoding the anchoring tx.
+	blockHash, blockNumber, err := sc.handler.decodeAnchoringTx(data)
+	assert.Equal(t, curBlk.Hash(), blockHash)
+	assert.Equal(t, curBlk.Header().Number.String(), blockNumber.String())
+}
+
 func generateBody(t *testing.T) *types.Body {
 	body := &types.Body{}
 

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -80,13 +80,42 @@ func (mce *MainChainEventHandler) ConvertChildChainBlockHashToParentChainTxHash(
 	return mce.mainbridge.chainDB.ConvertChildChainBlockHashToParentChainTxHash(scBlockHash)
 }
 
-// WriteChildChainTxHash stores a transaction hash of a transaction which contains
+// decodeAndWriteChildChainTxHash decodes and stores a transaction hash of a transaction which contains
 // AnchoringData, with the key made with given child chain block hash.
 // Index is built when child chain indexing is enabled.
-func (mce *MainChainEventHandler) WriteChildChainTxHash(ccBlockHash common.Hash, ccTxHash common.Hash) {
-	mce.mainbridge.chainDB.WriteChildChainTxHash(ccBlockHash, ccTxHash)
+func (mce *MainChainEventHandler) decodeAndWriteChildChainTxHash(tx *types.Transaction) {
+	data, err := tx.AnchoredData()
+	if err != nil {
+		logger.Error("writeChildChainTxHashFromBlock : failed to get anchoring data from the tx", "txHash", tx.Hash().String())
+		return
+	}
+	anchoringData := new(types.AnchoringData)
+	if err := rlp.DecodeBytes(data, anchoringData); err != nil {
+		// Try to decode old type without a type support for compatibility.
+		anchoringDataNoType := new(types.AnchoringDataInternalNoType)
+		if err := rlp.DecodeBytes(data, anchoringDataNoType); err != nil {
+			logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
+			return
+		}
+		mce.mainbridge.chainDB.WriteChildChainTxHash(anchoringDataNoType.BlockHash, tx.Hash())
+		logger.Trace("Write type0 anchoring data on chainDB", "blockHash", anchoringDataNoType.BlockHash.String(), "txHash", tx.Hash().String())
+		return
+	}
+	if anchoringData.Type == types.AnchoringDataType0 {
+		anchoringDataInternal := new(types.AnchoringDataInternalType0)
+		if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
+			logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
+			return
+		}
+		mce.mainbridge.chainDB.WriteChildChainTxHash(anchoringDataInternal.BlockHash, tx.Hash())
+		logger.Trace("Write type1 anchoring data on chainDB", "blockHash", anchoringDataInternal.BlockHash.String(), "txHash", tx.Hash().String())
+	} else {
+		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data. unknown type", "type", anchoringData.Type, "txHash", tx.Hash().String())
+		return
+	}
 }
 
+// TODO-Klaytn-ServiceChain: remove this method and a related option.
 // writeChildChainTxHashFromBlock writes transaction hashes of transactions which contain
 // AnchoringData.
 func (mce *MainChainEventHandler) writeChildChainTxHashFromBlock(block *types.Block) {
@@ -106,29 +135,7 @@ func (mce *MainChainEventHandler) writeChildChainTxHashFromBlock(block *types.Bl
 			if tx.Type() != types.TxTypeChainDataAnchoring {
 				continue
 			}
-
-			anchoringData := new(types.AnchoringData)
-			data, err := tx.AnchoredData()
-			if err != nil {
-				logger.Error("writeChildChainTxHashFromBlock : failed to get anchoring data from the tx", "txHash", tx.Hash().String())
-				continue
-			}
-			if err := rlp.DecodeBytes(data, anchoringData); err != nil {
-				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
-				continue
-			}
-			if anchoringData.Type == types.AnchoringDataType0 {
-				anchoringDataInternal := new(types.AnchoringDataInternalType0)
-				if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
-					logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
-					continue
-				}
-				mce.mainbridge.chainDB.WriteChildChainTxHash(anchoringDataInternal.BlockHash, tx.Hash())
-				logger.Trace("Write anchoring data on chainDB", "blockHash", anchoringDataInternal.BlockHash.String(), "txHash", tx.Hash().String())
-			} else {
-				logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data. unknown type", "type", anchoringData.Type, "txHash", tx.Hash().String())
-				return
-			}
+			mce.decodeAndWriteChildChainTxHash(tx)
 		}
 	}
 	logger.Trace("Done indexing Blocks", "begin", lastIndexedBlkNum+1, "end", chainHeadBlkNum)

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -92,13 +92,13 @@ func (mce *MainChainEventHandler) decodeAndWriteChildChainTxHash(tx *types.Trans
 	anchoringData := new(types.AnchoringData)
 	if err := rlp.DecodeBytes(data, anchoringData); err != nil {
 		// Try to decode old type without a type support for compatibility.
-		anchoringDataNoType := new(types.AnchoringDataInternalNoType)
-		if err := rlp.DecodeBytes(data, anchoringDataNoType); err != nil {
+		anchoringDataLegacy := new(types.AnchoringDataLegacy)
+		if err := rlp.DecodeBytes(data, anchoringDataLegacy); err != nil {
 			logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", tx.Hash().String())
 			return
 		}
-		mce.mainbridge.chainDB.WriteChildChainTxHash(anchoringDataNoType.BlockHash, tx.Hash())
-		logger.Trace("Write type0 anchoring data on chainDB", "blockHash", anchoringDataNoType.BlockHash.String(), "txHash", tx.Hash().String())
+		mce.mainbridge.chainDB.WriteChildChainTxHash(anchoringDataLegacy.BlockHash, tx.Hash())
+		logger.Trace("Write type0 anchoring data on chainDB", "blockHash", anchoringDataLegacy.BlockHash.String(), "txHash", tx.Hash().String())
 		return
 	}
 	if anchoringData.Type == types.AnchoringDataType0 {

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -98,7 +98,7 @@ func (mce *MainChainEventHandler) decodeAndWriteChildChainTxHash(tx *types.Trans
 			return
 		}
 		mce.mainbridge.chainDB.WriteChildChainTxHash(anchoringDataLegacy.BlockHash, tx.Hash())
-		logger.Trace("Write type0 anchoring data on chainDB", "blockHash", anchoringDataLegacy.BlockHash.String(), "txHash", tx.Hash().String())
+		logger.Trace("Write legacy anchoring data on chainDB", "blockHash", anchoringDataLegacy.BlockHash.String(), "txHash", tx.Hash().String())
 		return
 	}
 	if anchoringData.Type == types.AnchoringDataType0 {

--- a/node/sc/main_event_handler.go
+++ b/node/sc/main_event_handler.go
@@ -108,7 +108,7 @@ func (mce *MainChainEventHandler) decodeAndWriteChildChainTxHash(tx *types.Trans
 			return
 		}
 		mce.mainbridge.chainDB.WriteChildChainTxHash(anchoringDataInternal.BlockHash, tx.Hash())
-		logger.Trace("Write type1 anchoring data on chainDB", "blockHash", anchoringDataInternal.BlockHash.String(), "txHash", tx.Hash().String())
+		logger.Trace("Write type0 anchoring data on chainDB", "blockHash", anchoringDataInternal.BlockHash.String(), "txHash", tx.Hash().String())
 	} else {
 		logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data. unknown type", "type", anchoringData.Type, "txHash", tx.Hash().String())
 		return

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -319,19 +319,19 @@ func (sbh *SubBridgeHandler) broadcastServiceChainTx() {
 func (sbh *SubBridgeHandler) decodeAnchoringTx(data []byte) (common.Hash, *big.Int, error) {
 	anchoringData := new(types.AnchoringData)
 	if err := rlp.DecodeBytes(data, anchoringData); err != nil {
-		anchoringDataNoType := new(types.AnchoringDataInternalNoType)
-		if err := rlp.DecodeBytes(data, anchoringDataNoType); err != nil {
+		anchoringDataLegacy := new(types.AnchoringDataLegacy)
+		if err := rlp.DecodeBytes(data, anchoringDataLegacy); err != nil {
 			return common.Hash{}, nil, err
 		}
-		logger.Trace("decoded type0 anchoring tx", "blockNum", anchoringDataNoType.BlockNumber.String(), "blockHash", anchoringDataNoType.BlockHash.String(), "txHash", anchoringDataNoType.TxHash.String())
-		return anchoringDataNoType.BlockHash, anchoringDataNoType.BlockNumber, nil
+		logger.Trace("decoded legacy anchoring tx", "blockNum", anchoringDataLegacy.BlockNumber.String(), "blockHash", anchoringDataLegacy.BlockHash.String(), "txHash", anchoringDataLegacy.TxHash.String())
+		return anchoringDataLegacy.BlockHash, anchoringDataLegacy.BlockNumber, nil
 	}
 	if anchoringData.Type == types.AnchoringDataType0 {
 		anchoringDataInternal := new(types.AnchoringDataInternalType0)
 		if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
 			return common.Hash{}, nil, err
 		}
-		logger.Trace("decoded type1 anchoring tx", "blockNum", anchoringDataInternal.BlockNumber.String(), "blockHash", anchoringDataInternal.BlockHash.String(), "txHash", anchoringDataInternal.TxHash.String(), "txCount", anchoringDataInternal.TxCount)
+		logger.Trace("decoded type0 anchoring tx", "blockNum", anchoringDataInternal.BlockNumber.String(), "blockHash", anchoringDataInternal.BlockHash.String(), "txHash", anchoringDataInternal.TxHash.String(), "txCount", anchoringDataInternal.TxCount)
 		return anchoringDataInternal.BlockHash, anchoringDataInternal.BlockNumber, nil
 	} else {
 		return common.Hash{}, nil, errUnknownAnchoringTxType

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -17,6 +17,7 @@
 package sc
 
 import (
+	"errors"
 	"fmt"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -28,6 +29,10 @@ import (
 
 const (
 	SyncRequestInterval = 10
+)
+
+var (
+	errUnknownAnchoringTxType = errors.New("unknown anchoring tx type")
 )
 
 // parentChainInfo handles the information of parent chain, which is needed from child chain.
@@ -310,43 +315,53 @@ func (sbh *SubBridgeHandler) broadcastServiceChainTx() {
 	logger.Debug("broadcastServiceChainTx ServiceChainTxData", "len(txs)", len(txs), "len(peers)", len(peers))
 }
 
+// decodeAnchoringTx decodes an anchoring transaction.
+func (sbh *SubBridgeHandler) decodeAnchoringTx(data []byte) (common.Hash, *big.Int, error) {
+	anchoringData := new(types.AnchoringData)
+	if err := rlp.DecodeBytes(data, anchoringData); err != nil {
+		anchoringDataNoType := new(types.AnchoringDataInternalNoType)
+		if err := rlp.DecodeBytes(data, anchoringDataNoType); err != nil {
+			return common.Hash{}, nil, err
+		}
+		logger.Trace("decoded type0 anchoring tx", "blockNum", anchoringDataNoType.BlockNumber.String(), "blockHash", anchoringDataNoType.BlockHash.String(), "txHash", anchoringDataNoType.TxHash.String())
+		return anchoringDataNoType.BlockHash, anchoringDataNoType.BlockNumber, nil
+	}
+	if anchoringData.Type == types.AnchoringDataType0 {
+		anchoringDataInternal := new(types.AnchoringDataInternalType0)
+		if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
+			return common.Hash{}, nil, err
+		}
+		logger.Trace("decoded type1 anchoring tx", "blockNum", anchoringDataInternal.BlockNumber.String(), "blockHash", anchoringDataInternal.BlockHash.String(), "txHash", anchoringDataInternal.TxHash.String(), "txCount", anchoringDataInternal.TxCount)
+		return anchoringDataInternal.BlockHash, anchoringDataInternal.BlockNumber, nil
+	} else {
+		return common.Hash{}, nil, errUnknownAnchoringTxType
+	}
+}
+
 // writeServiceChainTxReceipts writes the received receipts of service chain transactions.
 func (sbh *SubBridgeHandler) writeServiceChainTxReceipts(bc *blockchain.BlockChain, receipts []*types.ReceiptForStorage) {
 	for _, receipt := range receipts {
 		txHash := receipt.TxHash
 		if tx := sbh.subbridge.GetBridgeTxPool().Get(txHash); tx != nil {
 			if tx.Type() == types.TxTypeChainDataAnchoring {
-				anchoringData := new(types.AnchoringData)
 				data, err := tx.AnchoredData()
 				if err != nil {
-					logger.Error("failed to get anchoring tx type from the tx", "txHash", txHash.String())
+					logger.Error("failed to get anchoring data", "txHash", txHash.String(), "err", err)
 					continue
 				}
-				if err := rlp.DecodeBytes(data, anchoringData); err != nil {
-					logger.Error("failed to RLP decode AnchoringData", "txHash", txHash.String())
+				blockHash, blockNumber, err := sbh.decodeAnchoringTx(data)
+				if err != nil {
+					logger.Error("failed to decode anchoring tx", "txHash", txHash.String(), "err", err)
 					continue
 				}
-				if anchoringData.Type == types.AnchoringDataType0 {
-					anchoringDataInternal := new(types.AnchoringDataInternalType0)
-					if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
-						logger.Error("writeChildChainTxHashFromBlock : failed to decode anchoring data", "txHash", txHash.String())
-						continue
-					}
-					sbh.WriteReceiptFromParentChain(anchoringDataInternal.BlockHash, (*types.Receipt)(receipt))
-					sbh.WriteAnchoredBlockNumber(anchoringDataInternal.BlockNumber.Uint64())
-					logger.Trace("received anchoring tx receipt", "blockNum", anchoringDataInternal.BlockNumber.String(), "blcokHash", anchoringDataInternal.BlockHash.String(), "txHash", txHash.String(), "txCount", anchoringDataInternal.TxCount)
-				} else {
-					logger.Error("writeChildChainTxReceipts : failed to decode anchoring data. unknown type", "type", anchoringData.Type, "txHash", txHash.String())
-					continue
-				}
+				sbh.WriteReceiptFromParentChain(blockHash, (*types.Receipt)(receipt))
+				sbh.WriteAnchoredBlockNumber(blockNumber.Uint64())
 			}
-
-			// TODO-Klaytn-ServiceChain: implement WriteReceiptFromParentChain if receipt is needed.
+			// TODO-Klaytn-ServiceChain: support other tx types if needed.
 			sbh.subbridge.GetBridgeTxPool().RemoveTx(tx)
 		} else {
 			logger.Trace("received service chain transaction receipt does not exist in sentServiceChainTxs", "txHash", txHash.String())
 		}
-
 		logger.Trace("received service chain transaction receipt", "txHash", txHash.String())
 	}
 }


### PR DESCRIPTION
## Proposed changes

- To handle previous anchoring tx type gracefully, added an exception handling for RLP decoding failure of an anchoring data.
- If RPL decoding failed with AnchoringDataInternalType0, it try to decoding with AnchoringDataInternalNoType that is an old anchoring tx type before merging #176.
- Added a related unit test.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #176