### PR TITLE
SC: add an anchoring option for sub-bridge

### DIFF
--- a/build/packaging/linux/bin/kscnd
+++ b/build/packaging/linux/bin/kscnd
@@ -179,6 +179,9 @@ start() {
     if [[ ! -z $SC_SUB_BRIDGE ]] && [[ $SC_SUB_BRIDGE -eq 1 ]]; then
         OPTIONS="$OPTIONS --subbridge --subbridgeport $SC_SUB_BRIDGE_PORT --chaintxperiod $SC_ANCHORING_PERIOD --chaintxlimit $SC_TX_LIMIT "
         OPTIONS="$OPTIONS --parentchainid $SC_PARENT_CHAIN_ID"
+        if [[ ! -z $SC_ANCHORING ]] && [[ $SC_ANCHORING -eq 1 ]]; then
+            OPTIONS="$OPTIONS --anchoring"
+        fi
     fi
 
     if [[ ! -z $VTRECOVERY ]] && [[ $VTRECOVERY -eq 1 ]]; then

--- a/build/packaging/linux/bin/ksend
+++ b/build/packaging/linux/bin/ksend
@@ -189,6 +189,9 @@ start() {
     if [[ ! -z $SC_SUB_BRIDGE ]] && [[ $SC_SUB_BRIDGE -eq 1 ]]; then
         OPTIONS="$OPTIONS --subbridge --subbridgeport $SC_SUB_BRIDGE_PORT --chaintxperiod $SC_ANCHORING_PERIOD --chaintxlimit $SC_TX_LIMIT "
         OPTIONS="$OPTIONS --parentchainid $SC_PARENT_CHAIN_ID"
+        if [[ ! -z $SC_ANCHORING ]] && [[ $SC_ANCHORING -eq 1 ]]; then
+            OPTIONS="$OPTIONS --anchoring"
+        fi
     fi
 
     if [[ ! -z $VTRECOVERY ]] && [[ $VTRECOVERY -eq 1 ]]; then

--- a/build/packaging/linux/bin/kspnd
+++ b/build/packaging/linux/bin/kspnd
@@ -189,6 +189,9 @@ start() {
     if [[ ! -z $SC_SUB_BRIDGE ]] && [[ $SC_SUB_BRIDGE -eq 1 ]]; then
         OPTIONS="$OPTIONS --subbridge --subbridgeport $SC_SUB_BRIDGE_PORT --chaintxperiod $SC_ANCHORING_PERIOD --chaintxlimit $SC_TX_LIMIT "
         OPTIONS="$OPTIONS --parentchainid $SC_PARENT_CHAIN_ID"
+        if [[ ! -z $SC_ANCHORING ]] && [[ $SC_ANCHORING -eq 1 ]]; then
+            OPTIONS="$OPTIONS --anchoring"
+        fi
     fi
 
     if [[ ! -z $VTRECOVERY ]] && [[ $VTRECOVERY -eq 1 ]]; then

--- a/build/packaging/linux/conf/kscnd.conf
+++ b/build/packaging/linux/conf/kscnd.conf
@@ -41,6 +41,7 @@ SC_MAIN_BRIDGE_INDEXING=0
 SC_SUB_BRIDGE=0
 SC_SUB_BRIDGE_PORT=50506  # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 50505, sub:50506)
 SC_PARENT_CHAIN_ID=8217
+SC_ANCHORING=0
 SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 

--- a/build/packaging/linux/conf/ksend.conf
+++ b/build/packaging/linux/conf/ksend.conf
@@ -40,6 +40,7 @@ SC_MAIN_BRIDGE_INDEXING=0
 SC_SUB_BRIDGE=0
 SC_SUB_BRIDGE_PORT=50506  # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 50505, sub:50506)
 SC_PARENT_CHAIN_ID=8217
+SC_ANCHORING=0
 SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 

--- a/build/packaging/linux/conf/kspnd.conf
+++ b/build/packaging/linux/conf/kspnd.conf
@@ -41,6 +41,7 @@ SC_MAIN_BRIDGE_INDEXING=0
 SC_SUB_BRIDGE=0
 SC_SUB_BRIDGE_PORT=50506  # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 50505, sub:50506)
 SC_PARENT_CHAIN_ID=8217
+SC_ANCHORING=0
 SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 

--- a/build/rpm/etc/init.d/kscnd
+++ b/build/rpm/etc/init.d/kscnd
@@ -152,6 +152,9 @@ fi
 if [[ ! -z $SC_SUB_BRIDGE ]] && [[ $SC_SUB_BRIDGE -eq 1 ]]; then
     OPTIONS="$OPTIONS --subbridge --subbridgeport $SC_SUB_BRIDGE_PORT --chaintxperiod $SC_ANCHORING_PERIOD --chaintxlimit $SC_TX_LIMIT "
     OPTIONS="$OPTIONS --parentchainid $SC_PARENT_CHAIN_ID"
+    if [[ ! -z $SC_ANCHORING ]] && [[ $SC_ANCHORING -eq 1 ]]; then
+            OPTIONS="$OPTIONS --anchoring"
+    fi
 fi
 
 if [[ ! -z $VTRECOVERY ]] && [[ $VTRECOVERY -eq 1 ]]; then

--- a/build/rpm/etc/init.d/ksend
+++ b/build/rpm/etc/init.d/ksend
@@ -162,6 +162,9 @@ fi
 if [[ ! -z $SC_SUB_BRIDGE ]] && [[ $SC_SUB_BRIDGE -eq 1 ]]; then
     OPTIONS="$OPTIONS --subbridge --subbridgeport $SC_SUB_BRIDGE_PORT --chaintxperiod $SC_ANCHORING_PERIOD --chaintxlimit $SC_TX_LIMIT "
     OPTIONS="$OPTIONS --parentchainid $SC_PARENT_CHAIN_ID"
+    if [[ ! -z $SC_ANCHORING ]] && [[ $SC_ANCHORING -eq 1 ]]; then
+            OPTIONS="$OPTIONS --anchoring"
+    fi
 fi
 
 if [[ ! -z $VTRECOVERY ]] && [[ $VTRECOVERY -eq 1 ]]; then

--- a/build/rpm/etc/init.d/kspnd
+++ b/build/rpm/etc/init.d/kspnd
@@ -162,6 +162,9 @@ fi
 if [[ ! -z $SC_SUB_BRIDGE ]] && [[ $SC_SUB_BRIDGE -eq 1 ]]; then
     OPTIONS="$OPTIONS --subbridge --subbridgeport $SC_SUB_BRIDGE_PORT --chaintxperiod $SC_ANCHORING_PERIOD --chaintxlimit $SC_TX_LIMIT "
     OPTIONS="$OPTIONS --parentchainid $SC_PARENT_CHAIN_ID"
+    if [[ ! -z $SC_ANCHORING ]] && [[ $SC_ANCHORING -eq 1 ]]; then
+            OPTIONS="$OPTIONS --anchoring"
+    fi
 fi
 
 if [[ ! -z $VTRECOVERY ]] && [[ $VTRECOVERY -eq 1 ]]; then

--- a/build/rpm/etc/kscnd/conf/kscnd.conf
+++ b/build/rpm/etc/kscnd/conf/kscnd.conf
@@ -41,6 +41,7 @@ SC_MAIN_BRIDGE_INDEXING=0
 SC_SUB_BRIDGE=0
 SC_SUB_BRIDGE_PORT=50506  # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 50505, sub:50506)
 SC_PARENT_CHAIN_ID=8217
+SC_ANCHORING=0
 SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 

--- a/build/rpm/etc/ksend/conf/ksend.conf
+++ b/build/rpm/etc/ksend/conf/ksend.conf
@@ -40,6 +40,7 @@ SC_MAIN_BRIDGE_INDEXING=0
 SC_SUB_BRIDGE=0
 SC_SUB_BRIDGE_PORT=50506  # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 50505, sub:50506)
 SC_PARENT_CHAIN_ID=8217
+SC_ANCHORING=0
 SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 

--- a/build/rpm/etc/kspnd/conf/kspnd.conf
+++ b/build/rpm/etc/kspnd/conf/kspnd.conf
@@ -41,6 +41,7 @@ SC_MAIN_BRIDGE_INDEXING=0
 SC_SUB_BRIDGE=0
 SC_SUB_BRIDGE_PORT=50506  # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 50505, sub:50506)
 SC_PARENT_CHAIN_ID=8217
+SC_ANCHORING=0
 SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 

--- a/cmd/kscn/main.go
+++ b/cmd/kscn/main.go
@@ -75,6 +75,7 @@ var scnHelpFlagGroups = []utils.FlagGroup{
 			utils.VTRecoveryFlag,
 			utils.VTRecoveryIntervalFlag,
 			utils.ServiceChainNewAccountFlag,
+			utils.ServiceChainAnchoringFlag,
 		},
 	},
 	{

--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -73,6 +73,7 @@ var senHelpFlagGroups = []utils.FlagGroup{
 			utils.ParentChainIDFlag,
 			utils.VTRecoveryFlag,
 			utils.VTRecoveryIntervalFlag,
+			utils.ServiceChainAnchoringFlag,
 		},
 	},
 	{

--- a/cmd/kspn/main.go
+++ b/cmd/kspn/main.go
@@ -81,6 +81,7 @@ var spnHelpFlagGroups = []utils.FlagGroup{
 			utils.ParentChainIDFlag,
 			utils.VTRecoveryFlag,
 			utils.VTRecoveryIntervalFlag,
+			utils.ServiceChainAnchoringFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -573,6 +573,10 @@ var (
 		Usage: "Set the service chain consensus (\"istanbul\", \"clique\")",
 		Value: "istanbul",
 	}
+	ServiceChainAnchoringFlag = cli.BoolFlag{
+		Name:  "anchoring",
+		Usage: "Enable anchoring for service chain",
+	}
 	// DBSyncer
 	EnableDBSyncerFlag = cli.BoolFlag{
 		Name:  "dbsyncer",

--- a/cmd/utils/nodecmd/dumpconfigcmd.go
+++ b/cmd/utils/nodecmd/dumpconfigcmd.go
@@ -222,6 +222,10 @@ func makeServiceChainConfig(ctx *cli.Context) (config sc.SCConfig) {
 		cfg.SubBridgePort = fmt.Sprintf(":%d", ctx.GlobalInt(utils.SubBridgeListenPortFlag.Name))
 	}
 
+	if ctx.GlobalBool(utils.ServiceChainAnchoringFlag.Name) {
+		cfg.Anchoring = true
+	}
+
 	cfg.ChildChainIndexing = ctx.GlobalIsSet(utils.ChildChainIndexingFlag.Name)
 	cfg.AnchoringPeriod = ctx.GlobalUint64(utils.AnchoringPeriodFlag.Name)
 	cfg.SentChainTxsLimit = ctx.GlobalUint64(utils.SentChainTxsLimit.Name)

--- a/cmd/utils/nodecmd/dumpconfigcmd.go
+++ b/cmd/utils/nodecmd/dumpconfigcmd.go
@@ -222,10 +222,7 @@ func makeServiceChainConfig(ctx *cli.Context) (config sc.SCConfig) {
 		cfg.SubBridgePort = fmt.Sprintf(":%d", ctx.GlobalInt(utils.SubBridgeListenPortFlag.Name))
 	}
 
-	if ctx.GlobalBool(utils.ServiceChainAnchoringFlag.Name) {
-		cfg.Anchoring = true
-	}
-
+	cfg.Anchoring = ctx.GlobalBool(utils.ServiceChainAnchoringFlag.Name)
 	cfg.ChildChainIndexing = ctx.GlobalIsSet(utils.ChildChainIndexingFlag.Name)
 	cfg.AnchoringPeriod = ctx.GlobalUint64(utils.AnchoringPeriodFlag.Name)
 	cfg.SentChainTxsLimit = ctx.GlobalUint64(utils.SentChainTxsLimit.Name)

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -165,12 +165,26 @@ var KSCNFlags = []cli.Flag{
 	utils.VTRecoveryFlag,
 	utils.VTRecoveryIntervalFlag,
 	utils.ServiceChainNewAccountFlag,
+	utils.ServiceChainAnchoringFlag,
 }
 
 var KSPNFlags = []cli.Flag{
 	utils.TxResendIntervalFlag,
 	utils.TxResendCountFlag,
 	utils.TxResendUseLegacyFlag,
+	utils.ServiceChainSignerFlag,
+	utils.AnchoringPeriodFlag,
+	utils.SentChainTxsLimit,
+	utils.MainBridgeFlag,
+	utils.MainBridgeListenPortFlag,
+	utils.ChildChainIndexingFlag,
+	utils.SubBridgeFlag,
+	utils.SubBridgeListenPortFlag,
+	utils.ParentChainIDFlag,
+	utils.VTRecoveryFlag,
+	utils.VTRecoveryIntervalFlag,
+	utils.ServiceChainNewAccountFlag,
+	utils.ServiceChainAnchoringFlag,
 }
 
 var KSENFlags = []cli.Flag{
@@ -185,6 +199,7 @@ var KSENFlags = []cli.Flag{
 	utils.ParentChainIDFlag,
 	utils.VTRecoveryFlag,
 	utils.VTRecoveryIntervalFlag,
+	utils.ServiceChainAnchoringFlag,
 	// DBSyncer
 	utils.EnableDBSyncerFlag,
 	utils.DBHostFlag,

--- a/node/sc/config.go
+++ b/node/sc/config.go
@@ -93,6 +93,7 @@ type SCConfig struct {
 	ParentChainID      uint64
 	VTRecovery         bool
 	VTRecoveryInterval uint64
+	Anchoring          bool
 }
 
 // NodeName returns the devp2p node identifier.

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -428,9 +428,7 @@ func (sbh *SubBridgeHandler) updateTxCount(block *types.Block) {
 // blockAnchoringManager generates anchoring transactions and updates transaction count.
 func (sbh *SubBridgeHandler) blockAnchoringManager(block *types.Block) {
 	sbh.updateTxCount(block)
-	if err := sbh.generateAndAddAnchoringTxIntoTxPool(block); err == nil {
-		logger.Info("Generate anchoring txs", "blockNumber", block.NumberU64())
-	}
+	sbh.generateAndAddAnchoringTxIntoTxPool(block)
 }
 
 func (sbh *SubBridgeHandler) generateAndAddAnchoringTxIntoTxPool(block *types.Block) error {
@@ -446,6 +444,7 @@ func (sbh *SubBridgeHandler) generateAndAddAnchoringTxIntoTxPool(block *types.Bl
 		logger.Error("Failed to generate service chain transaction", "blockNum", block.NumberU64(), "err", err)
 		return err
 	}
+	txCount := sbh.txCount
 	sbh.txCount = 0 // reset for the next anchoring period
 
 	signedTx, err := sbh.subbridge.bridgeAccounts.pAccount.SignTx(unsignedTx)
@@ -460,7 +459,7 @@ func (sbh *SubBridgeHandler) generateAndAddAnchoringTxIntoTxPool(block *types.Bl
 		return err
 	}
 
-	logger.Trace("blockAnchoringManager: Success to generate anchoring tx", "blockNum", block.NumberU64(), "blockhash", block.Hash().String(), "txHash", signedTx.Hash().String())
+	logger.Info("generate an anchoring tx", "blockNum", block.NumberU64(), "blockhash", block.Hash().String(), "txCount", txCount, "txHash", signedTx.Hash().String())
 
 	return nil
 }

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -175,7 +175,7 @@ func NewSubBridge(ctx *node.ServiceContext, config *SCConfig) (*SubBridge, error
 		handleEventCh:  make(chan *HandleValueTransferEvent, handleEventChanSize),
 		quitSync:       make(chan struct{}),
 		maxPeers:       config.MaxPeer,
-		onAnchoringTx:  false,
+		onAnchoringTx:  config.Anchoring,
 		bootFail:       false,
 		rpcSendCh:      make(chan []byte),
 	}


### PR DESCRIPTION
## Proposed changes

- Add an `--anchoring` option for sub-bridge that is enabled by `subbridge.anchoring()` API previously.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- n/a

## Further comments

- Package changes are tested by homi & docker-compose with modification of `ksend.conf`.
    - homi setup docker --cn-num 2 --en-num 2 --scn-num 2 --sen-num 2 --spn-num 2 --no-grafana
    - Edit docker-compose.yml of SEN-0 (`SC_ANCHORING=1`)
    - docker-compose up
    - `INFO[09/16,06:40:54 Z] [45|node/sc/sub_bridge_handler.go:462]            generate an anchoring tx                  blockNum=42 blockhash=0xa0ba0730f2a381b165a77edea8f6002d84b06068a10de28415ba6ef34834ad7b txCount=0 txHash=0xf6c7b88a162f6fa50841c07abe608b5639568f9b612fda694ffe20d388d642e8`