### PR TITLE
Klaytn node is able to restart by itself

### DIFF
--- a/build/packaging/linux/bin/kbnd
+++ b/build/packaging/linux/bin/kbnd
@@ -79,6 +79,10 @@ start() {
         OPTIONS="$OPTIONS --datadir $DATA_DIR"
     fi
 
+    BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+    CURRENTFILE=`basename "$0"`
+    OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
+
     $BIN/kbn ${OPTIONS} >> ${LOG_DIR}/kbnd.out 2>&1 &
     RETVAL=$?
     PIDNUM=$!

--- a/build/packaging/linux/bin/kcnd
+++ b/build/packaging/linux/bin/kcnd
@@ -196,6 +196,10 @@ start() {
         OPTIONS="$OPTIONS --rewardbase $REWARDBASE"
     fi
 
+    BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+    CURRENTFILE=`basename "$0"`
+    OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
+
     $BIN/kcn $OPTIONS >> ${LOG_DIR}/kcnd.out 2>&1 &
     RETVAL=$?
     PIDNUM=$!

--- a/build/packaging/linux/bin/kcnd
+++ b/build/packaging/linux/bin/kcnd
@@ -196,6 +196,10 @@ start() {
         OPTIONS="$OPTIONS --rewardbase $REWARDBASE"
     fi
 
+    if [[ ! -z $AUTO_RESTART ]] && [[ $AUTO_RESTART -eq 1 ]]; then
+        OPTIONS="$OPTIONS --auto.restart"
+    fi
+
     BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
     CURRENTFILE=`basename "$0"`
     OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"

--- a/build/packaging/linux/bin/kend
+++ b/build/packaging/linux/bin/kend
@@ -199,6 +199,10 @@ start() {
         OPTIONS="$OPTIONS $ADDITIONAL"
     fi
 
+    if [[ ! -z $AUTO_RESTART ]] && [[ $AUTO_RESTART -eq 1 ]]; then
+        OPTIONS="$OPTIONS --auto.restart"
+    fi
+
     BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
     CURRENTFILE=`basename "$0"`
     OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"

--- a/build/packaging/linux/bin/kend
+++ b/build/packaging/linux/bin/kend
@@ -199,6 +199,10 @@ start() {
         OPTIONS="$OPTIONS $ADDITIONAL"
     fi
 
+    BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+    CURRENTFILE=`basename "$0"`
+    OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
+
     $BIN/ken $OPTIONS >> ${LOG_DIR}/kend.out 2>&1 &
     RETVAL=$?
     PIDNUM=$!

--- a/build/packaging/linux/bin/kpnd
+++ b/build/packaging/linux/bin/kpnd
@@ -192,6 +192,10 @@ start() {
         OPTIONS="$OPTIONS $ADDITIONAL"
     fi
 
+    BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+    CURRENTFILE=`basename "$0"`
+    OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
+
     $BIN/kpn $OPTIONS >> ${LOG_DIR}/kpnd.out 2>&1 &
     RETVAL=$?
     PIDNUM=$!

--- a/build/packaging/linux/bin/kscnd
+++ b/build/packaging/linux/bin/kscnd
@@ -192,6 +192,10 @@ start() {
         OPTIONS="$OPTIONS $ADDITIONAL"
     fi
 
+    if [[ ! -z $AUTO_RESTART ]] && [[ $AUTO_RESTART -eq 1 ]]; then
+        OPTIONS="$OPTIONS --auto.restart"
+    fi
+
     BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
     CURRENTFILE=`basename "$0"`
     OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"

--- a/build/packaging/linux/bin/kscnd
+++ b/build/packaging/linux/bin/kscnd
@@ -192,6 +192,10 @@ start() {
         OPTIONS="$OPTIONS $ADDITIONAL"
     fi
 
+    BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+    CURRENTFILE=`basename "$0"`
+    OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
+
     $BIN/kscn $OPTIONS >> ${LOG_DIR}/kscnd.out 2>&1 &
     RETVAL=$?
     PIDNUM=$!

--- a/build/packaging/linux/bin/ksend
+++ b/build/packaging/linux/bin/ksend
@@ -202,6 +202,10 @@ start() {
         OPTIONS="$OPTIONS $ADDITIONAL"
     fi
 
+    if [[ ! -z $AUTO_RESTART ]] && [[ $AUTO_RESTART -eq 1 ]]; then
+        OPTIONS="$OPTIONS --auto.restart"
+    fi
+
     BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
     CURRENTFILE=`basename "$0"`
     OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"

--- a/build/packaging/linux/bin/ksend
+++ b/build/packaging/linux/bin/ksend
@@ -202,6 +202,10 @@ start() {
         OPTIONS="$OPTIONS $ADDITIONAL"
     fi
 
+    BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+    CURRENTFILE=`basename "$0"`
+    OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
+
     $BIN/ksen $OPTIONS >> ${LOG_DIR}/ksend.out 2>&1 &
     RETVAL=$?
     PIDNUM=$!

--- a/build/packaging/linux/bin/kspnd
+++ b/build/packaging/linux/bin/kspnd
@@ -202,6 +202,10 @@ start() {
         OPTIONS="$OPTIONS $ADDITIONAL"
     fi
 
+    BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+    CURRENTFILE=`basename "$0"`
+    OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
+
     $BIN/kspn $OPTIONS >> ${LOG_DIR}/kspnd.out 2>&1 &
     RETVAL=$?
     PIDNUM=$!

--- a/build/packaging/linux/conf/kcnd.conf
+++ b/build/packaging/linux/conf/kcnd.conf
@@ -37,6 +37,7 @@ WS_PORT=8552
 WS_ORIGINS="*"
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/build/packaging/linux/conf/kcnd_baobab.conf
+++ b/build/packaging/linux/conf/kcnd_baobab.conf
@@ -37,6 +37,7 @@ WS_PORT=8552
 WS_ORIGINS="*"
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/build/packaging/linux/conf/kend.conf
+++ b/build/packaging/linux/conf/kend.conf
@@ -40,6 +40,7 @@ SC_MAIN_BRIDGE_PORT=50505
 SC_MAIN_BRIDGE_INDEXING=0  # this option will be deprecated.
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/build/packaging/linux/conf/kend_baobab.conf
+++ b/build/packaging/linux/conf/kend_baobab.conf
@@ -40,6 +40,7 @@ SC_MAIN_BRIDGE_PORT=50505
 SC_MAIN_BRIDGE_INDEXING=0 # this option will be deprecated.
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/build/packaging/linux/conf/kscnd.conf
+++ b/build/packaging/linux/conf/kscnd.conf
@@ -46,6 +46,7 @@ SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 NO_DISCOVER=1

--- a/build/packaging/linux/conf/ksend.conf
+++ b/build/packaging/linux/conf/ksend.conf
@@ -45,6 +45,7 @@ SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/build/rpm/etc/init.d/kbnd
+++ b/build/rpm/etc/init.d/kbnd
@@ -69,6 +69,10 @@ start() {
             OPTIONS="$OPTIONS $ADDITIONAL"
         fi
 
+        BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+        CURRENTFILE=`basename "$0"`
+        OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
+
         $kbn ${OPTIONS} >> ${LOG_DIR}/kbnd.out 2>&1 &
         RETVAL=$?
         PIDNUM=$!

--- a/build/rpm/etc/init.d/kcnd
+++ b/build/rpm/etc/init.d/kcnd
@@ -169,6 +169,10 @@ if [[ ! -z $REWARDBASE ]] && [[ $REWARDBASE != "" ]]; then
     OPTIONS="$OPTIONS --rewardbase $REWARDBASE"
 fi
 
+if [[ ! -z $AUTO_RESTART ]] && [[ $AUTO_RESTART -eq 1 ]]; then
+    OPTIONS="$OPTIONS --auto.restart"
+fi
+
 BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 CURRENTFILE=`basename "$0"`
 OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"

--- a/build/rpm/etc/init.d/kcnd
+++ b/build/rpm/etc/init.d/kcnd
@@ -168,6 +168,10 @@ fi
 if [[ ! -z $REWARDBASE ]] && [[ $REWARDBASE != "" ]]; then
     OPTIONS="$OPTIONS --rewardbase $REWARDBASE"
 fi
+
+BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+CURRENTFILE=`basename "$0"`
+OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
 set +f
 
 start() {

--- a/build/rpm/etc/init.d/kend
+++ b/build/rpm/etc/init.d/kend
@@ -171,6 +171,10 @@ fi
 if [[ ! -z $ADDITIONAL ]] && [[ $ADDITIONAL != "" ]]; then
     OPTIONS="$OPTIONS $ADDITIONAL"
 fi
+
+BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+CURRENTFILE=`basename "$0"`
+OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
 set +f
 
 start() {

--- a/build/rpm/etc/init.d/kend
+++ b/build/rpm/etc/init.d/kend
@@ -172,6 +172,10 @@ if [[ ! -z $ADDITIONAL ]] && [[ $ADDITIONAL != "" ]]; then
     OPTIONS="$OPTIONS $ADDITIONAL"
 fi
 
+if [[ ! -z $AUTO_RESTART ]] && [[ $AUTO_RESTART -eq 1 ]]; then
+    OPTIONS="$OPTIONS --auto.restart"
+fi
+
 BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 CURRENTFILE=`basename "$0"`
 OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"

--- a/build/rpm/etc/init.d/kpnd
+++ b/build/rpm/etc/init.d/kpnd
@@ -164,6 +164,10 @@ fi
 if [[ ! -z $ADDITIONAL ]] && [[ $ADDITIONAL != "" ]]; then
     OPTIONS="$OPTIONS $ADDITIONAL"
 fi
+
+BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+CURRENTFILE=`basename "$0"`
+OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
 set +f
 
 start() {

--- a/build/rpm/etc/init.d/kscnd
+++ b/build/rpm/etc/init.d/kscnd
@@ -164,6 +164,10 @@ fi
 if [[ ! -z $ADDITIONAL ]] && [[ $ADDITIONAL != "" ]]; then
     OPTIONS="$OPTIONS $ADDITIONAL"
 fi
+
+BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+CURRENTFILE=`basename "$0"`
+OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
 set +f
 
 start() {

--- a/build/rpm/etc/init.d/kscnd
+++ b/build/rpm/etc/init.d/kscnd
@@ -165,6 +165,10 @@ if [[ ! -z $ADDITIONAL ]] && [[ $ADDITIONAL != "" ]]; then
     OPTIONS="$OPTIONS $ADDITIONAL"
 fi
 
+if [[ ! -z $AUTO_RESTART ]] && [[ $AUTO_RESTART -eq 1 ]]; then
+    OPTIONS="$OPTIONS --auto.restart"
+fi
+
 BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 CURRENTFILE=`basename "$0"`
 OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"

--- a/build/rpm/etc/init.d/ksend
+++ b/build/rpm/etc/init.d/ksend
@@ -174,6 +174,10 @@ fi
 if [[ ! -z $ADDITIONAL ]] && [[ $ADDITIONAL != "" ]]; then
     OPTIONS="$OPTIONS $ADDITIONAL"
 fi
+
+BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+CURRENTFILE=`basename "$0"`
+OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
 set +f
 
 start() {

--- a/build/rpm/etc/init.d/ksend
+++ b/build/rpm/etc/init.d/ksend
@@ -175,6 +175,10 @@ if [[ ! -z $ADDITIONAL ]] && [[ $ADDITIONAL != "" ]]; then
     OPTIONS="$OPTIONS $ADDITIONAL"
 fi
 
+if [[ ! -z $AUTO_RESTART ]] && [[ $AUTO_RESTART -eq 1 ]]; then
+    OPTIONS="$OPTIONS --auto.restart"
+fi
+
 BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 CURRENTFILE=`basename "$0"`
 OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"

--- a/build/rpm/etc/init.d/kspnd
+++ b/build/rpm/etc/init.d/kspnd
@@ -174,6 +174,10 @@ fi
 if [[ ! -z $ADDITIONAL ]] && [[ $ADDITIONAL != "" ]]; then
     OPTIONS="$OPTIONS $ADDITIONAL"
 fi
+
+BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+CURRENTFILE=`basename "$0"`
+OPTIONS="$OPTIONS --daemon.path $BASEDIR/$CURRENTFILE"
 set +f
 
 start() {

--- a/build/rpm/etc/kcnd/conf/kcnd.conf
+++ b/build/rpm/etc/kcnd/conf/kcnd.conf
@@ -37,6 +37,7 @@ WS_PORT=8552
 WS_ORIGINS="*"
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/build/rpm/etc/kcnd/conf/kcnd_baobab.conf
+++ b/build/rpm/etc/kcnd/conf/kcnd_baobab.conf
@@ -37,6 +37,7 @@ WS_PORT=8552
 WS_ORIGINS="*"
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/build/rpm/etc/kend/conf/kend.conf
+++ b/build/rpm/etc/kend/conf/kend.conf
@@ -40,6 +40,7 @@ SC_MAIN_BRIDGE_PORT=50505
 SC_MAIN_BRIDGE_INDEXING=0  # this option will be deprecated.
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/build/rpm/etc/kend/conf/kend_baobab.conf
+++ b/build/rpm/etc/kend/conf/kend_baobab.conf
@@ -40,6 +40,7 @@ SC_MAIN_BRIDGE_PORT=50505
 SC_MAIN_BRIDGE_INDEXING=0  # this option will be deprecated.
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/build/rpm/etc/kscnd/conf/kscnd.conf
+++ b/build/rpm/etc/kscnd/conf/kscnd.conf
@@ -46,6 +46,7 @@ SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 NO_DISCOVER=1

--- a/build/rpm/etc/ksend/conf/ksend.conf
+++ b/build/rpm/etc/ksend/conf/ksend.conf
@@ -45,6 +45,7 @@ SC_ANCHORING_PERIOD=1
 SC_TX_LIMIT=1000
 
 # Setting 1 is to enable options, otherwise disabled.
+AUTO_RESTART=1
 METRICS=1
 PROMETHEUS=1
 DB_NO_PARALLEL_WRITE=0

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -65,6 +65,10 @@ func StartNode(stack *node.Node) {
 }
 
 func RestartNode(ctx *cli.Context) {
+	if !ctx.GlobalBool(AutoRestartFlag.Name) {
+		return
+	}
+
 	daemonPath := ctx.GlobalString(DaemonPathFlag.Name)
 
 	time.Sleep(100 * time.Second)

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -28,11 +28,14 @@ import (
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/node"
 	"github.com/klaytn/klaytn/ser/rlp"
+	"gopkg.in/urfave/cli.v1"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 )
 
 const (
@@ -59,6 +62,16 @@ func StartNode(stack *node.Node) {
 			}
 		}
 	}()
+}
+
+func RestartNode(ctx *cli.Context) {
+	daemonPath := ctx.GlobalString(DaemonPathFlag.Name)
+
+	time.Sleep(100 * time.Second)
+
+	logger.Info("Restart node", "command", daemonPath+" restart")
+	cmd := exec.Command(daemonPath, "restart")
+	cmd.Run()
 }
 
 func ImportChain(chain *blockchain.BlockChain, fn string) error {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -662,6 +662,10 @@ var (
 		Usage: "Path of node daemon. Used to give signal to kill",
 		Value: "~/klaytn/bin/kend",
 	}
+	AutoRestartFlag = cli.BoolFlag{
+		Name:  "auto.restart",
+		Usage: "Node can restart itself when there is a problem making blocks",
+	}
 	// Data Archiving
 	// TODO-Klaytn-DataArchiving Please note that DataArchivingBlockNumFlag is just for development purpose.
 	DataArchivingBlockNumFlag = cli.Uint64Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -657,6 +657,11 @@ var (
 		Usage: "The maximum difference between current block and event block. 0 means off",
 		Value: 0,
 	}
+	DaemonPathFlag = cli.StringFlag{
+		Name:  "daemon.path",
+		Usage: "Path of node daemon. Used to give signal to kill",
+		Value: "~/klaytn/bin/kend",
+	}
 	// Data Archiving
 	// TODO-Klaytn-DataArchiving Please note that DataArchivingBlockNumFlag is just for development purpose.
 	DataArchivingBlockNumFlag = cli.Uint64Flag{

--- a/cmd/utils/nodecmd/defaultcmd.go
+++ b/cmd/utils/nodecmd/defaultcmd.go
@@ -61,6 +61,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 
 	// Start up the node itself
 	utils.StartNode(stack)
+	go utils.RestartNode(ctx)
 
 	// Unlock any account specifically requested
 	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)

--- a/cmd/utils/nodecmd/flags_test.go
+++ b/cmd/utils/nodecmd/flags_test.go
@@ -766,6 +766,13 @@ var flagsWithValues = []struct {
 		wrongValues: commonTwoErrors,
 		errors:      []int{ErrorInvalidValue, ErrorInvalidValue},
 	},
+	{
+		flag:        "--daemon.path",
+		flagType:    FlagTypeArgument,
+		values:      []string{"~/klaytn/bin/kcnd", "~/klaytn/bin/kpnd", "~/klaytn/bin/kend"},
+		wrongValues: commonThreeErrors,
+		errors:      []int{NonError, NonError, NonError},
+	},
 }
 
 func testFlags(t *testing.T, flag string, value string, idx int) {

--- a/cmd/utils/nodecmd/flags_test.go
+++ b/cmd/utils/nodecmd/flags_test.go
@@ -773,6 +773,10 @@ var flagsWithValues = []struct {
 		wrongValues: commonThreeErrors,
 		errors:      []int{NonError, NonError, NonError},
 	},
+	{
+		flag:     "--auto.restart",
+		flagType: FlagTypeBoolean,
+	},
 }
 
 func testFlags(t *testing.T, flag string, value string, idx int) {

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -90,6 +90,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.ExtraDataFlag,
 	utils.SrvTypeFlag,
 	utils.DaemonPathFlag,
+	utils.AutoRestartFlag,
 	ConfigFileFlag,
 }
 

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -89,6 +89,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.PrometheusExporterPortFlag,
 	utils.ExtraDataFlag,
 	utils.SrvTypeFlag,
+	utils.DaemonPathFlag,
 	ConfigFileFlag,
 }
 


### PR DESCRIPTION
## Proposed changes

- kcn can be restarted by calling `kcnd restart`. To do that, kcnd gives its path to kcn as parameter when calling `kcnd start`.
- 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
