### PR TITLE
Remove double quotes in .codecov.yml

### DIFF
--- a/.circleci/.codecov.yml
+++ b/.circleci/.codecov.yml
@@ -14,7 +14,7 @@ coverage:
                 if_ci_failed: error   # if ci fails report status as success, error, or failure
 
 ignore:
-  - "blockchain/types/account/legacy_account.go"            # disabled
-  - "blockchain/types/tx_internal_data_account_creation.go" # inactivated
-  - ".*/metrics.go"                                         # test not needed
-  - ".*/gen_config.go"                                      # test not needed
+  - blockchain/types/account/legacy_account.go            # disabled
+  - blockchain/types/tx_internal_data_account_creation.go # inactivated
+  - .*/metrics.go                                         # test not needed
+  - .*/gen_config.go                                      # test not needed


### PR DESCRIPTION
## Proposed changes

Ignore configuration of codecov is not working. 
As the previous configuration without double quotes was working, I removed them from the config file (codecov's example has double quotes in https://docs.codecov.io/docs/ignoring-paths, though).

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
