### PR TITLE
Deprecate 'gxp' namespace support of RPC server and change a log message

### DIFF
--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -460,8 +460,7 @@ func (s *Server) readRequest(codec ServerCodec) ([]*serverRequest, bool, Error) 
 		}
 
 		// for ethereum compatibility. convert ethereum namespace to klay namespace.
-		// TODO-Klaytn Deprecate supporting the `gxp` namespace
-		if r.service == "eth" || r.service == "gxp" {
+		if r.service == "eth" {
 			r.service = "klay"
 		}
 

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -465,14 +465,7 @@ func (s *Server) readRequest(codec ServerCodec) ([]*serverRequest, bool, Error) 
 		}
 
 		if svc, ok = s.services[r.service]; !ok { // rpc method isn't available
-
-			for name, sr := range s.services {
-				fmt.Printf("service %s \n", name)
-				for cname, callback := range sr.callbacks {
-					fmt.Printf("		callback %s  method %s\n", cname, callback.method.Name)
-				}
-			}
-
+			logger.Trace("rpc: got request from unsupported API namespace", "requestedNamespaces", r.service)
 			requests[i] = &serverRequest{id: r.id, err: &methodNotFoundError{r.service, r.method}}
 			continue
 		}


### PR DESCRIPTION
## Proposed changes

- Deprecate 'gxp' namespace support of RPC server
- Change a log message for calling unsupported API namespace
  - Before the change
     ```
     service klay
		callback isParallelDBWrite  method IsParallelDBWrite
		callback getBalance  method GetBalance
		callback sign  method Sign
		... ...
     ```
   - After the change
     ```
     29052 TRACE[10/11,10:03:11 +09] [39] rpc: got request from unsupported API namespace  requestedNamespaces=alay
     ```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
