### PR TITLE
Introduce fee-delegated version of ChainDataAnchoring Tx

### DIFF
--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -51,7 +51,7 @@ const (
 	TxTypeSmartContractExecution, TxTypeFeeDelegatedSmartContractExecution, TxTypeFeeDelegatedSmartContractExecutionWithRatio
 	TxTypeCancel, TxTypeFeeDelegatedCancel, TxTypeFeeDelegatedCancelWithRatio
 	TxTypeBatch, _, _
-	TxTypeChainDataAnchoring, _, _
+	TxTypeChainDataAnchoring, TxTypeFeeDelegatedChainDataAnchoring, TxTypeFeeDelegatedChainDataAnchoringWithRatio
 	TxTypeLast, _, _
 )
 
@@ -176,6 +176,10 @@ func (t TxType) String() string {
 		return "TxTypeBatch"
 	case TxTypeChainDataAnchoring:
 		return "TxTypeChainDataAnchoring"
+	case TxTypeFeeDelegatedChainDataAnchoring:
+		return "TxTypeFeeDelegatedChainDataAnchoring"
+	case TxTypeFeeDelegatedChainDataAnchoringWithRatio:
+		return "TxTypeFeeDelegatedChainDataAnchoringWithRatio"
 	}
 
 	return "UndefinedTxType"
@@ -211,7 +215,7 @@ func (t TxType) IsFeeDelegatedWithRatioTransaction() bool {
 
 // IsRPCExcluded returns true if the submission of such tx type is excluded via RPC.
 func (t TxType) IsRPCExcluded() bool {
-	return t == TxTypeChainDataAnchoring
+	return (t &^ ((1 << SubTxTypeBits) - 1)) == TxTypeChainDataAnchoring
 }
 
 type FeeRatio uint8
@@ -405,6 +409,10 @@ func NewTxInternalData(t TxType) (TxInternalData, error) {
 		return newTxInternalDataFeeDelegatedCancelWithRatio(), nil
 	case TxTypeChainDataAnchoring:
 		return newTxInternalDataChainDataAnchoring(), nil
+	case TxTypeFeeDelegatedChainDataAnchoring:
+		return newTxInternalDataFeeDelegatedChainDataAnchoring(), nil
+	case TxTypeFeeDelegatedChainDataAnchoringWithRatio:
+		return newTxInternalDataFeeDelegatedChainDataAnchoringWithRatio(), nil
 	}
 
 	return nil, errUndefinedTxType
@@ -454,6 +462,10 @@ func NewTxInternalDataWithMap(t TxType, values map[TxValueKeyType]interface{}) (
 		return newTxInternalDataFeeDelegatedCancelWithRatioWithMap(values)
 	case TxTypeChainDataAnchoring:
 		return newTxInternalDataChainDataAnchoringWithMap(values)
+	case TxTypeFeeDelegatedChainDataAnchoring:
+		return newTxInternalDataFeeDelegatedChainDataAnchoringWithMap(values)
+	case TxTypeFeeDelegatedChainDataAnchoringWithRatio:
+		return newTxInternalDataFeeDelegatedChainDataAnchoringWithRatioWithMap(values)
 	}
 
 	return nil, errUndefinedTxType

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
@@ -1,0 +1,364 @@
+// Copyright 2019 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"github.com/klaytn/klaytn/blockchain/types/accountkey"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/ser/rlp"
+	"math/big"
+)
+
+// TxInternalDataFeeDelegatedChainDataAnchoring represents the fee-delegated transaction anchoring child chain data.
+type TxInternalDataFeeDelegatedChainDataAnchoring struct {
+	AccountNonce uint64
+	Price        *big.Int
+	GasLimit     uint64
+	From         common.Address
+	Payload      []byte
+
+	TxSignatures
+
+	FeePayer           common.Address
+	FeePayerSignatures TxSignatures
+
+	// This is only used when marshaling to JSON.
+	Hash *common.Hash `json:"hash" rlp:"-"`
+}
+
+type TxInternalDataFeeDelegatedChainDataAnchoringJSON struct {
+	Type               TxType           `json:"typeInt"`
+	TypeStr            string           `json:"type"`
+	AccountNonce       hexutil.Uint64   `json:"nonce"`
+	Price              *hexutil.Big     `json:"gasPrice"`
+	GasLimit           hexutil.Uint64   `json:"gas"`
+	From               common.Address   `json:"from"`
+	Payload            hexutil.Bytes    `json:"input"`
+	TxSignatures       TxSignaturesJSON `json:"signatures"`
+	FeePayer           common.Address   `json:"feePayer"`
+	FeePayerSignatures TxSignaturesJSON `json:"feePayerSignatures"`
+	Hash               *common.Hash     `json:"hash"`
+}
+
+func newTxInternalDataFeeDelegatedChainDataAnchoring() *TxInternalDataFeeDelegatedChainDataAnchoring {
+	h := common.Hash{}
+
+	return &TxInternalDataFeeDelegatedChainDataAnchoring{
+		Price: new(big.Int),
+		Hash:  &h,
+	}
+}
+
+func newTxInternalDataFeeDelegatedChainDataAnchoringWithMap(values map[TxValueKeyType]interface{}) (*TxInternalDataFeeDelegatedChainDataAnchoring, error) {
+	d := newTxInternalDataFeeDelegatedChainDataAnchoring()
+
+	if v, ok := values[TxValueKeyNonce].(uint64); ok {
+		d.AccountNonce = v
+		delete(values, TxValueKeyNonce)
+	} else {
+		return nil, errValueKeyNonceMustUint64
+	}
+
+	if v, ok := values[TxValueKeyGasPrice].(*big.Int); ok {
+		d.Price.Set(v)
+		delete(values, TxValueKeyGasPrice)
+	} else {
+		return nil, errValueKeyGasPriceMustBigInt
+	}
+
+	if v, ok := values[TxValueKeyGasLimit].(uint64); ok {
+		d.GasLimit = v
+		delete(values, TxValueKeyGasLimit)
+	} else {
+		return nil, errValueKeyGasLimitMustUint64
+	}
+
+	if v, ok := values[TxValueKeyFrom].(common.Address); ok {
+		d.From = v
+		delete(values, TxValueKeyFrom)
+	} else {
+		return nil, errValueKeyFromMustAddress
+	}
+
+	if v, ok := values[TxValueKeyAnchoredData].([]byte); ok {
+		d.Payload = v
+		delete(values, TxValueKeyAnchoredData)
+	} else {
+		return nil, errValueKeyAnchoredDataMustByteSlice
+	}
+
+	if v, ok := values[TxValueKeyFeePayer].(common.Address); ok {
+		d.FeePayer = v
+		delete(values, TxValueKeyFeePayer)
+	} else {
+		return nil, errValueKeyFeePayerMustAddress
+	}
+
+	if len(values) != 0 {
+		for k := range values {
+			logger.Warn("unnecessary key", k.String())
+		}
+		return nil, errUndefinedKeyRemains
+	}
+
+	return d, nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) Type() TxType {
+	return TxTypeFeeDelegatedChainDataAnchoring
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetRoleTypeForValidation() accountkey.RoleType {
+	return accountkey.RoleTransaction
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) Equal(b TxInternalData) bool {
+	tb, ok := b.(*TxInternalDataFeeDelegatedChainDataAnchoring)
+	if !ok {
+		return false
+	}
+
+	return t.AccountNonce == tb.AccountNonce &&
+		t.Price.Cmp(tb.Price) == 0 &&
+		t.GasLimit == tb.GasLimit &&
+		t.From == tb.From &&
+		bytes.Equal(t.Payload, tb.Payload) &&
+		t.TxSignatures.equal(tb.TxSignatures) &&
+		t.FeePayer == tb.FeePayer &&
+		t.FeePayerSignatures.equal(tb.FeePayerSignatures)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) String() string {
+	ser := newTxInternalDataSerializerWithValues(t)
+	enc, _ := rlp.EncodeToBytes(ser)
+	tx := Transaction{data: t}
+
+	return fmt.Sprintf(`
+	TX(%x)
+	Type:          %s
+	From:          %s
+	Nonce:         %v
+	GasPrice:      %#x
+	GasLimit:      %#x
+	AnchoredData:  %s
+	Signature:     %s
+	FeePayer:      %s
+	FeePayerSig:   %s
+	Hex:           %x
+`,
+		tx.Hash(),
+		t.Type().String(),
+		t.From.String(),
+		t.AccountNonce,
+		t.Price,
+		t.GasLimit,
+		common.Bytes2Hex(t.Payload),
+		t.TxSignatures.string(),
+		t.FeePayer,
+		t.FeePayerSignatures.string(),
+		enc)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) SerializeForSignToBytes() []byte {
+	b, _ := rlp.EncodeToBytes(struct {
+		Txtype       TxType
+		AccountNonce uint64
+		Price        *big.Int
+		GasLimit     uint64
+		From         common.Address
+		AnchoredData []byte
+	}{
+		t.Type(),
+		t.AccountNonce,
+		t.Price,
+		t.GasLimit,
+		t.From,
+		t.Payload,
+	})
+
+	return b
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) SerializeForSign() []interface{} {
+	return []interface{}{
+		t.Type(),
+		t.AccountNonce,
+		t.Price,
+		t.GasLimit,
+		t.From,
+		t.Payload,
+	}
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) SenderTxHash() common.Hash {
+	hw := sha3.NewKeccak256()
+	rlp.Encode(hw, t.Type())
+	rlp.Encode(hw, []interface{}{
+		t.AccountNonce,
+		t.Price,
+		t.GasLimit,
+		t.From,
+		t.Payload,
+		t.TxSignatures,
+	})
+
+	h := common.Hash{}
+
+	hw.Sum(h[:0])
+
+	return h
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) IsLegacyTransaction() bool {
+	return false
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetAccountNonce() uint64 {
+	return t.AccountNonce
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetPrice() *big.Int {
+	return new(big.Int).Set(t.Price)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetGasLimit() uint64 {
+	return t.GasLimit
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetRecipient() *common.Address {
+	return nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetAmount() *big.Int {
+	return common.Big0
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetFrom() common.Address {
+	return t.From
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetHash() *common.Hash {
+	return t.Hash
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetPayload() []byte {
+	return t.Payload
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetFeePayer() common.Address {
+	return t.FeePayer
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) GetFeePayerRawSignatureValues() TxSignatures {
+	return t.FeePayerSignatures.RawSignatureValues()
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) SetHash(h *common.Hash) {
+	t.Hash = h
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) SetSignature(s TxSignatures) {
+	t.TxSignatures = s
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) SetFeePayerSignatures(s TxSignatures) {
+	t.FeePayerSignatures = s
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) RecoverFeePayerPubkey(txhash common.Hash, homestead bool, vfunc func(*big.Int) *big.Int) ([]*ecdsa.PublicKey, error) {
+	return t.FeePayerSignatures.RecoverPubkey(txhash, homestead, vfunc)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
+	gas := params.TxChainDataAnchoringGas + params.TxGasFeeDelegated
+
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	if err != nil {
+		return 0, err
+	}
+
+	return gasPayloadWithGas, nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) Validate(stateDB StateDB, currentBlockNumber uint64) error {
+	return t.ValidateMutableValue(stateDB, currentBlockNumber)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) ValidateMutableValue(stateDB StateDB, currentBlockNumber uint64) error {
+	return nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) Execute(sender ContractRef, vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) (ret []byte, usedGas uint64, err error) {
+	stateDB.IncNonce(sender.Address())
+	return nil, gas, nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) MakeRPCOutput() map[string]interface{} {
+	return map[string]interface{}{
+		"typeInt":            t.Type(),
+		"type":               t.Type().String(),
+		"gas":                hexutil.Uint64(t.GasLimit),
+		"gasPrice":           (*hexutil.Big)(t.Price),
+		"nonce":              hexutil.Uint64(t.AccountNonce),
+		"input":              hexutil.Bytes(t.Payload),
+		"signatures":         t.TxSignatures.ToJSON(),
+		"feePayer":           t.FeePayer,
+		"feePayerSignatures": t.FeePayerSignatures.ToJSON(),
+	}
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) MarshalJSON() ([]byte, error) {
+	return json.Marshal(TxInternalDataFeeDelegatedChainDataAnchoringJSON{
+		t.Type(),
+		t.Type().String(),
+		(hexutil.Uint64)(t.AccountNonce),
+		(*hexutil.Big)(t.Price),
+		(hexutil.Uint64)(t.GasLimit),
+		t.From,
+		t.Payload,
+		t.TxSignatures.ToJSON(),
+		t.FeePayer,
+		t.FeePayerSignatures.ToJSON(),
+		t.Hash,
+	})
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) UnmarshalJSON(b []byte) error {
+	js := &TxInternalDataFeeDelegatedChainDataAnchoringJSON{}
+	if err := json.Unmarshal(b, js); err != nil {
+		return err
+	}
+
+	t.AccountNonce = uint64(js.AccountNonce)
+	t.Price = (*big.Int)(js.Price)
+	t.GasLimit = uint64(js.GasLimit)
+	t.From = js.From
+	t.Payload = js.Payload
+	t.TxSignatures = js.TxSignatures.ToTxSignatures()
+	t.FeePayer = js.FeePayer
+	t.FeePayerSignatures = js.FeePayerSignatures.ToTxSignatures()
+	t.Hash = js.Hash
+
+	return nil
+}

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
@@ -1,0 +1,391 @@
+// Copyright 2019 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"github.com/klaytn/klaytn/blockchain/types/accountkey"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/ser/rlp"
+	"math/big"
+)
+
+// TxInternalDataFeeDelegatedChainDataAnchoringWithRatio represents the fee-delegated transaction
+// anchoring child chain data with a specified fee ratio between the sender and the fee payer.
+// The ratio is a fee payer's ratio in percentage.
+// For example, if it is 20, 20% of tx fee will be paid by the fee payer.
+// 80% of tx fee will be paid by the sender.
+type TxInternalDataFeeDelegatedChainDataAnchoringWithRatio struct {
+	AccountNonce uint64
+	Price        *big.Int
+	GasLimit     uint64
+	From         common.Address
+	Payload      []byte
+	FeeRatio     FeeRatio
+
+	TxSignatures
+
+	FeePayer           common.Address
+	FeePayerSignatures TxSignatures
+
+	// This is only used when marshaling to JSON.
+	Hash *common.Hash `json:"hash" rlp:"-"`
+}
+
+type TxInternalDataFeeDelegatedChainDataAnchoringWithRatioJSON struct {
+	Type               TxType           `json:"typeInt"`
+	TypeStr            string           `json:"type"`
+	AccountNonce       hexutil.Uint64   `json:"nonce"`
+	Price              *hexutil.Big     `json:"gasPrice"`
+	GasLimit           hexutil.Uint64   `json:"gas"`
+	From               common.Address   `json:"from"`
+	Payload            hexutil.Bytes    `json:"input"`
+	FeeRatio           hexutil.Uint     `json:"feeRatio"`
+	TxSignatures       TxSignaturesJSON `json:"signatures"`
+	FeePayer           common.Address   `json:"feePayer"`
+	FeePayerSignatures TxSignaturesJSON `json:"feePayerSignatures"`
+	Hash               *common.Hash     `json:"hash"`
+}
+
+func newTxInternalDataFeeDelegatedChainDataAnchoringWithRatio() *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio {
+	h := common.Hash{}
+
+	return &TxInternalDataFeeDelegatedChainDataAnchoringWithRatio{
+		Price: new(big.Int),
+		Hash:  &h,
+	}
+}
+
+func newTxInternalDataFeeDelegatedChainDataAnchoringWithRatioWithMap(values map[TxValueKeyType]interface{}) (*TxInternalDataFeeDelegatedChainDataAnchoringWithRatio, error) {
+	d := newTxInternalDataFeeDelegatedChainDataAnchoringWithRatio()
+
+	if v, ok := values[TxValueKeyNonce].(uint64); ok {
+		d.AccountNonce = v
+		delete(values, TxValueKeyNonce)
+	} else {
+		return nil, errValueKeyNonceMustUint64
+	}
+
+	if v, ok := values[TxValueKeyGasPrice].(*big.Int); ok {
+		d.Price.Set(v)
+		delete(values, TxValueKeyGasPrice)
+	} else {
+		return nil, errValueKeyGasPriceMustBigInt
+	}
+
+	if v, ok := values[TxValueKeyGasLimit].(uint64); ok {
+		d.GasLimit = v
+		delete(values, TxValueKeyGasLimit)
+	} else {
+		return nil, errValueKeyGasLimitMustUint64
+	}
+
+	if v, ok := values[TxValueKeyFrom].(common.Address); ok {
+		d.From = v
+		delete(values, TxValueKeyFrom)
+	} else {
+		return nil, errValueKeyFromMustAddress
+	}
+
+	if v, ok := values[TxValueKeyAnchoredData].([]byte); ok {
+		d.Payload = v
+		delete(values, TxValueKeyAnchoredData)
+	} else {
+		return nil, errValueKeyAnchoredDataMustByteSlice
+	}
+
+	if v, ok := values[TxValueKeyFeePayer].(common.Address); ok {
+		d.FeePayer = v
+		delete(values, TxValueKeyFeePayer)
+	} else {
+		return nil, errValueKeyFeePayerMustAddress
+	}
+
+	if v, ok := values[TxValueKeyFeeRatioOfFeePayer].(FeeRatio); ok {
+		d.FeeRatio = v
+		delete(values, TxValueKeyFeeRatioOfFeePayer)
+	} else {
+		return nil, errValueKeyFeeRatioMustUint8
+	}
+
+	if len(values) != 0 {
+		for k := range values {
+			logger.Warn("unnecessary key", k.String())
+		}
+		return nil, errUndefinedKeyRemains
+	}
+
+	return d, nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) Type() TxType {
+	return TxTypeFeeDelegatedChainDataAnchoringWithRatio
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetRoleTypeForValidation() accountkey.RoleType {
+	return accountkey.RoleTransaction
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) Equal(b TxInternalData) bool {
+	tb, ok := b.(*TxInternalDataFeeDelegatedChainDataAnchoringWithRatio)
+	if !ok {
+		return false
+	}
+
+	return t.AccountNonce == tb.AccountNonce &&
+		t.Price.Cmp(tb.Price) == 0 &&
+		t.GasLimit == tb.GasLimit &&
+		t.From == tb.From &&
+		t.FeeRatio == tb.FeeRatio &&
+		bytes.Equal(t.Payload, tb.Payload) &&
+		t.TxSignatures.equal(tb.TxSignatures) &&
+		t.FeePayer == tb.FeePayer &&
+		t.FeePayerSignatures.equal(tb.FeePayerSignatures)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) String() string {
+	ser := newTxInternalDataSerializerWithValues(t)
+	enc, _ := rlp.EncodeToBytes(ser)
+	tx := Transaction{data: t}
+
+	return fmt.Sprintf(`
+	TX(%x)
+	Type:          %s
+	From:          %s
+	Nonce:         %v
+	GasPrice:      %#x
+	GasLimit:      %#x
+	AnchoredData:  %s
+	Signature:     %s
+	FeePayer:      %s
+	FeeRatio:      %d
+	FeePayerSig:   %s
+	Hex:           %x
+`,
+		tx.Hash(),
+		t.Type().String(),
+		t.From.String(),
+		t.AccountNonce,
+		t.Price,
+		t.GasLimit,
+		common.Bytes2Hex(t.Payload),
+		t.TxSignatures.string(),
+		t.FeePayer,
+		t.FeeRatio,
+		t.FeePayerSignatures.string(),
+		enc)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) SerializeForSignToBytes() []byte {
+	b, _ := rlp.EncodeToBytes(struct {
+		Txtype       TxType
+		AccountNonce uint64
+		Price        *big.Int
+		GasLimit     uint64
+		From         common.Address
+		AnchoredData []byte
+		FeeRatio     FeeRatio
+	}{
+		t.Type(),
+		t.AccountNonce,
+		t.Price,
+		t.GasLimit,
+		t.From,
+		t.Payload,
+		t.FeeRatio,
+	})
+
+	return b
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) SerializeForSign() []interface{} {
+	return []interface{}{
+		t.Type(),
+		t.AccountNonce,
+		t.Price,
+		t.GasLimit,
+		t.From,
+		t.Payload,
+		t.FeeRatio,
+	}
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) SenderTxHash() common.Hash {
+	hw := sha3.NewKeccak256()
+	rlp.Encode(hw, t.Type())
+	rlp.Encode(hw, []interface{}{
+		t.AccountNonce,
+		t.Price,
+		t.GasLimit,
+		t.From,
+		t.Payload,
+		t.FeeRatio,
+		t.TxSignatures,
+	})
+
+	h := common.Hash{}
+
+	hw.Sum(h[:0])
+
+	return h
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) IsLegacyTransaction() bool {
+	return false
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetAccountNonce() uint64 {
+	return t.AccountNonce
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetPrice() *big.Int {
+	return new(big.Int).Set(t.Price)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetGasLimit() uint64 {
+	return t.GasLimit
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetRecipient() *common.Address {
+	return nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetAmount() *big.Int {
+	return common.Big0
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetFrom() common.Address {
+	return t.From
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetHash() *common.Hash {
+	return t.Hash
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetPayload() []byte {
+	return t.Payload
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetFeePayer() common.Address {
+	return t.FeePayer
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetFeePayerRawSignatureValues() TxSignatures {
+	return t.FeePayerSignatures.RawSignatureValues()
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) GetFeeRatio() FeeRatio {
+	return t.FeeRatio
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) SetHash(h *common.Hash) {
+	t.Hash = h
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) SetSignature(s TxSignatures) {
+	t.TxSignatures = s
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) SetFeePayerSignatures(s TxSignatures) {
+	t.FeePayerSignatures = s
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) RecoverFeePayerPubkey(txhash common.Hash, homestead bool, vfunc func(*big.Int) *big.Int) ([]*ecdsa.PublicKey, error) {
+	return t.FeePayerSignatures.RecoverPubkey(txhash, homestead, vfunc)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
+	gas := params.TxChainDataAnchoringGas + params.TxGasFeeDelegatedWithRatio
+
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	if err != nil {
+		return 0, err
+	}
+
+	return gasPayloadWithGas, nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) Validate(stateDB StateDB, currentBlockNumber uint64) error {
+	return t.ValidateMutableValue(stateDB, currentBlockNumber)
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) ValidateMutableValue(stateDB StateDB, currentBlockNumber uint64) error {
+	return nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) Execute(sender ContractRef, vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) (ret []byte, usedGas uint64, err error) {
+	stateDB.IncNonce(sender.Address())
+	return nil, gas, nil
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MakeRPCOutput() map[string]interface{} {
+	return map[string]interface{}{
+		"typeInt":            t.Type(),
+		"type":               t.Type().String(),
+		"gas":                hexutil.Uint64(t.GasLimit),
+		"gasPrice":           (*hexutil.Big)(t.Price),
+		"nonce":              hexutil.Uint64(t.AccountNonce),
+		"input":              hexutil.Bytes(t.Payload),
+		"feeRatio":           hexutil.Uint(t.FeeRatio),
+		"signatures":         t.TxSignatures.ToJSON(),
+		"feePayer":           t.FeePayer,
+		"feePayerSignatures": t.FeePayerSignatures.ToJSON(),
+	}
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MarshalJSON() ([]byte, error) {
+	return json.Marshal(TxInternalDataFeeDelegatedChainDataAnchoringWithRatioJSON{
+		t.Type(),
+		t.Type().String(),
+		(hexutil.Uint64)(t.AccountNonce),
+		(*hexutil.Big)(t.Price),
+		(hexutil.Uint64)(t.GasLimit),
+		t.From,
+		t.Payload,
+		(hexutil.Uint)(t.FeeRatio),
+		t.TxSignatures.ToJSON(),
+		t.FeePayer,
+		t.FeePayerSignatures.ToJSON(),
+		t.Hash,
+	})
+}
+
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) UnmarshalJSON(b []byte) error {
+	js := &TxInternalDataFeeDelegatedChainDataAnchoringWithRatioJSON{}
+	if err := json.Unmarshal(b, js); err != nil {
+		return err
+	}
+
+	t.AccountNonce = uint64(js.AccountNonce)
+	t.Price = (*big.Int)(js.Price)
+	t.GasLimit = uint64(js.GasLimit)
+	t.From = js.From
+	t.Payload = js.Payload
+	t.FeeRatio = FeeRatio(js.FeeRatio)
+	t.TxSignatures = js.TxSignatures.ToTxSignatures()
+	t.FeePayer = js.FeePayer
+	t.FeePayerSignatures = js.FeePayerSignatures.ToTxSignatures()
+	t.Hash = js.Hash
+
+	return nil
+}

--- a/blockchain/types/tx_internal_data_rlp_decode_test.go
+++ b/blockchain/types/tx_internal_data_rlp_decode_test.go
@@ -31,6 +31,7 @@ type testingF func(t *testing.T)
 func TestTxRLPDecode(t *testing.T) {
 	funcs := []testingF{
 		testTxRLPDecodeLegacy,
+
 		testTxRLPDecodeValueTransfer,
 		testTxRLPDecodeValueTransferMemo,
 		testTxRLPDecodeAccountUpdate,
@@ -38,18 +39,22 @@ func TestTxRLPDecode(t *testing.T) {
 		testTxRLPDecodeSmartContractExecution,
 		testTxRLPDecodeCancel,
 		testTxRLPDecodeChainDataAnchoring,
+
 		testTxRLPDecodeFeeDelegatedValueTransfer,
 		testTxRLPDecodeFeeDelegatedValueTransferMemo,
 		testTxRLPDecodeFeeDelegatedAccountUpdate,
 		testTxRLPDecodeFeeDelegatedSmartContractDeploy,
 		testTxRLPDecodeFeeDelegatedSmartContractExecution,
 		testTxRLPDecodeFeeDelegatedCancel,
+		testTxRLPDecodeFeeDelegatedChainDataAnchoring,
+
 		testTxRLPDecodeFeeDelegatedValueTransferWithRatio,
 		testTxRLPDecodeFeeDelegatedValueTransferMemoWithRatio,
 		testTxRLPDecodeFeeDelegatedAccountUpdateWithRatio,
 		testTxRLPDecodeFeeDelegatedSmartContractDeployWithRatio,
 		testTxRLPDecodeFeeDelegatedSmartContractExecutionWithRatio,
 		testTxRLPDecodeFeeDelegatedCancelWithRatio,
+		testTxRLPDecodeFeeDelegatedChainDataAnchoringWithRatio,
 	}
 
 	for _, f := range funcs {
@@ -524,6 +529,36 @@ func testTxRLPDecodeFeeDelegatedCancel(t *testing.T) {
 	}
 }
 
+func testTxRLPDecodeFeeDelegatedChainDataAnchoring(t *testing.T) {
+	tx := genFeeDelegatedChainDataTransaction().(*TxInternalDataFeeDelegatedChainDataAnchoring)
+
+	buffer := new(bytes.Buffer)
+	err := rlp.Encode(buffer, tx.Type())
+	assert.Equal(t, nil, err)
+
+	err = rlp.Encode(buffer, []interface{}{
+		tx.AccountNonce,
+		tx.Price,
+		tx.GasLimit,
+		tx.From,
+		tx.Payload,
+		tx.TxSignatures,
+		tx.FeePayer,
+		tx.FeePayerSignatures,
+	})
+	assert.Equal(t, nil, err)
+
+	dec := newTxInternalDataSerializer()
+
+	if err := rlp.DecodeBytes(buffer.Bytes(), &dec); err != nil {
+		panic(err)
+	}
+
+	if !tx.Equal(dec.tx) {
+		t.Fatalf("tx != dec.tx\ntx=%v\ndec.tx=%v", tx, dec.tx)
+	}
+}
+
 func testTxRLPDecodeFeeDelegatedValueTransferWithRatio(t *testing.T) {
 	tx := genFeeDelegatedValueTransferWithRatioTransaction().(*TxInternalDataFeeDelegatedValueTransferWithRatio)
 
@@ -703,6 +738,37 @@ func testTxRLPDecodeFeeDelegatedCancelWithRatio(t *testing.T) {
 		tx.Price,
 		tx.GasLimit,
 		tx.From,
+		tx.FeeRatio,
+		tx.TxSignatures,
+		tx.FeePayer,
+		tx.FeePayerSignatures,
+	})
+	assert.Equal(t, nil, err)
+
+	dec := newTxInternalDataSerializer()
+
+	if err := rlp.DecodeBytes(buffer.Bytes(), &dec); err != nil {
+		panic(err)
+	}
+
+	if !tx.Equal(dec.tx) {
+		t.Fatalf("tx != dec.tx\ntx=%v\ndec.tx=%v", tx, dec.tx)
+	}
+}
+
+func testTxRLPDecodeFeeDelegatedChainDataAnchoringWithRatio(t *testing.T) {
+	tx := genFeeDelegatedChainDataWithRatioTransaction().(*TxInternalDataFeeDelegatedChainDataAnchoringWithRatio)
+
+	buffer := new(bytes.Buffer)
+	err := rlp.Encode(buffer, tx.Type())
+	assert.Equal(t, nil, err)
+
+	err = rlp.Encode(buffer, []interface{}{
+		tx.AccountNonce,
+		tx.Price,
+		tx.GasLimit,
+		tx.From,
+		tx.Payload,
 		tx.FeeRatio,
 		tx.TxSignatures,
 		tx.FeePayer,

--- a/blockchain/types/tx_internal_data_sender_hash_test.go
+++ b/blockchain/types/tx_internal_data_sender_hash_test.go
@@ -41,7 +41,9 @@ func TestTransactionSenderTxHash(t *testing.T) {
 		{"ValueTransferMemo", genValueTransferMemoTransaction()},
 		{"FeeDelegatedValueTransferMemo", genFeeDelegatedValueTransferMemoTransaction()},
 		{"FeeDelegatedValueTransferMemoWithRatio", genFeeDelegatedValueTransferMemoWithRatioTransaction()},
-		{"ChainDataTx", genChainDataTransaction()},
+		{"ChainDataAnchoring", genChainDataTransaction()},
+		{"FeeDelegatedChainDataAnchoring", genFeeDelegatedChainDataTransaction()},
+		{"FeeDelegatedChainDataAnchoringWithRatio", genFeeDelegatedChainDataWithRatioTransaction()},
 		{"AccountUpdate", genAccountUpdateTransaction()},
 		{"FeeDelegatedAccountUpdate", genFeeDelegatedAccountUpdateTransaction()},
 		{"FeeDelegatedAccountUpdateWithRatio", genFeeDelegatedAccountUpdateWithRatioTransaction()},
@@ -376,6 +378,43 @@ func testTransactionSenderTxHash(t *testing.T, tx TxInternalData) {
 	case *TxInternalDataChainDataAnchoring:
 		senderTxHash := rawTx.GetTxInternalData().SenderTxHash()
 		assert.Equal(t, rawTx.Hash(), senderTxHash)
+
+	case *TxInternalDataFeeDelegatedChainDataAnchoring:
+		hw := sha3.NewKeccak256()
+		rlp.Encode(hw, rawTx.Type())
+		rlp.Encode(hw, []interface{}{
+			v.AccountNonce,
+			v.Price,
+			v.GasLimit,
+			v.From,
+			v.Payload,
+			v.TxSignatures,
+		})
+
+		h := common.Hash{}
+
+		hw.Sum(h[:0])
+		senderTxHash := rawTx.GetTxInternalData().SenderTxHash()
+		assert.Equal(t, h, senderTxHash)
+
+	case *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio:
+		hw := sha3.NewKeccak256()
+		rlp.Encode(hw, rawTx.Type())
+		rlp.Encode(hw, []interface{}{
+			v.AccountNonce,
+			v.Price,
+			v.GasLimit,
+			v.From,
+			v.Payload,
+			v.FeeRatio,
+			v.TxSignatures,
+		})
+
+		h := common.Hash{}
+
+		hw.Sum(h[:0])
+		senderTxHash := rawTx.GetTxInternalData().SenderTxHash()
+		assert.Equal(t, h, senderTxHash)
 
 	default:
 		t.Fatal("Undefined tx type.")

--- a/blockchain/types/tx_internal_data_serializer_test.go
+++ b/blockchain/types/tx_internal_data_serializer_test.go
@@ -51,7 +51,9 @@ func TestTransactionSerialization(t *testing.T) {
 		{"ValueTransferMemo", genValueTransferMemoTransaction()},
 		{"FeeDelegatedValueTransferMemo", genFeeDelegatedValueTransferMemoTransaction()},
 		{"FeeDelegatedValueTransferMemoWithRatio", genFeeDelegatedValueTransferMemoWithRatioTransaction()},
-		{"ChainDataTx", genChainDataTransaction()},
+		{"ChainDataAnchoring", genChainDataTransaction()},
+		{"FeeDelegatedChainDataAnchoring", genFeeDelegatedChainDataTransaction()},
+		{"FeeDelegatedChainDataAnchoringWithRatio", genFeeDelegatedChainDataWithRatioTransaction()},
 		{"AccountUpdate", genAccountUpdateTransaction()},
 		{"FeeDelegatedAccountUpdate", genFeeDelegatedAccountUpdateTransaction()},
 		{"FeeDelegatedAccountUpdateWithRatio", genFeeDelegatedAccountUpdateWithRatioTransaction()},
@@ -393,6 +395,71 @@ func genChainDataTransaction() TxInternalData {
 		TxValueKeyGasLimit:     gasLimit,
 		TxValueKeyGasPrice:     gasPrice,
 		TxValueKeyAnchoredData: anchoredData,
+	})
+
+	if err != nil {
+		// Since we do not have testing.T here, call panic() instead of t.Fatal().
+		panic(err)
+	}
+
+	return txdata
+}
+
+func genFeeDelegatedChainDataTransaction() TxInternalData {
+	data := &AnchoringDataInternalType0{common.HexToHash("0"), common.HexToHash("1"),
+		common.HexToHash("2"), common.HexToHash("3"),
+		common.HexToHash("4"), big.NewInt(5), big.NewInt(6), big.NewInt(7)}
+	encodedCCTxData, err := rlp.EncodeToBytes(data)
+	if err != nil {
+		panic(err)
+	}
+	blockTxData := &AnchoringData{0, encodedCCTxData}
+
+	anchoredData, err := rlp.EncodeToBytes(blockTxData)
+	if err != nil {
+		panic(err)
+	}
+
+	txdata, err := NewTxInternalDataWithMap(TxTypeFeeDelegatedChainDataAnchoring, map[TxValueKeyType]interface{}{
+		TxValueKeyNonce:        nonce,
+		TxValueKeyFrom:         from,
+		TxValueKeyGasLimit:     gasLimit,
+		TxValueKeyGasPrice:     gasPrice,
+		TxValueKeyAnchoredData: anchoredData,
+		TxValueKeyFeePayer:     feePayer,
+	})
+
+	if err != nil {
+		// Since we do not have testing.T here, call panic() instead of t.Fatal().
+		panic(err)
+	}
+
+	return txdata
+}
+
+func genFeeDelegatedChainDataWithRatioTransaction() TxInternalData {
+	data := &AnchoringDataInternalType0{common.HexToHash("0"), common.HexToHash("1"),
+		common.HexToHash("2"), common.HexToHash("3"),
+		common.HexToHash("4"), big.NewInt(5), big.NewInt(6), big.NewInt(7)}
+	encodedCCTxData, err := rlp.EncodeToBytes(data)
+	if err != nil {
+		panic(err)
+	}
+	blockTxData := &AnchoringData{0, encodedCCTxData}
+
+	anchoredData, err := rlp.EncodeToBytes(blockTxData)
+	if err != nil {
+		panic(err)
+	}
+
+	txdata, err := NewTxInternalDataWithMap(TxTypeFeeDelegatedChainDataAnchoringWithRatio, map[TxValueKeyType]interface{}{
+		TxValueKeyNonce:              nonce,
+		TxValueKeyFrom:               from,
+		TxValueKeyGasLimit:           gasLimit,
+		TxValueKeyGasPrice:           gasPrice,
+		TxValueKeyAnchoredData:       anchoredData,
+		TxValueKeyFeePayer:           feePayer,
+		TxValueKeyFeeRatioOfFeePayer: FeeRatio(30),
 	})
 
 	if err != nil {

--- a/blockchain/types/tx_internal_rlp_encode_test.go
+++ b/blockchain/types/tx_internal_rlp_encode_test.go
@@ -65,6 +65,8 @@ func TestTxRLPEncode(t *testing.T) {
 		testTxRLPEncodeFeeDelegatedCancelWithRatio,
 
 		testTxRLPEncodeChainDataAnchoring,
+		testTxRLPEncodeFeeDelegatedChainDataAnchoring,
+		testTxRLPEncodeFeeDelegatedChainDataAnchoringWithRatio,
 	}
 
 	for _, f := range funcs {
@@ -864,6 +866,69 @@ func testTxRLPEncodeFeeDelegatedCancel(t *testing.T) {
 	printFeeDelegatedRLPEncode(t, chainId, signer, sigRLP, feePayerSigRLP, txHashRLP, senderTxHashRLP, rawTx)
 }
 
+func testTxRLPEncodeFeeDelegatedChainDataAnchoring(t *testing.T) {
+	tx := genFeeDelegatedChainDataTransaction().(*TxInternalDataFeeDelegatedChainDataAnchoring)
+
+	signer := MakeSigner(params.BFTTestChainConfig, big.NewInt(2))
+	chainId := params.BFTTestChainConfig.ChainID
+	rawTx := &Transaction{data: tx}
+	rawTx.Sign(signer, key)
+	rawTx.SignFeePayer(signer, payerKey)
+
+	sigRLP := new(bytes.Buffer)
+
+	err := rlp.Encode(sigRLP, []interface{}{
+		tx.SerializeForSignToBytes(),
+		chainId,
+		uint(0),
+		uint(0),
+	})
+	assert.Equal(t, nil, err)
+
+	feePayerSigRLP := new(bytes.Buffer)
+
+	err = rlp.Encode(feePayerSigRLP, []interface{}{
+		tx.SerializeForSignToBytes(),
+		tx.FeePayer,
+		chainId,
+		uint(0),
+		uint(0),
+	})
+	assert.Equal(t, nil, err)
+
+	txHashRLP := new(bytes.Buffer)
+	err = rlp.Encode(txHashRLP, tx.Type())
+	assert.Equal(t, nil, err)
+
+	err = rlp.Encode(txHashRLP, []interface{}{
+		tx.AccountNonce,
+		tx.Price,
+		tx.GasLimit,
+		tx.From,
+		tx.Payload,
+		tx.TxSignatures,
+		tx.FeePayer,
+		tx.FeePayerSignatures,
+	})
+	assert.Equal(t, nil, err)
+
+	senderTxHashRLP := new(bytes.Buffer)
+	err = rlp.Encode(senderTxHashRLP, tx.Type())
+	assert.Equal(t, nil, err)
+
+	err = rlp.Encode(senderTxHashRLP, []interface{}{
+		tx.AccountNonce,
+		tx.Price,
+		tx.GasLimit,
+		tx.From,
+		tx.Payload,
+		tx.TxSignatures,
+	})
+	assert.Equal(t, nil, err)
+
+	printFeeDelegatedRLPEncode(t, chainId, signer, sigRLP, feePayerSigRLP, txHashRLP, senderTxHashRLP, rawTx)
+}
+
 func testTxRLPEncodeFeeDelegatedValueTransferWithRatio(t *testing.T) {
 	tx := genFeeDelegatedValueTransferWithRatioTransaction().(*TxInternalDataFeeDelegatedValueTransferWithRatio)
 
@@ -1264,6 +1329,71 @@ func testTxRLPEncodeFeeDelegatedCancelWithRatio(t *testing.T) {
 		tx.Price,
 		tx.GasLimit,
 		tx.From,
+		tx.FeeRatio,
+		tx.TxSignatures,
+	})
+	assert.Equal(t, nil, err)
+
+	printFeeDelegatedRLPEncode(t, chainId, signer, sigRLP, feePayerSigRLP, txHashRLP, senderTxHashRLP, rawTx)
+}
+
+func testTxRLPEncodeFeeDelegatedChainDataAnchoringWithRatio(t *testing.T) {
+	tx := genFeeDelegatedChainDataWithRatioTransaction().(*TxInternalDataFeeDelegatedChainDataAnchoringWithRatio)
+
+	signer := MakeSigner(params.BFTTestChainConfig, big.NewInt(2))
+	chainId := params.BFTTestChainConfig.ChainID
+	rawTx := &Transaction{data: tx}
+	rawTx.Sign(signer, key)
+	rawTx.SignFeePayer(signer, payerKey)
+
+	sigRLP := new(bytes.Buffer)
+
+	err := rlp.Encode(sigRLP, []interface{}{
+		tx.SerializeForSignToBytes(),
+		chainId,
+		uint(0),
+		uint(0),
+	})
+	assert.Equal(t, nil, err)
+
+	feePayerSigRLP := new(bytes.Buffer)
+
+	err = rlp.Encode(feePayerSigRLP, []interface{}{
+		tx.SerializeForSignToBytes(),
+		tx.FeePayer,
+		chainId,
+		uint(0),
+		uint(0),
+	})
+	assert.Equal(t, nil, err)
+
+	txHashRLP := new(bytes.Buffer)
+	err = rlp.Encode(txHashRLP, tx.Type())
+	assert.Equal(t, nil, err)
+
+	err = rlp.Encode(txHashRLP, []interface{}{
+		tx.AccountNonce,
+		tx.Price,
+		tx.GasLimit,
+		tx.From,
+		tx.Payload,
+		tx.FeeRatio,
+		tx.TxSignatures,
+		tx.FeePayer,
+		tx.FeePayerSignatures,
+	})
+	assert.Equal(t, nil, err)
+
+	senderTxHashRLP := new(bytes.Buffer)
+	err = rlp.Encode(senderTxHashRLP, tx.Type())
+	assert.Equal(t, nil, err)
+
+	err = rlp.Encode(senderTxHashRLP, []interface{}{
+		tx.AccountNonce,
+		tx.Price,
+		tx.GasLimit,
+		tx.From,
+		tx.Payload,
 		tx.FeeRatio,
 		tx.TxSignatures,
 	})

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -308,6 +308,21 @@ func generateDefaultTx(sender *TestAccountType, recipient *TestAccountType, txTy
 		values[types.TxValueKeyGasLimit] = gasLimit
 		values[types.TxValueKeyGasPrice] = gasPrice
 		values[types.TxValueKeyAnchoredData] = dataAnchor
+	case types.TxTypeFeeDelegatedChainDataAnchoring:
+		values[types.TxValueKeyNonce] = sender.Nonce
+		values[types.TxValueKeyFrom] = sender.Addr
+		values[types.TxValueKeyGasLimit] = gasLimit
+		values[types.TxValueKeyGasPrice] = gasPrice
+		values[types.TxValueKeyAnchoredData] = dataAnchor
+		values[types.TxValueKeyFeePayer] = recipient.Addr
+	case types.TxTypeFeeDelegatedChainDataAnchoringWithRatio:
+		values[types.TxValueKeyNonce] = sender.Nonce
+		values[types.TxValueKeyFrom] = sender.Addr
+		values[types.TxValueKeyGasLimit] = gasLimit
+		values[types.TxValueKeyGasPrice] = gasPrice
+		values[types.TxValueKeyAnchoredData] = dataAnchor
+		values[types.TxValueKeyFeePayer] = recipient.Addr
+		values[types.TxValueKeyFeeRatioOfFeePayer] = ratio
 	}
 
 	tx, err := types.NewTransactionWithMap(txType, values)
@@ -459,32 +474,12 @@ func TestDefaultTxsWithDefaultAccountKey(t *testing.T) {
 		accountkey.AccountKeyTypeRoleBased,
 	}
 
-	// select txtypes to be tested
-	txTypes := []types.TxType{
-		types.TxTypeLegacyTransaction,
-
-		types.TxTypeValueTransfer,
-		types.TxTypeValueTransferMemo,
-		types.TxTypeSmartContractDeploy,
-		types.TxTypeSmartContractExecution,
-		types.TxTypeAccountUpdate,
-		types.TxTypeCancel,
-
-		types.TxTypeFeeDelegatedValueTransfer,
-		types.TxTypeFeeDelegatedValueTransferMemo,
-		types.TxTypeFeeDelegatedSmartContractDeploy,
-		types.TxTypeFeeDelegatedSmartContractExecution,
-		types.TxTypeFeeDelegatedAccountUpdate,
-		types.TxTypeFeeDelegatedCancel,
-
-		types.TxTypeFeeDelegatedValueTransferWithRatio,
-		types.TxTypeFeeDelegatedValueTransferMemoWithRatio,
-		types.TxTypeFeeDelegatedSmartContractDeployWithRatio,
-		types.TxTypeFeeDelegatedSmartContractExecutionWithRatio,
-		types.TxTypeFeeDelegatedAccountUpdateWithRatio,
-		types.TxTypeFeeDelegatedCancelWithRatio,
-
-		types.TxTypeChainDataAnchoring,
+	txTypes := []types.TxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		_, err := types.NewTxInternalData(i)
+		if err == nil {
+			txTypes = append(txTypes, i)
+		}
 	}
 
 	// tests for all accountKeyTypes
@@ -1854,31 +1849,15 @@ func TestRoleBasedKeySendTx(t *testing.T) {
 
 	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
 
-	txTypes := []types.TxType{
-		//types.TxTypeLegacyTransaction, // accounts with role-based key cannot a send legacy tx.
-
-		types.TxTypeValueTransfer,
-		types.TxTypeValueTransferMemo,
-		types.TxTypeSmartContractDeploy,
-		types.TxTypeSmartContractExecution,
-		types.TxTypeAccountUpdate,
-		types.TxTypeCancel,
-
-		types.TxTypeFeeDelegatedValueTransfer,
-		types.TxTypeFeeDelegatedValueTransferMemo,
-		types.TxTypeFeeDelegatedSmartContractDeploy,
-		types.TxTypeFeeDelegatedSmartContractExecution,
-		types.TxTypeFeeDelegatedAccountUpdate,
-		types.TxTypeFeeDelegatedCancel,
-
-		types.TxTypeFeeDelegatedValueTransferWithRatio,
-		types.TxTypeFeeDelegatedValueTransferMemoWithRatio,
-		types.TxTypeFeeDelegatedSmartContractDeployWithRatio,
-		types.TxTypeFeeDelegatedSmartContractExecutionWithRatio,
-		types.TxTypeFeeDelegatedAccountUpdateWithRatio,
-		types.TxTypeFeeDelegatedCancelWithRatio,
-
-		types.TxTypeChainDataAnchoring,
+	txTypes := []types.TxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		if i == types.TxTypeLegacyTransaction {
+			continue // accounts with role-based key cannot a send legacy tx.
+		}
+		_, err := types.NewTxInternalData(i)
+		if err == nil {
+			txTypes = append(txTypes, i)
+		}
 	}
 
 	// deploy a contract to test smart contract execution.

--- a/tests/tx_gas_overflow_test.go
+++ b/tests/tx_gas_overflow_test.go
@@ -59,6 +59,8 @@ func TestGasOverflow(t *testing.T) {
 		{"FeeDelegatedWithRatioCancel", testGasOverflowFeeDelegatedWithRatioCancel},
 
 		{"ChainDataAnchoring", testGasOverflowChainDataAnchoring},
+		{"FeeDelegatedChainDataAnchoring", testGasOverflowFeeDelegatedChainDataAnchoring},
+		{"FeeDelegatedWithRatioChainDataAnchoring", testGasOverflowFeeDelegatedWithRatioChainDataAnchoring},
 	}
 
 	for _, f := range testFunctions {
@@ -274,12 +276,36 @@ func testGasOverflowFeeDelegatedWithRatioCancel(t *testing.T) {
 }
 
 func testGasOverflowChainDataAnchoring(t *testing.T) {
-	intrinsic := getIntrinsicGas(types.TxTypeCancel)
+	intrinsic := getIntrinsicGas(types.TxTypeChainDataAnchoring)
 	senderValidationGas := getMaxValidationKeyGas(t)
 
 	maxDataGas := mulUint64(t, blockchain.MaxTxDataSize, params.TxDataGas)
 
 	gas := addUint64(t, intrinsic, senderValidationGas)
+	gas = addUint64(t, gas, maxDataGas)
+}
+
+func testGasOverflowFeeDelegatedChainDataAnchoring(t *testing.T) {
+	intrinsic := getIntrinsicGas(types.TxTypeFeeDelegatedChainDataAnchoring)
+	senderValidationGas := getMaxValidationKeyGas(t)
+	payerValidationGas := getMaxValidationKeyGas(t)
+
+	maxDataGas := mulUint64(t, blockchain.MaxTxDataSize, params.TxDataGas)
+
+	gas := addUint64(t, intrinsic, senderValidationGas)
+	gas = addUint64(t, gas, payerValidationGas)
+	gas = addUint64(t, gas, maxDataGas)
+}
+
+func testGasOverflowFeeDelegatedWithRatioChainDataAnchoring(t *testing.T) {
+	intrinsic := getIntrinsicGas(types.TxTypeFeeDelegatedChainDataAnchoringWithRatio)
+	senderValidationGas := getMaxValidationKeyGas(t)
+	payerValidationGas := getMaxValidationKeyGas(t)
+
+	maxDataGas := mulUint64(t, blockchain.MaxTxDataSize, params.TxDataGas)
+
+	gas := addUint64(t, intrinsic, senderValidationGas)
+	gas = addUint64(t, gas, payerValidationGas)
 	gas = addUint64(t, gas, maxDataGas)
 }
 

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -93,27 +93,12 @@ func TestValidationPoolInsert(t *testing.T) {
 		enableLog()
 	}
 
-	var testTxTypes = []testTxType{
-		{"LegacyTransaction", types.TxTypeLegacyTransaction},
-		{"ValueTransfer", types.TxTypeValueTransfer},
-		{"ValueTransferWithMemo", types.TxTypeValueTransferMemo},
-		{"AccountUpdate", types.TxTypeAccountUpdate},
-		{"SmartContractDeploy", types.TxTypeSmartContractDeploy},
-		{"SmartContractExecution", types.TxTypeSmartContractExecution},
-		{"Cancel", types.TxTypeCancel},
-		{"ChainDataAnchoring", types.TxTypeChainDataAnchoring},
-		{"FeeDelegatedValueTransfer", types.TxTypeFeeDelegatedValueTransfer},
-		{"FeeDelegatedValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemo},
-		{"FeeDelegatedAccountUpdate", types.TxTypeFeeDelegatedAccountUpdate},
-		{"FeeDelegatedSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeploy},
-		{"FeeDelegatedSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecution},
-		{"FeeDelegatedCancel", types.TxTypeFeeDelegatedCancel},
-		{"FeeDelegatedWithRatioValueTransfer", types.TxTypeFeeDelegatedValueTransferWithRatio},
-		{"FeeDelegatedWithRatioValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemoWithRatio},
-		{"FeeDelegatedWithRatioAccountUpdate", types.TxTypeFeeDelegatedAccountUpdateWithRatio},
-		{"FeeDelegatedWithRatioSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeployWithRatio},
-		{"FeeDelegatedWithRatioSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecutionWithRatio},
-		{"FeeDelegatedWithRatioCancel", types.TxTypeFeeDelegatedCancelWithRatio},
+	var testTxTypes = []testTxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		_, err := types.NewTxInternalData(i)
+		if err == nil {
+			testTxTypes = append(testTxTypes, testTxType{i.String(), i})
+		}
 	}
 
 	var invalidCases = []struct {
@@ -233,27 +218,12 @@ func TestValidationBlockTx(t *testing.T) {
 		enableLog()
 	}
 
-	var testTxTypes = []testTxType{
-		{"LegacyTransaction", types.TxTypeLegacyTransaction},
-		{"ValueTransfer", types.TxTypeValueTransfer},
-		{"ValueTransferWithMemo", types.TxTypeValueTransferMemo},
-		{"AccountUpdate", types.TxTypeAccountUpdate},
-		{"SmartContractDeploy", types.TxTypeSmartContractDeploy},
-		{"SmartContractExecution", types.TxTypeSmartContractExecution},
-		{"Cancel", types.TxTypeCancel},
-		{"ChainDataAnchoring", types.TxTypeChainDataAnchoring},
-		{"FeeDelegatedValueTransfer", types.TxTypeFeeDelegatedValueTransfer},
-		{"FeeDelegatedValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemo},
-		{"FeeDelegatedAccountUpdate", types.TxTypeFeeDelegatedAccountUpdate},
-		{"FeeDelegatedSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeploy},
-		{"FeeDelegatedSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecution},
-		{"FeeDelegatedCancel", types.TxTypeFeeDelegatedCancel},
-		{"FeeDelegatedWithRatioValueTransfer", types.TxTypeFeeDelegatedValueTransferWithRatio},
-		{"FeeDelegatedWithRatioValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemoWithRatio},
-		{"FeeDelegatedWithRatioAccountUpdate", types.TxTypeFeeDelegatedAccountUpdateWithRatio},
-		{"FeeDelegatedWithRatioSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeployWithRatio},
-		{"FeeDelegatedWithRatioSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecutionWithRatio},
-		{"FeeDelegatedWithRatioCancel", types.TxTypeFeeDelegatedCancelWithRatio},
+	var testTxTypes = []testTxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		_, err := types.NewTxInternalData(i)
+		if err == nil {
+			testTxTypes = append(testTxTypes, testTxType{i.String(), i})
+		}
 	}
 
 	var invalidCases = []struct {
@@ -423,27 +393,12 @@ func invalidCodeFormat(txType types.TxType, values txValueMap, contract common.A
 
 // TestValidationInvalidSig generates txs signed by an invalid sender or a fee payer.
 func TestValidationInvalidSig(t *testing.T) {
-	var testTxTypes = []testTxType{
-		{"LegacyTransaction", types.TxTypeLegacyTransaction},
-		{"ValueTransfer", types.TxTypeValueTransfer},
-		{"ValueTransferWithMemo", types.TxTypeValueTransferMemo},
-		{"AccountUpdate", types.TxTypeAccountUpdate},
-		{"SmartContractDeploy", types.TxTypeSmartContractDeploy},
-		{"SmartContractExecution", types.TxTypeSmartContractExecution},
-		{"Cancel", types.TxTypeCancel},
-		{"ChainDataAnchoring", types.TxTypeChainDataAnchoring},
-		{"FeeDelegatedValueTransfer", types.TxTypeFeeDelegatedValueTransfer},
-		{"FeeDelegatedValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemo},
-		{"FeeDelegatedAccountUpdate", types.TxTypeFeeDelegatedAccountUpdate},
-		{"FeeDelegatedSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeploy},
-		{"FeeDelegatedSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecution},
-		{"FeeDelegatedCancel", types.TxTypeFeeDelegatedCancel},
-		{"FeeDelegatedWithRatioValueTransfer", types.TxTypeFeeDelegatedValueTransferWithRatio},
-		{"FeeDelegatedWithRatioValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemoWithRatio},
-		{"FeeDelegatedWithRatioAccountUpdate", types.TxTypeFeeDelegatedAccountUpdateWithRatio},
-		{"FeeDelegatedWithRatioSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeployWithRatio},
-		{"FeeDelegatedWithRatioSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecutionWithRatio},
-		{"FeeDelegatedWithRatioCancel", types.TxTypeFeeDelegatedCancelWithRatio},
+	var testTxTypes = []testTxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		_, err := types.NewTxInternalData(i)
+		if err == nil {
+			testTxTypes = append(testTxTypes, testTxType{i.String(), i})
+		}
 	}
 
 	var invalidCases = []struct {
@@ -656,27 +611,12 @@ func TestLegacyTxFromNonLegacyAcc(t *testing.T) {
 
 // TestInvalidBalance generates invalid txs which don't have enough KLAY, and will be invalidated during txPool insert process.
 func TestInvalidBalance(t *testing.T) {
-	var testTxTypes = []testTxType{
-		{"LegacyTransaction", types.TxTypeLegacyTransaction},
-		{"ValueTransfer", types.TxTypeValueTransfer},
-		{"ValueTransferWithMemo", types.TxTypeValueTransferMemo},
-		{"AccountUpdate", types.TxTypeAccountUpdate},
-		{"SmartContractDeploy", types.TxTypeSmartContractDeploy},
-		{"SmartContractExecution", types.TxTypeSmartContractExecution},
-		{"Cancel", types.TxTypeCancel},
-		{"ChainDataAnchoring", types.TxTypeChainDataAnchoring},
-		{"FeeDelegatedValueTransfer", types.TxTypeFeeDelegatedValueTransfer},
-		{"FeeDelegatedValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemo},
-		{"FeeDelegatedAccountUpdate", types.TxTypeFeeDelegatedAccountUpdate},
-		{"FeeDelegatedSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeploy},
-		{"FeeDelegatedSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecution},
-		{"FeeDelegatedCancel", types.TxTypeFeeDelegatedCancel},
-		{"FeeDelegatedWithRatioValueTransfer", types.TxTypeFeeDelegatedValueTransferWithRatio},
-		{"FeeDelegatedWithRatioValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemoWithRatio},
-		{"FeeDelegatedWithRatioAccountUpdate", types.TxTypeFeeDelegatedAccountUpdateWithRatio},
-		{"FeeDelegatedWithRatioSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeployWithRatio},
-		{"FeeDelegatedWithRatioSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecutionWithRatio},
-		{"FeeDelegatedWithRatioCancel", types.TxTypeFeeDelegatedCancelWithRatio},
+	var testTxTypes = []testTxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		_, err := types.NewTxInternalData(i)
+		if err == nil {
+			testTxTypes = append(testTxTypes, testTxType{i.String(), i})
+		}
 	}
 
 	prof := profile.NewProfiler()
@@ -1059,28 +999,14 @@ func TestInvalidBalanceBlockTx(t *testing.T) {
 		enableLog()
 	}
 
-	var testTxTypes = []testTxType{
-		{"LegacyTransaction", types.TxTypeLegacyTransaction},
-		{"ValueTransfer", types.TxTypeValueTransfer},
-		{"ValueTransferWithMemo", types.TxTypeValueTransferMemo},
-		{"AccountUpdate", types.TxTypeAccountUpdate},
-		{"SmartContractDeploy", types.TxTypeSmartContractDeploy},
-		{"SmartContractExecution", types.TxTypeSmartContractExecution},
-		{"Cancel", types.TxTypeCancel},
-		{"ChainDataAnchoring", types.TxTypeChainDataAnchoring},
-		{"FeeDelegatedValueTransfer", types.TxTypeFeeDelegatedValueTransfer},
-		{"FeeDelegatedValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemo},
-		{"FeeDelegatedAccountUpdate", types.TxTypeFeeDelegatedAccountUpdate},
-		{"FeeDelegatedSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeploy},
-		{"FeeDelegatedSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecution},
-		{"FeeDelegatedCancel", types.TxTypeFeeDelegatedCancel},
-		{"FeeDelegatedWithRatioValueTransfer", types.TxTypeFeeDelegatedValueTransferWithRatio},
-		{"FeeDelegatedWithRatioValueTransferWithMemo", types.TxTypeFeeDelegatedValueTransferMemoWithRatio},
-		{"FeeDelegatedWithRatioAccountUpdate", types.TxTypeFeeDelegatedAccountUpdateWithRatio},
-		{"FeeDelegatedWithRatioSmartContractDeploy", types.TxTypeFeeDelegatedSmartContractDeployWithRatio},
-		{"FeeDelegatedWithRatioSmartContractExecution", types.TxTypeFeeDelegatedSmartContractExecutionWithRatio},
-		{"FeeDelegatedWithRatioCancel", types.TxTypeFeeDelegatedCancelWithRatio},
+	var testTxTypes = []testTxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		_, err := types.NewTxInternalData(i)
+		if err == nil {
+			testTxTypes = append(testTxTypes, testTxType{i.String(), i})
+		}
 	}
+
 	// re-declare errors since those errors are private variables in 'blockchain' package.
 	errInsufficientBalanceForGas := errors.New("insufficient balance of the sender to pay for gas")
 	errInsufficientBalanceForGasFeePayer := errors.New("insufficient balance of the fee payer to pay for gas")
@@ -1480,18 +1406,15 @@ func TestInvalidBalanceBlockTx(t *testing.T) {
 // TestValidationTxSizeAfterRLP tests tx size validation during txPool insert process.
 // Since the size is RLP encoded tx size, the test also includes RLP encoding/decoding process which may raise an issue.
 func TestValidationTxSizeAfterRLP(t *testing.T) {
-	var testTxTypes = []types.TxType{
-		types.TxTypeLegacyTransaction,
-		types.TxTypeValueTransferMemo,
-		types.TxTypeSmartContractDeploy,
-		types.TxTypeSmartContractExecution,
-		types.TxTypeChainDataAnchoring,
-		types.TxTypeFeeDelegatedValueTransferMemo,
-		types.TxTypeFeeDelegatedSmartContractDeploy,
-		types.TxTypeFeeDelegatedSmartContractExecution,
-		types.TxTypeFeeDelegatedValueTransferMemoWithRatio,
-		types.TxTypeFeeDelegatedSmartContractDeployWithRatio,
-		types.TxTypeFeeDelegatedSmartContractExecutionWithRatio,
+	var testTxTypes = []types.TxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		tx, err := types.NewTxInternalData(i)
+		if err == nil {
+			// Since this test is for payload size, tx types without payload field will not be tested.
+			if _, ok := tx.(types.TxInternalDataPayload); ok {
+				testTxTypes = append(testTxTypes, i)
+			}
+		}
 	}
 
 	prof := profile.NewProfiler()
@@ -1642,31 +1565,12 @@ func TestValidationTxSizeAfterRLP(t *testing.T) {
 // TestValidationPoolResetAfterSenderKeyChange puts txs in the pending pool and generates a block only with the first tx.
 // Since the tx changes the sender's account key, all rest txs should drop from the pending pool.
 func TestValidationPoolResetAfterSenderKeyChange(t *testing.T) {
-	txTypes := []types.TxType{
-		types.TxTypeLegacyTransaction,
-
-		types.TxTypeValueTransfer,
-		types.TxTypeValueTransferMemo,
-		types.TxTypeSmartContractDeploy,
-		types.TxTypeSmartContractExecution,
-		types.TxTypeAccountUpdate,
-		types.TxTypeCancel,
-
-		types.TxTypeFeeDelegatedValueTransfer,
-		types.TxTypeFeeDelegatedValueTransferMemo,
-		types.TxTypeFeeDelegatedSmartContractDeploy,
-		types.TxTypeFeeDelegatedSmartContractExecution,
-		types.TxTypeFeeDelegatedAccountUpdate,
-		types.TxTypeFeeDelegatedCancel,
-
-		types.TxTypeFeeDelegatedValueTransferWithRatio,
-		types.TxTypeFeeDelegatedValueTransferMemoWithRatio,
-		types.TxTypeFeeDelegatedSmartContractDeployWithRatio,
-		types.TxTypeFeeDelegatedSmartContractExecutionWithRatio,
-		types.TxTypeFeeDelegatedAccountUpdateWithRatio,
-		types.TxTypeFeeDelegatedCancelWithRatio,
-
-		types.TxTypeChainDataAnchoring,
+	txTypes := []types.TxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		_, err := types.NewTxInternalData(i)
+		if err == nil {
+			txTypes = append(txTypes, i)
+		}
 	}
 
 	prof := profile.NewProfiler()
@@ -1799,20 +1703,15 @@ func TestValidationPoolResetAfterSenderKeyChange(t *testing.T) {
 // TestValidationPoolResetAfterFeePayerKeyChange puts txs in the pending pool and generates a block only with the first tx.
 // Since the tx changes the fee payer's account key, all rest txs should drop from the pending pool.
 func TestValidationPoolResetAfterFeePayerKeyChange(t *testing.T) {
-	txTypes := []types.TxType{
-		types.TxTypeFeeDelegatedValueTransfer,
-		types.TxTypeFeeDelegatedValueTransferMemo,
-		types.TxTypeFeeDelegatedSmartContractDeploy,
-		types.TxTypeFeeDelegatedSmartContractExecution,
-		types.TxTypeFeeDelegatedAccountUpdate,
-		types.TxTypeFeeDelegatedCancel,
-
-		types.TxTypeFeeDelegatedValueTransferWithRatio,
-		types.TxTypeFeeDelegatedValueTransferMemoWithRatio,
-		types.TxTypeFeeDelegatedSmartContractDeployWithRatio,
-		types.TxTypeFeeDelegatedSmartContractExecutionWithRatio,
-		types.TxTypeFeeDelegatedAccountUpdateWithRatio,
-		types.TxTypeFeeDelegatedCancelWithRatio,
+	txTypes := []types.TxType{}
+	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
+		_, err := types.NewTxInternalData(i)
+		if err == nil {
+			// This test is only for fee-delegated tx types
+			if i.IsFeeDelegatedTransaction() {
+				txTypes = append(txTypes, i)
+			}
+		}
 	}
 
 	prof := profile.NewProfiler()


### PR DESCRIPTION
## Proposed changes

For more usability of Service Chain,
 - Introduce a new tx type, FeeDelegatedChainDataAnchoring
 - Introduce a new tx type, FeeDelegatedChainDataAnchoringWithRatio
 - Add new tx types in tx test cases

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Test cases under `/node/sc/` will be updated later with the new functionality of `keystore`, signing tx as a fee payer. 

