### PR TITLE
Fixed a bug to create stateTrieMigrationDB initial folder

### DIFF
--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -254,7 +254,7 @@ func testParallelPutGet(db Database, t *testing.T) {
 func TestDBEntryLengthCheck(t *testing.T) {
 	dbRatioSum := 0
 	for i := 0; i < int(databaseEntryTypeSize); i++ {
-		if dbDirs[i] == "" {
+		if dbBaseDirs[i] == "" {
 			t.Fatalf("Database directory should be specified! index: %v", i)
 		}
 

--- a/storage/database/database_test_util.go
+++ b/storage/database/database_test_util.go
@@ -37,13 +37,13 @@ func NewLevelDBManagerForTest(dbc *DBConfig, levelDBOption *opt.Options) (DBMana
 				ldb, err = NewLevelDBWithOption(dbc.Dir, levelDBOption)
 			}
 		} else {
-			partitionDir := filepath.Join(dbc.Dir, dbDirs[i])
+			partitionDir := filepath.Join(dbc.Dir, dbBaseDirs[i])
 			partitionLDBOption := getLevelDBOptionByPartition(levelDBOption, DBEntryType(i))
 			partitionLDBOption.Compression = getCompressionType(dbc.LevelDBCompression, DBEntryType(i))
 
 			ldb, err = NewLevelDBWithOption(partitionDir, partitionLDBOption)
 
-			fmt.Printf("Database: %-15s Compression: %-15s DisableBufferPool: %v \n", dbDirs[i], partitionLDBOption.Compression, levelDBOption.DisableBufferPool)
+			fmt.Printf("Database: %-15s Compression: %-15s DisableBufferPool: %v \n", dbBaseDirs[i], partitionLDBOption.Compression, levelDBOption.DisableBufferPool)
 		}
 
 		if err != nil {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -477,6 +477,7 @@ func (dbm *databaseManager) NewBatch(dbEntryType DBEntryType) Batch {
 
 func (dbm *databaseManager) getDBDir(dbEntry DBEntryType) string {
 	miscDB := dbm.getDatabase(MiscDB)
+
 	enc, _ := miscDB.Get(databaseDirKey(uint64(dbEntry)))
 	if len(enc) == 0 {
 		return dbDirs[dbEntry]

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -362,12 +362,12 @@ func partitionedDatabaseDBManager(dbc *DBConfig) (*databaseManager, error) {
 
 		if entryType == StateTrieDB || entryType == StateTrieMigrationDB {
 			dir := dbm.getDBDir(entryType)
-			newDBC := getDBEntryConfig(dbc, entryType, dir)
 			if entryType == StateTrieMigrationDB && dir == dbDirs[StateTrieMigrationDB] {
 				// If there is no migration DB, skip to set.
 				continue
 			}
 
+			newDBC := getDBEntryConfig(dbc, entryType, dir)
 			if dbc.NumStateTriePartitions > 1 {
 				db, err = newPartitionedDB(newDBC, entryType, dbc.NumStateTriePartitions)
 			} else {
@@ -493,10 +493,12 @@ func (dbm *databaseManager) setDBDir(dbEntry DBEntryType, newDBDir string) {
 
 func (dbm *databaseManager) getStateTrieMigrationInfo() uint64 {
 	miscDB := dbm.getDatabase(MiscDB)
+
 	enc, _ := miscDB.Get(migrationStatusKey)
 	if len(enc) != 8 {
 		return 0
 	}
+
 	blockNum := binary.BigEndian.Uint64(enc)
 	return blockNum
 }

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -223,13 +223,13 @@ const (
 const notInMigrationFlag = 0
 const inMigrationFlag = 1
 
-var dbDirs = [databaseEntryTypeSize]string{
+var dbBaseDirs = [databaseEntryTypeSize]string{
 	"misc", // do not move misc
 	"header",
 	"body",
 	"receipts",
 	"statetrie",
-	"statetrie_", // not used
+	"statetrie_migrated", // "statetrie_migrated_#N" path will be used. (#N is a migrated block number.)
 	"txlookup",
 	"bridgeservice",
 }
@@ -335,13 +335,13 @@ func singleDatabaseDBManager(dbc *DBConfig) (DBManager, error) {
 
 // newMiscDB returns misc DBManager. If not exist, the function create DB before returning.
 func newMiscDB(dbc *DBConfig) Database {
-	newDBC := getDBEntryConfig(dbc, MiscDB, dbDirs[MiscDB])
+	newDBC := getDBEntryConfig(dbc, MiscDB, dbBaseDirs[MiscDB])
 	db, err := newDatabase(newDBC, MiscDB)
 	if err != nil {
 		logger.Crit("Failed while generating a MISC database", "err", err)
 	}
 
-	db.Meter(dbMetricPrefix + dbDirs[MiscDB] + "/")
+	db.Meter(dbMetricPrefix + dbBaseDirs[MiscDB] + "/")
 	return db
 }
 
@@ -359,30 +359,33 @@ func partitionedDatabaseDBManager(dbc *DBConfig) (*databaseManager, error) {
 	// Create other DBs
 	for et := int(MiscDB) + 1; et < int(databaseEntryTypeSize); et++ {
 		entryType := DBEntryType(et)
+		dir := dbm.getDBDir(entryType)
 
-		if entryType == StateTrieDB || entryType == StateTrieMigrationDB {
-			dir := dbm.getDBDir(entryType)
-			if entryType == StateTrieMigrationDB && dir == dbDirs[StateTrieMigrationDB] {
+		switch entryType {
+		case StateTrieMigrationDB:
+			if dir == dbBaseDirs[StateTrieMigrationDB] {
 				// If there is no migration DB, skip to set.
 				continue
 			}
-
+			fallthrough
+		case StateTrieDB:
 			newDBC := getDBEntryConfig(dbc, entryType, dir)
 			if dbc.NumStateTriePartitions > 1 {
 				db, err = newPartitionedDB(newDBC, entryType, dbc.NumStateTriePartitions)
 			} else {
 				db, err = newDatabase(newDBC, entryType)
 			}
-		} else {
-			newDBC := getDBEntryConfig(dbc, entryType, dbDirs[entryType])
+		default:
+			newDBC := getDBEntryConfig(dbc, entryType, dir)
 			db, err = newDatabase(newDBC, entryType)
 		}
 
 		if err != nil {
-			logger.Crit("Failed while generating a partition of LevelDB", "partition", dbDirs[et], "err", err)
+			logger.Crit("Failed while generating a partition of LevelDB", "partition", dbBaseDirs[et], "err", err)
 		}
+
 		dbm.dbs[et] = db
-		db.Meter(dbMetricPrefix + dbDirs[et] + "/") // Each partition collects metrics independently.
+		db.Meter(dbMetricPrefix + dbBaseDirs[et] + "/") // Each partition collects metrics independently.
 	}
 	return dbm, nil
 }
@@ -480,7 +483,7 @@ func (dbm *databaseManager) getDBDir(dbEntry DBEntryType) string {
 
 	enc, _ := miscDB.Get(databaseDirKey(uint64(dbEntry)))
 	if len(enc) == 0 {
-		return dbDirs[dbEntry]
+		return dbBaseDirs[dbEntry]
 	}
 	return string(enc)
 }
@@ -521,7 +524,7 @@ func (dbm *databaseManager) setStateTrieMigrationStatus(blockNum uint64) {
 }
 
 func newStateTrieMigrationDB(dbc *DBConfig, blockNum uint64) (Database, string) {
-	dbDir := dbDirs[StateTrieMigrationDB] + strconv.FormatUint(blockNum, 10)
+	dbDir := dbBaseDirs[StateTrieMigrationDB] + "_" + strconv.FormatUint(blockNum, 10)
 	newDBConfig := getDBEntryConfig(dbc, StateTrieMigrationDB, dbDir)
 	var newDB Database
 	var err error
@@ -533,7 +536,10 @@ func newStateTrieMigrationDB(dbc *DBConfig, blockNum uint64) (Database, string) 
 	if err != nil {
 		logger.Crit("Failed to create a new database for state trie migration", "err", err)
 	}
+
+	newDB.Meter(dbMetricPrefix + dbBaseDirs[StateTrieMigrationDB] + "/") // Each partition collects metrics independently.
 	logger.Info("Created a new database for state trie migration", "newStateTrieDB", newDBConfig.Dir)
+
 	return newDB, dbDir
 }
 


### PR DESCRIPTION
## Proposed changes
There is a bug when creating `statetrie_` database directory in the last PR.
This PR change not to create the `statetrie_` folder.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
