### PR TITLE
Remove autorestart option from kbnd

### DIFF
--- a/build/packaging/linux/bin/kbnd
+++ b/build/packaging/linux/bin/kbnd
@@ -79,10 +79,6 @@ start() {
         OPTIONS="$OPTIONS --datadir $DATA_DIR"
     fi
 
-    BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-    CURRENTFILE=`basename "$0"`
-    OPTIONS="$OPTIONS --autorestart.daemon.path $BASEDIR/$CURRENTFILE"
-
     $BIN/kbn ${OPTIONS} >> ${LOG_DIR}/kbnd.out 2>&1 &
     RETVAL=$?
     PIDNUM=$!

--- a/build/rpm/etc/init.d/kbnd
+++ b/build/rpm/etc/init.d/kbnd
@@ -69,10 +69,6 @@ start() {
             OPTIONS="$OPTIONS $ADDITIONAL"
         fi
 
-        BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-        CURRENTFILE=`basename "$0"`
-        OPTIONS="$OPTIONS --autorestart.daemon.path $BASEDIR/$CURRENTFILE"
-
         $kbn ${OPTIONS} >> ${LOG_DIR}/kbnd.out 2>&1 &
         RETVAL=$?
         PIDNUM=$!
@@ -108,6 +104,7 @@ case "$1" in
         ;;
     restart)
         stop
+        sleep 3
         start
         ;;
     *)


### PR DESCRIPTION
## Proposed changes

- `autorestart.daemon.path` is only for CN/PN/EN. With this option, BN fails to start.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
