### PR TITLE
Replace the circle ci docker image for linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
 
   linters:
     docker:
-      - image: circleci/golang:1.11.2
+      - image: klaytn/build_base:1.0
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout


### PR DESCRIPTION
## Proposed changes

After a recent change https://github.com/klaytn/klaytn/pull/281, Klaytn requires go version higher than go1.13. 
However, `linter` is still executing on the docker image supporting go1.11.2, and it makes nightly-linter fails like https://circleci.com/gh/klaytn/klaytn/7093. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

