### PR TITLE
fix temporary bad block issue during sync

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -27,7 +27,7 @@ import (
 	"math/big"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -46,6 +46,7 @@ type StakingManager struct {
 	bc           blockChain
 	chainHeadCh  chan blockchain.ChainHeadEvent
 	chainHeadSub event.Subscription
+	isActivated  bool
 }
 
 func NewStakingManager(bc blockChain, gh governanceHelper) *StakingManager {
@@ -55,6 +56,7 @@ func NewStakingManager(bc blockChain, gh governanceHelper) *StakingManager {
 		gh:          gh,
 		bc:          bc,
 		chainHeadCh: make(chan blockchain.ChainHeadEvent, chainHeadChanSize),
+		isActivated: false,
 	}
 }
 
@@ -77,13 +79,17 @@ func (sm *StakingManager) GetStakingInfo(blockNum uint64) *StakingInfo {
 	return stakingInfo
 }
 
+func (sm *StakingManager) IsActivated() bool {
+	return sm.isActivated
+}
+
 // updateStakingCache updates staking cache with a stakingInfo of a given block number.
 func (sm *StakingManager) updateStakingCache(blockNum uint64) (*StakingInfo, error) {
 	stakingInfo, err := sm.ac.getStakingInfoFromAddressBook(blockNum)
 	if err != nil {
 		return nil, err
 	}
-
+	sm.isActivated = true
 	sm.sic.add(stakingInfo)
 
 	logger.Info("Add a new stakingInfo to the stakingInfoCache", "stakingInfo", stakingInfo)


### PR DESCRIPTION
## Proposed changes

- Bad block occured while syncing cypress from EN at block #6554625, #10413057 and #10414081. This happened every time when syncing and bad block appeared for 1~3 time for each blocks.
- The main reason for this happening is that the proposer's weight was used for checking if the address book was activated. Therefore, I made a flag to check if the address book is activated.
- I tested syncing EN with block #864000(when the address book was activated), #6554625, #10413057 and #10414081. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

