### PR TITLE
Added metrics for RPC calls

### DIFF
--- a/networks/rpc/metrics.go
+++ b/networks/rpc/metrics.go
@@ -1,0 +1,10 @@
+package rpc
+
+import "github.com/klaytn/klaytn/metrics"
+
+var (
+	rpcTotalRequestsCounter    = metrics.NewRegisteredCounter("rpc/counts/total", nil)
+	rpcSuccessResponsesCounter = metrics.NewRegisteredCounter("rpc/counts/success", nil)
+	rpcErrorResponsesCounter   = metrics.NewRegisteredCounter("rpc/counts/errors", nil)
+	rpcPendingRequestCount     = metrics.NewRegisteredCounter("rpc/counts/pending", nil)
+)

--- a/networks/rpc/metrics.go
+++ b/networks/rpc/metrics.go
@@ -6,5 +6,5 @@ var (
 	rpcTotalRequestsCounter    = metrics.NewRegisteredCounter("rpc/counts/total", nil)
 	rpcSuccessResponsesCounter = metrics.NewRegisteredCounter("rpc/counts/success", nil)
 	rpcErrorResponsesCounter   = metrics.NewRegisteredCounter("rpc/counts/errors", nil)
-	rpcPendingRequestCount     = metrics.NewRegisteredCounter("rpc/counts/pending", nil)
+	rpcPendingRequestsCount    = metrics.NewRegisteredCounter("rpc/counts/pending", nil)
 )

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -192,7 +192,6 @@ func (s *Server) serveRequest(ctx context.Context, codec ServerCodec, singleShot
 	}
 	s.codecsMu.Lock()
 	if atomic.LoadInt32(&s.run) != 1 { // server stopped
-		rpcErrorResponsesCounter.Inc(1)
 		s.codecsMu.Unlock()
 		return &shutdownError{}
 	}

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -259,7 +259,7 @@ func (s *Server) serveRequest(ctx context.Context, codec ServerCodec, singleShot
 		// For multi-shot connections, start a goroutine to serve and loop back
 		pend.Add(1)
 		atomic.AddInt64(&pendingRequestCount, 1)
-		rpcPendingRequestCount.Inc(int64(len(reqs)))
+		rpcPendingRequestsCount.Inc(int64(len(reqs)))
 		go func(reqs []*serverRequest, batch bool) {
 			defer func() {
 				atomic.AddInt64(&pendingRequestCount, -1)


### PR DESCRIPTION
## Proposed changes
- metrics for RPC calls are added
  - total: total number of requests
  - success: total number of success responses
  - errors: total number of error responses
  - pending: total number of pending requests

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
