### PR TITLE
Introduce state trie migration

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -247,7 +247,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 	// Take ownership of this particular state
 	go bc.update()
 	go bc.gcCachedNodeLoop()
-	go bc.checkRestartStateMigration()
+	go bc.restartStateMigration()
 
 	return bc, nil
 }
@@ -381,7 +381,7 @@ func (bc *BlockChain) checkTrieContents(oldDB, newDB *statedb.Database, root com
 	return dirty, nil
 }
 
-func (bc *BlockChain) checkRestartStateMigration() {
+func (bc *BlockChain) restartStateMigration() {
 	if bc.db.InMigration() {
 		number := bc.db.MigrationBlockNumber()
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -406,7 +406,7 @@ func (bc *BlockChain) PrepareStateMigration() error {
 	bc.prepareStateMigration = true
 	currentBlock := bc.CurrentBlock().NumberU64()
 	nextCommittedBlock := currentBlock + (DefaultBlockInterval - currentBlock%DefaultBlockInterval)
-	logger.Warn("Prepare state migration", "nextCommittedBlock", nextCommittedBlock)
+	logger.Warn("Prepared state migration", "migrationStartingBlockNumber", nextCommittedBlock)
 
 	return nil
 }

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -228,6 +228,19 @@ web3._extend({
 			name: 'stopWS',
 			call: 'admin_stopWS'
 		}),
+		new web3._extend.Method({
+			name: 'startStateMigration',
+			call: 'admin_startStateMigration',
+			params: 1,
+		}),
+		new web3._extend.Method({
+			name: 'stopStateMigration',
+			call: 'admin_stopStateMigration',
+		}),
+		new web3._extend.Method({
+			name: 'statusStateMigration',
+			call: 'admin_statusStateMigration',
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -155,6 +155,40 @@ func (api *PrivateAdminAPI) ImportChain(file string) (bool, error) {
 	return true, nil
 }
 
+// StartStateMigration starts state migration.
+func (api *PrivateAdminAPI) StartStateMigration(immediately bool) error {
+	// TODO-Klaytn refine force option.
+	// if immediately is true, state migration begins immediately with last committed block. (for only TEST)
+	// if not, migration will be started after next committed block.
+	if immediately {
+		currentBlock := api.cn.blockchain.CurrentBlock().NumberU64()
+		targetBlock := currentBlock - (currentBlock % blockchain.DefaultBlockInterval)
+		targetRoot := api.cn.blockchain.GetBlockByNumber(targetBlock).Root()
+		logger.Info("Start state migration", "currentBlock", currentBlock, "targetBlock", targetBlock, "targetRoot", targetRoot)
+		return api.cn.BlockChain().StartStateMigration(targetBlock, targetRoot)
+	}
+	return api.cn.blockchain.PrepareStateMigration()
+}
+
+// StopStateMigration stops state migration and removes stateMigrationDB.
+func (api *PrivateAdminAPI) StopStateMigration() error {
+	// TODO-Klaytn need to support stopStateMigration
+	// return api.cn.BlockChain().StopStateMigration()
+	return errors.New("StopStateMigration is not yet supported")
+}
+
+// StatusStateMigration returns the status information of state trie migration.
+func (api *PrivateAdminAPI) StatusStateMigration() map[string]interface{} {
+	isMigration, blkNum, committed, pending := api.cn.BlockChain().StatusStateMigration()
+	return map[string]interface{}{
+		// TODO-Klaytn Add more information.
+		"isMigration":          isMigration,
+		"migrationBlockNumber": blkNum,
+		"committed":            committed,
+		"pending":              pending,
+	}
+}
+
 // PublicDebugAPI is the collection of Klaytn full node APIs exposed
 // over the public debugging endpoint.
 type PublicDebugAPI struct {

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -165,8 +165,10 @@ func (api *PrivateAdminAPI) StartStateMigration(immediately bool) error {
 		targetBlock := currentBlock - (currentBlock % blockchain.DefaultBlockInterval)
 		targetRoot := api.cn.blockchain.GetBlockByNumber(targetBlock).Root()
 		logger.Info("Start state migration", "currentBlock", currentBlock, "targetBlock", targetBlock, "targetRoot", targetRoot)
+
 		return api.cn.BlockChain().StartStateMigration(targetBlock, targetRoot)
 	}
+
 	return api.cn.blockchain.PrepareStateMigration()
 }
 
@@ -180,6 +182,7 @@ func (api *PrivateAdminAPI) StopStateMigration() error {
 // StatusStateMigration returns the status information of state trie migration.
 func (api *PrivateAdminAPI) StatusStateMigration() map[string]interface{} {
 	isMigration, blkNum, committed, pending := api.cn.BlockChain().StatusStateMigration()
+
 	return map[string]interface{}{
 		// TODO-Klaytn Add more information.
 		"isMigration":          isMigration,

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -580,6 +580,20 @@ func (mr *MockBlockChainMockRecorder) PostChainEvents(arg0, arg1 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostChainEvents", reflect.TypeOf((*MockBlockChain)(nil).PostChainEvents), arg0, arg1)
 }
 
+// PrepareStateMigration mocks base method
+func (m *MockBlockChain) PrepareStateMigration() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareStateMigration")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrepareStateMigration indicates an expected call of PrepareStateMigration
+func (mr *MockBlockChainMockRecorder) PrepareStateMigration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareStateMigration", reflect.TypeOf((*MockBlockChain)(nil).PrepareStateMigration))
+}
+
 // Processor mocks base method
 func (m *MockBlockChain) Processor() blockchain.Processor {
 	m.ctrl.T.Helper()
@@ -658,6 +672,20 @@ func (mr *MockBlockChainMockRecorder) SetUseGiniCoeff(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUseGiniCoeff", reflect.TypeOf((*MockBlockChain)(nil).SetUseGiniCoeff), arg0)
 }
 
+// StartStateMigration mocks base method
+func (m *MockBlockChain) StartStateMigration(arg0 uint64, arg1 common.Hash) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartStateMigration", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartStateMigration indicates an expected call of StartStateMigration
+func (mr *MockBlockChainMockRecorder) StartStateMigration(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartStateMigration", reflect.TypeOf((*MockBlockChain)(nil).StartStateMigration), arg0, arg1)
+}
+
 // State mocks base method
 func (m *MockBlockChain) State() (*state.StateDB, error) {
 	m.ctrl.T.Helper()
@@ -717,6 +745,23 @@ func (mr *MockBlockChainMockRecorder) StateCache() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateCache", reflect.TypeOf((*MockBlockChain)(nil).StateCache))
 }
 
+// StatusStateMigration mocks base method
+func (m *MockBlockChain) StatusStateMigration() (bool, uint64, int, int) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StatusStateMigration")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(uint64)
+	ret2, _ := ret[2].(int)
+	ret3, _ := ret[3].(int)
+	return ret0, ret1, ret2, ret3
+}
+
+// StatusStateMigration indicates an expected call of StatusStateMigration
+func (mr *MockBlockChainMockRecorder) StatusStateMigration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusStateMigration", reflect.TypeOf((*MockBlockChain)(nil).StatusStateMigration))
+}
+
 // Stop mocks base method
 func (m *MockBlockChain) Stop() {
 	m.ctrl.T.Helper()
@@ -727,6 +772,20 @@ func (m *MockBlockChain) Stop() {
 func (mr *MockBlockChainMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBlockChain)(nil).Stop))
+}
+
+// StopStateMigration mocks base method
+func (m *MockBlockChain) StopStateMigration() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopStateMigration")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopStateMigration indicates an expected call of StopStateMigration
+func (mr *MockBlockChainMockRecorder) StopStateMigration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopStateMigration", reflect.TypeOf((*MockBlockChain)(nil).StopStateMigration))
 }
 
 // SubscribeChainEvent mocks base method

--- a/work/work.go
+++ b/work/work.go
@@ -287,4 +287,10 @@ type BlockChain interface {
 	PostChainEvents(events []interface{}, logs []*types.Log)
 	TryGetCachedStateDB(rootHash common.Hash) (*state.StateDB, error)
 	ApplyTransaction(config *params.ChainConfig, author *common.Address, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg *vm.Config) (*types.Receipt, uint64, error)
+
+	// State Migration
+	PrepareStateMigration() error
+	StartStateMigration(uint64, common.Hash) error
+	StopStateMigration() error
+	StatusStateMigration() (bool, uint64, int, int)
 }


### PR DESCRIPTION
## Proposed changes
This PR introduces state trie migration feature to migrate latest state trie to new state trie DB and remove old state trie DB.

This can reduce the chain data size (state trie database).

- added related APIs
  - admin.startStateMigration
  - admin.stopStateMigration (not supported yet)
  - admin.statusStateMigration 
- state trie migration step
  - create `stateTrieMigrationDB`.
  - copy all last state tries to `stateTrieMigrationDB`
  - check if the copied state tries are valid
  - switch `stateTrieDB` and `stateTrieMigrationDB`
  - remove old `stateTrieDB`
- supports to restart state trie migration after Klaytn is restarted.

## TODO
- support to batch commit during migration
- support to store the snapshot of stakingInfo
- support to check if the copied storage tries are valid

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
