### PR TITLE
Refine Makefile commands 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,13 +89,14 @@ cover:
 	@echo "Two coverage reports coverage_report.txt and coverage_report.html are generated."
 
 fmt:
-	build/env.sh env GOFLAGS= go run build/ci.go fmt
+	build/env.sh env GOFLAGS= GO111MODULE=off go run build/ci.go fmt
 
-lint:
-	build/env.sh go run build/ci.go lint
+# Not supported. Use lint-try intead of lint
+#lint:
+#	build/env.sh env GOFLAGS= GO111MODULE=off go run build/ci.go lint
 
 lint-try:
-	build/env.sh go run build/ci.go lint-try
+	build/env.sh env GOFLAGS= GO111MODULE=off go run build/ci.go lint-try
 
 clean:
 	./build/clean_go_build_cache.sh


### PR DESCRIPTION
## Proposed changes

**Problem**
1. `make lint-try` is not working.
2. `make fmt` changes `go.mod` and `go.sum` files.

**Changes**
1. `fmt`, `lint` and `lint-try` try to execute `go get ~` to install `golangci-lint`, but the execution will fail because of the default flag value of `GOFLAGS="-mod=vendor"`. To remedy the problem, the value of `GOFLAGS` is removed in this PR.

2. The execution of `go get ~` updates `go.mod` and `go.sum` files. As the file update is not expected behavior, `GO111MODULE=off` is added. With the flag value, new modules will be updated on `$PWD/build/_workspace/src/github.com/`.

3. For a long time, `make lint` had not been used anywhere. We can use `make lint-try` instread of `make lint` as nightly-lint does.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

It is a following PR of https://github.com/klaytn/klaytn/commit/27a02df1feb93d71d87dabf50d161e2e3bd7c338.