### PR TITLE
Change golangci-lint installing method

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -332,7 +332,20 @@ func doFmt(cmdline []string) {
 		packages = flag.CommandLine.Args()
 	}
 	// Get metalinter and install all supported linters
-	build.MustRun(goTool("get", "github.com/golangci/golangci-lint/cmd/golangci-lint"))
+	lintInstaller := "golangci-lint-install.sh"
+	curlArgs := []string{
+		"-sSfL",
+		"-o" + lintInstaller,
+		"https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh",
+	}
+	build.MustRunCommand("curl", curlArgs...)
+
+	shArgs := []string{
+		lintInstaller,
+		"-b" + GOBIN,
+	}
+	build.MustRunCommand("sh", shArgs...)
+	build.MustRunCommand("rm", lintInstaller)
 
 	// Run fast linters batched together
 	configs := []string{
@@ -353,7 +366,20 @@ func doLint(cmdline []string, exitOnError bool) {
 		packages = flag.CommandLine.Args()
 	}
 	// Get metalinter and install all supported linters
-	build.MustRun(goTool("get", "github.com/golangci/golangci-lint/cmd/golangci-lint"))
+	lintInstaller := "golangci-lint-install.sh"
+	curlArgs := []string{
+		"-sSfL",
+		"-o" + lintInstaller,
+		"https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh",
+	}
+	build.MustRunCommand("curl", curlArgs...)
+
+	shArgs := []string{
+		lintInstaller,
+		"-b" + GOBIN,
+	}
+	build.MustRunCommand("sh", shArgs...)
+	build.MustRunCommand("rm", lintInstaller)
 
 	// Prepare a report file for linters
 	fname := "linter_report.txt"


### PR DESCRIPTION
## Proposed changes

circleCi failed to install `goalngci-lint` and current installing method is not recommended by `golangci-lint` (refer to https://github.com/golangci/golangci-lint/#go)
With this PR, Klaytn downloads, runs, and removes `goalngci-lint` installing script.
The PR was tested on `linux/amd64` and `darwin/amd64` environments.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
