### PR TITLE
Introduce APIs: EncodeAccountKey, DecodeAccountKey

### DIFF
--- a/api/api_public_klay.go
+++ b/api/api_public_klay.go
@@ -96,7 +96,7 @@ func (s *PublicKlayAPI) EncodeAccountKey(accKey accountkey.AccountKeyJSON) (hexu
 	}
 	accKeySerializer := accountkey.NewAccountKeySerializerWithAccountKey(key)
 	if err := accKeySerializer.EncodeRLP(buffer); err != nil {
-		return nil, errors.New("fail to rlp encoding. the key probably contains an invalid public key")
+		return nil, errors.New("the key probably contains an invalid public key: " + err.Error())
 	}
 	return (hexutil.Bytes)(buffer.Bytes()), nil
 }

--- a/blockchain/types/accountkey/public_key.go
+++ b/blockchain/types/accountkey/public_key.go
@@ -30,6 +30,7 @@ import (
 
 var (
 	errNotS256Curve = errors.New("key is not on the S256 curve")
+	errNoXYValue    = errors.New("X or Y value of the public key is not exist")
 )
 
 // Since ecdsa.PublicKey does not provide RLP/JSON serialization,
@@ -103,7 +104,9 @@ func (p *PublicKeySerializable) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &dec); err != nil {
 		return err
 	}
-
+	if dec.X == nil || dec.Y == nil {
+		return errNoXYValue
+	}
 	p.X = (*big.Int)(dec.X)
 	p.Y = (*big.Int)(dec.Y)
 

--- a/blockchain/types/accountkey/public_key.go
+++ b/blockchain/types/accountkey/public_key.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	errNotS256Curve = errors.New("key is not on the S256 curve")
-	errNoXYValue    = errors.New("X or Y value of the public key is not exist")
+	errNoXYValue    = errors.New("X or Y value of the public key does not exist")
 )
 
 // Since ecdsa.PublicKey does not provide RLP/JSON serialization,

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -686,6 +686,16 @@ web3._extend({
 			params: 1,
 			inputFormatter: [web3._extend.utils.toHex],
 		}),
+		new web3._extend.Method({
+			name: 'encodeAccountKey',
+			call: 'klay_encodeAccountKey',
+			params: 1,
+		}),
+		new web3._extend.Method({
+			name: 'decodeAccountKey',
+			call: 'klay_decodeAccountKey',
+			params: 1,
+		}),
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
## Proposed changes

When users update their account key through APIs like `klay_sendTransaction`, the key should be RLP encoded. The introduced APIs provide encoding/decoding functionality of the account key.


**Test Result**
AccountKey examples in https://docs.klaytn.com/klaytn/design/accounts#account-key are used for tests. The test case will be updated on the API tester.

KeyType 0
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_encodeAccountKey", "params": [{"keyType":0, "key":{}}], "id": 1}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":1,"result":"0x80"}

curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_decodeAccountKey", "params": ["0x80"], "id": 92}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":92,"result":{"keyType":0,"key":{}}}
```
KeyType 1
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_encodeAccountKey", "params": [{"keyType":1, "key":{}}], "id": 1}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":1,"result":"0x01c0"}

curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_decodeAccountKey", "params": ["0x01c0"], "id": 92}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":92,"result":{"keyType":1,"key":{}}}
```
KeyType 2
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_encodeAccountKey", "params": [{"keyType":2, "key":{"x":"0xdbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8", "y":"0x906d7170ba349c86879fb8006134cbf57bda9db9214a90b607b6b4ab57fc026e"}}], "id": 1}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":1,"result":"0x02a102dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8"}

curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_decodeAccountKey", "params": ["0x02a102dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8"], "id": 92}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":92,"result":{"keyType":2,"key":{"x":"0xdbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8","y":"0x906d7170ba349c86879fb8006134cbf57bda9db9214a90b607b6b4ab57fc026e"}}}
```
KeyType 3
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_encodeAccountKey", "params": [{"keyType":3, "key":{}}], "id": 1}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":1,"result":"0x03c0"}

curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_decodeAccountKey", "params": ["0x03c0"], "id": 92}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":92,"result":{"keyType":3,"key":{}}}
```
KeyType 4
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_encodeAccountKey", "params": [{"keyType":4, "key":{"threshold":3, "keys":[{"weight":1, "key":{"x":"0xc734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e", "y":"0x61a443ac3ffff164d1fb3617875f07641014cf17af6b7dc38e429fe838763712"}}, {"weight":1, "key":{"x":"0x12d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb", "y":"0x8ef355a8d524eb444eba507f236309ce08370debaa136cb91b2f445774bff842"}}, {"weight":1, "key":{"x":"0xea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cd", "y":"0xb95ebb02d9397b4a8faceb58d485d612f0379a923ec0ddcf083378460a56acca"}}, {"weight":1, "key":{"x":"0x8551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6", "y":"0x4206aa84bc8955fcbfcc396854228aa63ebacd81b7311a31ab9d71d90b7ec3d7"}}]}}], "id": 1}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":1,"result":"0x04f89303f890e301a102c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110ee301a10212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfbe301a102ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cde301a1038551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6"}

curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_decodeAccountKey", "params": ["0x04f89303f890e301a102c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110ee301a10212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfbe301a102ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cde301a1038551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6"], "id": 92}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":92,"result":{"keyType":4,"key":{"threshold":3,"keys":[{"weight":1,"key":{"x":"0xc734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e","y":"0x61a443ac3ffff164d1fb3617875f07641014cf17af6b7dc38e429fe838763712"}},{"weight":1,"key":{"x":"0x12d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb","y":"0x8ef355a8d524eb444eba507f236309ce08370debaa136cb91b2f445774bff842"}},{"weight":1,"key":{"x":"0xea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cd","y":"0xb95ebb02d9397b4a8faceb58d485d612f0379a923ec0ddcf083378460a56acca"}},{"weight":1,"key":{"x":"0x8551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6","y":"0x4206aa84bc8955fcbfcc396854228aa63ebacd81b7311a31ab9d71d90b7ec3d7"}}]}}}
```
KeyType 5
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_encodeAccountKey", "params": [{"keyType":5, "key":[{"keyType":2, "key":{"x":"0xe4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d", "y":"0xa5735a23ce1654b14680054a993441eae7c261983a56f8e0da61280758b5919"}}, {"keyType":4, "key": {"threshold":2, "keys":[{"weight":1, "key":{"x":"0xe4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d", "y":"0xa5735a23ce1654b14680054a993441eae7c261983a56f8e0da61280758b5919"}}, {"weight":1, "key":{"x":"0x36f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06", "y":"0x6fdf9fc87a16ac359e66d9761445d5ccbb417fb7757a3f5209d713824596a50d"}}]}},{"keyType":2, "key": {"x":"0xc8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447", "y":"0x94c27901465af0a703859ab47f8ae17e54aaba453b7cde5a6a9e4a32d45d72b2"}}]}], "id": 1}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":1,"result":"0x05f898a302a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512db84e04f84b02f848e301a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512de301a10336f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06a302a102c8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447"}

curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "klay_decodeAccountKey", "params": ["0x05f898a302a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512db84e04f84b02f848e301a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512de301a10336f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06a302a102c8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447"], "id": 92}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":92,"result":{"keyType":5,"key":[{"keyType":2,"key":{"x":"0xe4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d","y":"0xa5735a23ce1654b14680054a993441eae7c261983a56f8e0da61280758b5919"}},{"keyType":4,"key":{"threshold":2,"keys":[{"weight":1,"key":{"x":"0xe4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d","y":"0xa5735a23ce1654b14680054a993441eae7c261983a56f8e0da61280758b5919"}},{"weight":1,"key":{"x":"0x36f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06","y":"0x6fdf9fc87a16ac359e66d9761445d5ccbb417fb7757a3f5209d713824596a50d"}}]}},{"keyType":2,"key":{"x":"0xc8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447","y":"0x94c27901465af0a703859ab47f8ae17e54aaba453b7cde5a6a9e4a32d45d72b2"}}]}}
```


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

