### PR TITLE
reflect block to state for known block error

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1514,13 +1514,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		// Write the block to the chain and get the status.
 		status, err := bc.WriteBlockWithState(block, receipts, stateDB)
 		if err != nil {
-			if err != ErrKnownBlock {
-				return i, events, coalescedLogs, err
-			}
-			if bc.CurrentBlock().NumberU64() >= block.NumberU64() {
+			if err == ErrKnownBlock {
 				logger.Debug("Tried to insert already known block", "num", block.NumberU64(), "hash", block.Hash().String())
 				continue
 			}
+			return i, events, coalescedLogs, err
 		}
 
 		switch status {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -638,7 +638,7 @@ func (bc *BlockChain) HasBlockAndState(hash common.Hash, number uint64) bool {
 }
 
 // ShouldTryInserting returns the state whether the block should be inserted.
-// If node don't have a block or after it's current state, it should be insert.
+// If a node doesn't have the given block or the block number of given block is higher than the node's head block, it can try inserting the block.
 func (bc *BlockChain) ShouldTryInserting(block *types.Block) bool {
 	return !bc.HasBlockAndState(block.Hash(), block.NumberU64()) || bc.CurrentBlock().NumberU64() < block.NumberU64()
 }


### PR DESCRIPTION
## Proposed changes

- Fix for bad block occurrence.
- Bad block was generated by this flow :
  1. Block `#2` and the state are written in DB, but current state indicates previous (Block `#1`).
  2. Received block `#2` will not be reflected because the block is already in DB.
  3. The next block `#3` is not in the DB, so node tried to reflect it, but the previous block `#2` is not reflected in the state.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
