### PR TITLE
Don't compute stateDB for non-existing block number

### DIFF
--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -659,13 +659,13 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 	var err error
 
 	for i := uint64(0); i < reexec; i++ {
+		if statedb, err = state.New(block.Root(), database); err == nil {
+			break
+		}
 		blockNumber := block.NumberU64()
 		block = api.cn.blockchain.GetBlock(block.ParentHash(), blockNumber-1)
 		if block == nil {
 			return nil, fmt.Errorf("block #%d not found", blockNumber-1)
-		}
-		if statedb, err = state.New(block.Root(), database); err == nil {
-			break
 		}
 	}
 	if err != nil {

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -659,9 +659,10 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 	var err error
 
 	for i := uint64(0); i < reexec; i++ {
-		block = api.cn.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
+		blockNumber := block.NumberU64()
+		block = api.cn.blockchain.GetBlock(block.ParentHash(), blockNumber-1)
 		if block == nil {
-			break
+			return nil, fmt.Errorf("block #%d not found", blockNumber-1)
 		}
 		if statedb, err = state.New(block.Root(), database); err == nil {
 			break


### PR DESCRIPTION
## Proposed changes

1. In the changed logic, a break condition of the `for` loop can cause panic.
The values of `block` should not be `nil` since `block.NumberU64()` is called in the following logic. 

2. `computeStateDB` should find the state of the given block. However, it finds the state of the previous block of the given block. 

The panic can be triggered when `TraceBlock` API is called with the block number `1`. The API tries to lookup the previous state of the genesis. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
