### PR TITLE
Introduce admin_importChainFromString

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -204,6 +204,11 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'importChainFromString',
+			call: 'admin_importChainFromString',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'sleepBlocks',
 			call: 'admin_sleepBlocks',
 			params: 2

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -21,6 +21,7 @@
 package cn
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
@@ -121,10 +122,19 @@ func (api *PrivateAdminAPI) ImportChain(file string) (bool, error) {
 			return false, err
 		}
 	}
-
-	// Run actual the import in pre-configured batches
 	stream := rlp.NewStream(reader, 0)
 
+	return api.importChain(stream)
+}
+
+func (api *PrivateAdminAPI) ImportChainFromString(blockRlp string) (bool, error) {
+	// Run actual the import in pre-configured batches
+	stream := rlp.NewStream(bytes.NewReader(common.FromHex(blockRlp)), 0)
+
+	return api.importChain(stream)
+}
+
+func (api *PrivateAdminAPI) importChain(stream *rlp.Stream) (bool, error) {
 	blocks, index := make([]*types.Block, 0, 2500), 0
 	for batch := 0; ; batch++ {
 		// Load a batch of blocks from the input file


### PR DESCRIPTION
## Proposed changes

**PROBLEM**
Previously, admin_importChain() receives the first parameter as a filename.
Since it requires file system access, it would be better if we
admin_importChain() using string.

If we have such a function, we can easily import a block
using the RLP-encoded string of the block.

**SOLUTION**
This PR introduces admin_importChainFromString(). This function receives
the first parameter as an RLP-encoded string of a block.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

