### PR TITLE
Resolve weird balance of msg.sender in contract call

### DIFF
--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -160,7 +160,7 @@ func (b *CNAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 }
 
 func (b *CNAPIBackend) GetEVM(ctx context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error) {
-	// Add gas fee to sender's balance for estimating gasLimit.
+	// Add gas fee to sender for estimating gasLimit or calling a function by insufficient balance sender.
 	state.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.GasPrice()))
 	vmError := func() error { return nil }
 

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -31,7 +31,6 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/common/math"
 	"github.com/klaytn/klaytn/event"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/node/cn/gasprice"
@@ -161,7 +160,8 @@ func (b *CNAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 }
 
 func (b *CNAPIBackend) GetEVM(ctx context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error) {
-	state.SetBalance(msg.ValidatedSender(), math.MaxBig256)
+	// Add gas fee to sender's balance for estimating gasLimit.
+	state.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.GasPrice()))
 	vmError := func() error { return nil }
 
 	context := blockchain.NewEVMContext(msg, header, b.cn.BlockChain(), nil)

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -160,7 +160,7 @@ func (b *CNAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 }
 
 func (b *CNAPIBackend) GetEVM(ctx context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error) {
-	// Add gas fee to sender for estimating gasLimit or calling a function by insufficient balance sender.
+	// Add gas fee to sender for estimating gasLimit/computing cost or calling a function by insufficient balance sender.
 	state.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.GasPrice()))
 	vmError := func() error { return nil }
 


### PR DESCRIPTION
## Proposed changes
I already suggested https://github.com/klaytn/klaytn/pull/363. But it was too big change so there are much thing have to be tested. Therefore I made this PR simpler and better than before.

To resovle #359. 

This PR removed the root cause code to set very big balance to `from` for zero balance account.
~~Instead of the removed code, this PR added the code to set zero gas price if the gas price is not set in `klay_call` API.
`klay_call` is usually for just reading block chain without writing the state.
Therefore without gas fee, user can read the block chain. So I think it makes sense.
However, even though after this PR, if user want to call with non-zero gasPrice, it works well like before.~~

Instead of the removed code, this PR added `addBalance` for adding gas fee to sender's balance.
This means `msg.balance` in EVM will be same with the balance of the sender in the state :)
 
## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
