### PR TITLE
Update Dockerfiles used for builds to Go 1.13.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,11 @@
 #
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2.1
+executors:
+  build_base:
+    docker:
+      - image: klaytn/build_base:1.0-go1.13.3-solc0.4.24
+
 jobs:
   build:
     machine: true
@@ -19,8 +24,7 @@ jobs:
             make all
 
   test-datasync:
-    docker:
-      - image: klaytn/build_base:1.0
+    executor: build_base
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -30,8 +34,7 @@ jobs:
             make test-datasync
 
   test-networks:
-    docker:
-      - image: klaytn/build_base:1.0
+    executor: build_base
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -41,8 +44,7 @@ jobs:
             make test-networks
 
   test-tests:
-    docker:
-      - image: klaytn/build_base:1.0
+    executor: build_base
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -53,8 +55,7 @@ jobs:
             make test-tests
 
   test-others:
-    docker:
-      - image: klaytn/build_base:1.0
+    executor: build_base
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -64,8 +65,7 @@ jobs:
             make test-others
 
   coverage:
-    docker:
-      - image: klaytn/build_base:1.0
+    executor: build_base
     working_directory: /go/src/github.com/klaytn/klaytn
     resource_class: xlarge
     steps:
@@ -86,8 +86,7 @@ jobs:
           path: /tmp/coverage_reports
 
   linters:
-    docker:
-      - image: klaytn/build_base:1.0
+    executor: build_base
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ executors:
   build_base:
     docker:
       - image: klaytn/build_base:1.0-go1.13.3-solc0.4.24
+  rpmbuild:
+    docker:
+      - image: klaytndevops/circleci-rpmbuild:1.13.3
 
 jobs:
   build:
@@ -296,8 +299,7 @@ jobs:
 
 
   rpm-untagged:
-    docker:
-      - image: klaytndevops/circleci-rpmbuild:1.12.5
+    executor: rpmbuild
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -319,8 +321,7 @@ jobs:
             ssh -o StrictHostKeyChecking=no ec2-user@52.79.114.173 createrepo --update /srv/repo
 
   rpm-tagged:
-    docker:
-      - image: klaytndevops/circleci-rpmbuild:1.12.5
+    executor: rpmbuild
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -351,8 +352,7 @@ jobs:
             ssh -o StrictHostKeyChecking=no ec2-user@52.79.114.173 createrepo --update /srv/repo
 
   rpm-tagged-baobab:
-    docker:
-      - image: klaytndevops/circleci-rpmbuild:1.12.5
+    executor: rpmbuild
     working_directory: /go/src/github.com/klaytn/klaytn
     steps:
       - checkout
@@ -383,8 +383,7 @@ jobs:
             ssh -o StrictHostKeyChecking=no ec2-user@52.79.114.173 createrepo --update /srv/repo
 
   deploy-rpm-private:
-    docker:
-      - image: klaytndevops/circleci-rpmbuild:1.12.5
+    executor: rpmbuild
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/build/Dockerfile-go1.13.3-rpmbuild
+++ b/build/Dockerfile-go1.13.3-rpmbuild
@@ -1,0 +1,16 @@
+FROM alpine:3.8 as go_builder
+RUN \
+  apk add --no-cache --virtual .build-deps bash gcc musl-dev openssl go; \
+  wget -O go.src.tar.gz https://dl.google.com/go/go1.13.3.src.tar.gz; \
+  tar -C /usr/local -xzf go.src.tar.gz; \
+  cd /usr/local/go/src/ && ./make.bash; \
+  apk del .build-deps
+
+FROM centos:centos7
+
+COPY --from=go_builder /usr/local/go /usr/local
+RUN yum install -y make rpm-build git
+RUN mkdir -p /rpmbuild/{SOURCES,SPECS,BUILD,RPMS,SRPMS}
+RUN echo "%_topdir /rpmbuild" > ~/.rpmmacros
+
+CMD ["/bin/sh"]

--- a/build/Dockerfile-go1.13.3-solc0.4.24-alpine
+++ b/build/Dockerfile-go1.13.3-solc0.4.24-alpine
@@ -1,0 +1,28 @@
+FROM alpine:3.8 as solc_builder
+RUN \
+  apk --no-cache --update add build-base cmake boost-dev git; \
+  sed -i -E -e 's/include <sys\/poll.h>/include <poll.h>/' /usr/include/boost/asio/detail/socket_types.hpp; \
+  git clone --depth 1 --recursive -b v0.4.24 https://github.com/ethereum/solidity; \
+  cd /solidity && cmake -DCMAKE_BUILD_TYPE=Release -DTESTS=0 -DSTATIC_LINKING=1 && \
+  touch prerelease.txt && make -j8 solc && install -s solc/solc /usr/bin; \
+  cd / && rm -rf solidity; \
+  apk del sed build-base git make cmake gcc g++ musl-dev curl-dev boost-dev; \
+  rm -rf /var/cache/apk/*
+
+FROM alpine:3.8 as go_builder
+RUN \
+  apk add --no-cache --virtual .build-deps bash gcc musl-dev openssl go; \
+  wget -O go.src.tar.gz https://dl.google.com/go/go1.13.3.src.tar.gz; \
+  tar -C /usr/local -xzf go.src.tar.gz; \
+  cd /usr/local/go/src/ && ./make.bash; \
+  apk del .build-deps
+
+FROM alpine:3.8
+
+RUN apk add --no-cache ca-certificates boost git make gcc libc-dev curl bash
+COPY --from=solc_builder /usr/bin/solc /usr/bin/solc
+COPY --from=go_builder /usr/local/go /usr/local
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"

--- a/build/Dockerfile-go1.13.3-solc0.4.24-alpine
+++ b/build/Dockerfile-go1.13.3-solc0.4.24-alpine
@@ -18,7 +18,6 @@ RUN \
   apk del .build-deps
 
 FROM alpine:3.8
-
 RUN apk add --no-cache ca-certificates boost git make gcc libc-dev curl bash
 COPY --from=solc_builder /usr/bin/solc /usr/bin/solc
 COPY --from=go_builder /usr/local/go /usr/local


### PR DESCRIPTION
## Proposed changes

- Updates the Dockerfiles used for the build containers to use Go release 1.13.3.
- Adds the Dockerfile used for RPM builds -- since other logic and scripts for building Klaytn RPMs are located in this repo, I think it makes sense to include the Dockerfile as well. 
- Defines custom executors in circleci to simplify future image version updates

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others (dependency update)

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- TPT-1082
- GD-359

## Further comments

N/A
