### PR TITLE
Correct misspelled directive in initscripts

### DIFF
--- a/build/rpm/etc/init.d/kbnd
+++ b/build/rpm/etc/init.d/kbnd
@@ -2,7 +2,7 @@
 #
 # kbnd         Startup script for the kbn
 #
-# chkconifg: - 85 15
+# chkconfig: - 85 15
 # description : kbnd is Klaytn boot node daemon
 #
 # processname: kbnd

--- a/build/rpm/etc/init.d/kcnd
+++ b/build/rpm/etc/init.d/kcnd
@@ -2,7 +2,7 @@
 #
 # kcnd         Startup script for the kcn
 #
-# chkconifg: - 85 15
+# chkconfig: - 85 15
 # description : kcnd is Klaytn consensus node daemon
 #
 # processname: kcnd

--- a/build/rpm/etc/init.d/kend
+++ b/build/rpm/etc/init.d/kend
@@ -2,7 +2,7 @@
 #
 # kend         Startup script for the ken
 #
-# chkconifg: - 85 15
+# chkconfig: - 85 15
 # description : kend is the Klaytn endpoint node daemon
 #
 # processname: kend

--- a/build/rpm/etc/init.d/kpnd
+++ b/build/rpm/etc/init.d/kpnd
@@ -2,7 +2,7 @@
 #
 # kpnd         Startup script for the kpn
 #
-# chkconifg: - 85 15
+# chkconfig: - 85 15
 # description : kpnd is the Klaytn proxy node daemon
 #
 # processname: kpnd

--- a/build/rpm/etc/init.d/kscnd
+++ b/build/rpm/etc/init.d/kscnd
@@ -2,7 +2,7 @@
 #
 # kscnd         Startup script for the kscnd
 #
-# chkconifg: - 85 15
+# chkconfig: - 85 15
 # description : kscnd is Klaytn consensus node daemon
 #
 # processname: kscnd

--- a/build/rpm/etc/init.d/ksend
+++ b/build/rpm/etc/init.d/ksend
@@ -2,7 +2,7 @@
 #
 # ksend         Startup script for the ksen
 #
-# chkconifg: - 85 15
+# chkconfig: - 85 15
 # description : ksend is the Klaytn endpoint node daemon
 #
 # processname: ksend

--- a/build/rpm/etc/init.d/kspnd
+++ b/build/rpm/etc/init.d/kspnd
@@ -2,7 +2,7 @@
 #
 # kspnd         Startup script for the kspn
 #
-# chkconifg: - 85 15
+# chkconfig: - 85 15
 # description : kspnd is the Klaytn proxy node daemon
 #
 # processname: kspnd


### PR DESCRIPTION
## Proposed changes

- Corrects a misspelled directive `chkconifg` -> `chkconfig`
- This comment is used by the `chkconfig` tool. This fixes errors from `chkconfig` when attempting to enable the service

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- None

## Further comments

N/A