### PR TITLE
all: enable data archiving preparation

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -78,13 +78,14 @@ const (
 // 2) trie caching/pruning resident in a blockchain.
 type CacheConfig struct {
 	// TODO-Klaytn-Issue1666 Need to check the benefit of trie caching.
-	StateDBCaching       bool // Enables caching of state objects in stateDB.
-	TxPoolStateCache     bool // Enables caching of nonce and balance for txpool.
-	ArchiveMode          bool // If true, state trie is not pruned and always written to database.
-	CacheSize            int  // Size of in-memory cache of a trie (MiB) to flush matured singleton trie nodes to disk
-	BlockInterval        uint // Block interval to flush the trie. Each interval state trie will be flushed into disk.
-	TrieCacheLimit       int  // Memory allowance (MB) to use for caching trie nodes in memory
-	SenderTxHashIndexing bool // Enables saving senderTxHash to txHash mapping information to database and cache.
+	StateDBCaching        bool   // Enables caching of state objects in stateDB.
+	TxPoolStateCache      bool   // Enables caching of nonce and balance for txpool.
+	ArchiveMode           bool   // If true, state trie is not pruned and always written to database.
+	CacheSize             int    // Size of in-memory cache of a trie (MiB) to flush matured singleton trie nodes to disk
+	BlockInterval         uint   // Block interval to flush the trie. Each interval state trie will be flushed into disk.
+	TrieCacheLimit        int    // Memory allowance (MB) to use for caching trie nodes in memory
+	SenderTxHashIndexing  bool   // Enables saving senderTxHash to txHash mapping information to database and cache.
+	DataArchivingBlockNum uint64 // If not zero, the number indicates the starting point of data archiving operation.
 }
 
 // BlockChain represents the canonical chain given a database with a genesis
@@ -183,7 +184,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 		cacheConfig:     cacheConfig,
 		db:              db,
 		triegc:          prque.New(),
-		stateCache:      state.NewDatabaseWithCache(db, cacheConfig.TrieCacheLimit),
+		stateCache:      state.NewDatabaseWithCache(db, cacheConfig.TrieCacheLimit, cacheConfig.DataArchivingBlockNum),
 		quit:            make(chan struct{}),
 		futureBlocks:    futureBlocks,
 		engine:          engine,
@@ -772,7 +773,7 @@ func (bc *BlockChain) Stop() {
 				}
 
 				logger.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
-				if err := triedb.Commit(recent.Root(), true); err != nil {
+				if err := triedb.Commit(recent.Root(), true, statedb.NoDataArchivingPreparation); err != nil {
 					logger.Error("Failed to commit recent state trie", "err", err)
 				}
 			}
@@ -1012,7 +1013,7 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 
 	// If we're running an archive node, always flush
 	if bc.isArchiveMode() {
-		if err := trieDB.Commit(root, false); err != nil {
+		if err := trieDB.Commit(root, false, block.NumberU64()); err != nil {
 			return err
 		}
 	} else {
@@ -1035,7 +1036,7 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 
 		if isCommitTrieRequired(bc, block.NumberU64()) {
 			logger.Trace("Commit the state trie into the disk", "blocknum", block.NumberU64())
-			trieDB.Commit(block.Header().Root, true)
+			trieDB.Commit(block.Header().Root, true, block.NumberU64())
 		}
 
 		if current := block.NumberU64(); current > triesInMemory {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1013,7 +1013,7 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 
 	// If we're running an archive node, always flush
 	if bc.isArchiveMode() {
-		if err := trieDB.Commit(root, false, block.NumberU64()); err != nil {
+		if err := trieDB.Commit(root, false, statedb.NoDataArchivingPreparation); err != nil {
 			return err
 		}
 	} else {

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -187,7 +187,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			if err != nil {
 				panic(fmt.Sprintf("state write error: %v", err))
 			}
-			if err := statedb.Database().TrieDB().Commit(root, false); err != nil {
+			if err := statedb.Database().TrieDB().Commit(root, false, block.NumberU64()); err != nil {
 				panic(fmt.Sprintf("trie write error: %v", err))
 			}
 			return block, b.receipts

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -99,13 +99,13 @@ type Trie interface {
 // concurrent use, but does not retain any recent trie nodes in memory. To keep some
 // historical state in memory, use the NewDatabaseWithCache constructor.
 func NewDatabase(db database.DBManager) Database {
-	return NewDatabaseWithCache(db, 0)
+	return NewDatabaseWithCache(db, 0, 0)
 }
 
 // NewDatabaseWithCache creates a backing store for state. The returned database
 // is safe for concurrent use and retains a lot of collapsed RLP trie nodes in a
 // large memory cache.
-func NewDatabaseWithCache(db database.DBManager, cacheSize int) Database {
+func NewDatabaseWithCache(db database.DBManager, cacheSize int, dataArchivingBlockNum uint64) Database {
 	var cacheConfig common.CacheConfiger
 	switch common.DefaultCacheType {
 	case common.LRUShardCacheType:
@@ -120,7 +120,7 @@ func NewDatabaseWithCache(db database.DBManager, cacheSize int) Database {
 	csc := common.NewCache(cacheConfig)
 
 	return &cachingDB{
-		db:            statedb.NewDatabaseWithCache(db, cacheSize),
+		db:            statedb.NewDatabaseWithCache(db, cacheSize, dataArchivingBlockNum),
 		codeSizeCache: csc,
 	}
 }

--- a/cmd/kcn/main.go
+++ b/cmd/kcn/main.go
@@ -92,6 +92,7 @@ var cnHelpFlagGroups = []utils.FlagGroup{
 			utils.LevelDBNoBufferPoolFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
+			utils.DataArchivingBlockNumFlag,
 		},
 	},
 	{

--- a/cmd/ken/main.go
+++ b/cmd/ken/main.go
@@ -103,6 +103,7 @@ var enHelpFlagGroups = []utils.FlagGroup{
 			utils.LevelDBNoBufferPoolFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
+			utils.DataArchivingBlockNumFlag,
 		},
 	},
 	{

--- a/cmd/kpn/main.go
+++ b/cmd/kpn/main.go
@@ -103,6 +103,7 @@ var pnHelpFlagGroups = []utils.FlagGroup{
 			utils.LevelDBNoBufferPoolFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
+			utils.DataArchivingBlockNumFlag,
 		},
 	},
 	{

--- a/cmd/kscn/main.go
+++ b/cmd/kscn/main.go
@@ -110,6 +110,7 @@ var scnHelpFlagGroups = []utils.FlagGroup{
 			utils.LevelDBNoBufferPoolFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
+			utils.DataArchivingBlockNumFlag,
 		},
 	},
 	{

--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -111,6 +111,7 @@ var senHelpFlagGroups = []utils.FlagGroup{
 			utils.LevelDBNoBufferPoolFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
+			utils.DataArchivingBlockNumFlag,
 		},
 	},
 	{

--- a/cmd/kspn/main.go
+++ b/cmd/kspn/main.go
@@ -119,6 +119,7 @@ var spnHelpFlagGroups = []utils.FlagGroup{
 			utils.LevelDBNoBufferPoolFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
+			utils.DataArchivingBlockNumFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -661,7 +661,7 @@ var (
 	// TODO-Klaytn-DataArchiving Please note that DataArchivingBlockNumFlag is just for development purpose.
 	DataArchivingBlockNumFlag = cli.Uint64Flag{
 		Name:  "dataarchiving.blocknumber",
-		Usage: "The point when the data archiving starts from. 0 means off",
+		Usage: "The block number when the data archiving starts from. 0 means off",
 		Value: 0,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -657,6 +657,13 @@ var (
 		Usage: "The maximum difference between current block and event block. 0 means off",
 		Value: 0,
 	}
+	// Data Archiving
+	// TODO-Klaytn-DataArchiving Please note that DataArchivingBlockNumFlag is just for development purpose.
+	DataArchivingBlockNumFlag = cli.Uint64Flag{
+		Name:  "dataarchiving.blocknumber",
+		Usage: "The point when the data archiving starts from. 0 means off",
+		Value: 0,
+	}
 
 	// TODO-Klaytn-Bootnode: Add bootnode's metric options
 	// TODO-Klaytn-Bootnode: Implements bootnode's RPC
@@ -1154,6 +1161,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 	cfg.ParallelDBWrite = !ctx.GlobalIsSet(NoParallelDBWriteFlag.Name)
 	cfg.StateDBCaching = ctx.GlobalIsSet(StateDBCachingFlag.Name)
 	cfg.TrieCacheLimit = ctx.GlobalInt(TrieCacheLimitFlag.Name)
+	cfg.DataArchivingBlockNum = ctx.GlobalUint64(DataArchivingBlockNumFlag.Name)
 
 	if ctx.GlobalIsSet(VMEnableDebugFlag.Name) {
 		// TODO(fjl): force-enable this in --dev mode

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -54,6 +54,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.LevelDBNoBufferPoolFlag,
 	utils.LevelDBCacheSizeFlag,
 	utils.NoParallelDBWriteFlag,
+	utils.DataArchivingBlockNumFlag,
 	utils.SenderTxHashIndexingFlag,
 	utils.TrieMemoryCacheSizeFlag,
 	utils.TrieBlockIntervalFlag,

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -146,7 +146,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 
 	// Ensure we have a valid starting state before doing any work
 	origin := start.NumberU64()
-	database := state.NewDatabaseWithCache(api.cn.ChainDB(), 16) // Chain tracing will probably start at genesis
+	database := state.NewDatabaseWithCache(api.cn.ChainDB(), 16, 0) // Chain tracing will probably start at genesis
 
 	if number := start.NumberU64(); number > 0 {
 		start = api.cn.blockchain.GetBlock(start.ParentHash(), start.NumberU64()-1)
@@ -630,7 +630,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 	}
 	// Otherwise try to reexec blocks until we find a state or reach our limit
 	origin := block.NumberU64()
-	database := state.NewDatabaseWithCache(api.cn.ChainDB(), 16)
+	database := state.NewDatabaseWithCache(api.cn.ChainDB(), 16, 0)
 
 	for i := uint64(0); i < reexec; i++ {
 		block = api.cn.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -243,7 +243,8 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		vmConfig    = vm.Config{EnablePreimageRecording: config.EnablePreimageRecording}
 		cacheConfig = &blockchain.CacheConfig{StateDBCaching: config.StateDBCaching,
 			ArchiveMode: config.NoPruning, CacheSize: config.TrieCacheSize, BlockInterval: config.TrieBlockInterval,
-			TxPoolStateCache: config.TxPoolStateCache, TrieCacheLimit: config.TrieCacheLimit, SenderTxHashIndexing: config.SenderTxHashIndexing}
+			TxPoolStateCache: config.TxPoolStateCache, TrieCacheLimit: config.TrieCacheLimit,
+			SenderTxHashIndexing: config.SenderTxHashIndexing, DataArchivingBlockNum: config.DataArchivingBlockNum}
 	)
 	var err error
 

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -103,6 +103,7 @@ type Config struct {
 	StateDBCaching         bool
 	TxPoolStateCache       bool
 	TrieCacheLimit         int
+	DataArchivingBlockNum  uint64
 
 	// Mining-related options
 	ServiceChainSigner common.Address `toml:",omitempty"`

--- a/node/cn/gen_config.go
+++ b/node/cn/gen_config.go
@@ -41,6 +41,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		StateDBCaching          bool
 		TxPoolStateCache        bool
 		TrieCacheLimit          int
+		DataArchivingBlockNum   uint64
 		ServiceChainSigner      common.Address `toml:",omitempty"`
 		ExtraData               hexutil.Bytes  `toml:",omitempty"`
 		GasPrice                *big.Int
@@ -55,6 +56,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TxResendCount           int
 		TxResendUseLegacy       bool
 		NoAccountCreation       bool
+		IsPrivate               bool
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -78,6 +80,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.StateDBCaching = c.StateDBCaching
 	enc.TxPoolStateCache = c.TxPoolStateCache
 	enc.TrieCacheLimit = c.TrieCacheLimit
+	enc.DataArchivingBlockNum = c.DataArchivingBlockNum
 	enc.ServiceChainSigner = c.ServiceChainSigner
 	enc.ExtraData = c.ExtraData
 	enc.GasPrice = c.GasPrice
@@ -92,6 +95,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TxResendCount = c.TxResendCount
 	enc.TxResendUseLegacy = c.TxResendUseLegacy
 	enc.NoAccountCreation = c.NoAccountCreation
+	enc.IsPrivate = c.IsPrivate
 	return &enc, nil
 }
 
@@ -119,6 +123,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		StateDBCaching          *bool
 		TxPoolStateCache        *bool
 		TrieCacheLimit          *int
+		DataArchivingBlockNum   *uint64
 		ServiceChainSigner      *common.Address `toml:",omitempty"`
 		ExtraData               *hexutil.Bytes  `toml:",omitempty"`
 		GasPrice                *big.Int
@@ -133,6 +138,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TxResendCount           *int
 		TxResendUseLegacy       *bool
 		NoAccountCreation       *bool
+		IsPrivate               *bool
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -201,6 +207,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.TrieCacheLimit != nil {
 		c.TrieCacheLimit = *dec.TrieCacheLimit
 	}
+	if dec.DataArchivingBlockNum != nil {
+		c.DataArchivingBlockNum = *dec.DataArchivingBlockNum
+	}
 	if dec.ServiceChainSigner != nil {
 		c.ServiceChainSigner = *dec.ServiceChainSigner
 	}
@@ -242,6 +251,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.NoAccountCreation != nil {
 		c.NoAccountCreation = *dec.NoAccountCreation
+	}
+	if dec.IsPrivate != nil {
+		c.IsPrivate = *dec.IsPrivate
 	}
 	return nil
 }

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -836,7 +836,7 @@ func (db *Database) Commit(node common.Hash, report bool, blockNum uint64) error
 }
 
 func (db *Database) settingMigrationDBRequired(blockNum uint64) bool {
-	if blockNum == 0 {
+	if blockNum == NoDataArchivingPreparation {
 		return false
 	}
 	if blockNum >= db.dataArchivingBlockNum && !db.diskDB.InMigration() {

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -68,6 +68,10 @@ const secureKeyLength = 11 + 32
 // commitResultChSizeLimit limits the size of channel used for commitResult.
 const commitResultChSizeLimit = 100 * 10000
 
+// NoDataArchivingPreparation is used to indicate that certain Database.Commit operations
+// do not need preparation of data archiving.
+const NoDataArchivingPreparation = 0
+
 type DatabaseReader interface {
 	// Get retrieves the value associated with key from the database.
 	Get(key []byte) (value []byte, err error)
@@ -103,6 +107,8 @@ type Database struct {
 	lock sync.RWMutex
 
 	trieNodeCache *bigcache.BigCache // GC friendly memory cache of trie node RLPs
+
+	dataArchivingBlockNum uint64
 }
 
 // rawNode is a simple binary blob used to differentiate between collapsed trie
@@ -299,13 +305,13 @@ func (t trieNodeHasher) Sum64(key string) uint64 {
 // NewDatabase creates a new trie database to store ephemeral trie content before
 // its written out to disk or garbage collected.
 func NewDatabase(diskDB database.DBManager) *Database {
-	return NewDatabaseWithCache(diskDB, 0)
+	return NewDatabaseWithCache(diskDB, 0, 0)
 }
 
 // NewDatabaseWithCache creates a new trie database to store ephemeral trie content
 // before its written out to disk or garbage collected. It also acts as a read cache
 // for nodes loaded from disk.
-func NewDatabaseWithCache(diskDB database.DBManager, cacheSize int) *Database {
+func NewDatabaseWithCache(diskDB database.DBManager, cacheSize int, daBlockNum uint64) *Database {
 	var trieNodeCache *bigcache.BigCache
 	if cacheSize > 0 {
 		trieNodeCache, _ = bigcache.NewBigCache(bigcache.Config{
@@ -318,10 +324,11 @@ func NewDatabaseWithCache(diskDB database.DBManager, cacheSize int) *Database {
 		})
 	}
 	return &Database{
-		diskDB:        diskDB,
-		nodes:         map[common.Hash]*cachedNode{{}: {}},
-		preimages:     make(map[common.Hash][]byte),
-		trieNodeCache: trieNodeCache,
+		diskDB:                diskDB,
+		nodes:                 map[common.Hash]*cachedNode{{}: {}},
+		preimages:             make(map[common.Hash][]byte),
+		trieNodeCache:         trieNodeCache,
+		dataArchivingBlockNum: daBlockNum,
 	}
 }
 
@@ -773,7 +780,7 @@ func (db *Database) concurrentCommit(hash common.Hash, resultCh chan<- commitRes
 // to disk, forcefully tearing down all references in both directions.
 //
 // As a side effect, all pre-images accumulated up to this point are also written.
-func (db *Database) Commit(node common.Hash, report bool) error {
+func (db *Database) Commit(node common.Hash, report bool, blockNum uint64) error {
 	// Create a database batch to flush persistent data out. It is important that
 	// outside code doesn't see an inconsistent state (referenced data removed from
 	// memory cache during commit but not yet in persistent database). This is ensured
@@ -822,7 +829,20 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	db.gcnodes, db.gcsize, db.gctime = 0, 0, 0
 	db.flushnodes, db.flushsize, db.flushtime = 0, 0, 0
 
+	if db.settingMigrationDBRequired(blockNum) {
+		db.diskDB.SetStateTrieMigrationDB(blockNum)
+	}
 	return nil
+}
+
+func (db *Database) settingMigrationDBRequired(blockNum uint64) bool {
+	if blockNum == 0 {
+		return false
+	}
+	if blockNum >= db.dataArchivingBlockNum && !db.diskDB.InMigration() {
+		return true
+	}
+	return false
 }
 
 // commit iteratively encodes nodes from parents to child nodes.

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -839,6 +839,9 @@ func (db *Database) settingMigrationDBRequired(blockNum uint64) bool {
 	if blockNum == NoDataArchivingPreparation {
 		return false
 	}
+	if db.dataArchivingBlockNum == 0 {
+		return false
+	}
 	if blockNum >= db.dataArchivingBlockNum && !db.diskDB.InMigration() {
 		return true
 	}

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -28,7 +28,7 @@ var parentHash = common.HexToHash("1343A3F") // 20199999 in hexadecimal
 
 func TestDatabase_Reference(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithCache(memDB, 128)
+	db := NewDatabaseWithCache(memDB, 128, 0)
 
 	assert.Equal(t, memDB, db.DiskDB())
 	assert.Equal(t, 1, len(db.nodes)) // {} : {}
@@ -56,7 +56,7 @@ func TestDatabase_Reference(t *testing.T) {
 
 func TestDatabase_DeReference(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithCache(memDB, 128)
+	db := NewDatabaseWithCache(memDB, 128, 0)
 	assert.Equal(t, 1, len(db.nodes)) // {} : {}
 
 	db.Dereference(parentHash)
@@ -86,7 +86,7 @@ func TestDatabase_DeReference(t *testing.T) {
 
 func TestDatabase_Size(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithCache(memDB, 128)
+	db := NewDatabaseWithCache(memDB, 128, 0)
 
 	totalMemorySize, preimagesSize := db.Size()
 	assert.Equal(t, common.StorageSize(0), totalMemorySize)
@@ -111,7 +111,7 @@ func TestDatabase_Size(t *testing.T) {
 
 func TestDatabase_SecureKey(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithCache(memDB, 128)
+	db := NewDatabaseWithCache(memDB, 128, 0)
 
 	secKey1 := db.secureKey(childHash[:])
 	copiedSecKey := make([]byte, 0, len(secKey1))

--- a/storage/statedb/iterator_test.go
+++ b/storage/statedb/iterator_test.go
@@ -303,7 +303,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	}
 	tr.Commit(nil)
 	if !memonly {
-		triedb.Commit(tr.Hash(), true)
+		triedb.Commit(tr.Hash(), true, NoDataArchivingPreparation)
 	}
 	wantNodeCount := checkIteratorNoDups(t, tr.NodeIterator(nil), nil)
 
@@ -391,7 +391,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	}
 	root, _ := ctr.Commit(nil)
 	if !memonly {
-		triedb.Commit(root, true)
+		triedb.Commit(root, true, NoDataArchivingPreparation)
 	}
 	barNodeHash := common.HexToHash("05041990364eb72fcb1127652ce40d8bab765f2bfe53225b1170d276cc101c2e")
 	var (

--- a/storage/statedb/trie_test.go
+++ b/storage/statedb/trie_test.go
@@ -92,7 +92,7 @@ func testMissingNode(t *testing.T, memonly bool) {
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
 	root, _ := trie.Commit(nil)
 	if !memonly {
-		triedb.Commit(root, true)
+		triedb.Commit(root, true, NoDataArchivingPreparation)
 	}
 
 	trie, _ = NewTrie(root, triedb)

--- a/tags-for-todo-and-note.md
+++ b/tags-for-todo-and-note.md
@@ -55,4 +55,4 @@ Please note that the tag name always
 | gRPC                                           | Related to gRPC.                                          |
 | HF                                             | Related to HardFork.                                      |
 | StateDB                                        | Related to StateDB and stateObject.                       |
-| DataArchiving                                  | Related to Data Archiving feature                         |
+| DataArchiving                                  | Related to Data Archiving feature.                        |

--- a/tags-for-todo-and-note.md
+++ b/tags-for-todo-and-note.md
@@ -55,3 +55,4 @@ Please note that the tag name always
 | gRPC                                           | Related to gRPC.                                          |
 | HF                                             | Related to HardFork.                                      |
 | StateDB                                        | Related to StateDB and stateObject.                       |
+| DataArchiving                                  | Related to Data Archiving feature                         |


### PR DESCRIPTION
## Proposed changes

- Please note that this is in-developing and the way node sets the new database and subsequent operations will be changed in the future.
- With the flag `dataarchiving.blocknumber`, the node will set-up a new database partition for data archiving of state trie partition.
- Right before finishing `Database.Commit` operation, it will check  if current block number is equal to or greater than the given setting and it will set-up a new database.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Below is the list of related changes of data archiving feature.
- [database: introduce state migration database to DBManager](https://github.com/klaytn/klaytn/pull/316)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
