### PR TITLE
SC: Add API for get balance of operators

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -1105,6 +1105,16 @@ web3._extend({
 			getter: 'subbridge_getChildOperatorNonce'
 		}),
 		new web3._extend.Property({
+			name: 'parentOperatorBalance',
+			getter: 'subbridge_getParentOperatorBalance',
+			outputFormatter: web3._extend.formatters.outputBigNumberFormatter
+		}),
+			new web3._extend.Property({
+			name: 'childOperatorBalance',
+			getter: 'subbridge_getChildOperatorBalance',
+			outputFormatter: web3._extend.formatters.outputBigNumberFormatter
+		}),
+		new web3._extend.Property({
 			name: 'listBridge',
 			getter: 'subbridge_listBridge'
 		}),

--- a/node/sc/api_bridge.go
+++ b/node/sc/api_bridge.go
@@ -464,6 +464,14 @@ func (sb *SubBridgeAPI) GetChildOperatorNonce() uint64 {
 	return sb.subBridge.handler.getChildOperatorNonce()
 }
 
+func (sb *SubBridgeAPI) GetParentOperatorBalance() (*big.Int, error) {
+	return sb.subBridge.handler.getParentOperatorBalance()
+}
+
+func (sb *SubBridgeAPI) GetChildOperatorBalance() (*big.Int, error) {
+	return sb.subBridge.handler.getChildOperatorBalance()
+}
+
 // GetOperators returns the information of bridge operators.
 func (sb *SubBridgeAPI) GetOperators() map[string]interface{} {
 	return sb.subBridge.bridgeAccounts.GetBridgeOperators()

--- a/node/sc/local_backend.go
+++ b/node/sc/local_backend.go
@@ -70,6 +70,14 @@ func (lb *LocalBackend) CodeAt(ctx context.Context, contract common.Address, blo
 	return statedb.GetCode(contract), nil
 }
 
+func (lb *LocalBackend) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+	if blockNumber != nil && blockNumber.Cmp(lb.subbrige.blockchain.CurrentBlock().Number()) != 0 {
+		return nil, errBlockNumberUnsupported
+	}
+	statedb, _ := lb.subbrige.blockchain.State()
+	return statedb.GetBalance(account), nil
+}
+
 func (lb *LocalBackend) CallContract(ctx context.Context, call klaytn.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	if blockNumber != nil && blockNumber.Cmp(lb.subbrige.blockchain.CurrentBlock().Number()) != 0 {
 		return nil, errBlockNumberUnsupported

--- a/node/sc/remote_backend.go
+++ b/node/sc/remote_backend.go
@@ -77,6 +77,20 @@ func (rb *RemoteBackend) CodeAt(ctx context.Context, contract common.Address, bl
 	return result, err
 }
 
+func (rb *RemoteBackend) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+	if !rb.checkParentPeer() {
+		return nil, NoParentPeerErr
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	var hex hexutil.Big
+	err := rb.rpcClient.CallContext(ctx, &hex, "klay_getBalance", account, toBlockNumArg(blockNumber))
+	if err != nil {
+		return nil, err
+	}
+	return (*big.Int)(&hex), nil
+}
+
 func (rb *RemoteBackend) CallContract(ctx context.Context, call klaytn.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	if !rb.checkParentPeer() {
 		return nil, NoParentPeerErr

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -17,6 +17,7 @@
 package sc
 
 import (
+	"context"
 	"fmt"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -108,6 +109,13 @@ func (sbh *SubBridgeHandler) getParentOperatorNonceSynced() bool {
 	return sbh.nonceSynced
 }
 
+// getParentOperatorBalance returns the parent chain operator balance.
+func (sbh *SubBridgeHandler) getParentOperatorBalance() (*big.Int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return sbh.subbridge.remoteBackend.BalanceAt(ctx, sbh.subbridge.bridgeAccounts.pAccount.address, nil)
+}
+
 // setParentOperatorNonceSynced sets whether the parent chain operator account nonce is synced or not.
 func (sbh *SubBridgeHandler) setParentOperatorNonceSynced(synced bool) {
 	sbh.nonceSynced = synced
@@ -115,6 +123,13 @@ func (sbh *SubBridgeHandler) setParentOperatorNonceSynced(synced bool) {
 
 func (sbh *SubBridgeHandler) getChildOperatorNonce() uint64 {
 	return sbh.subbridge.txPool.GetPendingNonce(sbh.subbridge.bridgeAccounts.cAccount.address)
+}
+
+// getChildOperatorBalance returns the child chain operator balance.
+func (sbh *SubBridgeHandler) getChildOperatorBalance() (*big.Int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return sbh.subbridge.localBackend.BalanceAt(ctx, sbh.subbridge.bridgeAccounts.cAccount.address, nil)
 }
 
 func (sbh *SubBridgeHandler) getRemoteGasPrice() uint64 {

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -62,12 +62,14 @@ const (
 type RemoteBackendInterface interface {
 	bind.ContractBackend
 	TransactionReceiptRpcOutput(ctx context.Context, txHash common.Hash) (map[string]interface{}, error)
+	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 }
 
 // Backend wraps all methods for local and remote backend
 type Backend interface {
 	bind.ContractBackend
 	CurrentBlockNumber(context.Context) (uint64, error)
+	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 }
 
 // NodeInfo represents a short summary of the ServiceChain sub-protocol metadata


### PR DESCRIPTION
## Proposed changes
This PR introduce APIs for getting balance of operators.

```
> subbridge.parentOperatorBalance
1e+50
> subbridge.childOperatorBalance
1e+50
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
