### PR TITLE
SC: add a limit for pending request value transfer events

### DIFF
--- a/node/sc/bridge_manager.go
+++ b/node/sc/bridge_manager.go
@@ -99,7 +99,7 @@ type BridgeInfo struct {
 	counterpartToken map[common.Address]common.Address
 
 	pendingRequestEvent *bridgepool.ItemSortedMap
-	nextHandleNonce     uint64                    // This nonce will be used for getting pending request value transfer events.
+	nextHandleNonce     uint64 // This nonce will be used for getting pending request value transfer events.
 
 	isRunning                   bool
 	handleNonce                 uint64 // the nonce from the handle value transfer event from the bridge.


### PR DESCRIPTION
## Proposed changes

- To fix an OOM problem, introduce a max limit for adding pending request value transfer events.
    - There is a problem where the pending queue can grow indefinitely as the nonce diff grows, and there is a need to limit the size of the queue.
- memory profiling result:
```
Showing nodes accounting for 13210.15MB, 94.88% of 13922.81MB total
Dropped 453 nodes (cum <= 69.61MB)
Showing top 20 nodes out of 125
      flat  flat%   sum%        cum   cum%
 4097.37MB 29.43% 29.43%  4097.37MB 29.43%  github.com/klaytn/klaytn/vendor/github.com/allegro/bigcache/queue.(*BytesQueue).allocateAdditionalMemory
 2306.13MB 16.56% 45.99%  3799.71MB 27.29%  github.com/klaytn/klaytn/contracts/bridge.(*BridgeFilterer).WatchRequestValueTransfer.func1
 2255.62MB 16.20% 62.19%  2255.62MB 16.20%  github.com/klaytn/klaytn/blockchain/vm.(*Memory).Get (inline)
 1375.09MB  9.88% 72.07%  1375.09MB  9.88%  math/big.nat.make (inline)
  507.02MB  3.64% 75.71%  1493.58MB 10.73%  github.com/klaytn/klaytn/accounts/abi.readInteger
     469MB  3.37% 79.08%      469MB  3.37%  github.com/klaytn/klaytn/vendor/github.com/syndtr/goleveldb/leveldb/memdb.New
  443.06MB  3.18% 82.26%   510.84MB  3.67%  github.com/klaytn/klaytn/node/sc/bridgepool.(*ItemSortedMap).Put
  343.56MB  2.47% 84.73%   343.56MB  2.47%  reflect.New
  306.01MB  2.20% 86.93%  2560.63MB 18.39%  github.com/klaytn/klaytn/blockchain/vm.makeLog.func1
  286.01MB  2.05% 88.98%   637.03MB  4.58%  github.com/klaytn/klaytn/ser/rlp.decodeBigInt
  282.79MB  2.03% 91.01%  4381.17MB 31.47%  github.com/klaytn/klaytn/vendor/github.com/allegro/bigcache.(*cacheShard).set
  215.98MB  1.55% 92.56%   215.98MB  1.55%  github.com/klaytn/klaytn/vendor/github.com/syndtr/goleveldb/leveldb/util.(*BufferPool).Get
  151.01MB  1.08% 93.65%   151.01MB  1.08%  github.com/klaytn/klaytn/blockchain/types.newEmptyTxInternalDataLegacy (inline)
   87.95MB  0.63% 94.28%    87.95MB  0.63%  github.com/klaytn/klaytn/vendor/github.com/syndtr/goleveldb/leveldb/memdb.(*DB).Put
   72.65MB  0.52% 94.80%   287.61MB  2.07%  github.com/klaytn/klaytn/vendor/github.com/syndtr/goleveldb/leveldb.(*DB).get
    5.50MB  0.04% 94.84%   253.48MB  1.82%  github.com/klaytn/klaytn/storage/database.(*databaseManager).WriteAndCacheTxLookupEntries
    2.38MB 0.017% 94.86%  3754.20MB 26.96%  github.com/klaytn/klaytn/blockchain.(*BlockChain).insertChain
    1.01MB 0.0073% 94.87%    72.53MB  0.52%  github.com/klaytn/klaytn/blockchain/state.(*StateDB).Finalise
       1MB 0.0072% 94.87%  3335.19MB 23.95%  github.com/klaytn/klaytn/blockchain.(*StateProcessor).Process
       1MB 0.0072% 94.88%   168.58MB  1.21%  github.com/klaytn/klaytn/vendor/github.com/syndtr/goleveldb/leveldb/table.(*Reader).readBlock
```
- callstack
```
 goroutine 925 [select]:
 github.com/klaytn/klaytn/contracts/bridge.(*BridgeFilterer).WatchRequestValueTransfer.func1(0xc0ce5f7620, 0x0, 0x0)
     /go/src/github.com/klaytn/klaytn/build/_workspace/src/github.com/klaytn/klaytn/contracts/bridge/Bridge.go:2586 +0x1c7
 github.com/klaytn/klaytn/event.NewSubscription.func1(0xc0d2fd3400, 0xc0d2f65620)
     /go/src/github.com/klaytn/klaytn/build/_workspace/src/github.com/klaytn/klaytn/event/subscription.go:56 +0x65
 created by github.com/klaytn/klaytn/event.NewSubscription
     /go/src/github.com/klaytn/klaytn/build/_workspace/src/github.com/klaytn/klaytn/event/subscription.go:54 +0xc2
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- n/a

## Further comments

- n/a
