### PR TITLE
[Draft] Resolve weird balance of msg.sender in contract call

### DIFF
--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -215,16 +215,16 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (tx *Transaction) Gas() uint64                       { return tx.data.GetGasLimit() }
-func (tx *Transaction) GasPrice() *big.Int                { return new(big.Int).Set(tx.data.GetPrice()) }
-func (tx *Transaction) Value() *big.Int                   { return new(big.Int).Set(tx.data.GetAmount()) }
-func (tx *Transaction) Nonce() uint64                     { return tx.data.GetAccountNonce() }
-func (tx *Transaction) CheckNonceAndSubBalance() bool     { return tx.checkNonceAndSubBalance }
-func (tx *Transaction) Type() TxType                      { return tx.data.Type() }
-func (tx *Transaction) IsLegacyTransaction() bool         { return tx.data.IsLegacyTransaction() }
-func (tx *Transaction) ValidatedSender() common.Address   { return tx.validatedSender }
-func (tx *Transaction) ValidatedFeePayer() common.Address { return tx.validatedFeePayer }
-func (tx *Transaction) ValidatedIntrinsicGas() uint64     { return tx.validatedIntrinsicGas }
+func (tx *Transaction) Gas() uint64                           { return tx.data.GetGasLimit() }
+func (tx *Transaction) GasPrice() *big.Int                    { return new(big.Int).Set(tx.data.GetPrice()) }
+func (tx *Transaction) Value() *big.Int                       { return new(big.Int).Set(tx.data.GetAmount()) }
+func (tx *Transaction) Nonce() uint64                         { return tx.data.GetAccountNonce() }
+func (tx *Transaction) CheckNonceAndSubBalance() bool         { return tx.checkNonceAndSubBalance }
+func (tx *Transaction) Type() TxType                          { return tx.data.Type() }
+func (tx *Transaction) IsLegacyTransaction() bool             { return tx.data.IsLegacyTransaction() }
+func (tx *Transaction) ValidatedSender() common.Address       { return tx.validatedSender }
+func (tx *Transaction) ValidatedFeePayer() common.Address     { return tx.validatedFeePayer }
+func (tx *Transaction) ValidatedIntrinsicGas() uint64         { return tx.validatedIntrinsicGas }
 func (tx *Transaction) MakeRPCOutput() map[string]interface{} { return tx.data.MakeRPCOutput() }
 func (tx *Transaction) GetTxInternalData() TxInternalData     { return tx.data }
 

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -31,7 +31,6 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/common/math"
 	"github.com/klaytn/klaytn/event"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/node/cn/gasprice"
@@ -161,7 +160,6 @@ func (b *CNAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 }
 
 func (b *CNAPIBackend) GetEVM(ctx context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error) {
-	state.SetBalance(msg.ValidatedSender(), math.MaxBig256)
 	vmError := func() error { return nil }
 
 	context := blockchain.NewEVMContext(msg, header, b.cn.BlockChain(), nil)


### PR DESCRIPTION
## Proposed changes

To resovle https://github.com/klaytn/klaytn/issues/359.

This PR is just draft version. Let's discuss about this.
This PR added the code to skip to subtract the balance of msg.sender during contract call.

In ethereum, https://github.com/ethereum/go-ethereum/pull/2799 introduced `CheckNonce` flag which can skip the nonce check for contract call.
I think we can skip checking nonce and balance of msg.from for contract call.

As @kjhman21 said, we need to test more with this PR.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
