### PR TITLE
Enable EN to send transactions to CN

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1118,6 +1118,7 @@ func (pm *ProtocolManager) broadcastTxsFromPN(txs types.Transactions) {
 func (pm *ProtocolManager) broadcastTxsFromEN(txs types.Transactions) {
 	peersWithoutTxs := make(map[Peer]types.Transactions)
 	for _, tx := range txs {
+		pm.peers.UpdateTypePeersWithoutTxs(tx, common.CONSENSUSNODE, peersWithoutTxs)
 		pm.peers.UpdateTypePeersWithoutTxs(tx, common.PROXYNODE, peersWithoutTxs)
 		pm.peers.UpdateTypePeersWithoutTxs(tx, common.ENDPOINTNODE, peersWithoutTxs)
 		txSendCounter.Inc(1)

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -319,7 +319,7 @@ func TestBroadcastTxsFromPN_PN_Exists(t *testing.T) {
 	pm.BroadcastTxs(txs)
 }
 
-func TestBroadcastTxsFromEN_EN_NotExists(t *testing.T) {
+func TestBroadcastTxsFromEN_ALL_NotExists(t *testing.T) {
 	pm := &ProtocolManager{}
 	pm.nodetype = common.ENDPOINTNODE
 	mockCtrl := gomock.NewController(t)
@@ -329,21 +329,22 @@ func TestBroadcastTxsFromEN_EN_NotExists(t *testing.T) {
 	pm.peers = peers
 	cnPeer, pnPeer, enPeer := createAndRegisterPeers(mockCtrl, peers)
 
-	cnPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).Times(2)
-	pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).Times(2)
-	enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).Times(2)
+	cnPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).Times(3)
+	pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).Times(3)
+	enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).Times(3)
 
-	pnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(false).Times(1)
+	cnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(true).Times(1)
+	pnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(true).Times(1)
 	enPeer.EXPECT().KnowsTx(tx1.Hash()).Return(true).Times(1)
 
 	cnPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(0)
-	pnPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(1)
+	pnPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(0)
 	enPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(0)
 
 	pm.BroadcastTxs(txs)
 }
 
-func TestBroadcastTxsFromEN_EN_Exists(t *testing.T) {
+func TestBroadcastTxsFromEN_ALL_Exists(t *testing.T) {
 	pm := &ProtocolManager{}
 	pm.nodetype = common.ENDPOINTNODE
 	mockCtrl := gomock.NewController(t)
@@ -353,39 +354,16 @@ func TestBroadcastTxsFromEN_EN_Exists(t *testing.T) {
 	pm.peers = peers
 	cnPeer, pnPeer, enPeer := createAndRegisterPeers(mockCtrl, peers)
 
-	cnPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).Times(2)
-	pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).Times(2)
-	enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).Times(2)
+	cnPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).Times(3)
+	pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).Times(3)
+	enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).Times(3)
 
+	cnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(false).Times(1)
 	pnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(false).Times(1)
 	enPeer.EXPECT().KnowsTx(tx1.Hash()).Return(false).Times(1)
 
-	cnPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(0)
+	cnPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(1)
 	pnPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(1)
-	enPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(1)
-
-	pm.BroadcastTxs(txs)
-}
-
-func TestBroadcastTxsFromEN_PN_NotExists(t *testing.T) {
-	pm := &ProtocolManager{}
-	pm.nodetype = common.ENDPOINTNODE
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	peers := newPeerSet()
-	pm.peers = peers
-	cnPeer, pnPeer, enPeer := createAndRegisterPeers(mockCtrl, peers)
-
-	cnPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).Times(2)
-	pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).Times(2)
-	enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).Times(2)
-
-	pnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(true).Times(1)
-	enPeer.EXPECT().KnowsTx(tx1.Hash()).Return(false).Times(1)
-
-	cnPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(0)
-	pnPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(0)
 	enPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(1)
 
 	pm.BroadcastTxs(txs)
@@ -476,7 +454,7 @@ func TestReBroadcastTxs_EN(t *testing.T) {
 		pm.peers = peers
 
 		enPeer := NewMockPeer(mockCtrl)
-		enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).Times(2)
+		enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).Times(3)
 		enPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(1)
 
 		peers.enpeers[addrs[2]] = enPeer
@@ -496,7 +474,7 @@ func TestReBroadcastTxs_EN(t *testing.T) {
 		pm.peers = peers
 
 		pnPeer := NewMockPeer(mockCtrl)
-		pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).Times(1)
+		pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).Times(3)
 		pnPeer.EXPECT().SendTransactions(gomock.Eq(txs)).Times(1)
 
 		peers.pnpeers[addrs[2]] = pnPeer

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -329,9 +329,9 @@ func TestBroadcastTxsFromEN_ALL_NotExists(t *testing.T) {
 	pm.peers = peers
 	cnPeer, pnPeer, enPeer := createAndRegisterPeers(mockCtrl, peers)
 
-	cnPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).Times(3)
-	pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).Times(3)
-	enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).Times(3)
+	cnPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).AnyTimes()
+	pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).AnyTimes()
+	enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).AnyTimes()
 
 	cnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(true).Times(1)
 	pnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(true).Times(1)
@@ -354,9 +354,9 @@ func TestBroadcastTxsFromEN_ALL_Exists(t *testing.T) {
 	pm.peers = peers
 	cnPeer, pnPeer, enPeer := createAndRegisterPeers(mockCtrl, peers)
 
-	cnPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).Times(3)
-	pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).Times(3)
-	enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).Times(3)
+	cnPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).AnyTimes()
+	pnPeer.EXPECT().ConnType().Return(common.PROXYNODE).AnyTimes()
+	enPeer.EXPECT().ConnType().Return(common.ENDPOINTNODE).AnyTimes()
 
 	cnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(false).Times(1)
 	pnPeer.EXPECT().KnowsTx(tx1.Hash()).Return(false).Times(1)

--- a/node/cn/peer_set.go
+++ b/node/cn/peer_set.go
@@ -441,11 +441,11 @@ func (peers *peerSet) SampleResendPeersByType(nodeType common.ConnType) []Peer {
 	switch nodeType {
 	case common.ENDPOINTNODE:
 		sampledPeers = peers.typePeers(common.CONSENSUSNODE)
-		if len(sampledPeers) == 0 {
-			sampledPeers = peers.typePeers(common.PROXYNODE)
+		if len(sampledPeers) < 2 {
+			sampledPeers = append(sampledPeers, peers.typePeers(common.PROXYNODE)...)
 		}
-		if len(sampledPeers) == 0 {
-			sampledPeers = peers.typePeers(common.ENDPOINTNODE)
+		if len(sampledPeers) < 2 {
+			sampledPeers = append(sampledPeers, peers.typePeers(common.ENDPOINTNODE)...)
 		}
 		sampledPeers = samplingPeers(sampledPeers, 2)
 	case common.PROXYNODE:

--- a/node/cn/peer_set.go
+++ b/node/cn/peer_set.go
@@ -440,7 +440,10 @@ func (peers *peerSet) SampleResendPeersByType(nodeType common.ConnType) []Peer {
 	var sampledPeers []Peer
 	switch nodeType {
 	case common.ENDPOINTNODE:
-		sampledPeers = peers.typePeers(common.PROXYNODE)
+		sampledPeers = peers.typePeers(common.CONSENSUSNODE)
+		if len(sampledPeers) == 0 {
+			sampledPeers = peers.typePeers(common.PROXYNODE)
+		}
 		if len(sampledPeers) == 0 {
 			sampledPeers = peers.typePeers(common.ENDPOINTNODE)
 		}

--- a/node/cn/peer_set.go
+++ b/node/cn/peer_set.go
@@ -442,10 +442,10 @@ func (peers *peerSet) SampleResendPeersByType(nodeType common.ConnType) []Peer {
 	case common.ENDPOINTNODE:
 		sampledPeers = peers.typePeers(common.CONSENSUSNODE)
 		if len(sampledPeers) < 2 {
-			sampledPeers = append(sampledPeers, peers.typePeers(common.PROXYNODE)...)
+			sampledPeers = append(sampledPeers, samplingPeers(peers.typePeers(common.PROXYNODE), 2-len(sampledPeers))...)
 		}
 		if len(sampledPeers) < 2 {
-			sampledPeers = append(sampledPeers, peers.typePeers(common.ENDPOINTNODE)...)
+			sampledPeers = append(sampledPeers, samplingPeers(peers.typePeers(common.ENDPOINTNODE), 2-len(sampledPeers))...)
 		}
 		sampledPeers = samplingPeers(sampledPeers, 2)
 	case common.PROXYNODE:


### PR DESCRIPTION
## Proposed changes
This PR enable EN to send transactions to CN directly.
As below description, Service Chain may not have PN. So this PR was introduced.

~~I would like to discuss about this PR.~~

~~We don't allow EN to send tx to CN even if EN connected with CN.~~
~~How about allowing this?~~

In service chain, SP can want to use CN + EN topology. So I think this feature is needed.
However, In cypress, it is impossible CN connects EN cased by firewall. Therefore, this code doesn't make side effect in Cypress.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
