### PR TITLE
Increase FD limit if the server has a small limit

### DIFF
--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -179,7 +179,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, srv *Server) *fasthttp.Se
 	if len(cors) == 0 {
 		for _, vhost := range vhosts {
 			if vhost == "*" {
-				return &fasthttp.Server{Concurrency: 3000, Handler: srv.HandleFastHTTP}
+				return &fasthttp.Server{Concurrency: concurrencyLimit, Handler: srv.HandleFastHTTP}
 			}
 		}
 	}
@@ -190,7 +190,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, srv *Server) *fasthttp.Se
 	fhandler := fasthttpadaptor.NewFastHTTPHandler(handler)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
-	return &fasthttp.Server{Concurrency: 3000, Handler: fhandler}
+	return &fasthttp.Server{Concurrency: concurrencyLimit, Handler: fhandler}
 }
 
 // ServeHTTP serves JSON-RPC requests over HTTP.

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -62,12 +62,12 @@ func NewServer() *Server {
 	// increase the file descriptor limit if the process has a small limit
 	limit, err := fdlimit.Current()
 	if err != nil {
-		logger.Debug("fail to read fd limit", "err", err)
+		logger.Warn("fail to read fd limit. you may suffer fd exhaustion", "err", err)
 	} else {
 		if limit < minFDLimit {
 			err := fdlimit.Raise(uint64(limit + minFDLimit))
 			if err != nil {
-				logger.Debug("fail to set fd limit", "err", err)
+				logger.Warn("fail to increase fd limit. you may suffer fd exhaustion", "err", err)
 			}
 			logger.Warn("Increase the file descriptor limit of the process for RPC servers", "oldLimit", limit, "newLimit", limit+minFDLimit)
 		}

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -45,6 +45,9 @@ const (
 
 	// pendingRequestLimit is a limit for concurrent RPC method calls
 	pendingRequestLimit = 200000
+
+	// concurrencyLimit is a limit for the number of concurrency connection for RPC servers
+	concurrencyLimit = 3000
 )
 
 // pendingRequestCount is a total number of concurrent RPC method calls

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -23,6 +23,7 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"github.com/klaytn/klaytn/common/fdlimit"
 	"gopkg.in/fatih/set.v0"
 	"reflect"
 	"runtime"
@@ -48,6 +49,9 @@ const (
 
 	// concurrencyLimit is a limit for the number of concurrency connection for RPC servers
 	concurrencyLimit = 3000
+
+	// minFDLimit is the minimum file descriptor limit for RPC servers (heuristic value. concurrency limit of RPC and WS servers)
+	minFDLimit = concurrencyLimit * 2
 )
 
 // pendingRequestCount is a total number of concurrent RPC method calls
@@ -55,6 +59,20 @@ var pendingRequestCount int64 = 0
 
 // NewServer will create a new server instance with no registered handlers.
 func NewServer() *Server {
+	// increase the file descriptor limit if the process has a small limit
+	limit, err := fdlimit.Current()
+	if err != nil {
+		logger.Debug("fail to read fd limit", "err", err)
+	} else {
+		if limit < minFDLimit {
+			err := fdlimit.Raise(uint64(limit + minFDLimit))
+			if err != nil {
+				logger.Debug("fail to set fd limit", "err", err)
+			}
+			logger.Warn("Increase the file descriptor limit of the process for RPC servers", "oldLimit", limit, "newLimit", limit+minFDLimit)
+		}
+	}
+
 	server := &Server{
 		services: make(serviceRegistry),
 		codecs:   set.New(),

--- a/networks/rpc/websocket.go
+++ b/networks/rpc/websocket.go
@@ -138,7 +138,7 @@ func NewFastWSServer(allowedOrigins []string, srv *Server) *fasthttp.Server {
 	upgrader.CheckOrigin = wsFastHandshakeValidator(allowedOrigins)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
-	return &fasthttp.Server{Concurrency: 3000, MaxRequestBodySize: maxRequestContentLength, Handler: srv.FastWebsocketHandler}
+	return &fasthttp.Server{Concurrency: concurrencyLimit, MaxRequestBodySize: maxRequestContentLength, Handler: srv.FastWebsocketHandler}
 }
 
 func wsFastHandshakeValidator(allowedOrigins []string) func(ctx *fasthttp.RequestCtx) bool {


### PR DESCRIPTION
## Proposed changes

**Problem**
- If a server/process running a node exhausted all file descriptors (FD), it can cause the following problems. 
  - **halt a node** if it fails to write data to level DB
  - **can't receive blocks** if all P2P connections are closed 
  - **Bad Block**
- RPC requests can exhaust thousands of FD in a few seconds. 
  - Remote users can trigger the above problems

**Mitigation**
- Hard to mitigate all problems originated from FD exhaust, but easy to prevent FD exhaust from remote users.
  - RPC servers deny connections if the number of connection reaches more than the concurrency limit. 
- Increase the FD limit more than the maximum number of RPC requests allowed to prohibit remote users from exhausting all FD.
  - Partial but simple solution
  - Prevent DoS attack from remote users
  - fd limit > maximum concurrency connection of RPC (http, ws) servers 

**Change**
- Change a number to the const variable `concurrencyLimit`
- Increase FD limit if the server has a small limit

**Test with Scenario**
1. If a node having a small FD limit starts an RPC server, the FD limit is automatically updated with the following log. 
    ```
    WARN[10/15,11:05:48 +09] [39] increase the file descriptor limit of this process for RPC servers  oldLimit=2048 newLimit=8048
    ```
2. A remote user cannot exhaust EN's FD since EN only allows `concurrencyLimit` connections which are less than FD limit. 
    - The remote user will get the following message if he/she tried to connect more than 
    `concurrencyLimit` connections.
      ```
      The connection cannot be served because Server.Concurrency limit exceeded
      ```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
