### PR TITLE
Unify error format of GetModifiedAccountsByNumber, GetModifiedAccountsByHash

### DIFF
--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -272,19 +272,19 @@ func (api *PrivateDebugAPI) GetModifiedAccountsByNumber(startNum uint64, endNum 
 
 	startBlock = api.cn.blockchain.GetBlockByNumber(startNum)
 	if startBlock == nil {
-		return nil, fmt.Errorf("start block %x not found", startNum)
+		return nil, fmt.Errorf("start block number %d not found", startNum)
 	}
 
 	if endNum == nil {
 		endBlock = startBlock
 		startBlock = api.cn.blockchain.GetBlockByHash(startBlock.ParentHash())
 		if startBlock == nil {
-			return nil, fmt.Errorf("block %x has no parent", endBlock.Number())
+			return nil, fmt.Errorf("block number %d has no parent", startNum)
 		}
 	} else {
 		endBlock = api.cn.blockchain.GetBlockByNumber(*endNum)
 		if endBlock == nil {
-			return nil, fmt.Errorf("end block %d not found", *endNum)
+			return nil, fmt.Errorf("end block number %d not found", *endNum)
 		}
 	}
 	return api.getModifiedAccounts(startBlock, endBlock)
@@ -306,7 +306,7 @@ func (api *PrivateDebugAPI) GetModifiedAccountsByHash(startHash common.Hash, end
 		endBlock = startBlock
 		startBlock = api.cn.blockchain.GetBlockByHash(startBlock.ParentHash())
 		if startBlock == nil {
-			return nil, fmt.Errorf("block %x has no parent", endBlock.Number())
+			return nil, fmt.Errorf("block %x has no parent", startHash)
 		}
 	} else {
 		endBlock = api.cn.blockchain.GetBlockByHash(*endHash)


### PR DESCRIPTION
## Proposed changes

- `GetModifiedAccountsByNumber` returns errors containing `int` values 

before 
```
$ curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "debug_getModifiedAccountsByNumber", "params": [186873, 185873], "id": 42}' http://13.124.194.39:8551
{ "error": {"code": -32000, "message": "start block 2d9f9 not found"}, "id": 42, "jsonrpc": "2.0"}
```
after
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "debug_getModifiedAccountsByNumber", "params": [186873, 185873], "id": 42}' http://localhost:8551
{"error":{"code":-32000,"message":"start block 186873 not found"}, "jsonrpc":"2.0","id":42}
```

- `GetModifiedAccountsByHash` retursn errors containing `hash` values 

before
```
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "debug_getModifiedAccountsByHash", "params": ["0x0cd3171825e1787d742d213f2cdbdc23a2ee180f9d0d82519a649ff6af4be267"], "id": 42}' http://localhost:8551
{"jsonrpc":"2.0","id":42,"error":{"code":-32000,"message":"block 0 has no parent"}} 

// block number of "0x0cd3171825e1787d742d213f2cdbdc23a2ee180f9d0d82519a649ff6af4be267" is 0
```
after
```
$ curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "debug_getModifiedAccountsByHash", "params": ["0x0cd3171825e1787d742d213f2cdbdc23a2ee180f9d0d82519a649ff6af4be267"], "id": 42}' http://localhost:8551
{"jsonrpc":"2.0","id":42,"error":{"code":-32000,"message":"block 0cd3171825e1787d742d213f2cdbdc23a2ee180f9d0d82519a649ff6af4be267 has no parent"}}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
