### PR TITLE
Build and publish public docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,13 @@ aliases:
     tags:
       only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
     branches:
-      ignore: 
+      ignore:
         - /release\/.*/
         - master
 
 orbs:
   codecov: codecov/codecov@1.0.5
+  docker: circleci/docker@1.0.1
 
 executors:
   test-executor:
@@ -52,7 +53,7 @@ commands:
   pre-build:
     description: "before build, set version"
     steps:
-      - run: 
+      - run:
           name: "set variables"
           command: |
             export GOPATH=~/go
@@ -78,7 +79,7 @@ commands:
       - run:
           name: "build new(Cross compile)"
           command: |
-            export GOPATH=~/go 
+            export GOPATH=~/go
             export PATH=$HOME/go1.14.1/go/bin:$PATH
             make << parameters.os-network >>
   upload-repo:
@@ -101,13 +102,13 @@ commands:
       - run:
           name: "rpm tagging"
           command: make rpm-all
-      - run: 
+      - run:
           name: "upload S3 repo"
           command: |
             PLATFORM_SUFFIX=$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)
             KLAYTN_VERSION=$(go run build/rpm/main.go version)
 
-            for item in kcn kpn ken kscn kspn ksen kbn kgen homi; 
+            for item in kcn kpn ken kscn kspn ksen kbn kgen homi;
             do
               TARGET_RPM=$(find $item-linux-x86_64/rpmbuild/RPMS/x86_64/ | awk -v pat="$item(d)?-v" '$0~pat')
               aws s3 cp $TARGET_RPM s3://$FRONTEND_BUCKET/packages/rhel/7/prod/
@@ -122,10 +123,10 @@ commands:
               make rpm-baobab-kcn
               make rpm-baobab-kpn
               make rpm-baobab-ken
-      - run: 
+      - run:
           name: "upload S3 repo"
           command: |
-            for item in kcn kpn ken; 
+            for item in kcn kpn ken;
             do
               PLATFORM_SUFFIX=$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)
               TARGET_RPM=$(find $item-linux-x86_64/rpmbuild/RPMS/x86_64/ | awk -v pat="$item(d)?-baobab-v" '$0~pat')
@@ -175,14 +176,14 @@ commands:
               git checkout -b release/${CIRCLE_TAG%-*}
               git push origin release/${CIRCLE_TAG%-*}
       - run:
-          name: "Install hub" 
+          name: "Install hub"
           command: |
               curl -sSLf https://github.com/github/hub/releases/download/v2.12.3/hub-linux-amd64-2.12.3.tgz | \
                 tar zxf - --strip-components=1 -C /tmp && \
                 sudo mv /tmp/bin/hub /usr/local/bin/hub
               type hub
       - run:
-          name: "Create pull request" 
+          name: "Create pull request"
           command: |
               version=$(hub pr list -s open -L 10 -f "%H%n")
               echo $version
@@ -213,7 +214,7 @@ commands:
                 git push origin --delete release/$version
               else
                 echo "Need to delete branch manually"
-              fi  
+              fi
   notify-success:
     steps:
       - run:
@@ -293,7 +294,7 @@ jobs:
   pass-tests:
     executor: default
     steps:
-      - run: 
+      - run:
           name: "tests pass!"
           command: echo "tests pass!"
 
@@ -405,7 +406,7 @@ jobs:
       - checkout
       - pre-build
       - rpm-tagging-baobab
-      
+
   deploy-rpm-public:
     executor: rpm-executor
     steps:
@@ -441,15 +442,15 @@ workflows:
   version: 2
   build_n_packaging:
     jobs:
-      - build: 
+      - build:
           filters: *filter-version-not-release
-      - test-datasync: 
+      - test-datasync:
           filters: *filter-version-not-release
-      - test-networks: 
+      - test-networks:
           filters: *filter-version-not-release
-      - test-tests: 
+      - test-tests:
           filters: *filter-version-not-release
-      - test-others: 
+      - test-others:
          filters: *filter-version-not-release
       - tagger-verify:
          filters:
@@ -458,8 +459,8 @@ workflows:
             branches:
               ignore: /.*/
 
-      - pass-tests: 
-          requires: 
+      - pass-tests:
+          requires:
             - build
             - test-datasync
             - test-networks
@@ -468,11 +469,11 @@ workflows:
             - tag-verify
             - tagger-verify
           filters: *filter-version-not-release
-      
+
       - tag-verify:
           filters: *filter-only-version-tag
 
-      - deploy-rpm-public: 
+      - deploy-rpm-public:
           requires:
             - rpm-tagged
             - rpm-tagged-baobab
@@ -494,7 +495,7 @@ workflows:
             - packaging-linux-baobab
             - packaging-darwin
             - packaging-darwin-baobab
-          filters: 
+          filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+.*/
             branches:
@@ -508,7 +509,7 @@ workflows:
           filters: *filter-only-version-tag
           requires:
             - pass-tests
-      - packaging-linux: 
+      - packaging-linux:
           filters: *filter-only-version-tag
           requires:
             - pass-tests
@@ -516,7 +517,7 @@ workflows:
           filters: *filter-only-version-tag
           requires:
             - pass-tests
-      - packaging-darwin: 
+      - packaging-darwin:
           filters: *filter-only-version-tag
           requires:
             - pass-tests
@@ -524,6 +525,19 @@ workflows:
           filters: *filter-only-version-tag
           requires:
             - pass-tests
+
+      - docker/publish:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+            branches:
+              ignore: /.*/
+          requires:
+            - pass-tests
+          image: klaytn/klaytn
+          tag: $CIRCLE_TAG,latest
+          executor: docker/docker
+          use-remote-docker: true
 
       - major-tagging:
           filters:

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@
 
 build/_workspace
 build/_bin
+
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,33 @@
-ARG  DOCKER_BASE_IMAGE=klaytn/build_base:1.0-go1.14.1-solc0.4.24
-FROM ${DOCKER_BASE_IMAGE}
-MAINTAINER Jesse Lee jesse.lee@groundx.xyz
+# Global ARGs
+ARG DOCKER_BASE_IMAGE=klaytn/build_base:1.0-go1.14.1-solc0.4.24
+ARG PKG_DIR=/klaytn-docker-pkg
+ARG SRC_DIR=/go/src/github.com/klaytn/klaytn
 
-ENV PKG_DIR /klaytn-docker-pkg
-ENV SRC_DIR /go/src/github.com/klaytn/klaytn
+FROM ${DOCKER_BASE_IMAGE} AS builder
+LABEL maintainer="Austin Brown <austin.brown@groundx.xyz>"
+ARG SRC_DIR
+ARG PKG_DIR
 
 ARG KLAYTN_RACE_DETECT=0
 ENV KLAYTN_RACE_DETECT=$KLAYTN_RACE_DETECT
 
-RUN mkdir -p $PKG_DIR/bin
-RUN mkdir -p $PKG_DIR/conf
-
 ADD . $SRC_DIR
 RUN cd $SRC_DIR && make all
 
-RUN cp $SRC_DIR/build/bin/* /usr/bin/
+FROM alpine:3
+ARG SRC_DIR
+ARG PKG_DIR
 
-# packaging
-RUN cp $SRC_DIR/build/bin/* $PKG_DIR/bin/
+RUN mkdir -p $PKG_DIR/conf $PKG_DIR/bin
 
-RUN cp $SRC_DIR/build/packaging/linux/bin/* $PKG_DIR/bin/
+# Add bash as required by the Klaytn startup scripts
+RUN apk add --no-cache bash
 
-RUN cp $SRC_DIR/build/packaging/linux/conf/* $PKG_DIR/conf/
+# Startup scripts and binaries must be in the same location
+COPY --from=builder $SRC_DIR/build/bin/* $PKG_DIR/bin/
+COPY --from=builder $SRC_DIR/build/packaging/linux/bin/* $PKG_DIR/bin/
+COPY --from=builder $SRC_DIR/build/packaging/linux/conf/* $PKG_DIR/conf/
+
+ENV PATH=$PKG_DIR/bin:$PATH
 
 EXPOSE 8551 8552 32323 61001 32323/udp


### PR DESCRIPTION
## Proposed changes

- Builds and publishes a Docker image containing Klaytn binaries (unlike `build_base`) for each official release.
- Image is available at [klaytn/klaytn](https://hub.docker.com/r/klaytn/klaytn) on Docker Hub, tagged with the Klaytn version and `latest`
- Updates the Dockerfile to use a multi-stage build and to remove duplicated and unnecessary files. Image size is now ~174 MB.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://groundx.atlassian.net/browse/GD-471

## Further comments

N/A
