### PR TITLE
cn: more tests to increase the coverage of cn pkg

### DIFF
--- a/node/cn/api_backend_test.go
+++ b/node/cn/api_backend_test.go
@@ -433,24 +433,24 @@ func TestCNAPIBackend_SubscribeEvents(t *testing.T) {
 func TestCNAPIBackend_SendTx(t *testing.T) {
 	mockCtrl, _, _, api := newCNAPIBackend(t)
 	mockTxPool := mocks.NewMockTxPool(mockCtrl)
-	mockTxPool.EXPECT().AddLocal(tx1).Return(err).Times(1)
+	mockTxPool.EXPECT().AddLocal(tx1).Return(expectedErr).Times(1)
 	api.cn.txPool = mockTxPool
 
 	defer mockCtrl.Finish()
 
-	assert.Equal(t, err, api.SendTx(context.Background(), tx1))
+	assert.Equal(t, expectedErr, api.SendTx(context.Background(), tx1))
 }
 
 func TestCNAPIBackend_GetPoolTransactions(t *testing.T) {
 	{
 		mockCtrl, _, _, api := newCNAPIBackend(t)
 		mockTxPool := mocks.NewMockTxPool(mockCtrl)
-		mockTxPool.EXPECT().Pending().Return(nil, err).Times(1)
+		mockTxPool.EXPECT().Pending().Return(nil, expectedErr).Times(1)
 		api.cn.txPool = mockTxPool
 
 		txs, ReturnedErr := api.GetPoolTransactions()
 		assert.Nil(t, txs)
-		assert.Equal(t, err, ReturnedErr)
+		assert.Equal(t, expectedErr, ReturnedErr)
 		mockCtrl.Finish()
 	}
 	{

--- a/node/cn/api_tracer_test.go
+++ b/node/cn/api_tracer_test.go
@@ -1,0 +1,233 @@
+// Copyright 2019 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package cn
+
+import (
+	"context"
+	"github.com/golang/mock/gomock"
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/vm"
+	"github.com/klaytn/klaytn/common/hexutil"
+	mocks2 "github.com/klaytn/klaytn/consensus/mocks"
+	"github.com/klaytn/klaytn/networks/rpc"
+	mocks3 "github.com/klaytn/klaytn/node/cn/mocks"
+	"github.com/klaytn/klaytn/work/mocks"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func createCNMocks(t *testing.T) (*gomock.Controller, *PrivateDebugAPI, *mocks2.MockEngine, *mocks.MockBlockChain, *mocks3.MockMiner) {
+	mockCtrl, mockEngine, mockBlockChain, _ := newMocks(t)
+	mockMiner := mocks3.NewMockMiner(mockCtrl)
+	api := NewPrivateDebugAPI(nil, &CN{miner: mockMiner, blockchain: mockBlockChain, engine: mockEngine})
+	return mockCtrl, api, mockEngine, mockBlockChain, mockMiner
+}
+
+func TestPrivateDebugAPI_TraceChain(t *testing.T) {
+	endBlockNumber := rpc.BlockNumber(123)
+	block := newBlock(123)
+	{
+		mockCtrl, api, _, _, mockMiner := createCNMocks(t)
+		mockMiner.EXPECT().PendingBlock().Return(nil).Times(2)
+		sub, err := api.TraceChain(context.Background(), rpc.PendingBlockNumber, rpc.PendingBlockNumber, nil)
+		assert.Nil(t, sub)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+	{
+		mockCtrl, api, _, mockBlockChain, mockMiner := createCNMocks(t)
+		mockMiner.EXPECT().PendingBlock().Return(nil).Times(1)
+		mockBlockChain.EXPECT().CurrentBlock().Return(nil).Times(1)
+		sub, err := api.TraceChain(context.Background(), rpc.PendingBlockNumber, rpc.LatestBlockNumber, nil)
+		assert.Nil(t, sub)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+	{
+		mockCtrl, api, _, mockBlockChain, mockMiner := createCNMocks(t)
+		mockMiner.EXPECT().PendingBlock().Return(nil).Times(1)
+		mockBlockChain.EXPECT().GetBlockByNumber(uint64(endBlockNumber)).Return(nil).Times(1)
+		sub, err := api.TraceChain(context.Background(), rpc.PendingBlockNumber, endBlockNumber, nil)
+		assert.Nil(t, sub)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+	{
+		mockCtrl, api, _, mockBlockChain, mockMiner := createCNMocks(t)
+		mockMiner.EXPECT().PendingBlock().Return(block).Times(1)
+		mockBlockChain.EXPECT().CurrentBlock().Return(nil).Times(1)
+		sub, err := api.TraceChain(context.Background(), rpc.LatestBlockNumber, rpc.PendingBlockNumber, nil)
+		assert.Nil(t, sub)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+	{
+		endBlockNumber := rpc.BlockNumber(123)
+		mockCtrl, api, _, mockBlockChain, mockMiner := createCNMocks(t)
+		mockMiner.EXPECT().PendingBlock().Return(block).Times(1)
+		mockBlockChain.EXPECT().GetBlockByNumber(uint64(endBlockNumber)).Return(nil).Times(1)
+		sub, err := api.TraceChain(context.Background(), endBlockNumber, rpc.PendingBlockNumber, nil)
+		assert.Nil(t, sub)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+}
+
+func TestPrivateDebugAPI_TraceBlockByNumber(t *testing.T) {
+	blockNumber := rpc.BlockNumber(123)
+	{
+		mockCtrl, api, _, _, mockMiner := createCNMocks(t)
+		mockMiner.EXPECT().PendingBlock().Return(nil).Times(1)
+		sub, err := api.TraceBlockByNumber(context.Background(), rpc.PendingBlockNumber, nil)
+		assert.Nil(t, sub)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+	{
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().CurrentBlock().Return(nil).Times(1)
+		sub, err := api.TraceBlockByNumber(context.Background(), rpc.LatestBlockNumber, nil)
+		assert.Nil(t, sub)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+	{
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().GetBlockByNumber(uint64(blockNumber)).Return(nil).Times(1)
+		sub, err := api.TraceBlockByNumber(context.Background(), blockNumber, nil)
+		assert.Nil(t, sub)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+}
+
+func TestPrivateDebugAPI_TraceBlockByHash(t *testing.T) {
+	mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+	mockBlockChain.EXPECT().GetBlockByHash(hashes[0]).Return(nil).Times(1)
+	sub, err := api.TraceBlockByHash(context.Background(), hashes[0], nil)
+	assert.Nil(t, sub)
+	assert.Error(t, err)
+	mockCtrl.Finish()
+}
+
+func TestPrivateDebugAPI_TraceBlock(t *testing.T) {
+	mockCtrl, api, _, _, _ := createCNMocks(t)
+	sub, err := api.TraceBlock(context.Background(), hexutil.Bytes{}, nil)
+	assert.Nil(t, sub)
+	assert.Error(t, err)
+	mockCtrl.Finish()
+}
+
+func TestPrivateDebugAPI_TraceBlockFromFile(t *testing.T) {
+	mockCtrl, api, _, _, _ := createCNMocks(t)
+	sub, err := api.TraceBlockFromFile(context.Background(), "12345", nil)
+	assert.Nil(t, sub)
+	assert.Error(t, err)
+	mockCtrl.Finish()
+}
+
+func TestPrivateDebugAPI_TraceBadBlock(t *testing.T) {
+	{
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().BadBlocks().Return(nil, err).Times(1)
+		sub, returnedErr := api.TraceBadBlock(context.Background(), hashes[0], nil)
+		assert.Nil(t, sub)
+		assert.Equal(t, err, returnedErr)
+		mockCtrl.Finish()
+	}
+	{
+		block := newBlock(123)
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().BadBlocks().Return([]blockchain.BadBlockArgs{{Hash: block.Hash(), Block: block}}, err).Times(1)
+		sub, returnedErr := api.TraceBadBlock(context.Background(), hashes[0], nil)
+		assert.Nil(t, sub)
+		assert.Equal(t, err, returnedErr)
+		mockCtrl.Finish()
+	}
+}
+
+func TestPrivateDebugAPI_StandardTraceBlockToFile(t *testing.T) {
+	{
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().GetBlockByHash(hashes[0]).Return(nil).Times(1)
+		sub, returnedErr := api.StandardTraceBlockToFile(context.Background(), hashes[0], nil)
+		assert.Nil(t, sub)
+		assert.Error(t, returnedErr)
+		mockCtrl.Finish()
+	}
+}
+
+func TestPrivateDebugAPI_StandardTraceBadBlockToFile(t *testing.T) {
+	{
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().BadBlocks().Return(nil, err).Times(1)
+		sub, returnedErr := api.StandardTraceBadBlockToFile(context.Background(), hashes[0], nil)
+		assert.Nil(t, sub)
+		assert.Equal(t, err, returnedErr)
+		mockCtrl.Finish()
+	}
+	{
+		block := newBlock(123)
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().BadBlocks().Return([]blockchain.BadBlockArgs{{Hash: block.Hash(), Block: block}}, err).Times(1)
+		sub, returnedErr := api.StandardTraceBadBlockToFile(context.Background(), hashes[0], nil)
+		assert.Nil(t, sub)
+		assert.Equal(t, err, returnedErr)
+		mockCtrl.Finish()
+	}
+}
+
+func TestPrivateDebugAPI_computeTxEnv(t *testing.T) {
+	parentBlock := newBlock(122)
+	block := newBlock(123)
+	blockHash := block.Hash()
+	txIndex := 0
+	reexec := uint64(0)
+	{
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().GetBlockByHash(blockHash).Return(nil).Times(1)
+		msg, ctx, stateDB, err := api.computeTxEnv(blockHash, txIndex, reexec)
+		assert.Nil(t, msg)
+		assert.Equal(t, vm.Context{}, ctx)
+		assert.Nil(t, stateDB)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+	{
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().GetBlockByHash(blockHash).Return(block).Times(1)
+		mockBlockChain.EXPECT().GetBlock(block.ParentHash(), block.NumberU64()-1).Return(nil).Times(1)
+		msg, ctx, stateDB, err := api.computeTxEnv(blockHash, txIndex, reexec)
+		assert.Nil(t, msg)
+		assert.Equal(t, vm.Context{}, ctx)
+		assert.Nil(t, stateDB)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+	{
+		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
+		mockBlockChain.EXPECT().GetBlockByHash(blockHash).Return(block).Times(1)
+		mockBlockChain.EXPECT().GetBlock(block.ParentHash(), block.NumberU64()-1).Return(block).Times(1)
+		mockBlockChain.EXPECT().StateAt(parentBlock.Root()).Return(nil, err).Times(1)
+		msg, ctx, stateDB, err := api.computeTxEnv(blockHash, txIndex, reexec)
+		assert.Nil(t, msg)
+		assert.Equal(t, vm.Context{}, ctx)
+		assert.Nil(t, stateDB)
+		assert.Error(t, err)
+		mockCtrl.Finish()
+	}
+}

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 )
 
-var err = errors.New("some error")
+var expectedErr = errors.New("some error")
 
 // generateMsg creates a message struct for message handling tests.
 func generateMsg(t *testing.T, msgCode uint64, data interface{}) p2p.Msg {
@@ -87,7 +87,7 @@ func TestHandleBlockHeadersMsg(t *testing.T) {
 	{
 		mockCtrl, mockDownloader, mockPeer, pm := prepareDownloader(t)
 		msg := generateMsg(t, BlockHeadersMsg, headers)
-		mockDownloader.EXPECT().DeliverHeaders(nodeids[0].String(), gomock.Eq(headers)).Return(err).Times(1)
+		mockDownloader.EXPECT().DeliverHeaders(nodeids[0].String(), gomock.Eq(headers)).Return(expectedErr).Times(1)
 
 		assert.NoError(t, handleBlockHeadersMsg(pm, mockPeer, msg))
 		mockCtrl.Finish()
@@ -401,7 +401,7 @@ func TestHandleReceiptMsg(t *testing.T) {
 		receipts[0] = []*types.Receipt{newReceipt(123)}
 
 		mockCtrl, mockPeer, mockDownloader, pm := preparePeerAndDownloader(t)
-		mockDownloader.EXPECT().DeliverReceipts(nodeids[0].String(), gomock.Eq(receipts)).Times(1).Return(err)
+		mockDownloader.EXPECT().DeliverReceipts(nodeids[0].String(), gomock.Eq(receipts)).Times(1).Return(expectedErr)
 
 		msg := generateMsg(t, ReceiptsMsg, receipts)
 		assert.NoError(t, pm.handleMsg(mockPeer, addrs[0], msg))
@@ -438,7 +438,7 @@ func TestHandleNodeDataMsg(t *testing.T) {
 		nodeData[0] = hash1[:]
 
 		mockCtrl, mockPeer, mockDownloader, pm := preparePeerAndDownloader(t)
-		mockDownloader.EXPECT().DeliverNodeData(nodeids[0].String(), gomock.Eq(nodeData)).Times(1).Return(err)
+		mockDownloader.EXPECT().DeliverNodeData(nodeids[0].String(), gomock.Eq(nodeData)).Times(1).Return(expectedErr)
 
 		msg := generateMsg(t, NodeDataMsg, nodeData)
 		assert.NoError(t, pm.handleMsg(mockPeer, addrs[0], msg))

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -211,7 +211,7 @@ func TestProtocolManager_removePeer(t *testing.T) {
 		pm.downloader = mockDownloader
 
 		// Return
-		mockPeerSet.EXPECT().Unregister(peerID).Return(err).Times(1)
+		mockPeerSet.EXPECT().Unregister(peerID).Return(expectedErr).Times(1)
 
 		mockPeer.EXPECT().GetP2PPeer().Return(p2pPeers[0]).Times(1)
 


### PR DESCRIPTION
## Proposed changes

- added more tests to increase the coverage of cn package
- call `handleMsg` instead of specific message handling functions to increase the coverage of `handleMsg`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
