### PR TITLE
Add error exception code during traceBlock

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -68,7 +68,7 @@ const (
 )
 
 const (
-	triesInMemory = 4
+	triesInMemory = 128
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	BlockChainVersion    = 3
 	DefaultBlockInterval = 128

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -657,6 +657,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 		// balance check for fee-delegated tx
 		gasFeePayer, err = tx.ValidateFeePayer(pool.signer, pool.currentState, pool.currentBlockNumber)
 		if err != nil {
+			logger.Warn("failed to ValidateFeePayer", "block", pool.currentBlockNumber, "err", err)
 			return ErrInvalidFeePayer
 		}
 		feePayer := tx.ValidatedFeePayer()

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -479,7 +479,12 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
-				msg, _ := txs[task.index].AsMessageWithAccountKeyPicker(signer, task.statedb, block.NumberU64())
+				msg, err := txs[task.index].AsMessageWithAccountKeyPicker(signer, task.statedb, block.NumberU64())
+				if err != nil {
+					results[task.index] = &txTraceResult{Error: err.Error()}
+					continue
+				}
+
 				vmctx := blockchain.NewEVMContext(msg, block.Header(), api.cn.blockchain, nil)
 
 				res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -596,7 +596,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		}
 
 		var (
-			vmctx  = blockchain.NewEVMContext(msg, block.Header(), api.cn.blockchain, nil)
+			vmctx = blockchain.NewEVMContext(msg, block.Header(), api.cn.blockchain, nil)
 
 			vmConf vm.Config
 			dump   *os.File


### PR DESCRIPTION
## Proposed changes

This PR prevents the runtime panic error during traceBlock in https://github.com/klaytn/klaytn/issues/432.

This PR added exception code. 
After this PR, traceBlock will not make panic error. But it will show the error message in the result of traceBlock.


It is assumed that the root cause of the error was that the node had no account state of the block.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
