### PR TITLE
SC: Add checking the already handled events for Value Transfer Recovery

### DIFF
--- a/node/sc/vt_recovery.go
+++ b/node/sc/vt_recovery.go
@@ -249,7 +249,10 @@ func (vtr *valueTransferRecovery) retrievePendingEvents() error {
 // The filter uses a hint as a search range. It returns a slice of events that has log details.
 func retrievePendingEventsFrom(hint *valueTransferHint, from, to *BridgeInfo) ([]*RequestValueTransferEvent, error) {
 	if from.bridge == nil {
-		return nil, errors.New("bridge is nil")
+		return nil, errors.New("from bridge is nil")
+	}
+	if to.bridge == nil {
+		return nil, errors.New("to bridge is nil")
 	}
 	if hint.requestNonce == hint.handleNonce {
 		return nil, nil

--- a/node/sc/vt_recovery.go
+++ b/node/sc/vt_recovery.go
@@ -225,8 +225,11 @@ func updateRecoveryHintFromTo(prevHint *valueTransferHint, from, to *BridgeInfo)
 // retrievePendingEvents retrieves pending events on the child chain or parent chain.
 // The pending event is the value transfer without processing HandleValueTransfer.
 func (vtr *valueTransferRecovery) retrievePendingEvents() error {
-	if vtr.cBridgeInfo.bridge == nil {
-		return errors.New("bridge is nil")
+	if vtr.cBridgeInfo == nil {
+		return errors.New("child chain bridge is nil")
+	}
+	if vtr.pBridgeInfo == nil {
+		return errors.New("parent chain bridge is nil")
 	}
 
 	var err error


### PR DESCRIPTION
## Proposed changes

This PR added the routine checking the already handled event during value transfer recovery.
This makes VTR (Value Transfer Recovery) to be faster. And If the 1000 events is already handled from upperHandleNonce, this logic can deal with this situation.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
