### PR TITLE
state, blockchain: postpone updating storage root hash

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2023,7 +2023,7 @@ func (bc *BlockChain) ApplyTransaction(config *params.ChainConfig, author *commo
 		return nil, 0, err
 	}
 	// Update the state with pending changes
-	statedb.Finalise(true)
+	statedb.Finalise(true, false)
 	*usedGas += gas
 
 	receipt := types.NewReceipt(kerr.Status, tx.Hash(), gas)

--- a/blockchain/state/state_object.go
+++ b/blockchain/state/state_object.go
@@ -257,12 +257,24 @@ func (self *stateObject) updateStorageTrie(db Database) Trie {
 	return tr
 }
 
-// UpdateRoot calls updateStorageTrie to get the latest root hash of the object's storage trie
+// updateStorageRoot calls updateStorageTrie to get the latest root hash of the object's storage trie
 // and sets the storage trie root to the newly updated one.
 func (self *stateObject) updateStorageRoot(db Database) {
-	self.updateStorageTrie(db)
 	if acc := account.GetProgramAccount(self.account); acc != nil {
 		acc.SetStorageRoot(self.storageTrie.Hash())
+	}
+}
+
+// setStorageRoot calls SetStorageRoot if updateStorageRoot flag is given true.
+// Otherwise, it just marks the object and update their root hash later.
+func (self *stateObject) setStorageRoot(updateStorageRoot bool, objectsToUpdate map[common.Address]struct{}) {
+	if acc := account.GetProgramAccount(self.account); acc != nil {
+		if updateStorageRoot {
+			acc.SetStorageRoot(self.storageTrie.Hash())
+			return
+		}
+		// If updateStorageRoot == false, it just marks the object and update its storage root later.
+		objectsToUpdate[self.Address()] = struct{}{}
 	}
 }
 

--- a/blockchain/state/state_object.go
+++ b/blockchain/state/state_object.go
@@ -257,8 +257,7 @@ func (self *stateObject) updateStorageTrie(db Database) Trie {
 	return tr
 }
 
-// updateStorageRoot calls updateStorageTrie to get the latest root hash of the object's storage trie
-// and sets the storage trie root to the newly updated one.
+// updateStorageRoot sets the storage trie root to the newly updated one.
 func (self *stateObject) updateStorageRoot(db Database) {
 	if acc := account.GetProgramAccount(self.account); acc != nil {
 		acc.SetStorageRoot(self.storageTrie.Hash())
@@ -273,7 +272,7 @@ func (self *stateObject) setStorageRoot(updateStorageRoot bool, objectsToUpdate 
 			acc.SetStorageRoot(self.storageTrie.Hash())
 			return
 		}
-		// If updateStorageRoot == false, it just marks the object and update its storage root later.
+		// If updateStorageRoot == false, it just marks the object and updates its storage root later.
 		objectsToUpdate[self.Address()] = struct{}{}
 	}
 }

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -62,8 +62,9 @@ type StateDB struct {
 	trie Trie
 
 	// This map holds 'live' objects, which will get modified while processing a state transition.
-	stateObjects      map[common.Address]*stateObject
-	stateObjectsDirty map[common.Address]struct{}
+	stateObjects             map[common.Address]*stateObject
+	stateObjectsDirty        map[common.Address]struct{}
+	stateObjectsDirtyStorage map[common.Address]struct{}
 
 	// cachedStateObjects stores the most recent finalized stateObjects.
 	cachedStateObjects common.Cache
@@ -106,14 +107,15 @@ func New(root common.Hash, db Database) (*StateDB, error) {
 		return nil, err
 	}
 	return &StateDB{
-		db:                 db,
-		trie:               tr,
-		stateObjects:       make(map[common.Address]*stateObject),
-		stateObjectsDirty:  make(map[common.Address]struct{}),
-		cachedStateObjects: nil,
-		logs:               make(map[common.Hash][]*types.Log),
-		preimages:          make(map[common.Hash][]byte),
-		journal:            newJournal(),
+		db:                       db,
+		trie:                     tr,
+		stateObjects:             make(map[common.Address]*stateObject),
+		stateObjectsDirtyStorage: make(map[common.Address]struct{}),
+		stateObjectsDirty:        make(map[common.Address]struct{}),
+		cachedStateObjects:       nil,
+		logs:                     make(map[common.Hash][]*types.Log),
+		preimages:                make(map[common.Hash][]byte),
+		journal:                  newJournal(),
 	}, nil
 }
 
@@ -816,36 +818,48 @@ func (self *StateDB) GetRefund() uint64 {
 
 // Finalise finalises the state by removing the self destructed objects
 // and clears the journal as well as the refunds.
-func (s *StateDB) Finalise(deleteEmptyObjects bool) {
-	for addr := range s.journal.dirties {
-		stateObject, exist := s.stateObjects[addr]
+func (stateDB *StateDB) Finalise(deleteEmptyObjects bool, setStorageRoot bool) {
+	for addr := range stateDB.journal.dirties {
+		stateObject, exist := stateDB.stateObjects[addr]
 		if !exist {
 			// ripeMD is 'touched' at block 1714175, in tx 0x1237f737031e40bcde4a8b7e717b2d15e3ecadfe49bb1bbc71ee9deb09c6fcf2
 			// That tx goes out of gas, and although the notion of 'touched' does not exist there, the
 			// touch-event will still be recorded in the journal. Since ripeMD is a special snowflake,
 			// it will persist in the journal even though the journal is reverted. In this special circumstance,
-			// it may exist in `s.journal.dirties` but not in `s.stateObjects`.
+			// it may exist in `stateDB.journal.dirties` but not in `stateDB.stateObjects`.
 			// Thus, we can safely ignore it here
 			continue
 		}
 
 		if stateObject.suicided || (deleteEmptyObjects && stateObject.empty()) {
-			s.deleteStateObject(stateObject)
+			stateDB.deleteStateObject(stateObject)
 		} else {
-			stateObject.updateStorageRoot(s.db)
-			s.updateStateObject(stateObject)
+			stateObject.updateStorageTrie(stateDB.db)
+			stateObject.setStorageRoot(setStorageRoot, stateDB.stateObjectsDirtyStorage)
+			stateDB.updateStateObject(stateObject)
 		}
-		s.stateObjectsDirty[addr] = struct{}{}
+		stateDB.stateObjectsDirty[addr] = struct{}{}
 	}
 	// Invalidate journal because reverting across transactions is not allowed.
-	s.clearJournalAndRefund()
+	stateDB.clearJournalAndRefund()
+
+	if setStorageRoot && len(stateDB.stateObjectsDirtyStorage) > 0 {
+		for addr := range stateDB.stateObjectsDirtyStorage {
+			so, exist := stateDB.stateObjects[addr]
+			if exist {
+				so.updateStorageRoot(stateDB.db)
+				stateDB.updateStateObject(so)
+			}
+		}
+		stateDB.stateObjectsDirtyStorage = make(map[common.Address]struct{})
+	}
 }
 
 // IntermediateRoot computes the current root hash of the state statedb.
 // It is called in between transactions to get the root hash that
 // goes into transaction receipts.
 func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
-	s.Finalise(deleteEmptyObjects)
+	s.Finalise(deleteEmptyObjects, true)
 	return s.trie.Hash()
 }
 

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -820,7 +820,7 @@ func (self *StateDB) GetRefund() uint64 {
 // and clears the journal as well as the refunds.
 func (stateDB *StateDB) Finalise(deleteEmptyObjects bool, setStorageRoot bool) {
 	for addr := range stateDB.journal.dirties {
-		stateObject, exist := stateDB.stateObjects[addr]
+		so, exist := stateDB.stateObjects[addr]
 		if !exist {
 			// ripeMD is 'touched' at block 1714175, in tx 0x1237f737031e40bcde4a8b7e717b2d15e3ecadfe49bb1bbc71ee9deb09c6fcf2
 			// That tx goes out of gas, and although the notion of 'touched' does not exist there, the
@@ -831,12 +831,12 @@ func (stateDB *StateDB) Finalise(deleteEmptyObjects bool, setStorageRoot bool) {
 			continue
 		}
 
-		if stateObject.suicided || (deleteEmptyObjects && stateObject.empty()) {
-			stateDB.deleteStateObject(stateObject)
+		if so.suicided || (deleteEmptyObjects && so.empty()) {
+			stateDB.deleteStateObject(so)
 		} else {
-			stateObject.updateStorageTrie(stateDB.db)
-			stateObject.setStorageRoot(setStorageRoot, stateDB.stateObjectsDirtyStorage)
-			stateDB.updateStateObject(stateObject)
+			so.updateStorageTrie(stateDB.db)
+			so.setStorageRoot(setStorageRoot, stateDB.stateObjectsDirtyStorage)
+			stateDB.updateStateObject(so)
 		}
 		stateDB.stateObjectsDirty[addr] = struct{}{}
 	}

--- a/blockchain/state/statedb_test.go
+++ b/blockchain/state/statedb_test.go
@@ -139,7 +139,7 @@ func TestCopy(t *testing.T) {
 		obj.AddBalance(big.NewInt(int64(i)))
 		orig.updateStateObject(obj)
 	}
-	orig.Finalise(false)
+	orig.Finalise(false, true)
 
 	// Copy the state, modify both in-memory
 	copy := orig.Copy()
@@ -159,11 +159,11 @@ func TestCopy(t *testing.T) {
 	done := make(chan struct{})
 
 	go func() {
-		orig.Finalise(true)
+		orig.Finalise(true, true)
 		close(done)
 	}()
 
-	copy.Finalise(true)
+	copy.Finalise(true, true)
 	<-done
 
 	// Verify that the two states have been updated independently

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -213,7 +213,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 						logger.Warn("Tracing failed", "hash", tx.Hash(), "block", task.block.NumberU64(), "err", err)
 						break
 					}
-					task.statedb.Finalise(true)
+					task.statedb.Finalise(true, true)
 					task.results[i] = &txTraceResult{Result: res}
 				}
 				// Stream the result back to the user or abort on teardown
@@ -507,7 +507,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 			break
 		}
 		// Finalize the state so any modifications are written to the trie
-		statedb.Finalise(true)
+		statedb.Finalise(true, true)
 	}
 	close(jobs)
 	pend.Wait()
@@ -609,7 +609,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 			return dumps, kerr.ErrTxInvalid
 		}
 		// Finalize the state so any modifications are written to the trie
-		statedb.Finalise(true)
+		statedb.Finalise(true, true)
 
 		// If we've traced the transaction we were looking for, abort
 		if tx.Hash() == txHash {
@@ -800,7 +800,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 			return nil, vm.Context{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 		// Ensure any modifications are committed to the state
-		statedb.Finalise(true)
+		statedb.Finalise(true, true)
 	}
 	return nil, vm.Context{}, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, blockHash)
 }


### PR DESCRIPTION
## Proposed changes

- Before this change, root hash of storage trie is calculated by every transaction execution
- With this change, root hash is calculated only if `IntermediateRoot` calls `Finalise`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
