### PR TITLE
blockchain, statedb, tests: correct CacheSize

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -159,7 +159,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 		cacheConfig = &CacheConfig{
 			StateDBCaching: false,
 			ArchiveMode:    false,
-			CacheSize:      512 * 1024 * 1024,
+			CacheSize:      512,
 			BlockInterval:  DefaultBlockInterval,
 			TrieCacheLimit: 0,
 		}

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -162,7 +162,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		cacheConfig := &CacheConfig{
 			StateDBCaching: false,
 			ArchiveMode:    false,
-			CacheSize:      512 * 1024 * 1024,
+			CacheSize:      512,
 			BlockInterval:  DefaultBlockInterval,
 			TrieCacheLimit: 0,
 		}

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -38,8 +38,8 @@ var (
 	logger = log.NewModuleLogger(log.StorageStateDB)
 
 	memcacheFlushTimeGauge  = metrics.NewRegisteredGauge("trie/memcache/flush/time", nil)
-	memcacheFlushNodesMeter = metrics.NewRegisteredMeter("trie/memcache/flush/nodes", nil)
-	memcacheFlushSizeMeter  = metrics.NewRegisteredMeter("trie/memcache/flush/size", nil)
+	memcacheFlushNodesGauge = metrics.NewRegisteredGauge("trie/memcache/flush/nodes", nil)
+	memcacheFlushSizeGauge  = metrics.NewRegisteredGauge("trie/memcache/flush/size", nil)
 
 	memcacheGCTimeGauge  = metrics.NewRegisteredGauge("trie/memcache/gc/time", nil)
 	memcacheGCNodesMeter = metrics.NewRegisteredMeter("trie/memcache/gc/nodes", nil)
@@ -668,8 +668,8 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	db.flushtime += time.Since(start)
 
 	memcacheFlushTimeGauge.Update(int64(time.Since(start)))
-	memcacheFlushSizeMeter.Mark(int64(nodeSize - db.nodesSize))
-	memcacheFlushNodesMeter.Mark(int64(nodes - len(db.nodes)))
+	memcacheFlushSizeGauge.Update(int64(nodeSize - db.nodesSize))
+	memcacheFlushNodesGauge.Update(int64(nodes - len(db.nodes)))
 
 	logger.Debug("Persisted nodes from memory database", "nodes", nodes-len(db.nodes), "size", nodeSize-db.nodesSize, "time", time.Since(start),
 		"flushnodes", db.flushnodes, "flushsize", db.flushsize, "flushtime", db.flushtime, "livenodes", len(db.nodes), "livesize", db.nodesSize)

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -473,7 +473,7 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 		StateDBCaching:   true,
 		TxPoolStateCache: true,
 		ArchiveMode:      false,
-		CacheSize:        512 * 1024 * 1024,
+		CacheSize:        512,
 		BlockInterval:    blockchain.DefaultBlockInterval,
 		TrieCacheLimit:   4096,
 	}


### PR DESCRIPTION
## Proposed changes

- `CacheConfig.CacheSize` indicates the limit of in-memory state trie size in MiB like below, however, some places it is used as Byte.
- https://github.com/klaytn/klaytn/blob/97ef4585044e8dd1849b67d4f7ca9bda3974df51/blockchain/blockchain.go#L1024-L1028
- Also replaced some metrics related to `Database.Cap` into gauge from meter for precise statistics.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
