### PR TITLE
Refine APIs: SendTransaction, SignTransaction

### DIFF
--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -353,9 +353,8 @@ func (s *PublicTransactionPoolAPI) Sign(addr common.Address, data hexutil.Bytes)
 	// Sign the requested hash with the wallet
 	signature, err := wallet.SignHash(account, signHash(data))
 	if err == nil {
-		return nil, err
+		signature[64] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
 	}
-	signature[64] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
 	return signature, err
 }
 

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -308,19 +308,6 @@ func submitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 // SendTransaction creates a transaction for the given argument, sign it and submit it to the
 // transaction pool.
 func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args SendTxArgs) (common.Hash, error) {
-	if args.TypeInt != nil {
-		if args.TypeInt.IsFeeDelegatedTransaction() {
-			return common.Hash{}, errNotForFeeDelegationTx
-		}
-	}
-	// Look up the wallet containing the requested signer
-	account := accounts.Account{Address: args.From}
-
-	wallet, err := s.b.AccountManager().Find(account)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
 	if args.Nonce == nil {
 		// Hold the addresse's mutex around signing to prevent concurrent assignment of
 		// the same nonce to multiple accounts.
@@ -328,21 +315,12 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 		defer s.nonceLock.UnlockAddr(args.From)
 	}
 
-	// Set some sanity defaults and terminate on failure
-	if err := args.setDefaults(ctx, s.b); err != nil {
-		return common.Hash{}, err
-	}
-	// Assemble the transaction and sign with the wallet
-	tx, err := args.toTransaction()
+	signedTx, err := s.SignTransaction(ctx, args)
 	if err != nil {
 		return common.Hash{}, err
 	}
 
-	signed, err := wallet.SignTx(account, tx, s.b.ChainConfig().ChainID)
-	if err != nil {
-		return common.Hash{}, err
-	}
-	return submitTransaction(ctx, s.b, signed)
+	return submitTransaction(ctx, s.b, signedTx.Tx)
 }
 
 // SendRawTransaction will add the signed transaction to the transaction pool.
@@ -375,8 +353,9 @@ func (s *PublicTransactionPoolAPI) Sign(addr common.Address, data hexutil.Bytes)
 	// Sign the requested hash with the wallet
 	signature, err := wallet.SignHash(account, signHash(data))
 	if err == nil {
-		signature[64] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
+		return nil, err
 	}
+	signature[64] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
 	return signature, err
 }
 
@@ -390,6 +369,8 @@ type SignTransactionResult struct {
 // The node needs to have the private key of the account corresponding with
 // the given from address and it needs to be unlocked.
 func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args SendTxArgs) (*SignTransactionResult, error) {
+	// No need to obtain the noncelock mutex, since we won't be sending this
+	// tx into the transaction pool, but right back to the user
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Proposed changes

- Match `personal_sendTransaction` logic up with `klay_sendTransaction` logic
- Match `personal_signTransaction` logic up with `klay_signTransaction` logic

After this change, the code of each pair looks the same except the password handling of Keystore.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

**After Change** - Test to check no side effect

- SendTransaction
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "personal_sendTransaction", "params": [{"typeInt": 16, "from": "0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95", "to": "0x44711E89b0c23845b5B2ed9D3716BA42b8a3e075", "gas": "0x76c0", "gasPrice": "0x5d21dba00", "value": "0xf4", "data": "0xb3f98adc0000000000000000000000000000000000000000000000000000000000000001"}, ""], "id": 97}' http://127.0.0.1:8551
{
    "id": 97,
    "jsonrpc": "2.0",
    "result": "0x978ae3b946265838245c4325af3d53b9d91919c50dff312c491e7aa92e3522c5"
}

curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_getTransactionReceipt", "params": ["0x978ae3b946265838245c4325af3d53b9d91919c50dff312c491e7aa92e3522c5"], "id": 45}' http://127.0.0.1:8551
{
    "id": 45,
    "jsonrpc": "2.0",
    "result": {
        "blockHash": "0x86355035a3ecd63256fe22c781504c6e5bb60479c62c67d994d191a9fb9416f8",
        "blockNumber": "0x791b",
        "contractAddress": null,
        "from": "0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95",
        "gas": "0x76c0",
        "gasPrice": "0x5d21dba00",
        "gasUsed": "0x6018",
        "input": "0xb3f98adc0000000000000000000000000000000000000000000000000000000000000001",
        "logs": [],
        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
        "nonce": "0x33",
        "senderTxHash": "0x978ae3b946265838245c4325af3d53b9d91919c50dff312c491e7aa92e3522c5",
        "signatures": [
            {
                "R": "0xdb5ee4e668f68b2bb8bff7903538dbe4d51648e6b72e74496c7f8e5395035613",
                "S": "0x15220be520733f791dc2e54cf701602dbe02d5717e3e6c8e21cbe77b9c7eb861",
                "V": "0x4e44"
            }
        ],
        "status": "0x1",
        "to": "0x44711e89b0c23845b5b2ed9d3716ba42b8a3e075",
        "transactionHash": "0x978ae3b946265838245c4325af3d53b9d91919c50dff312c491e7aa92e3522c5",
        "transactionIndex": "0x0",
        "type": "TxTypeValueTransferMemo",
        "typeInt": 16,
        "value": "0xf4"
    }
}
```
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_sendTransaction", "params": [{"typeInt": 16, "from": "0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95", "to": "0x44711E89b0c23845b5B2ed9D3716BA42b8a3e075", "gas": "0x76c0", "gasPrice": "0x5d21dba00", "value": "0xf4", "data": "0xb3f98adc0000000000000000000000000000000000000000000000000000000000000001"}], "id": 43}' http://127.0.0.1:8551
{
    "id": 43,
    "jsonrpc": "2.0",
    "result": "0x5e966d9a5c2ac7616ab28f76ef1b688d5666051d0f880502086f75a8f45c9fa5"
}

curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_getTransactionReceipt", "params": ["0x5e966d9a5c2ac7616ab28f76ef1b688d5666051d0f880502086f75a8f45c9fa5"], "id": 23}' http://127.0.0.1:8551
{
    "id": 23,
    "jsonrpc": "2.0",
    "result": {
        "blockHash": "0x110a6b92d301cee013c7859a9a44fcc3ac5bde59e8e77bae9807110e94588c76",
        "blockNumber": "0x7926",
        "contractAddress": null,
        "from": "0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95",
        "gas": "0x76c0",
        "gasPrice": "0x5d21dba00",
        "gasUsed": "0x6018",
        "input": "0xb3f98adc0000000000000000000000000000000000000000000000000000000000000001",
        "logs": [],
        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
        "nonce": "0x34",
        "senderTxHash": "0x5e966d9a5c2ac7616ab28f76ef1b688d5666051d0f880502086f75a8f45c9fa5",
        "signatures": [
            {
                "R": "0xa797b78406217949b6638822eff941388e9f1c91fc3eabad3cb9bfece7696800",
                "S": "0x1015eec6c36a1dd4d8243e3a31f263a707522bcfbdd27c79050cb9c57ec2cd5b",
                "V": "0x4e44"
            }
        ],
        "status": "0x1",
        "to": "0x44711e89b0c23845b5b2ed9d3716ba42b8a3e075",
        "transactionHash": "0x5e966d9a5c2ac7616ab28f76ef1b688d5666051d0f880502086f75a8f45c9fa5",
        "transactionIndex": "0x0",
        "type": "TxTypeValueTransferMemo",
        "typeInt": 16,
        "value": "0xf4"
    }
}
```
- SignTransaction
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "personal_signTransaction", "params": [{"typeInt": 16, "from": "0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95", "to": "0x44711E89b0c23845b5B2ed9D3716BA42b8a3e075", "gas": "0x76c0", "gasPrice": "0x5d21dba00", "value": "0xf4", "data": "0xb3f98adc0000000000000000000000000000000000000000000000000000000000000001"}, ""], "id": 76}' http://127.0.0.1:8551
{
    "id": 76,
    "jsonrpc": "2.0",
    "result": {
        "raw": "0x10f8a4348505d21dba008276c09444711e89b0c23845b5b2ed9d3716ba42b8a3e07581f4940fc6bc72c6481bb44660cf8a572f831cc8c35c95a4b3f98adc0000000000000000000000000000000000000000000000000000000000000001f847f845824e44a0a797b78406217949b6638822eff941388e9f1c91fc3eabad3cb9bfece7696800a01015eec6c36a1dd4d8243e3a31f263a707522bcfbdd27c79050cb9c57ec2cd5b",
        "tx": {
            "from": "0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95",
            "gas": "0x76c0",
            "gasPrice": "0x5d21dba00",
            "hash": "0x5e966d9a5c2ac7616ab28f76ef1b688d5666051d0f880502086f75a8f45c9fa5",
            "input": "0xb3f98adc0000000000000000000000000000000000000000000000000000000000000001",
            "nonce": "0x34",
            "signatures": [
                {
                    "R": "0xa797b78406217949b6638822eff941388e9f1c91fc3eabad3cb9bfece7696800",
                    "S": "0x1015eec6c36a1dd4d8243e3a31f263a707522bcfbdd27c79050cb9c57ec2cd5b",
                    "V": "0x4e44"
                }
            ],
            "to": "0x44711e89b0c23845b5b2ed9d3716ba42b8a3e075",
            "type": "TxTypeValueTransferMemo",
            "typeInt": 16,
            "value": "0xf4"
        }
    }
}
```
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_signTransaction", "params": [{"typeInt": 16, "from": "0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95", "to": "0x44711E89b0c23845b5B2ed9D3716BA42b8a3e075", "gas": "0x76c0", "gasPrice": "0x5d21dba00", "value": "0xf4", "data": "0xb3f98adc0000000000000000000000000000000000000000000000000000000000000001"}], "id": 24}' http://127.0.0.1:8551
{
    "id": 24,
    "jsonrpc": "2.0",
    "result": {
        "raw": "0x10f8a4358505d21dba008276c09444711e89b0c23845b5b2ed9d3716ba42b8a3e07581f4940fc6bc72c6481bb44660cf8a572f831cc8c35c95a4b3f98adc0000000000000000000000000000000000000000000000000000000000000001f847f845824e44a08b535fdf128d91db19c53a70f74768582dd65dfb6496bdca59dcca3916663cada007f6d525899f7508752c53a6ceb71b7554ca45119cacb687693da269d3381796",
        "tx": {
            "from": "0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95",
            "gas": "0x76c0",
            "gasPrice": "0x5d21dba00",
            "hash": "0x0d4dc7eef498491042d698e1bec36fd4c0e1f45afc5d13352489c02622c45800",
            "input": "0xb3f98adc0000000000000000000000000000000000000000000000000000000000000001",
            "nonce": "0x35",
            "signatures": [
                {
                    "R": "0x8b535fdf128d91db19c53a70f74768582dd65dfb6496bdca59dcca3916663cad",
                    "S": "0x7f6d525899f7508752c53a6ceb71b7554ca45119cacb687693da269d3381796",
                    "V": "0x4e44"
                }
            ],
            "to": "0x44711e89b0c23845b5b2ed9d3716ba42b8a3e075",
            "type": "TxTypeValueTransferMemo",
            "typeInt": 16,
            "value": "0xf4"
        }
    }
}
```
