### PR TITLE
fast close peer error handler

### DIFF
--- a/networks/p2p/peer.go
+++ b/networks/p2p/peer.go
@@ -353,6 +353,9 @@ loop:
 		case errRW.err = <-p.disc:
 			reason = discReasonForError(errRW.err)
 			break loop
+		case <- p.closed:
+			reason = DiscQuitting
+			break loop
 		}
 	}
 

--- a/networks/p2p/peer.go
+++ b/networks/p2p/peer.go
@@ -353,7 +353,7 @@ loop:
 		case errRW.err = <-p.disc:
 			reason = discReasonForError(errRW.err)
 			break loop
-		case <- p.closed:
+		case <-p.closed:
 			reason = DiscQuitting
 			break loop
 		}


### PR DESCRIPTION
## Proposed changes

-  Improved the error handler to terminate when the peer terminates. If not improved, a 30 second wait will occur.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
