### PR TITLE
Change roundchange default timeout from 10 seconds to 3 seconds

### DIFF
--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -37,7 +37,7 @@ type Config struct {
 }
 
 var DefaultConfig = &Config{
-	RequestTimeout: 10000,
+	RequestTimeout: 3000,
 	BlockPeriod:    1,
 	ProposerPolicy: RoundRobin,
 	Epoch:          30000,


### PR DESCRIPTION
## Proposed changes

- This PR is to change requestTimeout to 3 seconds. requestTimeout is being used as a default value of roundchange timer.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
