### PR TITLE
Enable more linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
       - checkout
       - run:
           name: "Run golangci-lint"
-          command: golangci-lint run --new-from-rev=dev --presets format,style -v
+          command: golangci-lint run --new-from-rev=dev --presets format,style -v --timeout 10m
 
   test-datasync:
     executor: test-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
       - checkout
       - run:
           name: "Run golangci-lint"
-          command: golangci-lint run --new-from-rev=dev -v
+          command: golangci-lint run --new-from-rev=dev --presets format,style -v
 
   test-datasync:
     executor: test-executor


### PR DESCRIPTION
## Proposed changes

This commit enables more linters such as format and style preset
linters. The enabled linters are shown below:

depguard dogsled dupl funlen gochecknoglobals gochecknoinits goconst gocritic godox gofmt goimports golint gomnd goprintffuncname gosimple interfacer lll misspell stylecheck unconvert whitespace wsl

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
