### PR TITLE
change argument type to pointer

### DIFF
--- a/api/debug/api.go
+++ b/api/debug/api.go
@@ -120,7 +120,7 @@ func (h *HandlerT) StartPProf(ptrAddr *string, ptrPort *int) error {
 		address = *ptrAddr
 	}
 
-	if ptrPort == nil || port == 0 {
+	if ptrPort == nil || *ptrPort == 0 {
 		port = pprofPortFlag.Value
 	} else {
 		port = *ptrPort

--- a/api/debug/api.go
+++ b/api/debug/api.go
@@ -108,13 +108,22 @@ func (*HandlerT) GcStats() *debug.GCStats {
 }
 
 // StartPProf starts the pprof server.
-func (h *HandlerT) StartPProf(address string, port int) error {
+func (h *HandlerT) StartPProf(ptrAddr *string, ptrPort *int) error {
 	// Set the default server address and port if they are not set
-	if address == "" {
+	var (
+		address string
+		port int
+	)
+	if ptrAddr == nil || *ptrAddr == "" {
 		address = pprofAddrFlag.Value
+	} else {
+		address = *ptrAddr
 	}
-	if port == 0 {
+
+	if ptrPort == nil || port == 0 {
 		port = pprofPortFlag.Value
+	} else {
+		port = *ptrPort
 	}
 
 	h.mu.Lock()

--- a/api/debug/api.go
+++ b/api/debug/api.go
@@ -112,7 +112,7 @@ func (h *HandlerT) StartPProf(ptrAddr *string, ptrPort *int) error {
 	// Set the default server address and port if they are not set
 	var (
 		address string
-		port int
+		port    int
 	)
 	if ptrAddr == nil || *ptrAddr == "" {
 		address = pprofAddrFlag.Value

--- a/api/debug/flags.go
+++ b/api/debug/flags.go
@@ -159,7 +159,9 @@ func Setup(ctx *cli.Context) error {
 
 	// pprof server
 	if ctx.GlobalBool(pprofFlag.Name) {
-		Handler.StartPProf(ctx.GlobalString(pprofAddrFlag.Name), ctx.GlobalInt(pprofPortFlag.Name))
+		addr := ctx.GlobalString(pprofAddrFlag.Name)
+		port := ctx.GlobalInt(pprofPortFlag.Name)
+		Handler.StartPProf(&addr, &port)
 	}
 	return nil
 }


### PR DESCRIPTION
## Proposed changes

- The param of `debug_startPProf` is optional, but an error occurs when no value is entered in the RPC call.

```
$ curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "debug_startPProf", "params": [], "id": 81}' localhost:8551
```

result:
```
{
    "error": {
        "code": -32602,
        "message": "missing value for required argument 0"
    },
    "id": 79,
    "jsonrpc": "2.0"
}
```
## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
