### PR TITLE
[DO NOT MERGE] Allocate BigCache scaling to physical memory size

### DIFF
--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -105,7 +105,7 @@ type Trie interface {
 // concurrent use, but does not retain any recent trie nodes in memory. To keep some
 // historical state in memory, use the NewDatabaseWithCache constructor.
 func NewDatabase(db database.DBManager) Database {
-	return NewDatabaseWithCache(db, -1, 0)
+	return NewDatabaseWithCache(db, 0, 0)
 }
 
 // NewDatabaseWithCache creates a backing store for state. The returned database

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -105,7 +105,7 @@ type Trie interface {
 // concurrent use, but does not retain any recent trie nodes in memory. To keep some
 // historical state in memory, use the NewDatabaseWithCache constructor.
 func NewDatabase(db database.DBManager) Database {
-	return NewDatabaseWithCache(db, 0, 0)
+	return NewDatabaseWithCache(db, -1, 0)
 }
 
 // NewDatabaseWithCache creates a backing store for state. The returned database

--- a/build/packaging/linux/conf/kcnd.conf
+++ b/build/packaging/linux/conf/kcnd.conf
@@ -48,7 +48,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--state.trie-cache-limit 8192"
+ADDITIONAL=""
 
 DATA_DIR=
 LOG_DIR=$DATA_DIR/logs

--- a/build/packaging/linux/conf/kcnd_baobab.conf
+++ b/build/packaging/linux/conf/kcnd_baobab.conf
@@ -48,7 +48,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--state.trie-cache-limit 8192"
+ADDITIONAL=""
 
 DATA_DIR=
 LOG_DIR=$DATA_DIR/logs

--- a/build/packaging/windows/conf/kcn-conf.cmd
+++ b/build/packaging/windows/conf/kcn-conf.cmd
@@ -40,7 +40,7 @@ set DB_NO_PARALLEL_WRITE=0
 set MULTICHANNEL=1
 
 REM Raw options e.g) "--txpool.nolocals"
-set ADDITIONAL="--state.trie-cache-limit 8192"
+set ADDITIONAL=""
 
 set KLAY_HOME=%homepath%\.kcn
 

--- a/build/rpm/etc/kcnd/conf/kcnd.conf
+++ b/build/rpm/etc/kcnd/conf/kcnd.conf
@@ -48,7 +48,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--state.trie-cache-limit 8192"
+ADDITIONAL=""
 
 DATA_DIR=/var/kcnd/data
 LOG_DIR=/var/log/kcnd

--- a/build/rpm/etc/kcnd/conf/kcnd_baobab.conf
+++ b/build/rpm/etc/kcnd/conf/kcnd_baobab.conf
@@ -48,7 +48,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--state.trie-cache-limit 8192"
+ADDITIONAL=""
 
 DATA_DIR=/var/kcnd/data
 LOG_DIR=/var/log/kcnd

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -251,7 +251,8 @@ var (
 	}
 	TrieCacheLimitFlag = cli.IntFlag{
 		Name:  "state.trie-cache-limit",
-		Usage: "Memory allowance (MB) to use for caching trie nodes in memory",
+		Usage: "Memory allowance (MB) to use for caching trie nodes in memory. -1 is for auto-scaling",
+		Value: -1,
 	}
 
 	SenderTxHashIndexingFlag = cli.BoolFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -252,7 +252,6 @@ var (
 	TrieCacheLimitFlag = cli.IntFlag{
 		Name:  "state.trie-cache-limit",
 		Usage: "Memory allowance (MB) to use for caching trie nodes in memory",
-		Value: 4096,
 	}
 
 	SenderTxHashIndexingFlag = cli.BoolFlag{

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -75,6 +75,10 @@ const commitResultChSizeLimit = 100 * 10000
 // do not need preparation of data archiving.
 const NoDataArchivingPreparation = 0
 
+// AutoScaling is for auto-scaling cache size. If cacheSize is set to this value,
+// cache size is set scaling to physical memeory
+const AutoScaling = -1
+
 type DatabaseReader interface {
 	// Get retrieves the value associated with key from the database.
 	Get(key []byte) (value []byte, err error)
@@ -309,7 +313,7 @@ func (t trieNodeHasher) Sum64(key string) uint64 {
 // NewDatabase creates a new trie database to store ephemeral trie content before
 // its written out to disk or garbage collected.
 func NewDatabase(diskDB database.DBManager) *Database {
-	return NewDatabaseWithCache(diskDB, -1, 0)
+	return NewDatabaseWithCache(diskDB, 0, 0)
 }
 
 // NewDatabaseWithCache creates a new trie database to store ephemeral trie content
@@ -317,7 +321,7 @@ func NewDatabase(diskDB database.DBManager) *Database {
 // for nodes loaded from disk.
 func NewDatabaseWithCache(diskDB database.DBManager, cacheSizeMB int, daBlockNum uint64) *Database {
 	var trieNodeCache *bigcache.BigCache
-	if cacheSizeMB == 0 {
+	if cacheSizeMB == AutoScaling {
 		cacheSizeMB = getTrieNodeCacheSizeMB()
 	}
 	if cacheSizeMB > 0 {

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -317,11 +317,12 @@ func NewDatabase(diskDB database.DBManager) *Database {
 func NewDatabaseWithCache(diskDB database.DBManager, cacheSize int, daBlockNum uint64) *Database {
 	var trieNodeCache *bigcache.BigCache
 	if cacheSize > 0 {
+		maxEntrySize := 512
 		trieNodeCache, _ = bigcache.NewBigCache(bigcache.Config{
 			Shards:             1024,
-			LifeWindow:         time.Hour,
-			MaxEntriesInWindow: cacheSize * 1024,
-			MaxEntrySize:       512,
+			LifeWindow:         time.Hour * 24 * 365 * 200,
+			MaxEntriesInWindow: cacheSize * 1024 * 1024 / maxEntrySize,
+			MaxEntrySize:       maxEntrySize,
 			HardMaxCacheSize:   cacheSize,
 			Hasher:             trieNodeHasher{},
 		})

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -316,16 +316,9 @@ func NewDatabase(diskDB database.DBManager) *Database {
 // for nodes loaded from disk.
 func NewDatabaseWithCache(diskDB database.DBManager, cacheSize int, daBlockNum uint64) *Database {
 	var trieNodeCache *bigcache.BigCache
-	if cacheSize >= 0 {
+	if cacheSize > 0 {
 		if cacheSize == 0 {
-			totalPhysicalMem := float32(common.TotalPhysicalMemGB)
-			var cacheSizeGB float32
-			if totalPhysicalMem/4 < 2.5 {
-				cacheSizeGB = totalPhysicalMem - 2.5
-			} else {
-				cacheSizeGB = totalPhysicalMem * 3 / 4
-			}
-			cacheSize = int(cacheSizeGB * 1024)
+			cacheSize = getCacheSize()
 		}
 		maxEntrySize := 512
 		trieNodeCache, _ = bigcache.NewBigCache(bigcache.Config{
@@ -344,6 +337,17 @@ func NewDatabaseWithCache(diskDB database.DBManager, cacheSize int, daBlockNum u
 		trieNodeCache:         trieNodeCache,
 		dataArchivingBlockNum: daBlockNum,
 	}
+}
+
+func getCacheSize() int {
+	totalPhysicalMem := float32(common.TotalPhysicalMemGB)
+	var cacheSizeGB float32
+	if totalPhysicalMem/4 < 2.5 {
+		cacheSizeGB = totalPhysicalMem - 2.5
+	} else {
+		cacheSizeGB = totalPhysicalMem * 3 / 4
+	}
+	return int(cacheSizeGB * 1024)
 }
 
 // DiskDB retrieves the persistent database backing the trie database.

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -944,6 +944,10 @@ func (db *Database) Size() (common.StorageSize, common.StorageSize) {
 	return db.nodesSize + flushlistSize, db.preimagesSize
 }
 
+func (db *Database) CacheSize() int {
+	return db.trieNodeCache.Capacity()
+}
+
 // verifyIntegrity is a debug method to iterate over the entire trie stored in
 // memory and check whether every node is reachable from the meta root. The goal
 // is to find any errors that might cause memory leaks and or trie nodes to go

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -330,7 +330,7 @@ func NewDatabaseWithCache(diskDB database.DBManager, cacheSizeMB int, daBlockNum
 			HardMaxCacheSize:   cacheSizeMB,
 			Hasher:             trieNodeHasher{},
 		})
-		logger.Debug("Initialize BigCache", "HardMaxCacheSize", cacheSizeMB, "Shards", shards, "MaxEntrySize", maxEntrySizeByte)
+		logger.Debug("Initialize BigCache", "HardMaxCacheSize", cacheSizeMB, "MaxEntrySize", maxEntrySizeByte)
 	}
 	return &Database{
 		diskDB:                diskDB,

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -349,9 +349,10 @@ func NewDatabaseWithCache(diskDB database.DBManager, cacheSizeMB int, daBlockNum
 // getTrieNodeCacheSizeMB retrieves size for trie cache
 func getTrieNodeCacheSizeMB() int {
 	totalPhysicalMem := float64(common.TotalPhysicalMemGB)
-	memoryMarginGB := 20.0
+	memoryMarginGB := 20.0    // margin for processing and other cache
+	memoryScalePercent := 0.6 // leave margin proportional to physical memory size
 
-	cacheSizeGB := math.Max((totalPhysicalMem-memoryMarginGB)*0.6, 0.0)
+	cacheSizeGB := math.Max((totalPhysicalMem-memoryMarginGB)*memoryScalePercent, 0.0)
 
 	return int(cacheSizeGB * 1024)
 }

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -86,7 +86,8 @@ func TestDatabase_DeReference(t *testing.T) {
 
 func TestDatabase_Size(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithCache(memDB, 128, 0)
+	cacheSizeMB := 128
+	db := NewDatabaseWithCache(memDB, cacheSizeMB, 0)
 
 	totalMemorySize, preimagesSize := db.Size()
 	assert.Equal(t, common.StorageSize(0), totalMemorySize)
@@ -107,6 +108,9 @@ func TestDatabase_Size(t *testing.T) {
 	totalMemorySize, preimagesSize = db.Size()
 	assert.Equal(t, common.StorageSize(128), totalMemorySize)
 	assert.Equal(t, common.StorageSize(100), preimagesSize)
+
+	cacheSize := db.CacheSize()
+	assert.Equal(t, cacheSizeMB*1024*1024, cacheSize)
 }
 
 func TestDatabase_SecureKey(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

- The default size of Bigcache is not static. It is set in proportion to physical memory size of server.
- The initial cache size is identical to `cacheSize`.
- Bigcache will have 200 years of LifeWindow.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
