### PR TITLE
Rename `GetTransactOpts` to `GenerateTransactOpts` and refine a test function

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -87,6 +87,10 @@ func (b *SimulatedBackend) BlockChain() *blockchain.BlockChain {
 	return b.blockchain
 }
 
+func (b *SimulatedBackend) PendingBlock() *types.Block {
+	return b.pendingBlock
+}
+
 // Commit imports all the pending transactions as a single block and starts a
 // fresh new state.
 func (b *SimulatedBackend) Commit() {

--- a/accounts/abi/bind/util.go
+++ b/accounts/abi/bind/util.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/log"
@@ -73,7 +74,7 @@ func CheckWaitMined(b DeployBackend, tx *types.Transaction) error {
 	}
 
 	if receipt.Status != types.ReceiptStatusSuccessful {
-		return errors.New("not successful receipt")
+		return blockchain.GetVMerrFromReceiptStatus(receipt.Status)
 	}
 	return nil
 }

--- a/node/sc/api_bridge.go
+++ b/node/sc/api_bridge.go
@@ -104,19 +104,19 @@ func (sb *SubBridgeAPI) GetValueTransferOperatorThreshold(bridgeAddr common.Addr
 }
 
 func (sb *SubBridgeAPI) DeployBridge() ([]common.Address, error) {
-	cBridge, cBridgeAddr, err := sb.subBridge.bridgeManager.DeployBridge(sb.subBridge.localBackend, true)
+	cAcc := sb.subBridge.bridgeAccounts.cAccount
+	pAcc := sb.subBridge.bridgeAccounts.pAccount
+
+	cBridge, cBridgeAddr, err := sb.subBridge.bridgeManager.DeployBridge(cAcc.GetTransactOpts(), sb.subBridge.localBackend, true)
 	if err != nil {
 		logger.Error("Failed to deploy child bridge.", "err", err)
 		return nil, err
 	}
-	pBridge, pBridgeAddr, err := sb.subBridge.bridgeManager.DeployBridge(sb.subBridge.remoteBackend, false)
+	pBridge, pBridgeAddr, err := sb.subBridge.bridgeManager.DeployBridge(pAcc.GetTransactOpts(), sb.subBridge.remoteBackend, false)
 	if err != nil {
 		logger.Error("Failed to deploy parent bridge.", "err", err)
 		return nil, err
 	}
-
-	pAcc := sb.subBridge.bridgeAccounts.pAccount
-	cAcc := sb.subBridge.bridgeAccounts.cAccount
 
 	err = sb.subBridge.bridgeManager.SetBridgeInfo(cBridgeAddr, cBridge, pBridgeAddr, pBridge, cAcc, true, false)
 	if err != nil {

--- a/node/sc/api_bridge.go
+++ b/node/sc/api_bridge.go
@@ -107,12 +107,12 @@ func (sb *SubBridgeAPI) DeployBridge() ([]common.Address, error) {
 	cAcc := sb.subBridge.bridgeAccounts.cAccount
 	pAcc := sb.subBridge.bridgeAccounts.pAccount
 
-	cBridge, cBridgeAddr, err := sb.subBridge.bridgeManager.DeployBridge(cAcc.GetTransactOpts(), sb.subBridge.localBackend, true)
+	cBridge, cBridgeAddr, err := sb.subBridge.bridgeManager.DeployBridge(cAcc.GenerateTransactOpts(), sb.subBridge.localBackend, true)
 	if err != nil {
 		logger.Error("Failed to deploy child bridge.", "err", err)
 		return nil, err
 	}
-	pBridge, pBridgeAddr, err := sb.subBridge.bridgeManager.DeployBridge(pAcc.GetTransactOpts(), sb.subBridge.remoteBackend, false)
+	pBridge, pBridgeAddr, err := sb.subBridge.bridgeManager.DeployBridge(pAcc.GenerateTransactOpts(), sb.subBridge.remoteBackend, false)
 	if err != nil {
 		logger.Error("Failed to deploy parent bridge.", "err", err)
 		return nil, err
@@ -315,7 +315,7 @@ func (sb *SubBridgeAPI) RegisterToken(cBridgeAddr, pBridgeAddr, cTokenAddr, pTok
 	}
 
 	cBi.account.Lock()
-	tx, err := cBi.bridge.RegisterToken(cBi.account.GetTransactOpts(), cTokenAddr, pTokenAddr)
+	tx, err := cBi.bridge.RegisterToken(cBi.account.GenerateTransactOpts(), cTokenAddr, pTokenAddr)
 	if err != nil {
 		cBi.account.UnLock()
 		return err
@@ -325,7 +325,7 @@ func (sb *SubBridgeAPI) RegisterToken(cBridgeAddr, pBridgeAddr, cTokenAddr, pTok
 	logger.Debug("cBridge registered token", "txHash", tx.Hash().String(), "cToken", cTokenAddr.String(), "pToken", pTokenAddr.String())
 
 	pBi.account.Lock()
-	tx, err = pBi.bridge.RegisterToken(pBi.account.GetTransactOpts(), pTokenAddr, cTokenAddr)
+	tx, err = pBi.bridge.RegisterToken(pBi.account.GenerateTransactOpts(), pTokenAddr, cTokenAddr)
 	if err != nil {
 		pBi.account.UnLock()
 		return err
@@ -387,7 +387,7 @@ func (sb *SubBridgeAPI) DeregisterToken(cBridgeAddr, pBridgeAddr, cTokenAddr, pT
 
 	cBi.account.Lock()
 	defer cBi.account.UnLock()
-	tx, err := cBi.bridge.DeregisterToken(cBi.account.GetTransactOpts(), cTokenAddr)
+	tx, err := cBi.bridge.DeregisterToken(cBi.account.GenerateTransactOpts(), cTokenAddr)
 	if err != nil {
 		return err
 	}
@@ -396,7 +396,7 @@ func (sb *SubBridgeAPI) DeregisterToken(cBridgeAddr, pBridgeAddr, cTokenAddr, pT
 
 	pBi.account.Lock()
 	defer pBi.account.UnLock()
-	tx, err = pBi.bridge.DeregisterToken(pBi.account.GetTransactOpts(), pTokenAddr)
+	tx, err = pBi.bridge.DeregisterToken(pBi.account.GenerateTransactOpts(), pTokenAddr)
 	if err != nil {
 		return err
 	}

--- a/node/sc/bridge_accounts.go
+++ b/node/sc/bridge_accounts.go
@@ -168,8 +168,8 @@ func (acc *accountInfo) GetAccountInfo() map[string]interface{} {
 	return res
 }
 
-// GetTransactOpts returns a transactOpts for transact on local/remote backend.
-func (acc *accountInfo) GetTransactOpts() *bind.TransactOpts {
+// GenerateTransactOpts returns a transactOpts for transact on local/remote backend.
+func (acc *accountInfo) GenerateTransactOpts() *bind.TransactOpts {
 	var nonce *big.Int
 
 	// Only for unit test, if the nonce is not synced yet, return transaction option with nil nonce.

--- a/node/sc/bridge_manager.go
+++ b/node/sc/bridge_manager.go
@@ -297,7 +297,7 @@ func (bi *BridgeInfo) handleRequestValueTransferEvent(ev *RequestValueTransferEv
 	bridgeAcc.Lock()
 	defer bridgeAcc.UnLock()
 
-	auth := bridgeAcc.GetTransactOpts()
+	auth := bridgeAcc.GenerateTransactOpts()
 
 	var handleTx *types.Transaction
 	var err error
@@ -755,7 +755,7 @@ func (bm *BridgeManager) SetValueTransferOperatorThreshold(bridgeAddr common.Add
 
 	bi.account.Lock()
 	defer bi.account.UnLock()
-	tx, err := bi.bridge.SetOperatorThreshold(bi.account.GetTransactOpts(), voteTypeValueTransfer, threshold)
+	tx, err := bi.bridge.SetOperatorThreshold(bi.account.GenerateTransactOpts(), voteTypeValueTransfer, threshold)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -1003,7 +1003,7 @@ func (bm *BridgeManager) SetERC20Fee(bridgeAddr, tokenAddr common.Address, fee *
 		return common.Hash{}, err
 	}
 
-	tx, err := bi.bridge.SetERC20Fee(auth.GetTransactOpts(), tokenAddr, fee, rn)
+	tx, err := bi.bridge.SetERC20Fee(auth.GenerateTransactOpts(), tokenAddr, fee, rn)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -1029,7 +1029,7 @@ func (bm *BridgeManager) SetKLAYFee(bridgeAddr common.Address, fee *big.Int) (co
 		return common.Hash{}, err
 	}
 
-	tx, err := bi.bridge.SetKLAYFee(auth.GetTransactOpts(), fee, rn)
+	tx, err := bi.bridge.SetKLAYFee(auth.GenerateTransactOpts(), fee, rn)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -1050,7 +1050,7 @@ func (bm *BridgeManager) SetFeeReceiver(bridgeAddr, receiver common.Address) (co
 	auth.Lock()
 	defer auth.UnLock()
 
-	tx, err := bi.bridge.SetFeeReceiver(auth.GetTransactOpts(), receiver)
+	tx, err := bi.bridge.SetFeeReceiver(auth.GenerateTransactOpts(), receiver)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/node/sc/bridge_manager.go
+++ b/node/sc/bridge_manager.go
@@ -780,7 +780,7 @@ func (bm *BridgeManager) GetValueTransferOperatorThreshold(bridgeAddr common.Add
 }
 
 // Deploy Bridge SmartContract on same node or remote node
-func (bm *BridgeManager) DeployBridge(backend bind.ContractBackend, local bool) (*bridgecontract.Bridge, common.Address, error) {
+func (bm *BridgeManager) DeployBridge(auth *bind.TransactOpts, backend bind.ContractBackend, local bool) (*bridgecontract.Bridge, common.Address, error) {
 	var acc *accountInfo
 	var modeMintBurn bool
 
@@ -792,7 +792,7 @@ func (bm *BridgeManager) DeployBridge(backend bind.ContractBackend, local bool) 
 		modeMintBurn = false
 	}
 
-	addr, bridge, err := bm.deployBridge(acc, backend, modeMintBurn)
+	addr, bridge, err := bm.deployBridge(acc, auth, backend, modeMintBurn)
 	if err != nil {
 		return nil, common.Address{}, err
 	}
@@ -803,9 +803,8 @@ func (bm *BridgeManager) DeployBridge(backend bind.ContractBackend, local bool) 
 // DeployBridge handles actual smart contract deployment.
 // To create contract, the chain ID, nonce, account key, private key, contract binding and gas price are used.
 // The deployed contract address, transaction are returned. An error is also returned if any.
-func (bm *BridgeManager) deployBridge(acc *accountInfo, backend bind.ContractBackend, modeMintBurn bool) (common.Address, *bridgecontract.Bridge, error) {
+func (bm *BridgeManager) deployBridge(acc *accountInfo, auth *bind.TransactOpts, backend bind.ContractBackend, modeMintBurn bool) (common.Address, *bridgecontract.Bridge, error) {
 	acc.Lock()
-	auth := acc.GetTransactOpts()
 	addr, tx, contract, err := bridgecontract.DeployBridge(auth, backend, modeMintBurn)
 	if err != nil {
 		logger.Error("Failed to deploy contract.", "err", err)

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -94,8 +94,8 @@ func TestBridgeManager(t *testing.T) {
 	bacc.pAccount.chainID = big.NewInt(0)
 	bacc.cAccount.chainID = big.NewInt(0)
 
-	pAuth := bacc.cAccount.GetTransactOpts()
-	cAuth := bacc.pAccount.GetTransactOpts()
+	pAuth := bacc.cAccount.GenerateTransactOpts()
+	cAuth := bacc.pAccount.GenerateTransactOpts()
 
 	// Generate a new random account and a funded simulator
 	aliceKey, _ := crypto.GenerateKey()
@@ -337,8 +337,8 @@ func TestBridgeManagerERC721_notSupportURI(t *testing.T) {
 	bacc.pAccount.chainID = big.NewInt(0)
 	bacc.cAccount.chainID = big.NewInt(0)
 
-	//pAuth := bacc.cAccount.GetTransactOpts()
-	cAuth := bacc.pAccount.GetTransactOpts()
+	//pAuth := bacc.cAccount.GenerateTransactOpts()
+	cAuth := bacc.pAccount.GenerateTransactOpts()
 
 	// Generate a new random account and a funded simulator
 	aliceKey, _ := crypto.GenerateKey()
@@ -534,8 +534,8 @@ func TestBridgeManagerWithFee(t *testing.T) {
 	bacc.pAccount.chainID = big.NewInt(0)
 	bacc.cAccount.chainID = big.NewInt(0)
 
-	pAuth := bacc.cAccount.GetTransactOpts()
-	cAuth := bacc.pAccount.GetTransactOpts()
+	pAuth := bacc.cAccount.GenerateTransactOpts()
+	cAuth := bacc.pAccount.GenerateTransactOpts()
 
 	// Create Simulated backend
 	initialValue := int64(10000000000)
@@ -1499,7 +1499,7 @@ func TestAnchoringBasic(t *testing.T) {
 	assert.Equal(t, uint64(1), sc.handler.chainTxPeriod)
 
 	// Encoding anchoring tx
-	auth := bAcc.pAccount.GetTransactOpts()
+	auth := bAcc.pAccount.GenerateTransactOpts()
 	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
 	sim.Commit()
 	curBlk := sim.BlockChain().CurrentBlock()
@@ -1585,7 +1585,7 @@ func TestAnchoringStart(t *testing.T) {
 	sim.Commit() // start with arbitrary block number.
 
 	// 1. Fresh start with dummy tx and check tx count
-	auth := bAcc.pAccount.GetTransactOpts()
+	auth := bAcc.pAccount.GenerateTransactOpts()
 	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
 	sim.Commit()
 	curBlk := sim.BlockChain().CurrentBlock()
@@ -1666,7 +1666,7 @@ func TestAnchoringPeriod(t *testing.T) {
 
 	// Period 1
 	sim.Commit()
-	auth := bAcc.pAccount.GetTransactOpts()
+	auth := bAcc.pAccount.GenerateTransactOpts()
 	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
 	sim.Commit()
 	curBlk := sim.BlockChain().CurrentBlock()
@@ -1781,7 +1781,7 @@ func TestDecodingLegacyAnchoringTx(t *testing.T) {
 	}
 
 	// Encoding anchoring tx.
-	auth := bAcc.pAccount.GetTransactOpts()
+	auth := bAcc.pAccount.GenerateTransactOpts()
 	_, _, _, err = bridge.DeployBridge(auth, sim, true) // dummy tx
 	sim.Commit()
 	curBlk := sim.BlockChain().CurrentBlock()
@@ -1825,7 +1825,7 @@ func (bm *BridgeManager) DeployBridgeTest(backend *backends.SimulatedBackend, lo
 		acc = bm.subBridge.bridgeAccounts.pAccount
 	}
 
-	auth := acc.GetTransactOpts()
+	auth := acc.GenerateTransactOpts()
 	auth.Value = big.NewInt(10000)
 
 	// Deploy a bridge contract

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -1803,7 +1803,7 @@ func TestDecodingLegacyAnchoringTx(t *testing.T) {
 	assert.Equal(t, curBlk.Header().Number.String(), decodedData.GetBlockNumber().String())
 }
 
-// DeployBridgeTest is test-only function which deploy a bridge contract with some amount of KLAY.
+// DeployBridgeTest is a test-only function which deploys a bridge contract with some amount of KLAY.
 func (bm *BridgeManager) DeployBridgeTest(backend *backends.SimulatedBackend, local bool) (common.Address, error) {
 	var acc *accountInfo
 

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
 	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/math"
 	"github.com/klaytn/klaytn/contracts/sc_erc20"
@@ -853,20 +854,23 @@ func requestTokenTransfer(info *testInfo, bi *BridgeInfo) {
 	bi.account.Lock()
 	defer bi.account.UnLock()
 
+	var tx *types.Transaction
+
 	testToken := big.NewInt(testToken)
 	opts := bi.account.GenerateTransactOpts()
 
 	var err error
 	if bi.onChildChain {
-		_, err = info.tokenLocalBridge.RequestValueTransfer(opts, testToken, info.chainAuth.From, big.NewInt(0), nil)
+		tx, err = info.tokenLocalBridge.RequestValueTransfer(opts, testToken, info.chainAuth.From, big.NewInt(0), nil)
 	} else {
-		_, err = info.tokenRemoteBridge.RequestValueTransfer(opts, testToken, info.nodeAuth.From, big.NewInt(0), nil)
+		tx, err = info.tokenRemoteBridge.RequestValueTransfer(opts, testToken, info.nodeAuth.From, big.NewInt(0), nil)
 	}
 
 	if err != nil {
 		log.Fatalf("Failed to RequestValueTransfer for charging: %v", err)
 	}
 	info.sim.Commit()
+	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
 }
 
 func handleTokenTransfer(info *testInfo, bi *BridgeInfo, ev *RequestValueTransferEvent) {
@@ -874,12 +878,13 @@ func handleTokenTransfer(info *testInfo, bi *BridgeInfo, ev *RequestValueTransfe
 	defer bi.account.UnLock()
 
 	assert.Equal(info.t, new(big.Int).SetUint64(testToken), ev.ValueOrTokenId)
-	_, err := bi.bridge.HandleERC20Transfer(
+	tx, err := bi.bridge.HandleERC20Transfer(
 		bi.account.GenerateTransactOpts(), ev.Raw.TxHash, ev.From, ev.To, info.tokenRemoteAddr, ev.ValueOrTokenId, ev.RequestNonce, ev.Raw.BlockNumber, ev.ExtraData)
 	if err != nil {
 		log.Fatalf("Failed to HandleERC20Transfer: %v", err)
 	}
 	info.sim.Commit()
+	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
 }
 
 // TODO-Klaytn-ServiceChain: use ChildChainEventHandler
@@ -894,15 +899,17 @@ func requestNFTTransfer(info *testInfo, bi *BridgeInfo) {
 	bi.account.Lock()
 	defer bi.account.UnLock()
 
+	var tx *types.Transaction
+
 	opts := bi.account.GenerateTransactOpts()
 	// TODO-Klaytn need to separate child / parent chain nftIndex.
 	nftIndex := new(big.Int).SetInt64(info.nftIndex)
 
 	var err error
 	if bi.onChildChain {
-		_, err = info.nftLocalBridge.RequestValueTransfer(opts, nftIndex, info.aliceAuth.From, nil)
+		tx, err = info.nftLocalBridge.RequestValueTransfer(opts, nftIndex, info.aliceAuth.From, nil)
 	} else {
-		_, err = info.nftRemoteBridge.RequestValueTransfer(opts, nftIndex, info.aliceAuth.From, nil)
+		tx, err = info.nftRemoteBridge.RequestValueTransfer(opts, nftIndex, info.aliceAuth.From, nil)
 	}
 
 	if err != nil {
@@ -910,6 +917,7 @@ func requestNFTTransfer(info *testInfo, bi *BridgeInfo) {
 	}
 	info.nftIndex++
 	info.sim.Commit()
+	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
 }
 
 func handleNFTTransfer(info *testInfo, bi *BridgeInfo, ev *RequestValueTransferEvent) {
@@ -924,13 +932,14 @@ func handleNFTTransfer(info *testInfo, bi *BridgeInfo, ev *RequestValueTransferE
 		nftAddr = info.nftRemoteAddr
 	}
 
-	_, err := bi.bridge.HandleERC721Transfer(
+	tx, err := bi.bridge.HandleERC721Transfer(
 		bi.account.GenerateTransactOpts(),
 		ev.Raw.TxHash, ev.From, ev.To, nftAddr, ev.ValueOrTokenId, ev.RequestNonce, ev.Raw.BlockNumber, "", ev.ExtraData)
 	if err != nil {
 		log.Fatalf("Failed to handleERC721Transfer: %v", err)
 	}
 	info.sim.Commit()
+	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
 }
 
 // TODO-Klaytn-ServiceChain: use ChildChainEventHandler

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -833,11 +833,12 @@ func handleKLAYTransfer(info *testInfo, bi *BridgeInfo, ev *RequestValueTransfer
 
 	assert.Equal(info.t, new(big.Int).SetUint64(testAmount), ev.ValueOrTokenId)
 	opts := bi.account.GetTransactOpts()
-	_, err := bi.bridge.HandleKLAYTransfer(opts, ev.Raw.TxHash, ev.From, ev.To, ev.ValueOrTokenId, ev.RequestNonce, ev.Raw.BlockNumber, ev.ExtraData)
+	tx, err := bi.bridge.HandleKLAYTransfer(opts, ev.Raw.TxHash, ev.From, ev.To, ev.ValueOrTokenId, ev.RequestNonce, ev.Raw.BlockNumber, ev.ExtraData)
 	if err != nil {
 		log.Fatalf("\tFailed to HandleKLAYTransfer: %v", err)
 	}
 	info.sim.Commit()
+	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
 }
 
 // TODO-Klaytn-ServiceChain: use ChildChainEventHandler

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -623,8 +623,8 @@ func prepare(t *testing.T, vtcallback func(*testInfo)) *testInfo {
 	bacc.pAccount.chainID = big.NewInt(0)
 	bacc.cAccount.chainID = big.NewInt(0)
 
-	cAcc := bacc.cAccount.GetTransactOpts()
-	pAcc := bacc.pAccount.GetTransactOpts()
+	cAcc := bacc.cAccount.GenerateTransactOpts()
+	pAcc := bacc.pAccount.GenerateTransactOpts()
 
 	// Generate a new random account and a funded simulator.
 	aliceKey, _ := crypto.GenerateKey()
@@ -817,7 +817,7 @@ func requestKLAYTransfer(info *testInfo, bi *BridgeInfo) {
 	bi.account.Lock()
 	defer bi.account.UnLock()
 
-	opts := bi.account.GetTransactOpts()
+	opts := bi.account.GenerateTransactOpts()
 	opts.Value = big.NewInt(testAmount)
 	tx, err := bi.bridge.RequestKLAYTransfer(opts, info.aliceAuth.From, big.NewInt(testAmount), nil)
 	if err != nil {
@@ -832,7 +832,7 @@ func handleKLAYTransfer(info *testInfo, bi *BridgeInfo, ev *RequestValueTransfer
 	defer bi.account.UnLock()
 
 	assert.Equal(info.t, new(big.Int).SetUint64(testAmount), ev.ValueOrTokenId)
-	opts := bi.account.GetTransactOpts()
+	opts := bi.account.GenerateTransactOpts()
 	tx, err := bi.bridge.HandleKLAYTransfer(opts, ev.Raw.TxHash, ev.From, ev.To, ev.ValueOrTokenId, ev.RequestNonce, ev.Raw.BlockNumber, ev.ExtraData)
 	if err != nil {
 		log.Fatalf("\tFailed to HandleKLAYTransfer: %v", err)
@@ -854,7 +854,7 @@ func requestTokenTransfer(info *testInfo, bi *BridgeInfo) {
 	defer bi.account.UnLock()
 
 	testToken := big.NewInt(testToken)
-	opts := bi.account.GetTransactOpts()
+	opts := bi.account.GenerateTransactOpts()
 
 	var err error
 	if bi.onChildChain {
@@ -875,7 +875,7 @@ func handleTokenTransfer(info *testInfo, bi *BridgeInfo, ev *RequestValueTransfe
 
 	assert.Equal(info.t, new(big.Int).SetUint64(testToken), ev.ValueOrTokenId)
 	_, err := bi.bridge.HandleERC20Transfer(
-		bi.account.GetTransactOpts(), ev.Raw.TxHash, ev.From, ev.To, info.tokenRemoteAddr, ev.ValueOrTokenId, ev.RequestNonce, ev.Raw.BlockNumber, ev.ExtraData)
+		bi.account.GenerateTransactOpts(), ev.Raw.TxHash, ev.From, ev.To, info.tokenRemoteAddr, ev.ValueOrTokenId, ev.RequestNonce, ev.Raw.BlockNumber, ev.ExtraData)
 	if err != nil {
 		log.Fatalf("Failed to HandleERC20Transfer: %v", err)
 	}
@@ -894,7 +894,7 @@ func requestNFTTransfer(info *testInfo, bi *BridgeInfo) {
 	bi.account.Lock()
 	defer bi.account.UnLock()
 
-	opts := bi.account.GetTransactOpts()
+	opts := bi.account.GenerateTransactOpts()
 	// TODO-Klaytn need to separate child / parent chain nftIndex.
 	nftIndex := new(big.Int).SetInt64(info.nftIndex)
 
@@ -925,7 +925,7 @@ func handleNFTTransfer(info *testInfo, bi *BridgeInfo, ev *RequestValueTransferE
 	}
 
 	_, err := bi.bridge.HandleERC721Transfer(
-		bi.account.GetTransactOpts(),
+		bi.account.GenerateTransactOpts(),
 		ev.Raw.TxHash, ev.From, ev.To, nftAddr, ev.ValueOrTokenId, ev.RequestNonce, ev.Raw.BlockNumber, "", ev.ExtraData)
 	if err != nil {
 		log.Fatalf("Failed to handleERC721Transfer: %v", err)


### PR DESCRIPTION
## Proposed changes

- Refine `DeployBridgeTest` to use DeployBridge instead of a test function.
- Rename `GetTransactOpts` to `GenerateTransactOpts` since the function generates and returns a new object of `TransactOpts`. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

