### PR TITLE
Introduce GCLock for cachedNode

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1095,8 +1095,8 @@ func (bc *BlockChain) gcCachedNodeLoop() {
 	gcTrigger := make(chan uint64)
 	trieDB := bc.stateCache.TrieDB()
 
+	bc.wg.Add(2)
 	go func() {
-		bc.wg.Add(1)
 		defer bc.wg.Done()
 		for {
 			select {
@@ -1118,7 +1118,6 @@ func (bc *BlockChain) gcCachedNodeLoop() {
 	}()
 
 	go func() {
-		bc.wg.Add(1)
 		defer bc.wg.Done()
 		for {
 			select {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -454,7 +454,7 @@ func (bc *BlockChain) StateAtWithGCLock(root common.Hash) (*state.StateDB, error
 	if exist {
 		return state.New(root, bc.stateCache)
 	}
-	bc.UnLockGCCachedNode()
+	bc.UnlockGCCachedNode()
 	return nil, errors.New("the node does not exist in state cache")
 }
 
@@ -1073,9 +1073,9 @@ func (bc *BlockChain) LockGCCachedNode() {
 	bc.stateCache.LockGCCachedNode()
 }
 
-// UnLockGCCachedNode unlocks the GC lock of CachedNode.
-func (bc *BlockChain) UnLockGCCachedNode() {
-	bc.stateCache.UnLockGCCachedNode()
+// UnlockGCCachedNode unlocks the GC lock of CachedNode.
+func (bc *BlockChain) UnlockGCCachedNode() {
+	bc.stateCache.UnlockGCCachedNode()
 }
 
 // gcCachedNodeLoop runs a loop to gc.

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -55,11 +55,11 @@ type Database interface {
 	// TrieDB retrieves the low level trie database used for data storage.
 	TrieDB() *statedb.Database
 
-	// LockGCCachedNode locks the GC lock of CachedNode.
-	LockGCCachedNode()
+	// RLockGCCachedNode locks the GC lock of CachedNode.
+	RLockGCCachedNode()
 
-	// UnlockGCCachedNode unlocks the GC lock of CachedNode.
-	UnlockGCCachedNode()
+	// RUnlockGCCachedNode unlocks the GC lock of CachedNode.
+	RUnlockGCCachedNode()
 }
 
 // Trie is a Klaytn Merkle Patricia trie.
@@ -179,12 +179,12 @@ func (db *cachingDB) TrieDB() *statedb.Database {
 	return db.db
 }
 
-// LockGCCachedNode locks the GC lock of CachedNode.
-func (db *cachingDB) LockGCCachedNode() {
-	db.db.LockGCCachedNode()
+// RLockGCCachedNode locks the GC lock of CachedNode.
+func (db *cachingDB) RLockGCCachedNode() {
+	db.db.RLockGCCachedNode()
 }
 
-// UnlockGCCachedNode unlocks the GC lock of CachedNode.
-func (db *cachingDB) UnlockGCCachedNode() {
-	db.db.UnlockGCCachedNode()
+// RUnlockGCCachedNode unlocks the GC lock of CachedNode.
+func (db *cachingDB) RUnlockGCCachedNode() {
+	db.db.RUnlockGCCachedNode()
 }

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -58,8 +58,8 @@ type Database interface {
 	// LockGCCachedNode locks the GC lock of CachedNode.
 	LockGCCachedNode()
 
-	// UnLockGCCachedNode unlocks the GC lock of CachedNode.
-	UnLockGCCachedNode()
+	// UnlockGCCachedNode unlocks the GC lock of CachedNode.
+	UnlockGCCachedNode()
 }
 
 // Trie is a Klaytn Merkle Patricia trie.
@@ -184,7 +184,7 @@ func (db *cachingDB) LockGCCachedNode() {
 	db.db.LockGCCachedNode()
 }
 
-// UnLockGCCachedNode unlocks the GC lock of CachedNode.
-func (db *cachingDB) UnLockGCCachedNode() {
-	db.db.UnLockGCCachedNode()
+// UnlockGCCachedNode unlocks the GC lock of CachedNode.
+func (db *cachingDB) UnlockGCCachedNode() {
+	db.db.UnlockGCCachedNode()
 }

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -54,6 +54,12 @@ type Database interface {
 
 	// TrieDB retrieves the low level trie database used for data storage.
 	TrieDB() *statedb.Database
+
+	// LockGCCachedNode locks the GC lock of CachedNode.
+	LockGCCachedNode()
+
+	// UnLockGCCachedNode unlocks the GC lock of CachedNode.
+	UnLockGCCachedNode()
 }
 
 // Trie is a Klaytn Merkle Patricia trie.
@@ -171,4 +177,14 @@ func (db *cachingDB) ContractCodeSize(codeHash common.Hash) (int, error) {
 // TrieDB retrieves the low level trie database used for data storage.
 func (db *cachingDB) TrieDB() *statedb.Database {
 	return db.db
+}
+
+// LockGCCachedNode locks the GC lock of CachedNode.
+func (db *cachingDB) LockGCCachedNode() {
+	db.db.LockGCCachedNode()
+}
+
+// UnLockGCCachedNode unlocks the GC lock of CachedNode.
+func (db *cachingDB) UnLockGCCachedNode() {
+	db.db.UnLockGCCachedNode()
 }

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -132,9 +132,9 @@ func (self *StateDB) LockGCCachedNode() {
 	self.db.LockGCCachedNode()
 }
 
-// UnLockGCCachedNode unlocks the GC lock of CachedNode.
-func (self *StateDB) UnLockGCCachedNode() {
-	self.db.UnLockGCCachedNode()
+// UnlockGCCachedNode unlocks the GC lock of CachedNode.
+func (self *StateDB) UnlockGCCachedNode() {
+	self.db.UnlockGCCachedNode()
 }
 
 // setError remembers the first non-nil error it is called with.

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -127,6 +127,16 @@ func NewWithCache(root common.Hash, db Database, cachedStateObjects common.Cache
 	}
 }
 
+// LockGCCachedNode locks the GC lock of CachedNode.
+func (self *StateDB) LockGCCachedNode() {
+	self.db.LockGCCachedNode()
+}
+
+// UnLockGCCachedNode unlocks the GC lock of CachedNode.
+func (self *StateDB) UnLockGCCachedNode() {
+	self.db.UnLockGCCachedNode()
+}
+
 // setError remembers the first non-nil error it is called with.
 func (self *StateDB) setError(err error) {
 	if self.dbErr == nil {

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -127,14 +127,14 @@ func NewWithCache(root common.Hash, db Database, cachedStateObjects common.Cache
 	}
 }
 
-// LockGCCachedNode locks the GC lock of CachedNode.
+// RLockGCCachedNode locks the GC lock of CachedNode.
 func (self *StateDB) LockGCCachedNode() {
-	self.db.LockGCCachedNode()
+	self.db.RLockGCCachedNode()
 }
 
-// UnlockGCCachedNode unlocks the GC lock of CachedNode.
+// RUnlockGCCachedNode unlocks the GC lock of CachedNode.
 func (self *StateDB) UnlockGCCachedNode() {
-	self.db.UnlockGCCachedNode()
+	self.db.RUnlockGCCachedNode()
 }
 
 // setError remembers the first non-nil error it is called with.

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -462,10 +462,10 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 	}
 
 	statedb, deferFn, err := api.stateAt(parent, reexec)
+	defer deferFn()
 	if err != nil {
 		return nil, fmt.Errorf("can not get the state of block %#x: %v", parent.Root(), err)
 	}
-	defer deferFn()
 
 	// Execute all the transaction contained within the block concurrently
 	var (
@@ -570,10 +570,10 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 	}
 
 	statedb, deferFn, err := api.stateAt(parent, reexec)
+	defer deferFn()
 	if err != nil {
 		return nil, fmt.Errorf("can not get the state of block %#x: %v", parent.Root(), err)
 	}
-	defer deferFn()
 
 	// Retrieve the tracing configurations, or use default values
 	var (
@@ -810,7 +810,7 @@ func (api *PrivateDebugAPI) stateAt(block *types.Block, reexec uint64) (*state.S
 		logger.Debug("Get stateDB by computeStateDB", "block", block.NumberU64())
 		return stateDB, func() {}, nil
 	}
-	logger.Debug("Get stateDB from stateCache", "block", block.NumberU64())
+	logger.Debug("Get stateDB from stateCache", "block", block.NumberU64(), "reexec", reexec)
 	// During this processing, this lock will prevent to evict the state.
 	return stateDB, stateDB.UnlockGCCachedNode, nil
 }
@@ -828,10 +828,10 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	}
 
 	statedb, deferFn, err := api.stateAt(parent, reexec)
+	defer deferFn()
 	if err != nil {
 		return nil, vm.Context{}, nil, fmt.Errorf("can not get the state of block %#x: %v", parent.Root(), err)
 	}
-	defer deferFn()
 
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(api.config, block.Number())

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -472,7 +472,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		}
 		logger.Debug("Get stateDB by computeStateDB", "block", block.NumberU64())
 	} else {
-		logger.Debug("Get stateDB from stateCache", "block", block.NumberU64(), "&stateDB", fmt.Sprintf("%p", statedb))
+		logger.Debug("Get stateDB from stateCache", "block", block.NumberU64())
 		// During this processing, this lock will prevent to evict the state.
 		defer statedb.UnlockGCCachedNode()
 	}
@@ -590,7 +590,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		}
 		logger.Debug("Get stateDB by computeStateDB", "block", block.NumberU64())
 	} else {
-		logger.Debug("Get stateDB from stateCache", "block", block.NumberU64(), "&stateDB", fmt.Sprintf("%p", statedb))
+		logger.Debug("Get stateDB from stateCache", "block", block.NumberU64())
 		// During this processing, this lock will prevent to evict the state.
 		defer statedb.UnlockGCCachedNode()
 	}

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -838,7 +838,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 		}
 		logger.Debug("Get stateDB by computeStateDB", "block", block.NumberU64())
 	} else {
-		logger.Debug("Get stateDB from stateCache", "block", block.NumberU64(), "&stateDB", fmt.Sprintf("%p", statedb))
+		logger.Debug("Get stateDB from stateCache", "block", block.NumberU64())
 		// During this processing, this lock will prevent to evict the state.
 		defer statedb.UnlockGCCachedNode()
 	}

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -802,13 +802,15 @@ func (api *PrivateDebugAPI) stateAt(block *types.Block, reexec uint64) (*state.S
 	// If we have the state fully available, use that.
 	stateDB, err := api.cn.blockchain.StateAtWithGCLock(block.Root())
 	if err != nil {
+		emptyFn := func() {}
+
 		// If no state is locally available, the desired state will be generated.
 		stateDB, err = api.computeStateDB(block, reexec)
 		if err != nil {
-			return nil, func() {}, err
+			return nil, emptyFn, err
 		}
 		logger.Debug("Get stateDB by computeStateDB", "block", block.NumberU64())
-		return stateDB, func() {}, nil
+		return stateDB, emptyFn, nil
 	}
 	logger.Debug("Get stateDB from stateCache", "block", block.NumberU64(), "reexec", reexec)
 	// During this processing, this lock will prevent to evict the state.

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -474,7 +474,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 	} else {
 		logger.Debug("Get stateDB from stateCache", "block", block.NumberU64(), "&stateDB", fmt.Sprintf("%p", statedb))
 		// During this processing, this lock will prevent to evict the state.
-		defer statedb.UnLockGCCachedNode()
+		defer statedb.UnlockGCCachedNode()
 	}
 
 	// Execute all the transaction contained within the block concurrently
@@ -592,7 +592,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 	} else {
 		logger.Debug("Get stateDB from stateCache", "block", block.NumberU64(), "&stateDB", fmt.Sprintf("%p", statedb))
 		// During this processing, this lock will prevent to evict the state.
-		defer statedb.UnLockGCCachedNode()
+		defer statedb.UnlockGCCachedNode()
 	}
 
 	// Retrieve the tracing configurations, or use default values
@@ -840,7 +840,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	} else {
 		logger.Debug("Get stateDB from stateCache", "block", block.NumberU64(), "&stateDB", fmt.Sprintf("%p", statedb))
 		// During this processing, this lock will prevent to evict the state.
-		defer statedb.UnLockGCCachedNode()
+		defer statedb.UnlockGCCachedNode()
 	}
 
 	// Recompute transactions up to the target index.

--- a/node/cn/api_tracer_test.go
+++ b/node/cn/api_tracer_test.go
@@ -193,7 +193,7 @@ func TestPrivateDebugAPI_StandardTraceBadBlockToFile(t *testing.T) {
 
 func TestPrivateDebugAPI_computeTxEnv(t *testing.T) {
 	parentBlock := newBlock(122)
-	block := newBlock(123)
+	block := newBlockWithParentHash(123, parentBlock.Hash())
 	blockHash := block.Hash()
 	txIndex := 0
 	reexec := uint64(0)
@@ -211,18 +211,6 @@ func TestPrivateDebugAPI_computeTxEnv(t *testing.T) {
 		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
 		mockBlockChain.EXPECT().GetBlockByHash(blockHash).Return(block).Times(1)
 		mockBlockChain.EXPECT().GetBlock(block.ParentHash(), block.NumberU64()-1).Return(nil).Times(1)
-		msg, ctx, stateDB, err := api.computeTxEnv(blockHash, txIndex, reexec)
-		assert.Nil(t, msg)
-		assert.Equal(t, vm.Context{}, ctx)
-		assert.Nil(t, stateDB)
-		assert.Error(t, err)
-		mockCtrl.Finish()
-	}
-	{
-		mockCtrl, api, _, mockBlockChain, _ := createCNMocks(t)
-		mockBlockChain.EXPECT().GetBlockByHash(blockHash).Return(block).Times(1)
-		mockBlockChain.EXPECT().GetBlock(block.ParentHash(), block.NumberU64()-1).Return(block).Times(1)
-		mockBlockChain.EXPECT().StateAt(parentBlock.Root()).Return(nil, expectedErr).Times(1)
 		msg, ctx, stateDB, err := api.computeTxEnv(blockHash, txIndex, reexec)
 		assert.Nil(t, msg)
 		assert.Equal(t, vm.Context{}, ctx)

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -112,6 +112,24 @@ func newBlock(blockNum int) *types.Block {
 	return block
 }
 
+func newBlockWithParentHash(blockNum int, parentHash common.Hash) *types.Block {
+	header := &types.Header{
+		Number:     big.NewInt(int64(blockNum)),
+		BlockScore: big.NewInt(int64(1)),
+		Extra:      addrs[0][:],
+		Governance: addrs[0][:],
+		Vote:       addrs[0][:],
+		ParentHash: parentHash,
+	}
+	header.Hash()
+	block := types.NewBlockWithHeader(header)
+	block = block.WithBody(types.Transactions{})
+	block.Hash()
+	block.Size()
+	block.BlockScore()
+	return block
+}
+
 func newReceipt(gasUsed int) *types.Receipt {
 	rct := types.NewReceipt(uint(gasUsed), common.Hash{}, uint64(gasUsed))
 	rct.Logs = []*types.Log{}

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -345,8 +345,8 @@ func (db *Database) LockGCCachedNode() {
 	db.gcLock.Lock()
 }
 
-// UnLockGCCachedNode unlocks the GC lock of CachedNode.
-func (db *Database) UnLockGCCachedNode() {
+// UnlockGCCachedNode unlocks the GC lock of CachedNode.
+func (db *Database) UnlockGCCachedNode() {
 	db.gcLock.Unlock()
 }
 

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -487,10 +487,12 @@ func (db *Database) Node(hash common.Hash) ([]byte, error) {
 	return enc, err
 }
 
-// DoesExistCachedNode return if the noce exist from cached trie node in memory.
+// DoesExistCachedNode returns if the node exists on cached trie node in memory.
 func (db *Database) DoesExistCachedNode(hash common.Hash) bool {
 	// Retrieve the node from cache if available
+	db.lock.RLock()
 	_, ok := db.nodes[hash]
+	db.lock.RUnlock()
 	return ok
 }
 

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -98,7 +98,7 @@ type Database struct {
 	gctime  time.Duration      // Time spent on garbage collection since last commit
 	gcnodes uint64             // Nodes garbage collected since last commit
 	gcsize  common.StorageSize // Data storage garbage collected since last commit
-	gcLock  sync.Mutex         // Lock for preventing to garbage collect cachedNode without flushing.
+	gcLock  sync.RWMutex       // Lock for preventing to garbage collect cachedNode without flushing.
 
 	flushtime  time.Duration      // Time spent on data flushing since last commit
 	flushnodes uint64             // Nodes flushed since last commit
@@ -340,14 +340,14 @@ func (db *Database) DiskDB() database.DBManager {
 	return db.diskDB
 }
 
-// LockGCCachedNode locks the GC lock of CachedNode.
-func (db *Database) LockGCCachedNode() {
-	db.gcLock.Lock()
+// RLockGCCachedNode locks the GC lock of CachedNode.
+func (db *Database) RLockGCCachedNode() {
+	db.gcLock.RLock()
 }
 
-// UnlockGCCachedNode unlocks the GC lock of CachedNode.
-func (db *Database) UnlockGCCachedNode() {
-	db.gcLock.Unlock()
+// RUnlockGCCachedNode unlocks the GC lock of CachedNode.
+func (db *Database) RUnlockGCCachedNode() {
+	db.gcLock.RUnlock()
 }
 
 // InsertBlob writes a new reference tracked blob to the memory database if it's

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -98,7 +98,7 @@ type Database struct {
 	gctime  time.Duration      // Time spent on garbage collection since last commit
 	gcnodes uint64             // Nodes garbage collected since last commit
 	gcsize  common.StorageSize // Data storage garbage collected since last commit
-	gcLock  sync.RWMutex       // Lock for preventing to garbage collect cachedNode without flushing.
+	gcLock  sync.RWMutex       // Lock for preventing to garbage collect cachedNode without flushing
 
 	flushtime  time.Duration      // Time spent on data flushing since last commit
 	flushnodes uint64             // Nodes flushed since last commit

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -688,6 +688,21 @@ func (mr *MockBlockChainMockRecorder) StateAt(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateAt", reflect.TypeOf((*MockBlockChain)(nil).StateAt), arg0)
 }
 
+// StateAtWithGCLock mocks base method
+func (m *MockBlockChain) StateAtWithGCLock(arg0 common.Hash) (*state.StateDB, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StateAtWithGCLock", arg0)
+	ret0, _ := ret[0].(*state.StateDB)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StateAtWithGCLock indicates an expected call of StateAtWithGCLock
+func (mr *MockBlockChainMockRecorder) StateAtWithGCLock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateAtWithGCLock", reflect.TypeOf((*MockBlockChain)(nil).StateAtWithGCLock), arg0)
+}
+
 // StateCache mocks base method
 func (m *MockBlockChain) StateCache() state.Database {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -215,7 +215,7 @@ func (self *Miner) PendingBlock() *types.Block {
 	return self.worker.pendingBlock()
 }
 
-//go:generate mockgen -destination=work/mocks/blockchain_mock.go -package=mocks github.com/klaytn/klaytn/work BlockChain
+//go:generate mockgen -destination=mocks/blockchain_mock.go -package=mocks github.com/klaytn/klaytn/work BlockChain
 // BlockChain is an interface of blockchain.BlockChain used by ProtocolManager.
 type BlockChain interface {
 	Genesis() *types.Block

--- a/work/work.go
+++ b/work/work.go
@@ -269,6 +269,7 @@ type BlockChain interface {
 	Processor() blockchain.Processor
 	BadBlocks() ([]blockchain.BadBlockArgs, error)
 	StateAt(root common.Hash) (*state.StateDB, error)
+	StateAtWithGCLock(root common.Hash) (*state.StateDB, error)
 	Export(w io.Writer) error
 	Engine() consensus.Engine
 	GetNonceInCache(addr common.Address) (uint64, bool)


### PR DESCRIPTION
## Proposed changes

This PR resolves https://github.com/klaytn/klaytn/issues/432 without increasing `triesInMemory`.
This added a lock for GC cachedNode.

During `traceBlock`, this GCLock can prevent to gc the cachedNode in the stateDB.

Also this added some exception code for error case of `AsMessageWithAccountKeyPicker` during `traceBlock`, `traceXXXX`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/klaytn/klaytn/issues/432

## Further comments

After this PR, I will rename caches related with state trie later.
