### PR TITLE
Bigcache size up 

### DIFF
--- a/build/packaging/linux/conf/kcnd.conf
+++ b/build/packaging/linux/conf/kcnd.conf
@@ -48,7 +48,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--state.trie-cache-limit 8192"
+ADDITIONAL="--state.trie-cache-limit 30720"
 
 DATA_DIR=
 LOG_DIR=$DATA_DIR/logs

--- a/build/packaging/linux/conf/kcnd_baobab.conf
+++ b/build/packaging/linux/conf/kcnd_baobab.conf
@@ -48,7 +48,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--state.trie-cache-limit 8192"
+ADDITIONAL="--state.trie-cache-limit 30720"
 
 DATA_DIR=
 LOG_DIR=$DATA_DIR/logs

--- a/build/packaging/linux/conf/kpnd.conf
+++ b/build/packaging/linux/conf/kpnd.conf
@@ -47,7 +47,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--txpool.nolocals"
+ADDITIONAL="--txpool.nolocals --state.trie-cache-limit 30720"
 
 DATA_DIR=
 LOG_DIR=$DATA_DIR/logs

--- a/build/packaging/linux/conf/kpnd_baobab.conf
+++ b/build/packaging/linux/conf/kpnd_baobab.conf
@@ -47,7 +47,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--txpool.nolocals"
+ADDITIONAL="--txpool.nolocals --state.trie-cache-limit 30720"
 
 DATA_DIR=
 LOG_DIR=$DATA_DIR/logs

--- a/build/packaging/linux/conf/kspnd.conf
+++ b/build/packaging/linux/conf/kspnd.conf
@@ -58,7 +58,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--txpool.nolocals"
+ADDITIONAL="--txpool.nolocals --state.trie-cache-limit 30720"
 
 DATA_DIR=
 LOG_DIR=$DATA_DIR/logs

--- a/build/packaging/windows/conf/kcn-conf.cmd
+++ b/build/packaging/windows/conf/kcn-conf.cmd
@@ -40,7 +40,7 @@ set DB_NO_PARALLEL_WRITE=0
 set MULTICHANNEL=1
 
 REM Raw options e.g) "--txpool.nolocals"
-set ADDITIONAL="--state.trie-cache-limit 8192"
+set ADDITIONAL="--state.trie-cache-limit 30720"
 
 set KLAY_HOME=%homepath%\.kcn
 

--- a/build/packaging/windows/conf/kpn-conf.cmd
+++ b/build/packaging/windows/conf/kpn-conf.cmd
@@ -39,7 +39,7 @@ set DB_NO_PARALLEL_WRITE=0
 set MULTICHANNEL=1
 
 REM Raw options e.g) "--txpool.nolocals"
-set ADDITIONAL="--txpool.nolocals"
+set ADDITIONAL="--txpool.nolocals --state.trie-cache-limit 30720"
 
 set KLAY_HOME=%homepath%\.kpn
 

--- a/build/rpm/etc/kcnd/conf/kcnd.conf
+++ b/build/rpm/etc/kcnd/conf/kcnd.conf
@@ -48,7 +48,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--state.trie-cache-limit 8192"
+ADDITIONAL="--state.trie-cache-limit 30720"
 
 DATA_DIR=/var/kcnd/data
 LOG_DIR=/var/log/kcnd

--- a/build/rpm/etc/kcnd/conf/kcnd_baobab.conf
+++ b/build/rpm/etc/kcnd/conf/kcnd_baobab.conf
@@ -48,7 +48,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--state.trie-cache-limit 8192"
+ADDITIONAL="--state.trie-cache-limit 30720"
 
 DATA_DIR=/var/kcnd/data
 LOG_DIR=/var/log/kcnd

--- a/build/rpm/etc/kpnd/conf/kpnd.conf
+++ b/build/rpm/etc/kpnd/conf/kpnd.conf
@@ -47,7 +47,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--txpool.nolocals"
+ADDITIONAL="--txpool.nolocals --state.trie-cache-limit 30720"
 
 DATA_DIR=/var/kpnd/data
 LOG_DIR=/var/log/kpnd

--- a/build/rpm/etc/kpnd/conf/kpnd_baobab.conf
+++ b/build/rpm/etc/kpnd/conf/kpnd_baobab.conf
@@ -47,7 +47,7 @@ NO_DISCOVER=0 # setting 1 to disable discovery
 BOOTNODES=""
 
 # Raw options e.g) "--txpool.nolocals"
-ADDITIONAL="--txpool.nolocals"
+ADDITIONAL="--txpool.nolocals --state.trie-cache-limit 30720"
 
 DATA_DIR=/var/kpnd/data
 LOG_DIR=/var/log/kpnd

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -252,7 +252,7 @@ var (
 	TrieCacheLimitFlag = cli.IntFlag{
 		Name:  "state.trie-cache-limit",
 		Usage: "Memory allowance (MB) to use for caching trie nodes in memory",
-		Value: 4096,
+		Value: 6144,
 	}
 
 	SenderTxHashIndexingFlag = cli.BoolFlag{

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -931,6 +931,10 @@ func (db *Database) Size() (common.StorageSize, common.StorageSize) {
 	return db.nodesSize + flushlistSize, db.preimagesSize
 }
 
+func (db *Database) CacheSize() int {
+	return db.trieNodeCache.Capacity()
+}
+
 // verifyIntegrity is a debug method to iterate over the entire trie stored in
 // memory and check whether every node is reachable from the meta root. The goal
 // is to find any errors that might cause memory leaks and or trie nodes to go

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -86,7 +86,8 @@ func TestDatabase_DeReference(t *testing.T) {
 
 func TestDatabase_Size(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithCache(memDB, 128, 0)
+	cacheSizeMB := 128
+	db := NewDatabaseWithCache(memDB, cacheSizeMB, 0)
 
 	totalMemorySize, preimagesSize := db.Size()
 	assert.Equal(t, common.StorageSize(0), totalMemorySize)
@@ -107,6 +108,9 @@ func TestDatabase_Size(t *testing.T) {
 	totalMemorySize, preimagesSize = db.Size()
 	assert.Equal(t, common.StorageSize(128), totalMemorySize)
 	assert.Equal(t, common.StorageSize(100), preimagesSize)
+
+	cacheSize := db.CacheSize()
+	assert.Equal(t, cacheSizeMB*1024*1024, cacheSize)
 }
 
 func TestDatabase_SecureKey(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

- The default size of Bigcache is increased. (CN/PN: 30G, EN:6G)
- The initial cache size is identical to `cacheSize`.
- Bigcache will have 200 years of LifeWindow.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

The bigger bigcache size is, lesser the disk access happens. Therefore there is an improvement in TPS.

