### PR TITLE
SC: update the default genesis with a round-robin policy

### DIFF
--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -347,7 +347,7 @@ func genServiceChainCommonGenesis(nodeAddrs, testAddrs []common.Address) *blockc
 				},
 			},
 			Istanbul: &params.IstanbulConfig{
-				ProposerPolicy: 2,
+				ProposerPolicy: 0,
 				SubGroupSize:   22,
 			},
 			UnitPrice: 0,
@@ -365,7 +365,7 @@ func genServiceChainGenesis(nodeAddrs, testAddrs []common.Address) *blockchain.G
 	genesisJson.Config.Governance.Reward.StakingUpdateInterval = 86400
 	genesisJson.Config.Governance.Reward.ProposerUpdateInterval = 3600
 	genesisJson.Config.Governance.Reward.MinimumStake = new(big.Int).SetUint64(5000000)
-	allocationFunction := genesis.AllocWithBaobabContract(append(nodeAddrs, testAddrs...), new(big.Int).Exp(big.NewInt(10), big.NewInt(10), nil))
+	allocationFunction := genesis.Alloc(append(nodeAddrs, testAddrs...), new(big.Int).Exp(big.NewInt(10), big.NewInt(10), nil))
 	allocationFunction(genesisJson)
 	return genesisJson
 }
@@ -376,7 +376,7 @@ func genServiceChainTestGenesis(nodeAddrs, testAddrs []common.Address) *blockcha
 	genesisJson.Config.Governance.Reward.StakingUpdateInterval = 60
 	genesisJson.Config.Governance.Reward.ProposerUpdateInterval = 30
 	genesisJson.Config.Governance.Reward.MinimumStake = new(big.Int).SetUint64(5000000)
-	allocationFunction := genesis.AllocWithPrecypressContract(append(nodeAddrs, testAddrs...), new(big.Int).Exp(big.NewInt(10), big.NewInt(50), nil))
+	allocationFunction := genesis.Alloc(append(nodeAddrs, testAddrs...), new(big.Int).Exp(big.NewInt(10), big.NewInt(50), nil))
 	allocationFunction(genesisJson)
 	return genesisJson
 }

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -328,7 +328,6 @@ func genCypressGenesis(nodeAddrs, testAddrs []common.Address) *blockchain.Genesi
 }
 
 func genServiceChainCommonGenesis(nodeAddrs, testAddrs []common.Address) *blockchain.Genesis {
-	mintingAmount, _ := new(big.Int).SetString("0", 10)
 	genesisJson := &blockchain.Genesis{
 		Timestamp:  uint64(time.Now().Unix()),
 		BlockScore: big.NewInt(genesis.InitBlockScore),
@@ -336,16 +335,6 @@ func genServiceChainCommonGenesis(nodeAddrs, testAddrs []common.Address) *blockc
 		Config: &params.ChainConfig{
 			ChainID:       big.NewInt(1000),
 			DeriveShaImpl: 2,
-			Governance: &params.GovernanceConfig{
-				GoverningNode:  nodeAddrs[0],
-				GovernanceMode: "single",
-				Reward: &params.RewardConfig{
-					MintingAmount: mintingAmount,
-					Ratio:         "100/0/0",
-					UseGiniCoeff:  true,
-					DeferredTxFee: true,
-				},
-			},
 			Istanbul: &params.IstanbulConfig{
 				ProposerPolicy: 0,
 				SubGroupSize:   22,
@@ -362,9 +351,6 @@ func genServiceChainCommonGenesis(nodeAddrs, testAddrs []common.Address) *blockc
 func genServiceChainGenesis(nodeAddrs, testAddrs []common.Address) *blockchain.Genesis {
 	genesisJson := genServiceChainCommonGenesis(nodeAddrs, testAddrs)
 	genesisJson.Config.Istanbul.Epoch = 3600
-	genesisJson.Config.Governance.Reward.StakingUpdateInterval = 86400
-	genesisJson.Config.Governance.Reward.ProposerUpdateInterval = 3600
-	genesisJson.Config.Governance.Reward.MinimumStake = new(big.Int).SetUint64(5000000)
 	allocationFunction := genesis.Alloc(append(nodeAddrs, testAddrs...), new(big.Int).Exp(big.NewInt(10), big.NewInt(10), nil))
 	allocationFunction(genesisJson)
 	return genesisJson
@@ -373,9 +359,6 @@ func genServiceChainGenesis(nodeAddrs, testAddrs []common.Address) *blockchain.G
 func genServiceChainTestGenesis(nodeAddrs, testAddrs []common.Address) *blockchain.Genesis {
 	genesisJson := genServiceChainCommonGenesis(nodeAddrs, testAddrs)
 	genesisJson.Config.Istanbul.Epoch = 30
-	genesisJson.Config.Governance.Reward.StakingUpdateInterval = 60
-	genesisJson.Config.Governance.Reward.ProposerUpdateInterval = 30
-	genesisJson.Config.Governance.Reward.MinimumStake = new(big.Int).SetUint64(5000000)
 	allocationFunction := genesis.Alloc(append(nodeAddrs, testAddrs...), new(big.Int).Exp(big.NewInt(10), big.NewInt(50), nil))
 	allocationFunction(genesisJson)
 	return genesisJson


### PR DESCRIPTION
## Proposed changes

- This PR changes default service chain proposer policy from weighted random (2) to round-robin (0). The precompiled address book is also removed.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- n/a

## Further comments

- n/a