### PR TITLE
cn: added more tests of basePeer

### DIFF
--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -119,7 +119,9 @@ func (sb *backend) SetBroadcaster(broadcaster consensus.Broadcaster, nodetype p2
 
 // RegisterConsensusMsgCode registers the channel of consensus msg.
 func (sb *backend) RegisterConsensusMsgCode(peer consensus.Peer) {
-	peer.RegisterConsensusMsgCode(IstanbulMsg)
+	if err := peer.RegisterConsensusMsgCode(IstanbulMsg); err != nil {
+		logger.Error("RegisterConsensusMsgCode failed", "err", err)
+	}
 }
 
 func (sb *backend) NewChainHead() error {

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -73,5 +73,5 @@ type Peer interface {
 	Send(msgcode uint64, data interface{}) error
 
 	// RegisterConsensusMsgCode registers the channel of consensus msg.
-	RegisterConsensusMsgCode(msgCode uint64)
+	RegisterConsensusMsgCode(msgCode uint64) error
 }

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -39,10 +39,11 @@ import (
 )
 
 var (
-	errClosed             = errors.New("peer set is closed")
-	errAlreadyRegistered  = errors.New("peer is already registered")
-	errNotRegistered      = errors.New("peer is not registered")
-	errUnexpectedNodeType = errors.New("unexpected node type of peer")
+	errClosed                 = errors.New("peer set is closed")
+	errAlreadyRegistered      = errors.New("peer is already registered")
+	errNotRegistered          = errors.New("peer is not registered")
+	errUnexpectedNodeType     = errors.New("unexpected node type of peer")
+	errNotSupportedByBasePeer = errors.New("not supported by basePeer")
 )
 
 const (
@@ -222,7 +223,7 @@ type Peer interface {
 	downloader.Peer
 
 	// RegisterConsensusMsgCode registers the channel of consensus msg.
-	RegisterConsensusMsgCode(msgCode uint64)
+	RegisterConsensusMsgCode(msgCode uint64) error
 }
 
 // basePeer is a common data structure used by implementation of Peer.
@@ -732,8 +733,8 @@ func (p *basePeer) UpdateRWImplementationVersion() {
 }
 
 // RegisterConsensusMsgCode is not supported by this peer.
-func (p *basePeer) RegisterConsensusMsgCode(msgCode uint64) {
-	logger.Error("RegisterConsensusMsgCode is not supported by this peer.")
+func (p *basePeer) RegisterConsensusMsgCode(msgCode uint64) error {
+	return fmt.Errorf("%v peerID: %v ", errNotSupportedByBasePeer, p.GetID())
 }
 
 // singleChannelPeer is a peer that uses a single channel.
@@ -755,8 +756,9 @@ func (p *multiChannelPeer) RegisterMsgCode(channelId uint, msgCode uint64) {
 }
 
 // RegisterConsensusMsgCode registers the channel of consensus msg.
-func (p *multiChannelPeer) RegisterConsensusMsgCode(msgCode uint64) {
+func (p *multiChannelPeer) RegisterConsensusMsgCode(msgCode uint64) error {
 	p.chMgr.RegisterMsgCode(ConsensusChannel, msgCode)
+	return nil
 }
 
 // Broadcast is a write loop that multiplexes block propagations, announcements

--- a/node/cn/peer_mock_test.go
+++ b/node/cn/peer_mock_test.go
@@ -374,9 +374,11 @@ func (mr *MockPeerMockRecorder) ReSendTransactions(arg0 interface{}) *gomock.Cal
 }
 
 // RegisterConsensusMsgCode mocks base method
-func (m *MockPeer) RegisterConsensusMsgCode(arg0 uint64) {
+func (m *MockPeer) RegisterConsensusMsgCode(arg0 uint64) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterConsensusMsgCode", arg0)
+	ret := m.ctrl.Call(m, "RegisterConsensusMsgCode", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // RegisterConsensusMsgCode indicates an expected call of RegisterConsensusMsgCode

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -18,9 +18,12 @@ package cn
 
 import (
 	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/networks/p2p"
+	"github.com/klaytn/klaytn/node"
 	"github.com/stretchr/testify/assert"
 	"math/big"
+	"strings"
 	"testing"
 )
 
@@ -136,4 +139,33 @@ func TestBasePeer_AsyncSendTransactions(t *testing.T) {
 
 	assert.True(t, basePeer.KnowsTx(tx1.Hash()))
 	assert.False(t, basePeer.KnowsTx(lastTxs[0].Hash()))
+}
+
+func TestBasePeer_ConnType(t *testing.T) {
+	basePeer, _, _ := newBasePeer()
+	assert.Equal(t, p2p.ConnType(node.CONSENSUSNODE), basePeer.ConnType())
+}
+
+func TestBasePeer_GetAndSetAddr(t *testing.T) {
+	basePeer, _, _ := newBasePeer()
+	assert.Equal(t, common.Address{}, basePeer.GetAddr())
+	basePeer.SetAddr(addrs[0])
+	assert.Equal(t, addrs[0], basePeer.GetAddr())
+	basePeer.SetAddr(addrs[1])
+	assert.Equal(t, addrs[1], basePeer.GetAddr())
+}
+
+func TestBasePeer_GetVersion(t *testing.T) {
+	basePeer, _, _ := newBasePeer()
+	assert.Equal(t, version, basePeer.GetVersion())
+}
+
+func TestBasePeer_RegisterConsensusMsgCode(t *testing.T) {
+	basePeer, _, _ := newBasePeer()
+	assert.True(t, strings.Contains(basePeer.RegisterConsensusMsgCode(NewBlockHashesMsg).Error(), errNotSupportedByBasePeer.Error()))
+}
+
+func TestBasePeer_GetRW(t *testing.T) {
+	basePeer, pipe1, _ := newBasePeer()
+	assert.Equal(t, pipe1, basePeer.GetRW())
 }


### PR DESCRIPTION
## Proposed changes

- added more tests of basePeer to peer_test.go
- made `RegisterConsensusMsgCode` to return an error to distinguish `basePeer` and `multiChannelPeer`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
