### PR TITLE
Modify transaction beat logic to prevent lose queued transactions before timeout

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -312,7 +312,6 @@ func (pool *TxPool) loop() {
 			// Handle inactive account transaction eviction
 		case <-evict.C:
 			pool.mu.Lock()
-			for addr := range pool.queue {
 			for addr, beat := range pool.beats {
 				if pool.config.KeepLocals && pool.locals.contains(addr) {
 					delete(pool.beats, addr)

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -313,11 +313,13 @@ func (pool *TxPool) loop() {
 		case <-evict.C:
 			pool.mu.Lock()
 			for addr, beat := range pool.beats {
+				// Skip local transactions from the eviction mechanism
 				if pool.config.KeepLocals && pool.locals.contains(addr) {
 					delete(pool.beats, addr)
 					continue
 				}
 
+				// Any non-locals old enough should be removed
 				if time.Since(beat) > pool.config.Lifetime {
 					if pool.queue[addr] != nil {
 						for _, tx := range pool.queue[addr].Flatten() {

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -867,7 +867,7 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) (bool, er
 		pool.priced.Put(tx)
 	}
 
-	pool.checkAndUpdateBeat(from)
+	pool.checkAndSetBeat(from)
 	return old != nil, nil
 }
 
@@ -1085,8 +1085,8 @@ func (pool *TxPool) Get(hash common.Hash) *types.Transaction {
 	return pool.all[hash]
 }
 
-// checkAndUpdateBeat set the beat of the account if there is no beat of the account.
-func (pool *TxPool) checkAndUpdateBeat(addr common.Address) {
+// checkAndSetBeat sets the beat of the account if there is no beat of the account.
+func (pool *TxPool) checkAndSetBeat(addr common.Address) {
 	_, exist := pool.beats[addr]
 
 	if !exist {

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -319,8 +319,10 @@ func (pool *TxPool) loop() {
 				}
 
 				if time.Since(beat) > pool.config.Lifetime {
-					for _, tx := range pool.queue[addr].Flatten() {
-						pool.removeTx(tx.Hash(), true)
+					if pool.queue[addr] != nil {
+						for _, tx := range pool.queue[addr].Flatten() {
+							pool.removeTx(tx.Hash(), true)
+						}
 					}
 					delete(pool.beats, addr)
 				}


### PR DESCRIPTION
## Proposed changes

This PR is to prevent lose queued transactions before timeout.

Before this PR, queued transactions is dropped in 1 minute, before timeout.
Because, when pending list is empty, beat time also removed.
So when beat time checking logic compares beat time and now time, every 1 minute, the beat time doesn't exist and it calculate with zero time. Therefore the queued transaction will be removed.

In this PR, below logics are modified.

- if beat time is timed out, all queued txs are removed and the beat time is removed.
- if there is no beat time and new transaction is enqueued, the beat time is set.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
