### PR TITLE
Fix an expected error string in a test case

### DIFF
--- a/networks/p2p/discover/node_test.go
+++ b/networks/p2p/discover/node_test.go
@@ -220,7 +220,7 @@ var parseNodeTests = []struct {
 	{
 		// This test checks that errors from url.Parse are handled.
 		rawurl:    "://foo",
-		wantError: `parse ://foo: missing protocol scheme`,
+		wantError: `missing protocol scheme`,
 	},
 }
 


### PR DESCRIPTION
## Proposed changes

In `net/url` package, url parsing error message formats are changed to add quotes on invalid URLs.
The change (https://github.com/golang/go/commit/64cfe9fe22113cd6bc05a2c5d0cbe872b1b57860) was applied on golang 1.14 which is going to be adopted to Klaytn. 

Because of the change, Klaytn with golang 1.14.1 causes a trivial error on a test case like the following.
```
--- FAIL: TestParseNode (0.00s)
    node_test.go:243: test "://foo":
          got error `parse "://foo": missing protocol scheme`, expected `parse ://foo: missing protocol scheme`
FAIL
```

This PR changes an expected error message of the test case to be compatible with golang v1.14.1. 


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules


