### PR TITLE
Fix restart bug due to staking info activation

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -373,12 +373,9 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 			logger.Trace(logMsg, "header.Number", header.Number.Uint64(), "node address", sb.address, "rewardbase", header.Rewardbase)
 		}
 
-		stakingInfo := sb.GetStakingManager().GetStakingInfo(header.Number.Uint64())
-		if sb.GetStakingManager().IsActivated() {
-			if stakingInfo != nil {
-				kirAddr = stakingInfo.KIRAddr
-				pocAddr = stakingInfo.PoCAddr
-			}
+		if stakingInfo := sb.GetStakingManager().GetStakingInfo(header.Number.Uint64()); stakingInfo != nil {
+			kirAddr = stakingInfo.KIRAddr
+			pocAddr = stakingInfo.PoCAddr
 		}
 
 		if err := sb.rewardDistributor.DistributeBlockReward(state, header, pocAddr, kirAddr); err != nil {

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -127,7 +127,10 @@ func (sm *StakingManager) handleChainHeadEvent() {
 		case ev := <-sm.chainHeadChan:
 			if sm.governanceHelper.ProposerPolicy() == params.WeightedRandom {
 				// check and update if staking info is not valid beforehand
-				sm.GetStakingInfo(ev.Block.NumberU64())
+				stakingManager := sm.GetStakingInfo(ev.Block.NumberU64())
+				if stakingManager == nil {
+					logger.Error("unable to fetch staking info")
+				}
 			}
 		case <-sm.chainHeadSub.Err():
 			return

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -126,8 +126,8 @@ func (sm *StakingManager) handleChainHeadEvent() {
 		// Handle ChainHeadEvent
 		case ev := <-sm.chainHeadChan:
 			if sm.governanceHelper.ProposerPolicy() == params.WeightedRandom {
-				// check and update if staking info is not valid beforehand
-				stakingManager := sm.GetStakingInfo(ev.Block.NumberU64())
+				// check and update if staking info is not valid before for the next update interval blocks
+				stakingManager := sm.GetStakingInfo(ev.Block.NumberU64() + params.StakingUpdateInterval())
 				if stakingManager == nil {
 					logger.Error("unable to fetch staking info", "blockNum", ev.Block.NumberU64())
 

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -129,7 +129,7 @@ func (sm *StakingManager) handleChainHeadEvent() {
 				// check and update if staking info is not valid beforehand
 				stakingManager := sm.GetStakingInfo(ev.Block.NumberU64())
 				if stakingManager == nil {
-					logger.Error("unable to fetch staking info", "blockNum", ev.Block.NumberU64(), "stakingNumber", stakingBlockNum)
+					logger.Error("unable to fetch staking info", "blockNum", ev.Block.NumberU64())
 
 				}
 			}

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -126,7 +126,7 @@ func (sm *StakingManager) handleChainHeadEvent() {
 		// Handle ChainHeadEvent
 		case ev := <-sm.chainHeadChan:
 			if sm.governanceHelper.ProposerPolicy() == params.WeightedRandom {
-				// check if staking info is valid beforehand
+				// check and update if staking info is not valid beforehand
 				sm.GetStakingInfo(ev.Block.NumberU64())
 			}
 		case <-sm.chainHeadSub.Err():

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -130,7 +130,6 @@ func (sm *StakingManager) handleChainHeadEvent() {
 				stakingManager := sm.GetStakingInfo(ev.Block.NumberU64() + params.StakingUpdateInterval())
 				if stakingManager == nil {
 					logger.Error("unable to fetch staking info", "blockNum", ev.Block.NumberU64())
-
 				}
 			}
 		case <-sm.chainHeadSub.Err():

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -129,7 +129,8 @@ func (sm *StakingManager) handleChainHeadEvent() {
 				// check and update if staking info is not valid beforehand
 				stakingManager := sm.GetStakingInfo(ev.Block.NumberU64())
 				if stakingManager == nil {
-					logger.Error("unable to fetch staking info")
+					logger.Error("unable to fetch staking info", "blockNum", ev.Block.NumberU64(), "stakingNumber", stakingBlockNum)
+
 				}
 			}
 		case <-sm.chainHeadSub.Err():


### PR DESCRIPTION
## Proposed changes

- `IsActivated()` in staking manager is deleted.
    - Staking manager is always used even if token manager is not set.
    - Its usage is determined by if the addresses are empty or not.
- Staking info is stored to cache if it is fetched from DB or address book.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related PR

- [PR#508](https://github.com/klaytn/klaytn/pull/508)
- [PR#512](https://github.com/klaytn/klaytn/pull/512)

## Further comments

Test is on progress; continues restarting of ken adhered to baobab and cypress.
