### PR TITLE
Add istanbul.timeout to governance items

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -423,3 +423,7 @@ func (api *APIExtension) GetBlockWithConsensusInfoByHash(blockHash common.Hash) 
 
 	return api.makeRPCOutput(block, proposer, committee, block.Transactions(), receipts), nil
 }
+
+func (api *API) GetRequestTimeout() uint64 {
+	return istanbul.DefaultConfig.RequestTimeout
+}

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -424,6 +424,6 @@ func (api *APIExtension) GetBlockWithConsensusInfoByHash(blockHash common.Hash) 
 	return api.makeRPCOutput(block, proposer, committee, block.Transactions(), receipts), nil
 }
 
-func (api *API) GetRequestTimeout() uint64 {
-	return istanbul.DefaultConfig.RequestTimeout
+func (api *API) GetTimeout() uint64 {
+	return istanbul.DefaultConfig.Timeout
 }

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -29,7 +29,7 @@ const (
 )
 
 type Config struct {
-	RequestTimeout uint64         `toml:",omitempty"` // The timeout for each Istanbul round in milliseconds.
+	Timeout        uint64         `toml:",omitempty"` // The timeout for each Istanbul round in milliseconds.
 	BlockPeriod    uint64         `toml:",omitempty"` // Default minimum difference between two consecutive block's timestamps in second
 	ProposerPolicy ProposerPolicy `toml:",omitempty"` // The policy for proposer selection
 	Epoch          uint64         `toml:",omitempty"` // The number of blocks after which to checkpoint and reset the pending votes
@@ -37,7 +37,7 @@ type Config struct {
 }
 
 var DefaultConfig = &Config{
-	RequestTimeout: 3000,
+	Timeout:        3000,
 	BlockPeriod:    1,
 	ProposerPolicy: RoundRobin,
 	Epoch:          30000,

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -353,7 +353,7 @@ func (c *core) newRoundChangeTimer() {
 	c.stopTimer()
 
 	// set timeout based on the round number
-	timeout := time.Duration(c.config.Timeout) * time.Millisecond
+	timeout := time.Duration(istanbul.DefaultConfig.Timeout) * time.Millisecond
 	round := c.current.Round().Uint64()
 	if round > 0 {
 		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -353,7 +353,7 @@ func (c *core) newRoundChangeTimer() {
 	c.stopTimer()
 
 	// set timeout based on the round number
-	timeout := time.Duration(istanbul.DefaultConfig.Timeout) * time.Millisecond
+	timeout := time.Duration(atomic.LoadUint64(&istanbul.DefaultConfig.Timeout)) * time.Millisecond
 	round := c.current.Round().Uint64()
 	if round > 0 {
 		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -353,7 +353,7 @@ func (c *core) newRoundChangeTimer() {
 	c.stopTimer()
 
 	// set timeout based on the round number
-	timeout := time.Duration(c.config.RequestTimeout) * time.Millisecond
+	timeout := time.Duration(c.config.Timeout) * time.Millisecond
 	round := c.current.Round().Uint64()
 	if round > 0 {
 		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -878,6 +878,10 @@ web3._extend({
 			name: 'candidates',
 			getter: 'istanbul_candidates'
 		}),
+		new web3._extend.Property({
+			name: 'requestTimeout',
+			getter: 'istanbul_getRequestTimeout'
+		})
 	]
 });
 `

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -879,7 +879,7 @@ web3._extend({
 			getter: 'istanbul_candidates'
 		}),
 		new web3._extend.Property({
-			name: 'requestTimeout',
+			name: 'roundchangeTimer',
 			getter: 'istanbul_getRequestTimeout'
 		})
 	]

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -879,8 +879,8 @@ web3._extend({
 			getter: 'istanbul_candidates'
 		}),
 		new web3._extend.Property({
-			name: 'roundchangeTimer',
-			getter: 'istanbul_getRequestTimeout'
+			name: 'timeout',
+			getter: 'istanbul_getTimeout'
 		})
 	]
 });

--- a/governance/default.go
+++ b/governance/default.go
@@ -63,7 +63,7 @@ var (
 		"governance.addvalidator":       params.AddValidator,
 		"governance.removevalidator":    params.RemoveValidator,
 		"param.txgashumanreadable":      params.ConstTxGasHumanReadable,
-		"istanbul.requesttimeout":       params.RequestTimeout,
+		"istanbul.roundchangetimer":     params.RequestTimeout,
 	}
 
 	GovernanceForbiddenKeyMap = map[string]int{
@@ -90,7 +90,7 @@ var (
 		params.AddValidator:            "governance.addvalidator",
 		params.RemoveValidator:         "governance.removevalidator",
 		params.ConstTxGasHumanReadable: "param.txgashumanreadable",
-		params.RequestTimeout:          "istanbul.requesttimeout",
+		params.RequestTimeout:          "istanbul.roundchangetimer",
 	}
 
 	ProposerPolicyMap = map[string]int{

--- a/governance/default.go
+++ b/governance/default.go
@@ -63,7 +63,7 @@ var (
 		"governance.addvalidator":       params.AddValidator,
 		"governance.removevalidator":    params.RemoveValidator,
 		"param.txgashumanreadable":      params.ConstTxGasHumanReadable,
-		"istanbul.roundchangetimer":     params.RequestTimeout,
+		"istanbul.timeout":              params.Timeout,
 	}
 
 	GovernanceForbiddenKeyMap = map[string]int{
@@ -90,7 +90,7 @@ var (
 		params.AddValidator:            "governance.addvalidator",
 		params.RemoveValidator:         "governance.removevalidator",
 		params.ConstTxGasHumanReadable: "param.txgashumanreadable",
-		params.RequestTimeout:          "istanbul.roundchangetimer",
+		params.Timeout:                 "istanbul.timeout",
 	}
 
 	ProposerPolicyMap = map[string]int{
@@ -504,7 +504,7 @@ func (g *Governance) ParseVoteValue(gVote *GovernanceVote) (*GovernanceVote, err
 		val = string(gVote.Value.([]uint8))
 	case params.GoverningNode, params.AddValidator, params.RemoveValidator:
 		val = common.BytesToAddress(gVote.Value.([]uint8))
-	case params.Epoch, params.CommitteeSize, params.UnitPrice, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.ConstTxGasHumanReadable, params.Policy, params.RequestTimeout:
+	case params.Epoch, params.CommitteeSize, params.UnitPrice, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.ConstTxGasHumanReadable, params.Policy, params.Timeout:
 		gVote.Value = append(make([]byte, 8-len(gVote.Value.([]uint8))), gVote.Value.([]uint8)...)
 		val = binary.BigEndian.Uint64(gVote.Value.([]uint8))
 	case params.UseGiniCoeff, params.DeferredTxFee:
@@ -535,7 +535,7 @@ func (gov *Governance) updateChangeSet(vote GovernanceVote) bool {
 	case params.GovernanceMode, params.Ratio:
 		gov.changeSet.SetValue(GovernanceKeyMap[vote.Key], vote.Value.(string))
 		return true
-	case params.Epoch, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.CommitteeSize, params.UnitPrice, params.ConstTxGasHumanReadable, params.RequestTimeout:
+	case params.Epoch, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.CommitteeSize, params.UnitPrice, params.ConstTxGasHumanReadable, params.Timeout:
 		gov.changeSet.SetValue(GovernanceKeyMap[vote.Key], vote.Value.(uint64))
 		return true
 	case params.Policy:

--- a/governance/default.go
+++ b/governance/default.go
@@ -535,10 +535,7 @@ func (gov *Governance) updateChangeSet(vote GovernanceVote) bool {
 	case params.GovernanceMode, params.Ratio:
 		gov.changeSet.SetValue(GovernanceKeyMap[vote.Key], vote.Value.(string))
 		return true
-	case params.Epoch, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.CommitteeSize, params.UnitPrice, params.ConstTxGasHumanReadable, params.Timeout:
-		gov.changeSet.SetValue(GovernanceKeyMap[vote.Key], vote.Value.(uint64))
-		return true
-	case params.Policy:
+	case params.Epoch, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.CommitteeSize, params.UnitPrice, params.ConstTxGasHumanReadable, params.Policy, params.Timeout:
 		gov.changeSet.SetValue(GovernanceKeyMap[vote.Key], vote.Value.(uint64))
 		return true
 	case params.MintingAmount, params.MinimumStake:

--- a/governance/default.go
+++ b/governance/default.go
@@ -63,6 +63,7 @@ var (
 		"governance.addvalidator":       params.AddValidator,
 		"governance.removevalidator":    params.RemoveValidator,
 		"param.txgashumanreadable":      params.ConstTxGasHumanReadable,
+		"istanbul.requesttimeout":       params.RequestTimeout,
 	}
 
 	GovernanceForbiddenKeyMap = map[string]int{
@@ -89,6 +90,7 @@ var (
 		params.AddValidator:            "governance.addvalidator",
 		params.RemoveValidator:         "governance.removevalidator",
 		params.ConstTxGasHumanReadable: "param.txgashumanreadable",
+		params.RequestTimeout:          "istanbul.requesttimeout",
 	}
 
 	ProposerPolicyMap = map[string]int{
@@ -502,7 +504,7 @@ func (g *Governance) ParseVoteValue(gVote *GovernanceVote) (*GovernanceVote, err
 		val = string(gVote.Value.([]uint8))
 	case params.GoverningNode, params.AddValidator, params.RemoveValidator:
 		val = common.BytesToAddress(gVote.Value.([]uint8))
-	case params.Epoch, params.CommitteeSize, params.UnitPrice, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.ConstTxGasHumanReadable, params.Policy:
+	case params.Epoch, params.CommitteeSize, params.UnitPrice, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.ConstTxGasHumanReadable, params.Policy, params.RequestTimeout:
 		gVote.Value = append(make([]byte, 8-len(gVote.Value.([]uint8))), gVote.Value.([]uint8)...)
 		val = binary.BigEndian.Uint64(gVote.Value.([]uint8))
 	case params.UseGiniCoeff, params.DeferredTxFee:
@@ -533,7 +535,7 @@ func (gov *Governance) updateChangeSet(vote GovernanceVote) bool {
 	case params.GovernanceMode, params.Ratio:
 		gov.changeSet.SetValue(GovernanceKeyMap[vote.Key], vote.Value.(string))
 		return true
-	case params.Epoch, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.CommitteeSize, params.UnitPrice, params.ConstTxGasHumanReadable:
+	case params.Epoch, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.CommitteeSize, params.UnitPrice, params.ConstTxGasHumanReadable, params.RequestTimeout:
 		gov.changeSet.SetValue(GovernanceKeyMap[vote.Key], vote.Value.(uint64))
 		return true
 	case params.Policy:

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -98,11 +98,11 @@ var tstData = []voteValue{
 	{k: "reward.minimumstake", v: 200000000000000, e: false},
 	{k: "reward.stakingupdateinterval", v: uint64(20), e: false},
 	{k: "reward.proposerupdateinterval", v: uint64(20), e: false},
-	{k: "istanbul.roundchangetimer", v: uint64(10000), e: true},
-	{k: "istanbul.roundchangetimer", v: uint64(5000), e: true},
-	{k: "istanbul.roundchangetimer", v: true, e: false},
-	{k: "istanbul.roundchangetimer", v: "10", e: false},
-	{k: "istanbul.roundchangetimer", v: 5.3, e: false},
+	{k: "istanbul.timeout", v: uint64(10000), e: true},
+	{k: "istanbul.timeout", v: uint64(5000), e: true},
+	{k: "istanbul.timeout", v: true, e: false},
+	{k: "istanbul.timeout", v: "10", e: false},
+	{k: "istanbul.timeout", v: 5.3, e: false},
 }
 
 var goodVotes = []voteValue{
@@ -114,7 +114,7 @@ var goodVotes = []voteValue{
 	{k: "reward.useginicoeff", v: false, e: true},
 	{k: "reward.mintingamount", v: "9600000000000000000", e: true},
 	{k: "reward.ratio", v: "10/10/80", e: true},
-	{k: "istanbul.roundchangetimer", v: uint64(5000), e: true},
+	{k: "istanbul.timeout", v: uint64(5000), e: true},
 }
 
 func getTestConfig() *params.ChainConfig {
@@ -636,13 +636,13 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.BlockScore = common.Big1
 
-	newValue := istanbul.DefaultConfig.RequestTimeout + uint64(10000)
-	gov.AddVote("istanbul.roundchangetimer", newValue)
+	newValue := istanbul.DefaultConfig.Timeout + uint64(10000)
+	gov.AddVote("istanbul.timeout", newValue)
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
 	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
 
-	if istanbul.DefaultConfig.RequestTimeout != newValue {
+	if istanbul.DefaultConfig.Timeout != newValue {
 		t.Errorf("Vote had to be applied but it wasn't")
 	}
 	gov.voteMap.Clear()
@@ -721,8 +721,8 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	// Test for "istanbul.roundchangetimer" in "ballot" mode
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.BlockScore = common.Big1
-	newValue := istanbul.DefaultConfig.RequestTimeout + uint64(10000)
-	gov.AddVote("istanbul.roundchangetimer", newValue)
+	newValue := istanbul.DefaultConfig.Timeout + uint64(10000)
+	gov.AddVote("istanbul.timeout", newValue)
 
 	header.Vote = gov.GetEncodedVote(council[0], blockCounter.Uint64())
 	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[0], self)
@@ -730,13 +730,13 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	header.Vote = gov.GetEncodedVote(council[1], blockCounter.Uint64())
 	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[1], self)
 
-	if istanbul.DefaultConfig.RequestTimeout == newValue {
+	if istanbul.DefaultConfig.Timeout == newValue {
 		t.Errorf("Vote shouldn't be applied yet but it was applied")
 	}
 
 	header.Vote = gov.GetEncodedVote(council[2], blockCounter.Uint64())
 	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[2], self)
-	if istanbul.DefaultConfig.RequestTimeout != newValue {
+	if istanbul.DefaultConfig.Timeout != newValue {
 		t.Errorf("Vote should be applied but it was not")
 	}
 

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -98,11 +98,11 @@ var tstData = []voteValue{
 	{k: "reward.minimumstake", v: 200000000000000, e: false},
 	{k: "reward.stakingupdateinterval", v: uint64(20), e: false},
 	{k: "reward.proposerupdateinterval", v: uint64(20), e: false},
-	{k: "istanbul.requesttimeout", v: uint64(10000), e: true},
-	{k: "istanbul.requesttimeout", v: uint64(5000), e: true},
-	{k: "istanbul.requesttimeout", v: true, e: false},
-	{k: "istanbul.requesttimeout", v: "10", e: false},
-	{k: "istanbul.requesttimeout", v: 5.3, e: false},
+	{k: "istanbul.roundchangetimer", v: uint64(10000), e: true},
+	{k: "istanbul.roundchangetimer", v: uint64(5000), e: true},
+	{k: "istanbul.roundchangetimer", v: true, e: false},
+	{k: "istanbul.roundchangetimer", v: "10", e: false},
+	{k: "istanbul.roundchangetimer", v: 5.3, e: false},
 }
 
 var goodVotes = []voteValue{
@@ -114,7 +114,7 @@ var goodVotes = []voteValue{
 	{k: "reward.useginicoeff", v: false, e: true},
 	{k: "reward.mintingamount", v: "9600000000000000000", e: true},
 	{k: "reward.ratio", v: "10/10/80", e: true},
-	{k: "istanbul.requesttimeout", v: uint64(5000), e: true},
+	{k: "istanbul.roundchangetimer", v: uint64(5000), e: true},
 }
 
 func getTestConfig() *params.ChainConfig {
@@ -637,7 +637,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	header.BlockScore = common.Big1
 
 	newValue := istanbul.DefaultConfig.RequestTimeout + uint64(10000)
-	gov.AddVote("istanbul.requesttimeout", newValue)
+	gov.AddVote("istanbul.roundchangetimer", newValue)
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
 	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
@@ -718,11 +718,11 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	gov.RemoveVote("governance.unitprice", uint64(22000), blockCounter.Uint64())
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
-	// Test for "istanbul.requesttimeout" in "ballot" mode
+	// Test for "istanbul.roundchangetimer" in "ballot" mode
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.BlockScore = common.Big1
 	newValue := istanbul.DefaultConfig.RequestTimeout + uint64(10000)
-	gov.AddVote("istanbul.requesttimeout", newValue)
+	gov.AddVote("istanbul.roundchangetimer", newValue)
 
 	header.Vote = gov.GetEncodedVote(council[0], blockCounter.Uint64())
 	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[0], self)

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -98,6 +98,11 @@ var tstData = []voteValue{
 	{k: "reward.minimumstake", v: 200000000000000, e: false},
 	{k: "reward.stakingupdateinterval", v: uint64(20), e: false},
 	{k: "reward.proposerupdateinterval", v: uint64(20), e: false},
+	{k: "istanbul.requesttimeout", v: uint64(10000), e: true},
+	{k: "istanbul.requesttimeout", v: uint64(5000), e: true},
+	{k: "istanbul.requesttimeout", v: true, e: false},
+	{k: "istanbul.requesttimeout", v: "10", e: false},
+	{k: "istanbul.requesttimeout", v: 5.3, e: false},
 }
 
 var goodVotes = []voteValue{
@@ -109,6 +114,7 @@ var goodVotes = []voteValue{
 	{k: "reward.useginicoeff", v: false, e: true},
 	{k: "reward.mintingamount", v: "9600000000000000000", e: true},
 	{k: "reward.ratio", v: "10/10/80", e: true},
+	{k: "istanbul.requesttimeout", v: uint64(5000), e: true},
 }
 
 func getTestConfig() *params.ChainConfig {
@@ -626,6 +632,22 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Test for "istanbul.requesttimeout" in "none" mode
+	header.Number = blockCounter.Add(blockCounter, common.Big1)
+	header.BlockScore = common.Big1
+
+	newValue := istanbul.DefaultConfig.RequestTimeout + uint64(10000)
+	gov.AddVote("istanbul.requesttimeout", newValue)
+	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
+
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+
+	if istanbul.DefaultConfig.RequestTimeout != newValue {
+		t.Errorf("Vote had to be applied but it wasn't")
+	}
+	gov.voteMap.Clear()
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Test removing a validator
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	gov.AddVote("governance.removevalidator", council[1].String())
@@ -690,10 +712,35 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	header.Vote = gov.GetEncodedVote(council[2], blockCounter.Uint64())
 	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[2], self)
 	if _, ok := gov.changeSet.items["governance.unitprice"]; !ok {
-		t.Errorf("Vote should be applied yet but it was not")
+		t.Errorf("Vote should be applied but it was not")
 	}
 
 	gov.RemoveVote("governance.unitprice", uint64(22000), blockCounter.Uint64())
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Test for "istanbul.requesttimeout" in "ballot" mode
+	header.Number = blockCounter.Add(blockCounter, common.Big1)
+	header.BlockScore = common.Big1
+	newValue := istanbul.DefaultConfig.RequestTimeout + uint64(10000)
+	gov.AddVote("istanbul.requesttimeout", newValue)
+
+	header.Vote = gov.GetEncodedVote(council[0], blockCounter.Uint64())
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[0], self)
+
+	header.Vote = gov.GetEncodedVote(council[1], blockCounter.Uint64())
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[1], self)
+
+	if istanbul.DefaultConfig.RequestTimeout == newValue {
+		t.Errorf("Vote shouldn't be applied yet but it was applied")
+	}
+
+	header.Vote = gov.GetEncodedVote(council[2], blockCounter.Uint64())
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[2], self)
+	if istanbul.DefaultConfig.RequestTimeout != newValue {
+		t.Errorf("Vote should be applied but it was not")
+	}
+
+	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Test removing a validator, because there are 4 nodes 3 votes are required to remove a validator

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -632,7 +632,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
-	// Test for "istanbul.requesttimeout" in "none" mode
+	// Test for "istanbul.timeout" in "none" mode
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.BlockScore = common.Big1
 
@@ -642,9 +642,8 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 
 	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
 
-	if istanbul.DefaultConfig.Timeout != newValue {
-		t.Errorf("Vote had to be applied but it wasn't")
-	}
+	assert.Equal(t, istanbul.DefaultConfig.Timeout, newValue, "Vote had to be applied but it wasn't")
+
 	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -718,7 +717,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	gov.RemoveVote("governance.unitprice", uint64(22000), blockCounter.Uint64())
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
-	// Test for "istanbul.roundchangetimer" in "ballot" mode
+	// Test for "istanbul.timeout" in "ballot" mode
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.BlockScore = common.Big1
 	newValue := istanbul.DefaultConfig.Timeout + uint64(10000)
@@ -730,15 +729,12 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	header.Vote = gov.GetEncodedVote(council[1], blockCounter.Uint64())
 	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[1], self)
 
-	if istanbul.DefaultConfig.Timeout == newValue {
-		t.Errorf("Vote shouldn't be applied yet but it was applied")
-	}
+	assert.NotEqual(t, istanbul.DefaultConfig.Timeout, newValue, "Vote shouldn't be applied yet but it was applied")
 
 	header.Vote = gov.GetEncodedVote(council[2], blockCounter.Uint64())
 	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, council[2], self)
-	if istanbul.DefaultConfig.Timeout != newValue {
-		t.Errorf("Vote should be applied but it was not")
-	}
+
+	assert.Equal(t, istanbul.DefaultConfig.Timeout, newValue, "Vote should be applied but it was not")
 
 	gov.voteMap.Clear()
 

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -60,6 +60,7 @@ var GovernanceItems = map[int]check{
 	params.Policy:                  {uint64T, checkUint64andBool, updateProposerPolicy},
 	params.CommitteeSize:           {uint64T, checkUint64andBool, nil},
 	params.ConstTxGasHumanReadable: {uint64T, checkUint64andBool, updateTxGasHumanReadable},
+	params.RequestTimeout:          {uint64T, checkUint64andBool, nil},
 }
 
 func updateTxGasHumanReadable(g *Governance, k string, v interface{}) {
@@ -383,6 +384,12 @@ func (gov *Governance) addNewVote(valset istanbul.ValidatorSet, votes []Governan
 				target := gVote.Value.(common.Address)
 				valset.RemoveValidator(target)
 				votes = gov.removeVotesFromRemovedNode(votes, target)
+			case params.RequestTimeout:
+				timeout := gVote.Value.(uint64)
+				istanbul.DefaultConfig.RequestTimeout = timeout
+				if blockNum > atomic.LoadUint64(&gov.lastGovernanceStateBlock) {
+					gov.ReflectVotes(*gVote)
+				}
 			default:
 				if blockNum > atomic.LoadUint64(&gov.lastGovernanceStateBlock) {
 					gov.ReflectVotes(*gVote)

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -386,7 +386,7 @@ func (gov *Governance) addNewVote(valset istanbul.ValidatorSet, votes []Governan
 				votes = gov.removeVotesFromRemovedNode(votes, target)
 			case params.Timeout:
 				timeout := gVote.Value.(uint64)
-				istanbul.DefaultConfig.Timeout = timeout
+				atomic.StoreUint64(&istanbul.DefaultConfig.Timeout, timeout)
 				if blockNum > atomic.LoadUint64(&gov.lastGovernanceStateBlock) {
 					gov.ReflectVotes(*gVote)
 				}

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -60,7 +60,7 @@ var GovernanceItems = map[int]check{
 	params.Policy:                  {uint64T, checkUint64andBool, updateProposerPolicy},
 	params.CommitteeSize:           {uint64T, checkUint64andBool, nil},
 	params.ConstTxGasHumanReadable: {uint64T, checkUint64andBool, updateTxGasHumanReadable},
-	params.RequestTimeout:          {uint64T, checkUint64andBool, nil},
+	params.Timeout:                 {uint64T, checkUint64andBool, nil},
 }
 
 func updateTxGasHumanReadable(g *Governance, k string, v interface{}) {
@@ -384,9 +384,9 @@ func (gov *Governance) addNewVote(valset istanbul.ValidatorSet, votes []Governan
 				target := gVote.Value.(common.Address)
 				valset.RemoveValidator(target)
 				votes = gov.removeVotesFromRemovedNode(votes, target)
-			case params.RequestTimeout:
+			case params.Timeout:
 				timeout := gVote.Value.(uint64)
-				istanbul.DefaultConfig.RequestTimeout = timeout
+				istanbul.DefaultConfig.Timeout = timeout
 				if blockNum > atomic.LoadUint64(&gov.lastGovernanceStateBlock) {
 					gov.ReflectVotes(*gVote)
 				}

--- a/params/governance_params.go
+++ b/params/governance_params.go
@@ -87,6 +87,7 @@ const (
 	ProposerRefreshInterval
 	ConstTxGasHumanReadable
 	CliqueEpoch
+	RequestTimeout
 )
 
 const (

--- a/params/governance_params.go
+++ b/params/governance_params.go
@@ -87,7 +87,7 @@ const (
 	ProposerRefreshInterval
 	ConstTxGasHumanReadable
 	CliqueEpoch
-	RequestTimeout
+	Timeout
 )
 
 const (


### PR DESCRIPTION
## Proposed changes

- This PR is to make the default timeout for a roundchange changeable by the governance vote
- Added an API `istanbul.roundchangeTimer` to check current timeout value in milliseconds
- Added a governance key of `istanbul.roundchangetimer` for `governance.vote` API
  ex) 
```shell
> istanbul.roundchangeTimer
3000
>governance.vote("istanbul.roundchangeTimer", 10000) 
==> this will change the timeout interval into 10 seconds
> istanbul.roundchangeTimer
10000
```
- This change is applied instantly as soon as the vote passes like `addValidator` and `removeValidator`
- Added test codes to test the new feature

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
