### PR TITLE
Remove an unnecessary test function

### DIFF
--- a/crypto/ecies/ecies_test.go
+++ b/crypto/ecies/ecies_test.go
@@ -39,21 +39,12 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/klaytn/klaytn/crypto"
 )
-
-var dumpEnc bool
-
-func init() {
-	flDump := flag.Bool("dump", false, "write encrypted test message to file")
-	flag.Parse()
-	dumpEnc = *flDump
-}
 
 // Ensure the KDF generates appropriately sized keys.
 func TestKDF(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

go1.13 delayed testing flag registration introducing `testing.Init` in https://github.com/golang/go/commit/fbc6a972226f889d2ab1150468755615098ee80f.
The change helps non-testing binaries not to define testing flags.

However, it makes hard to parse testing flags in `init` function since the flags were not set yet when `init` function is called. 

~This PR mitigates the issue by explicitly executing `testing.Init` only for go1.13 and onward.~
This PR removed the `init` function of `ecies` packages since it is not necessary.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- For more detailed information, see https://github.com/golang/go/issues/31859
