### PR TITLE
api: Allow contract deploying txs not to specify recipient

### DIFF
--- a/api/api_public_transaction_pool_test.go
+++ b/api/api_public_transaction_pool_test.go
@@ -197,7 +197,7 @@ func testTxTypeSupport_noFieldValues(t *testing.T, api PublicTransactionPoolAPI,
 	}
 
 	args := oriArgs
-	if args.Recipient != nil {
+	if args.Recipient != nil && !(*args.TypeInt).IsContractDeploy() {
 		args.Recipient = nil
 
 		_, err := api.SignTransaction(ctx, args)

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -172,7 +172,7 @@ func (args *SendTxArgs) checkArgs() error {
 
 		// An args field doesn't have a value but the field name exist on the tx type
 		if argsValue.Field(i).IsNil() && isTxField[*args.TypeInt][argsType.Field(i).Name] {
-			// Allow contract deploying txs not to specify recipient value
+			// Allow only contract deploying txs to set the recipient as nil
 			if (*args.TypeInt).IsContractDeploy() && argsType.Field(i).Name == "Recipient" {
 				continue
 			}

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -172,6 +172,10 @@ func (args *SendTxArgs) checkArgs() error {
 
 		// An args field doesn't have a value but the field name exist on the tx type
 		if argsValue.Field(i).IsNil() && isTxField[*args.TypeInt][argsType.Field(i).Name] {
+			// Allow contract deploying txs not to specify recipient value
+			if (*args.TypeInt).IsContractDeploy() && argsType.Field(i).Name == "Recipient" {
+				continue
+			}
 			return errors.New((string)(argsType.Field(i).Tag) + " is required for " + (*args.TypeInt).String())
 		}
 


### PR DESCRIPTION
## Proposed changes

`checkArgs` checks the validity of SendTxArgs values.
This change makes the function allows contract deploying txs not to specify recipient value.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
