### PR TITLE
[SC] set last proposer to a new valset

### DIFF
--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -385,7 +385,8 @@ func (valSet *defaultSet) Copy() istanbul.ValidatorSet {
 	}
 
 	newValSet := NewSubSet(addresses, valSet.policy, valSet.subSize).(*defaultSet)
-	newValSet.proposer = valSet.proposer
+	_, proposer := newValSet.GetByAddress(valSet.proposer.Address())
+	newValSet.proposer = proposer
 	return newValSet
 }
 

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -163,7 +163,7 @@ func (valSet *defaultSet) SubList(prevHash common.Hash, view *istanbul.View) []i
 	subset := make([]istanbul.Validator, valSet.subSize)
 	subset[0] = valSet.GetProposer()
 	// next proposer
-	subset[1] = valSet.selector(valSet, subset[0].Address(), view.Round.Uint64()+1)
+	subset[1] = valSet.selector(valSet, subset[0].Address(), view.Round.Uint64())
 
 	proposerIdx, _ := valSet.GetByAddress(subset[0].Address())
 	nextproposerIdx, _ := valSet.GetByAddress(subset[1].Address())
@@ -222,7 +222,7 @@ func (valSet *defaultSet) SubListWithProposer(prevHash common.Hash, proposer com
 	subset := make([]istanbul.Validator, valSet.subSize)
 	subset[0] = New(proposer)
 	// next proposer
-	subset[1] = valSet.selector(valSet, subset[0].Address(), view.Round.Uint64()+1)
+	subset[1] = valSet.selector(valSet, subset[0].Address(), view.Round.Uint64())
 
 	proposerIdx, _ := valSet.GetByAddress(subset[0].Address())
 	nextproposerIdx, _ := valSet.GetByAddress(subset[1].Address())
@@ -383,7 +383,10 @@ func (valSet *defaultSet) Copy() istanbul.ValidatorSet {
 	for _, v := range valSet.validators {
 		addresses = append(addresses, v.Address())
 	}
-	return NewSubSet(addresses, valSet.policy, valSet.subSize)
+
+	newValSet := NewSubSet(addresses, valSet.policy, valSet.subSize).(*defaultSet)
+	newValSet.proposer = valSet.proposer
+	return newValSet
 }
 
 func (valSet *defaultSet) F() int {

--- a/consensus/istanbul/validator/default_test.go
+++ b/consensus/istanbul/validator/default_test.go
@@ -21,6 +21,7 @@
 package validator
 
 import (
+	"fmt"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/crypto"
@@ -245,4 +246,38 @@ func TestDefaultSet_SubList(t *testing.T) {
 
 		valSet.CalcProposer(currentProposer.Address(), view.Round.Uint64())
 	}
+}
+
+func TestDefaultSet_Copy(t *testing.T) {
+	b1 := common.Hex2Bytes(testAddress)
+	b2 := common.Hex2Bytes(testAddress2)
+	b3 := common.Hex2Bytes(testAddress3)
+	b4 := common.Hex2Bytes(testAddress4)
+	b5 := common.Hex2Bytes(testAddress5)
+	addr1 := common.BytesToAddress(b1)
+	addr2 := common.BytesToAddress(b2)
+	addr3 := common.BytesToAddress(b3)
+	addr4 := common.BytesToAddress(b4)
+	addr5 := common.BytesToAddress(b5)
+	testAddresses := []common.Address{addr1, addr2, addr3, addr4, addr5}
+
+	valSet := NewSet(testAddresses, istanbul.RoundRobin)
+	copiedValSet := valSet.Copy()
+
+	assert.NotEqual(t, fmt.Sprintf("%p", &valSet), fmt.Sprintf("%p", &copiedValSet))
+
+	assert.Equal(t, valSet.List(), copiedValSet.List())
+	assert.NotEqual(t, fmt.Sprintf("%p", valSet.List()), fmt.Sprintf("%p", copiedValSet.List()))
+
+	for i := uint64(0); i < valSet.Size(); i++ {
+		assert.Equal(t, valSet.List()[i], copiedValSet.List()[i])
+		assert.NotEqual(t, fmt.Sprintf("%p", valSet.List()[i]), fmt.Sprintf("%p", copiedValSet.List())[i])
+	}
+
+	assert.Equal(t, valSet.GetProposer(), copiedValSet.GetProposer())
+	assert.NotEqual(t, fmt.Sprintf("%p", valSet.GetProposer()), fmt.Sprintf("%p", copiedValSet.GetProposer()))
+
+	assert.Equal(t, valSet.Policy(), copiedValSet.Policy())
+	assert.Equal(t, valSet.SubGroupSize(), copiedValSet.SubGroupSize())
+	assert.Equal(t, valSet.TotalVotingPower(), copiedValSet.TotalVotingPower())
 }


### PR DESCRIPTION
## Proposed changes

This pr is related with round robin policy.

- set last proposer to a new validator set
- only use round to calc next proposer

default validator set for round robin has copy() function.
but in the copy function it makes a new validator set.
Therefore, the proposer of the last block is missed on a new validator set.
the change is to set the last proposer to the new validator set.

also,
To calculate the next proposer in round robin policy, only current round is required.
There is no need to add 1

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
