### PR TITLE
SC: fix temp dir creation with a random suffix

### DIFF
--- a/node/sc/bridge_account_test.go
+++ b/node/sc/bridge_account_test.go
@@ -30,8 +30,8 @@ import (
 
 // TestBridgeAccountLockUnlock checks the lock/unlock functionality.
 func TestBridgeAccountLockUnlock(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -151,8 +151,8 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 
 // TestBridgeAccountInformation checks if the information result is right or not.
 func TestBridgeAccountInformation(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/klaytn/klaytn/ser/rlp"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"log"
 	"math/big"
 	"os"
@@ -73,8 +74,8 @@ func CheckReceipt(b bind.DeployBackend, tx *types.Transaction, duration time.Dur
 // - consider parent/child chain simulated backend.
 // - separate each test
 func TestBridgeManager(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -115,7 +116,6 @@ func TestBridgeManager(t *testing.T) {
 		peers:          newBridgePeerSet(),
 		bridgeAccounts: bacc,
 	}
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -312,8 +312,8 @@ func TestBridgeManager(t *testing.T) {
 
 // TestBridgeManagerWithFee tests the KLAY/ERC20 transfer with fee.
 func TestBridgeManagerWithFee(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -358,7 +358,6 @@ func TestBridgeManagerWithFee(t *testing.T) {
 		peers:          newBridgePeerSet(),
 		bridgeAccounts: bacc,
 	}
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -715,8 +714,8 @@ func TestBridgeManagerWithFee(t *testing.T) {
 
 // TestBasicJournal tests basic journal functionality.
 func TestBasicJournal(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -760,7 +759,6 @@ func TestBasicJournal(t *testing.T) {
 		remoteBackend:  sim,
 		bridgeAccounts: bacc,
 	}
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -795,8 +793,8 @@ func TestBasicJournal(t *testing.T) {
 
 // TestMethodRestoreBridges tests restoring bridges from the journal.
 func TestMethodRestoreBridges(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -841,7 +839,6 @@ func TestMethodRestoreBridges(t *testing.T) {
 		bridgeAccounts: bacc,
 	}
 
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -912,8 +909,8 @@ func TestMethodRestoreBridges(t *testing.T) {
 
 // TestMethodGetAllBridge tests a method GetAllBridge.
 func TestMethodGetAllBridge(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -943,8 +940,8 @@ func TestMethodGetAllBridge(t *testing.T) {
 
 // TestErrorDuplication tests if duplication of journal insertion is ignored or not.
 func TestErrorDuplication(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -983,8 +980,8 @@ func TestErrorDuplication(t *testing.T) {
 
 // TestMethodSetJournal tests if duplication of journal insertion is ignored or not.
 func TestMethodSetJournal(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -1020,8 +1017,8 @@ func TestMethodSetJournal(t *testing.T) {
 
 // TestErrorDuplicatedSetBridgeInfo tests if duplication of bridge info insertion.
 func TestErrorDuplicatedSetBridgeInfo(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -1065,7 +1062,6 @@ func TestErrorDuplicatedSetBridgeInfo(t *testing.T) {
 		bridgeAccounts: bacc,
 	}
 
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -1085,8 +1081,8 @@ func TestErrorDuplicatedSetBridgeInfo(t *testing.T) {
 
 // TestScenarioSubUnsub tests subscription and unsubscription scenario.
 func TestScenarioSubUnsub(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -1130,7 +1126,6 @@ func TestScenarioSubUnsub(t *testing.T) {
 		bridgeAccounts: bacc,
 	}
 
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -1159,8 +1154,8 @@ func TestScenarioSubUnsub(t *testing.T) {
 
 // TestErrorEmptyAccount tests empty account error in case of journal insertion.
 func TestErrorEmptyAccount(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -1190,8 +1185,8 @@ func TestErrorEmptyAccount(t *testing.T) {
 
 // TestErrorDupSubscription tests duplicated subscription error.
 func TestErrorDupSubscription(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -1235,7 +1230,6 @@ func TestErrorDupSubscription(t *testing.T) {
 		bridgeAccounts: bacc,
 	}
 
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -1272,8 +1266,8 @@ func TestAnchoringBasic(t *testing.T) {
 		startBlkNum  = 10
 		startTxCount = 100
 	)
-	tempDir := os.TempDir() + "anchoring"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoring")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -1300,7 +1294,6 @@ func TestAnchoringBasic(t *testing.T) {
 	}
 	sc.blockchain = sim.BlockChain()
 
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -1360,8 +1353,8 @@ func TestAnchoringBasic(t *testing.T) {
 // 1. set anchoring period to 1, 2, 3
 // 2. check txCountEnabledBlockNumber
 func TestAnchoringUpdateTxCount(t *testing.T) {
-	tempDir := os.TempDir() + "anchoring"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoring")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -1388,7 +1381,6 @@ func TestAnchoringUpdateTxCount(t *testing.T) {
 	}
 	sc.blockchain = sim.BlockChain()
 
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -1436,8 +1428,8 @@ func TestAnchoringPeriod(t *testing.T) {
 	const (
 		startTxCount = 100
 	)
-	tempDir := os.TempDir() + "anchoringPeriod"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoringPeriod")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -1464,7 +1456,6 @@ func TestAnchoringPeriod(t *testing.T) {
 	}
 	sc.blockchain = sim.BlockChain()
 
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)
@@ -1562,8 +1553,8 @@ func TestDecodingLegacyAnchoringTx(t *testing.T) {
 		startBlkNum  = 10
 		startTxCount = 100
 	)
-	tempDir := os.TempDir() + "anchoring"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoring")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -1590,7 +1581,6 @@ func TestDecodingLegacyAnchoringTx(t *testing.T) {
 	}
 	sc.blockchain = sim.BlockChain()
 
-	var err error
 	sc.handler, err = NewSubBridgeHandler(sc)
 	if err != nil {
 		log.Fatalf("Failed to initialize bridgeHandler : %v", err)

--- a/node/sc/vt_contract_test.go
+++ b/node/sc/vt_contract_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/klaytn/klaytn/contracts/sc_erc20"
 	"github.com/klaytn/klaytn/contracts/sc_erc721"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"math/big"
 	"os"
 	"strconv"
@@ -30,8 +31,8 @@ import (
 
 // TestTokenPublicVariables checks the results of the public variables.
 func TestTokenPublicVariables(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -76,8 +77,8 @@ func TestTokenPublicVariables(t *testing.T) {
 
 // TestTokenPublicVariables checks the results of the public variables.
 func TestNFTPublicVariables(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/params"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"log"
 	"math/big"
 	"os"
@@ -99,8 +100,8 @@ var (
 
 // TestBasicKLAYTransferRecovery tests each methods of the value transfer recovery.
 func TestBasicKLAYTransferRecovery(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -116,7 +117,7 @@ func TestBasicKLAYTransferRecovery(t *testing.T) {
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
 
 	// 2. Update recovery hint.
-	err := vtr.updateRecoveryHint()
+	err = vtr.updateRecoveryHint()
 	if err != nil {
 		t.Fatal("fail to update value transfer hint")
 	}
@@ -165,8 +166,8 @@ func TestBasicKLAYTransferRecovery(t *testing.T) {
 
 // TestBasicTokenTransferRecovery tests the token transfer recovery.
 func TestBasicTokenTransferRecovery(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -180,7 +181,7 @@ func TestBasicTokenTransferRecovery(t *testing.T) {
 	})
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
-	err := vtr.updateRecoveryHint()
+	err = vtr.updateRecoveryHint()
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
@@ -204,8 +205,8 @@ func TestBasicTokenTransferRecovery(t *testing.T) {
 // TestBasicNFTTransferRecovery tests the NFT transfer recovery.
 // TODO-Klaytn-ServiceChain: implement NFT transfer.
 func TestBasicNFTTransferRecovery(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -219,7 +220,7 @@ func TestBasicNFTTransferRecovery(t *testing.T) {
 	})
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
-	err := vtr.updateRecoveryHint()
+	err = vtr.updateRecoveryHint()
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
@@ -242,8 +243,8 @@ func TestBasicNFTTransferRecovery(t *testing.T) {
 
 // TestMethodRecover tests the valueTransferRecovery.Recover() method.
 func TestMethodRecover(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -256,7 +257,7 @@ func TestMethodRecover(t *testing.T) {
 		}
 	})
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
-	err := vtr.updateRecoveryHint()
+	err = vtr.updateRecoveryHint()
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
@@ -278,8 +279,8 @@ func TestMethodRecover(t *testing.T) {
 
 // TestMethodStop tests the Stop method for stop the internal goroutine.
 func TestMethodStop(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -292,7 +293,7 @@ func TestMethodStop(t *testing.T) {
 		}
 	})
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 1}, info.localInfo, info.remoteInfo)
-	err := vtr.updateRecoveryHint()
+	err = vtr.updateRecoveryHint()
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
@@ -313,8 +314,8 @@ func TestMethodStop(t *testing.T) {
 
 // TestFlagVTRecovery tests the disabled vtrecovery option.
 func TestFlagVTRecovery(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -333,15 +334,15 @@ func TestFlagVTRecovery(t *testing.T) {
 	vtr.Stop()
 
 	vtr = NewValueTransferRecovery(&SCConfig{VTRecovery: false}, info.localInfo, info.remoteInfo)
-	err := vtr.Start()
+	err = vtr.Start()
 	assert.Equal(t, ErrVtrDisabled, err)
 	vtr.Stop()
 }
 
 // TestAlreadyStartedVTRecovery tests the already started VTR error cases.
 func TestAlreadyStartedVTRecovery(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -354,7 +355,7 @@ func TestAlreadyStartedVTRecovery(t *testing.T) {
 	})
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 60}, info.localInfo, info.remoteInfo)
-	err := vtr.Start()
+	err = vtr.Start()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, nil, vtr.WaitRunningStatus(true, 5*time.Second))
 
@@ -366,8 +367,8 @@ func TestAlreadyStartedVTRecovery(t *testing.T) {
 
 // TestScenarioMainChainRecovery tests the value transfer recovery of the parent chain to child chain value transfers.
 func TestScenarioMainChainRecovery(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -381,7 +382,7 @@ func TestScenarioMainChainRecovery(t *testing.T) {
 	})
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
-	err := vtr.updateRecoveryHint()
+	err = vtr.updateRecoveryHint()
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
@@ -403,8 +404,8 @@ func TestScenarioMainChainRecovery(t *testing.T) {
 
 // TestScenarioAutomaticRecovery tests the recovery of the internal goroutine.
 func TestScenarioAutomaticRecovery(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -417,7 +418,7 @@ func TestScenarioAutomaticRecovery(t *testing.T) {
 		}
 	})
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 1}, info.localInfo, info.remoteInfo)
-	err := vtr.updateRecoveryHint()
+	err = vtr.updateRecoveryHint()
 	if err != nil {
 		t.Fatal("fail to update a value transfer hint")
 	}
@@ -441,8 +442,8 @@ func TestScenarioAutomaticRecovery(t *testing.T) {
 
 // TestMultiOperatorRequestRecovery tests value transfer recovery for the multi-operator.
 func TestMultiOperatorRequestRecovery(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
 			t.Fatalf("fail to delete file %v", err)
@@ -460,7 +461,7 @@ func TestMultiOperatorRequestRecovery(t *testing.T) {
 	cAcc := info.nodeAuth
 	pAcc := info.chainAuth
 	opts := &bind.TransactOpts{From: cAcc.From, Signer: cAcc.Signer, GasLimit: testGasLimit}
-	_, err := info.localInfo.bridge.RegisterOperator(opts, pAcc.From)
+	_, err = info.localInfo.bridge.RegisterOperator(opts, pAcc.From)
 	assert.NoError(t, err)
 	opts = &bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}
 	_, err = info.remoteInfo.bridge.RegisterOperator(opts, cAcc.From)
@@ -547,7 +548,14 @@ func TestMultiOperatorRequestRecovery(t *testing.T) {
 func prepare(t *testing.T, vtcallback func(*testInfo)) *testInfo {
 	// Setup configuration.
 	config := &SCConfig{}
-	config.DataDir = os.TempDir() + "sc"
+	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	assert.NoError(t, err)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("fail to delete file %v", err)
+		}
+	}()
+	config.DataDir = tempDir
 	config.VTRecovery = true
 
 	bacc, err := NewBridgeAccounts(config.DataDir)


### PR DESCRIPTION
## Proposed changes

- CI occasionally failed. This may be caused by overlapping directories that are created temporarily.
    - https://circleci.com/gh/klaytn/klaytn/5848
- To prevent this, temporary directory creation is modified to create the directory based on random string.

```
(X) tempDir := os.TempDir() + "sc"
(O) tempDir, err := ioutil.TempDir(os.TempDir(), "sc")## Types of changes
```

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- n/a

## Further comments

- n/a
