### PR TITLE
database, blockchain, cn, sc: Read/Write DatabaseVersion

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1423,18 +1423,18 @@ func TestCheckBlockChainVersion(t *testing.T) {
 	// 1. If DatabaseVersion is not stored yet,
 	// calling CheckBlockChainVersion stores BlockChainVersion to DatabaseVersion.
 	assert.Nil(t, memDB.ReadDatabaseVersion())
-	assert.Nil(t, CheckBlockChainVersion(memDB))
+	assert.NoError(t, CheckBlockChainVersion(memDB))
 	assert.Equal(t, uint64(BlockChainVersion), *memDB.ReadDatabaseVersion())
 
 	// 2. If DatabaseVersion is stored but less than BlockChainVersion,
 	// calling CheckBlockChainVersion stores BlockChainVersion to DatabaseVersion.
 	memDB.WriteDatabaseVersion(BlockChainVersion - 1)
-	assert.Nil(t, CheckBlockChainVersion(memDB))
+	assert.NoError(t, CheckBlockChainVersion(memDB))
 	assert.Equal(t, uint64(BlockChainVersion), *memDB.ReadDatabaseVersion())
 
 	// 3. If DatabaseVersion is stored but greater than BlockChainVersion,
 	// calling CheckBlockChainVersion returns an error and does not change the value.
 	memDB.WriteDatabaseVersion(BlockChainVersion + 1)
-	assert.NoError(t, CheckBlockChainVersion(memDB))
+	assert.Error(t, CheckBlockChainVersion(memDB))
 	assert.Equal(t, uint64(BlockChainVersion+1), *memDB.ReadDatabaseVersion())
 }

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1432,9 +1432,9 @@ func TestCheckBlockChainVersion(t *testing.T) {
 	assert.Nil(t, CheckBlockChainVersion(memDB))
 	assert.Equal(t, uint64(BlockChainVersion), *memDB.ReadDatabaseVersion())
 
-	// 2. If DatabaseVersion is stored but greater than BlockChainVersion,
+	// 3. If DatabaseVersion is stored but greater than BlockChainVersion,
 	// calling CheckBlockChainVersion returns an error and does not change the value.
 	memDB.WriteDatabaseVersion(BlockChainVersion + 1)
-	assert.NotNil(t, CheckBlockChainVersion(memDB))
+	assert.NoError(t, CheckBlockChainVersion(memDB))
 	assert.Equal(t, uint64(BlockChainVersion+1), *memDB.ReadDatabaseVersion())
 }

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -205,11 +205,9 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	logger.Info("Initialising Klaytn protocol", "versions", cn.engine.Protocol().Versions, "network", config.NetworkId)
 
 	if !config.SkipBcVersionCheck {
-		bcVersion := chainDB.ReadDatabaseVersion()
-		if bcVersion != blockchain.BlockChainVersion && bcVersion != 0 {
-			return nil, fmt.Errorf("Blockchain DB version mismatch (%d / %d).\n", bcVersion, blockchain.BlockChainVersion)
+		if err := blockchain.CheckBlockChainVersion(chainDB); err != nil {
+			return nil, err
 		}
-		chainDB.WriteDatabaseVersion(blockchain.BlockChainVersion)
 	}
 	var (
 		vmConfig    = vm.Config{EnablePreimageRecording: config.EnablePreimageRecording}

--- a/node/cn/sc_backend.go
+++ b/node/cn/sc_backend.go
@@ -122,11 +122,9 @@ func NewServiceChain(ctx *node.ServiceContext, config *Config) (*ServiceChain, e
 	logger.Info("Initialising Klaytn protocol", "versions", cn.engine.Protocol().Versions, "network", config.NetworkId)
 
 	if !config.SkipBcVersionCheck {
-		bcVersion := chainDB.ReadDatabaseVersion()
-		if bcVersion != blockchain.BlockChainVersion && bcVersion != 0 {
-			return nil, fmt.Errorf("Blockchain DB version mismatch (%d / %d).\n", bcVersion, blockchain.BlockChainVersion)
+		if err := blockchain.CheckBlockChainVersion(chainDB); err != nil {
+			return nil, err
 		}
-		chainDB.WriteDatabaseVersion(blockchain.BlockChainVersion)
 	}
 	var (
 		vmConfig    = vm.Config{EnablePreimageRecording: config.EnablePreimageRecording}

--- a/node/sc/mainbridge.go
+++ b/node/sc/mainbridge.go
@@ -137,13 +137,6 @@ func NewMainBridge(ctx *node.ServiceContext, config *SCConfig) (*MainBridge, err
 	}
 
 	logger.Info("Initialising Klaytn-Bridge protocol", "network", config.NetworkId)
-
-	bcVersion := chainDB.ReadDatabaseVersion()
-	if bcVersion != blockchain.BlockChainVersion && bcVersion != 0 {
-		return nil, fmt.Errorf("Blockchain DB version mismatch (%d / %d).\n", bcVersion, blockchain.BlockChainVersion)
-	}
-	chainDB.WriteDatabaseVersion(blockchain.BlockChainVersion)
-
 	sc.APIBackend = &MainBridgeAPI{sc}
 
 	var err error

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -188,13 +188,6 @@ func NewSubBridge(ctx *node.ServiceContext, config *SCConfig) (*SubBridge, error
 	}
 
 	logger.Info("Initialising Klaytn-Bridge protocol", "network", config.NetworkId)
-
-	bcVersion := chainDB.ReadDatabaseVersion()
-	if bcVersion != blockchain.BlockChainVersion && bcVersion != 0 {
-		return nil, fmt.Errorf("Blockchain DB version mismatch (%d / %d).\n", bcVersion, blockchain.BlockChainVersion)
-	}
-	chainDB.WriteDatabaseVersion(blockchain.BlockChainVersion)
-
 	sc.APIBackend = &SubBridgeAPI{sc}
 
 	sc.bridgeTxPool = bridgepool.NewBridgeTxPool(bridgetxConfig)

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -502,18 +502,17 @@ func TestDBManager_Sections(t *testing.T) {
 
 // TestDBManager_DatabaseVersion tests read/write operations of database version.
 func TestDBManager_DatabaseVersion(t *testing.T) {
-	// TODO-Klaytn-Database DatabaseVersion should be handled carefully.
-	//for i, dbm := range dbManagers {
-	//	c := dbConfigs[i]
-	//
-	//	assert.Equal(t, uint64(0), dbm.ReadDatabaseVersion())
-	//
-	//	dbm.WriteDatabaseVersion(uint64(1))
-	//	assert.Equal(t, uint64(1), dbm.ReadDatabaseVersion())
-	//
-	//	dbm.WriteDatabaseVersion(uint64(2))
-	//	assert.Equal(t, uint64(2), dbm.ReadDatabaseVersion())
-	//}
+	for _, dbm := range dbManagers {
+		assert.Nil(t, dbm.ReadDatabaseVersion())
+
+		dbm.WriteDatabaseVersion(uint64(1))
+		assert.NotNil(t, dbm.ReadDatabaseVersion())
+		assert.Equal(t, uint64(1), *dbm.ReadDatabaseVersion())
+
+		dbm.WriteDatabaseVersion(uint64(2))
+		assert.NotNil(t, dbm.ReadDatabaseVersion())
+		assert.Equal(t, uint64(2), *dbm.ReadDatabaseVersion())
+	}
 }
 
 // TestDBManager_ChainConfig tests read/write operations of chain configuration.


### PR DESCRIPTION
## Proposed changes

- Before this change, read and write operations of DatabaseVersion is not done properly.
- This is because `int` type cannot be RLP-encoded. Hence change it to `uint64`.
- Removed DatabaseVersion handling logic from main-bridge and sub-bridge as they are additional structure, which are not essential. DatabaseVersion is handled by backend or sc_backend.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...