### PR TITLE
api: GetBlockWithConsensusInfoByNumber return an error for no arguments

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -144,6 +144,7 @@ var (
 	errRangeNil                = errors.New("range values should not be nil")
 	errExtractIstanbulExtra    = errors.New("extract Istanbul Extra from block header of the given block number")
 	errNoBlockExist            = errors.New("block with the given block number is not existed")
+	errNoBlockNumber           = errors.New("block number is not assigned")
 )
 
 // GetCouncil retrieves the list of authorized validators at the specified block.
@@ -311,8 +312,8 @@ func (api *APIExtension) GetBlockWithConsensusInfoByNumber(number *rpc.BlockNumb
 	var blockNumber uint64
 
 	if number == nil {
-		number = new(rpc.BlockNumber)
-		*number = rpc.LatestBlockNumber
+		logger.Trace("block number is not assigned")
+		return nil, errNoBlockNumber
 	}
 
 	if *number == rpc.PendingBlockNumber {

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -154,14 +154,14 @@ func (api *APIExtension) GetCouncil(number *rpc.BlockNumber) ([]common.Address, 
 	if number == nil || *number == rpc.LatestBlockNumber {
 		header = api.chain.CurrentHeader()
 	} else if *number == rpc.PendingBlockNumber {
-		logger.Error("Cannot get council of the pending block.", "number", number)
+		logger.Trace("Cannot get council of the pending block.", "number", number)
 		return nil, errPendingNotAllowed
 	} else {
 		header = api.chain.GetHeaderByNumber(uint64(number.Int64()))
 	}
 	// Ensure we have an actually valid block and return the council from its snapshot
 	if header == nil {
-		logger.Error("Failed to find the requested block", "number", number)
+		logger.Trace("Failed to find the requested block", "number", number)
 		return nil, errNoBlockExist // return nil if block is not found.
 	}
 	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
@@ -187,7 +187,7 @@ func (api *APIExtension) GetCommittee(number *rpc.BlockNumber) ([]common.Address
 	if number == nil || *number == rpc.LatestBlockNumber {
 		header = api.chain.CurrentHeader()
 	} else if *number == rpc.PendingBlockNumber {
-		logger.Error("Cannot get validators of the pending block.", "number", number)
+		logger.Trace("Cannot get validators of the pending block.", "number", number)
 		return nil, errPendingNotAllowed
 	} else {
 		header = api.chain.GetHeaderByNumber(uint64(number.Int64()))
@@ -264,7 +264,7 @@ func (api *APIExtension) getProposerAndValidators(block *types.Block) (common.Ad
 	//		}
 	//	}
 	//	if found == false {
-	//		logger.Error("validator is different!", "snap", commiteeAddrs, "istanbul", istanbulAddrs)
+	//		logger.Trace("validator is different!", "snap", commiteeAddrs, "istanbul", istanbulAddrs)
 	//		return proposer, commiteeAddrs, errors.New("validator set is different from Istanbul engine!!")
 	//	}
 	//}
@@ -317,7 +317,7 @@ func (api *APIExtension) GetBlockWithConsensusInfoByNumber(number *rpc.BlockNumb
 	}
 
 	if *number == rpc.PendingBlockNumber {
-		logger.Error("Cannot get consensus information of the PendingBlock.")
+		logger.Trace("Cannot get consensus information of the PendingBlock.")
 		return nil, errPendingNotAllowed
 	}
 
@@ -331,7 +331,7 @@ func (api *APIExtension) GetBlockWithConsensusInfoByNumber(number *rpc.BlockNumb
 	}
 
 	if block == nil {
-		logger.Error("Finding a block by number failed.", "blockNum", blockNumber)
+		logger.Trace("Finding a block by number failed.", "blockNum", blockNumber)
 		return nil, fmt.Errorf("the block does not exist (block number: %d)", blockNumber)
 	}
 	blockHash := block.Hash()
@@ -353,7 +353,7 @@ func (api *APIExtension) GetBlockWithConsensusInfoByNumberRange(start *rpc.Block
 	blocks := make(map[string]interface{})
 
 	if start == nil || end == nil {
-		logger.Error("the range values should not be nil.", "start", start, "end", end)
+		logger.Trace("the range values should not be nil.", "start", start, "end", end)
 		return nil, errRangeNil
 	}
 
@@ -361,23 +361,23 @@ func (api *APIExtension) GetBlockWithConsensusInfoByNumberRange(start *rpc.Block
 	s := start.Int64()
 	e := end.Int64()
 	if s < 0 {
-		logger.Error("start should be positive", "start", s)
+		logger.Trace("start should be positive", "start", s)
 		return nil, errStartNotPositive
 	}
 
 	eChain := api.chain.CurrentHeader().Number.Int64()
 	if e > eChain {
-		logger.Error("end should be smaller than the lastest block number", "end", end, "eChain", eChain)
+		logger.Trace("end should be smaller than the lastest block number", "end", end, "eChain", eChain)
 		return nil, errEndLargetThanLatest
 	}
 
 	if s > e {
-		logger.Error("start should be smaller than end", "start", s, "end", e)
+		logger.Trace("start should be smaller than end", "start", s, "end", e)
 		return nil, errStartLargerThanEnd
 	}
 
 	if (e - s) > 50 {
-		logger.Error("number of requested blocks should be smaller than 50", "start", s, "end", e)
+		logger.Trace("number of requested blocks should be smaller than 50", "start", s, "end", e)
 		return nil, errRequestedBlocksTooLarge
 	}
 
@@ -407,7 +407,7 @@ func (api *APIExtension) GetBlockWithConsensusInfoByHash(blockHash common.Hash) 
 
 	block := b.GetBlockByHash(blockHash)
 	if block == nil {
-		logger.Error("Finding a block failed.", "blockHash", blockHash)
+		logger.Trace("Finding a block failed.", "blockHash", blockHash)
 		return nil, fmt.Errorf("the block does not exist (block hash: %s)", blockHash.String())
 	}
 


### PR DESCRIPTION
## Proposed changes

1. `GetBlockWithConsensusInfoByNumber` returns an error when the argument is nil for the consistency between other `~ByNumber` APIs.
2. Change log level of API errors: `Error` -> `Trace`

**Test 1 - nil**
```
curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay_getBlockWithConsensusInfoByNumber","params":[],"id":1}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"block number is not assigned"}}
```
**Test 2 - "latest"**
```
url -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay_getBlockWithConsensusInfoByNumber","params":["latest"],"id":1}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":1,"result":{"blockscore":"0x1","committee":["0xcd01b2b44584fb143824c1ea0231bebaea826b9d"],"extraData":"0xd983010300846b6c617988676f312e31332e338664617277696e000000000000f89ed594cd01b2b44584fb143824c1ea0231bebaea826b9db841d6e55d088ed2a741953c1a9af1467821d1e7e3ef903392391398fee32ffb153961c7686e150a7d3b1fd2b585f9d32f652c30e99a18de7fe106318d748925124201f843b8417f69197461c1e4fb806af30209b02ba193925e750a73c7fa2af0fddd9879194a7b7583ea89dfb66b17cbe3a538925b0b68640320ebd3880b72dc3bd83cc8299100","gasUsed":"0x0","governanceData":"0x","hash":"0x602f78b77201aa74669bc900ceb8978f23e7493db5fb044eb05bd686d5f08e6c","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","number":"0x4051c","parentHash":"0x3560b958c6252999bb401d7ef0ba1b54dc60a51a3e54488f7f0920c2eca14694","proposer":"0xcd01b2b44584fb143824c1ea0231bebaea826b9d","receiptsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","reward":"0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95","size":"0x273","stateRoot":"0x22f817b57de91ea7281f45bf74322818b2f6ed8ee2f7bccfd332ed5214bf375d","timestamp":"0x5de7acdc","timestampFoS":"0x29","totalBlockScore":"0x4051d","transactions":[],"transactionsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","voteData":"0x"}}
```
**Test 3 - 0x11**
```
curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay_getBlockWithConsensusInfoByNumber","params":["0x11"],"id":1}' http://127.0.0.1:8551
{"jsonrpc":"2.0","id":1,"result":{"blockscore":"0x1","committee":["0xcd01b2b44584fb143824c1ea0231bebaea826b9d"],"extraData":"0xd983010200846b6c617988676f312e31332e338664617277696e000000000000f89ed594cd01b2b44584fb143824c1ea0231bebaea826b9db8416ffb71af31980ee02598c41cd17c11a0d79145d26700c9f48ca10ec2d66e6bba08c94ac50b50be274112528464b2fe49a023ff6e01bbf58049dab81f8ed2166d01f843b84181230d8e95de22b747450197f08a1b03e444ebe1322580130750e80b61568aab5fdd640dbcf8b01a4f7e43c328c754c751268b9b052e4a8ecf4b89879865b9ba01","gasUsed":"0x0","governanceData":"0x","hash":"0x828dae480560fcbf57729a531f4e4a3879fd76c21b58c91b8da365eace0a55c4","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","number":"0x11","parentHash":"0xb3b1432259598d10bd733c166afe594ea5689657e95c3fdae11ee36b871f9a14","proposer":"0xcd01b2b44584fb143824c1ea0231bebaea826b9d","receiptsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","reward":"0x0fc6bc72c6481bb44660cf8a572f831cc8c35c95","size":"0x270","stateRoot":"0x172bf1998c54f7a1e26300de67bd669c5a2fe78af5b7d8ca6232049a047958c7","timestamp":"0x5db5a8ad","timestampFoS":"0x54","totalBlockScore":"0x12","transactions":[],"transactionsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","voteData":"0x"}}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
