### PR TITLE
statedb: concurrent hashRoot

### DIFF
--- a/storage/statedb/hasher.go
+++ b/storage/statedb/hasher.go
@@ -114,7 +114,7 @@ func (h *hasher) hash(n node, db *Database, force bool) (node, node) {
 	return hashed, cached
 }
 
-func (h *hasher) hashRoot(n node, db *Database, force bool, onleaf LeafCallback) (node, node) {
+func (h *hasher) hashRoot(n node, db *Database, force bool) (node, node) {
 	// If we're not storing the node, just hashing, use available cached data
 	if hash, dirty := n.cache(); hash != nil {
 		if db == nil {
@@ -130,7 +130,7 @@ func (h *hasher) hashRoot(n node, db *Database, force bool, onleaf LeafCallback)
 		}
 	}
 	// Trie not processed yet or needs storage, walk the children
-	collapsed, cached := h.hashChildrenFromRoot(n, db, onleaf)
+	collapsed, cached := h.hashChildrenFromRoot(n, db)
 	hashed, lenEncoded := h.store(collapsed, db, force)
 	// Cache the hash of the node for later reuse and remove
 	// the dirty flag in commit mode. It's fine to assign these values directly
@@ -193,7 +193,7 @@ type hashResult struct {
 	cached    node
 }
 
-func (h *hasher) hashChildrenFromRoot(original node, db *Database, onleaf LeafCallback) (node, node) {
+func (h *hasher) hashChildrenFromRoot(original node, db *Database) (node, node) {
 	switch n := original.(type) {
 	case *shortNode:
 		// Hash the short node's child, caching the newly hashed subtree
@@ -216,7 +216,7 @@ func (h *hasher) hashChildrenFromRoot(original node, db *Database, onleaf LeafCa
 			if n.Children[i] != nil {
 				numRootChildren++
 				go func(i int, n node) {
-					childHasher := newHasher(onleaf)
+					childHasher := newHasher(h.onleaf)
 					defer returnHasherToPool(childHasher)
 					collapsedFromChild, cachedFromChild := childHasher.hash(n, db, false)
 					hashResultCh <- hashResult{i, collapsedFromChild, cachedFromChild}

--- a/storage/statedb/hasher.go
+++ b/storage/statedb/hasher.go
@@ -114,6 +114,45 @@ func (h *hasher) hash(n node, db *Database, force bool) (node, node) {
 	return hashed, cached
 }
 
+func (h *hasher) hashRoot(n node, db *Database, force bool) (node, node) {
+	// If we're not storing the node, just hashing, use available cached data
+	if hash, dirty := n.cache(); hash != nil {
+		if db == nil {
+			return hash, n
+		}
+		if !dirty {
+			switch n.(type) {
+			case *fullNode, *shortNode:
+				return hash, hash
+			default:
+				return hash, n
+			}
+		}
+	}
+	// Trie not processed yet or needs storage, walk the children
+	collapsed, cached := h.hashChildren(n, db)
+	hashed, lenEncoded := h.store(collapsed, db, force)
+	// Cache the hash of the node for later reuse and remove
+	// the dirty flag in commit mode. It's fine to assign these values directly
+	// without copying the node first because hashChildren copies it.
+	cachedHash, _ := hashed.(hashNode)
+	switch cn := cached.(type) {
+	case *shortNode:
+		cn.flags.hash = cachedHash
+		cn.flags.lenEncoded = lenEncoded
+		if db != nil {
+			cn.flags.dirty = false
+		}
+	case *fullNode:
+		cn.flags.hash = cachedHash
+		cn.flags.lenEncoded = lenEncoded
+		if db != nil {
+			cn.flags.dirty = false
+		}
+	}
+	return hashed, cached
+}
+
 // hashChildren replaces the children of a node with their hashes if the encoded
 // size of the child is larger than a hash, returning the collapsed node as well
 // as a replacement for the original node with the child hashes cached in.
@@ -139,6 +178,56 @@ func (h *hasher) hashChildren(original node, db *Database) (node, node) {
 				collapsed.Children[i], cached.Children[i] = h.hash(n.Children[i], db, false)
 			}
 		}
+		cached.Children[16] = n.Children[16]
+		return collapsed, cached
+
+	default:
+		// Value and hash nodes don't have children so they're left as were
+		return n, original
+	}
+}
+
+type hashResult struct {
+	index     int
+	collapsed node
+	cached    node
+}
+
+func (h *hasher) hashChildrenFromRoot(original node, db *Database) (node, node) {
+	switch n := original.(type) {
+	case *shortNode:
+		// Hash the short node's child, caching the newly hashed subtree
+		collapsed, cached := n.copy(), n.copy()
+		collapsed.Key = hexToCompact(n.Key)
+		cached.Key = common.CopyBytes(n.Key)
+
+		if _, ok := n.Val.(valueNode); !ok {
+			collapsed.Val, cached.Val = h.hash(n.Val, db, false)
+		}
+		return collapsed, cached
+
+	case *fullNode:
+		// Hash the full node's children, caching the newly hashed subtrees
+		collapsed, cached := n.copy(), n.copy()
+
+		hashResultCh := make(chan hashResult, 16)
+		numRootChildren := 0
+		for i := 0; i < 16; i++ {
+			if n.Children[i] != nil {
+				numRootChildren++
+				go func(i int, n node) {
+					collapsedFromChild, cachedFromChild := h.hash(n, db, false)
+					hashResultCh <- hashResult{i, collapsedFromChild, cachedFromChild}
+				}(i, n.Children[i])
+			}
+		}
+
+		for i := 0; i < numRootChildren; i++ {
+			hashResult := <-hashResultCh
+			idx := hashResult.index
+			collapsed.Children[idx], cached.Children[idx] = hashResult.collapsed, hashResult.cached
+		}
+
 		cached.Children[16] = n.Children[16]
 		return collapsed, cached
 

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -436,7 +436,7 @@ func (t *Trie) hashRoot(db *Database, onleaf LeafCallback) (node, node) {
 	}
 	h := newHasher(onleaf)
 	defer returnHasherToPool(h)
-	return h.hashRoot(t.root, db, true)
+	return h.hashRoot(t.root, db, true, onleaf)
 }
 
 func GetHashAndHexKey(key []byte) ([]byte, []byte) {

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -436,7 +436,7 @@ func (t *Trie) hashRoot(db *Database, onleaf LeafCallback) (node, node) {
 	}
 	h := newHasher(onleaf)
 	defer returnHasherToPool(h)
-	return h.hash(t.root, db, true)
+	return h.hashRoot(t.root, db, true)
 }
 
 func GetHashAndHexKey(key []byte) ([]byte, []byte) {

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -436,7 +436,7 @@ func (t *Trie) hashRoot(db *Database, onleaf LeafCallback) (node, node) {
 	}
 	h := newHasher(onleaf)
 	defer returnHasherToPool(h)
-	return h.hashRoot(t.root, db, true, onleaf)
+	return h.hashRoot(t.root, db, true)
 }
 
 func GetHashAndHexKey(key []byte) ([]byte, []byte) {


### PR DESCRIPTION
## Proposed changes

- This is to improve the performance of `Trie.hashRoot`
- As `hasher.hashChildren` sequentially visits its children, another child needs to wait previous child(ren) to be finished. But children don't have any dependencies during `hash` operations.
- In this commit, topmost full node makes individual goroutines for its children.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
