### PR TITLE
database: introduce state migration database to DBManager

### DIFF
--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1226,8 +1226,7 @@ func (dbm *databaseManager) ReadStateTrieNodeFromOld(key []byte) ([]byte, error)
 }
 
 func (dbm *databaseManager) HasStateTrieNodeFromOld(key []byte) (bool, error) {
-	db := dbm.getDatabase(StateTrieDB)
-	val, err := db.Get(key)
+	val, err := dbm.ReadStateTrieNodeFromOld(key)
 	if val == nil || err != nil {
 		return false, err
 	}

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -444,7 +444,7 @@ func (dbm *databaseManager) SetStateTrieMigrationDB(blockNum uint64) {
 		return
 	}
 
-	logger.Info("Start setting a new database for state trie migration", blockNum, blockNum)
+	logger.Info("Start setting a new database for state trie migration", "blockNum", blockNum)
 
 	// Store the directory of the new database first to avoid missing directory name situation
 	newDBDir := dbm.config.Dir + strconv.FormatUint(blockNum, 10)

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -202,8 +202,8 @@ const (
 	databaseEntryTypeSize
 )
 
-const notInMigration = 0
-const inMigration = 1
+const notInMigrationFlag = 0
+const inMigrationFlag = 1
 
 var dbDirs = [databaseEntryTypeSize]string{
 	"header",
@@ -462,7 +462,7 @@ func (dbm *databaseManager) SetStateTrieMigrationDB(blockNum uint64) {
 	// If it fails to store the migration status, remove the new database and kill the process.
 	dbm.newStateTrieDB = newDB
 	dbm.inMigration = true
-	if err := miscDB.Put(migrationStatusKey, encodeUint64(inMigration)); err != nil {
+	if err := miscDB.Put(migrationStatusKey, encodeUint64(inMigrationFlag)); err != nil {
 		logger.Error("Failed to store the migration status, trying to remove the new database for state trie migration", "err", err)
 		newDB.Close()
 		if err := os.RemoveAll(newDBDir); err != nil {

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -387,6 +387,34 @@ func TestDBManager_TrieNode(t *testing.T) {
 
 		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash1[:])
 		assert.True(t, hasStateTrieNode)
+
+		dbm.SetStateTrieMigrationDB(123)
+
+		cachedNode, _ = dbm.ReadCachedTrieNode(hash1)
+		assert.Equal(t, hash1[:], cachedNode)
+
+		stateTrieNode, _ = dbm.ReadStateTrieNode(hash1[:])
+		assert.Equal(t, hash1[:], stateTrieNode)
+
+		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash1[:])
+		assert.True(t, hasStateTrieNode)
+
+		batch = dbm.NewBatch(StateTrieDB)
+		if err := batch.Put(hash2[:], hash2[:]); err != nil {
+			t.Fatal("Failed putting a row into the batch", "err", err)
+		}
+		if _, err := WriteBatches(batch); err != nil {
+			t.Fatal("Failed writing batch", "err", err)
+		}
+
+		cachedNode, _ = dbm.ReadCachedTrieNode(hash2)
+		assert.Equal(t, hash2[:], cachedNode)
+
+		stateTrieNode, _ = dbm.ReadStateTrieNode(hash2[:])
+		assert.Equal(t, hash2[:], stateTrieNode)
+
+		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash2[:])
+		assert.True(t, hasStateTrieNode)
 	}
 }
 

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -388,16 +388,25 @@ func TestDBManager_TrieNode(t *testing.T) {
 		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash1[:])
 		assert.True(t, hasStateTrieNode)
 
+		if !dbm.IsPartitioned() {
+			continue
+		}
 		dbm.SetStateTrieMigrationDB(123)
 
 		cachedNode, _ = dbm.ReadCachedTrieNode(hash1)
+		oldCachedNode, _ := dbm.ReadCachedTrieNodeFromOld(hash1)
 		assert.Equal(t, hash1[:], cachedNode)
+		assert.Equal(t, hash1[:], oldCachedNode)
 
 		stateTrieNode, _ = dbm.ReadStateTrieNode(hash1[:])
+		oldStateTrieNode, _ := dbm.ReadStateTrieNodeFromOld(hash1[:])
 		assert.Equal(t, hash1[:], stateTrieNode)
+		assert.Equal(t, hash1[:], oldStateTrieNode)
 
 		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash1[:])
+		hasOldStateTrieNode, _ := dbm.HasStateTrieNodeFromOld(hash1[:])
 		assert.True(t, hasStateTrieNode)
+		assert.True(t, hasOldStateTrieNode)
 
 		batch = dbm.NewBatch(StateTrieDB)
 		if err := batch.Put(hash2[:], hash2[:]); err != nil {
@@ -408,13 +417,19 @@ func TestDBManager_TrieNode(t *testing.T) {
 		}
 
 		cachedNode, _ = dbm.ReadCachedTrieNode(hash2)
+		oldCachedNode, _ = dbm.ReadCachedTrieNodeFromOld(hash2)
 		assert.Equal(t, hash2[:], cachedNode)
+		assert.Nil(t, oldCachedNode)
 
 		stateTrieNode, _ = dbm.ReadStateTrieNode(hash2[:])
+		oldStateTrieNode, _ = dbm.ReadStateTrieNodeFromOld(hash2[:])
 		assert.Equal(t, hash2[:], stateTrieNode)
+		assert.Nil(t, oldStateTrieNode)
 
 		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash2[:])
+		hasOldStateTrieNode, _ = dbm.HasStateTrieNodeFromOld(hash2[:])
 		assert.True(t, hasStateTrieNode)
+		assert.False(t, hasOldStateTrieNode)
 	}
 }
 
@@ -652,6 +667,18 @@ func TestDBManager_CliqueSnapshot(t *testing.T) {
 
 func TestDBManager_Governance(t *testing.T) {
 	// TODO-Klaytn-Database Implement this!
+}
+
+func TestDBManager_StateTrieMigration(t *testing.T) {
+	for i, dbm := range dbManagers {
+		if !dbm.IsPartitioned() || dbConfigs[i].DBType == MemoryDB {
+			continue
+		}
+		dbm.SetStateTrieMigrationDB(12345)
+		dbm.Close()
+		dbManagers[i] = NewDBManager(dbConfigs[i])
+		assert.True(t, dbManagers[i].InMigration())
+	}
 }
 
 func genReceipt(gasUsed int) *types.Receipt {

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -84,6 +84,9 @@ var (
 	governancePrefix     = []byte("governance")
 	governanceHistoryKey = []byte("governanceIdxHistory")
 	governanceStateKey   = []byte("governanceState")
+
+	databaseDirPrefix  = []byte("databaseDirectory")
+	migrationStatusKey = []byte("migrationStatus")
 )
 
 // TxLookupEntry is a positional metadata to help looking up the data content of
@@ -94,8 +97,8 @@ type TxLookupEntry struct {
 	Index      uint64
 }
 
-// encodeBlockNumber encodes a block number as big endian uint64
-func encodeBlockNumber(number uint64) []byte {
+// encodeUint64 encodes a block number as big endian uint64
+func encodeUint64(number uint64) []byte {
 	enc := make([]byte, 8)
 	binary.BigEndian.PutUint64(enc, number)
 	return enc
@@ -103,7 +106,7 @@ func encodeBlockNumber(number uint64) []byte {
 
 // headerKey = headerPrefix + num (uint64 big endian) + hash
 func headerKey(number uint64, hash common.Hash) []byte {
-	return append(append(headerPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+	return append(append(headerPrefix, encodeUint64(number)...), hash.Bytes()...)
 }
 
 // headerTDKey = headerPrefix + num (uint64 big endian) + hash + headerTDSuffix
@@ -113,7 +116,7 @@ func headerTDKey(number uint64, hash common.Hash) []byte {
 
 // headerHashKey = headerPrefix + num (uint64 big endian) + headerHashSuffix
 func headerHashKey(number uint64) []byte {
-	return append(append(headerPrefix, encodeBlockNumber(number)...), headerHashSuffix...)
+	return append(append(headerPrefix, encodeUint64(number)...), headerHashSuffix...)
 }
 
 // headerNumberKey = headerNumberPrefix + hash
@@ -123,12 +126,12 @@ func headerNumberKey(hash common.Hash) []byte {
 
 // blockBodyKey = blockBodyPrefix + num (uint64 big endian) + hash
 func blockBodyKey(number uint64, hash common.Hash) []byte {
-	return append(append(blockBodyPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+	return append(append(blockBodyPrefix, encodeUint64(number)...), hash.Bytes()...)
 }
 
 // blockReceiptsKey = blockReceiptsPrefix + num (uint64 big endian) + hash
 func blockReceiptsKey(number uint64, hash common.Hash) []byte {
-	return append(append(blockReceiptsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+	return append(append(blockReceiptsPrefix, encodeUint64(number)...), hash.Bytes()...)
 }
 
 // TxLookupKey = txLookupPrefix + hash
@@ -184,4 +187,8 @@ func governanceKey(num uint64) []byte {
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, num)
 	return append(governancePrefix[:], b[:]...)
+}
+
+func databaseDirKey(dbEntryType uint64) []byte {
+	return append(databaseDirPrefix, encodeUint64(dbEntryType)...)
 }

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -97,7 +97,7 @@ type TxLookupEntry struct {
 	Index      uint64
 }
 
-// encodeUint64 encodes a block number as big endian uint64
+// encodeUint64 encodes a number as big endian uint64
 func encodeUint64(number uint64) []byte {
 	enc := make([]byte, 8)
 	binary.BigEndian.PutUint64(enc, number)


### PR DESCRIPTION
## Proposed changes

- New member variables `newStateTrieDB` and `inMigration` have been added to `databaseManager` struct for data archiving.
- **All write operations** of state trie database are processed by a batch and the batch will be created from `newStateTrieDB` if `inMigration` flag is `true`.
- **All read operations** will search `newStateTrieDB` first and then search so called `oldStateTrieDB` next if not found. This behavior can be changed to use go-routines.
- **Read operations with suffix** `FromOld` are used to retrieve the data only from the old state trie database. This will be used for data archiving, which migrates the state data from old state trie database to the new one.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
