### PR TITLE
State Trie Migration : before migration, check if stakinginfo is stored

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -322,7 +322,8 @@ func RegisterMigrationPrerequisites(f func(uint64) error) {
 
 func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	for _, f := range migrationPrerequisites {
-		err := f(*bc.GetBlockNumber(rootHash))
+		err := f(bc.CurrentBlock().NumberU64())
+
 		if err != nil {
 			return err
 		}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -312,7 +312,7 @@ func (bc *BlockChain) concurrentRead(db *statedb.Database, quitCh chan struct{},
 }
 
 // migrationPrerequisites is a collection of functions that needs to be run
-// before state tire migration. If it fails to run one of the functions,
+// before state trie migration. If it fails to run one of the functions,
 // the migration will not start.
 var migrationPrerequisites []func(uint64) error
 
@@ -322,7 +322,7 @@ func RegisterMigrationPrerequisites(f func(uint64) error) {
 
 func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	for _, f := range migrationPrerequisites {
-		err := f(bc.CurrentBlock().NumberU64())
+		err := f(bc.db.MigrationBlockNumber())
 
 		if err != nil {
 			return err

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -311,24 +311,7 @@ func (bc *BlockChain) concurrentRead(db *statedb.Database, quitCh chan struct{},
 	}
 }
 
-// migrationPrerequisites is a collection of functions that needs to be run
-// before state trie migration. If it fails to run one of the functions,
-// the migration will not start.
-var migrationPrerequisites []func(uint64) error
-
-func RegisterMigrationPrerequisites(f func(uint64) error) {
-	migrationPrerequisites = append(migrationPrerequisites, f)
-}
-
 func (bc *BlockChain) migrateState(rootHash common.Hash) error {
-	for _, f := range migrationPrerequisites {
-		err := f(bc.db.MigrationBlockNumber())
-
-		if err != nil {
-			return err
-		}
-	}
-
 	bc.wg.Add(1)
 	defer bc.wg.Done()
 
@@ -509,10 +492,27 @@ func (bc *BlockChain) checkStartStateMigration(number uint64, root common.Hash) 
 	}
 }
 
+// migrationPrerequisites is a collection of functions that needs to be run
+// before state trie migration. If it fails to run one of the functions,
+// the migration will not start.
+var migrationPrerequisites []func(uint64) error
+
+func RegisterMigrationPrerequisites(f func(uint64) error) {
+	migrationPrerequisites = append(migrationPrerequisites, f)
+}
+
 func (bc *BlockChain) StartStateMigration(number uint64, root common.Hash) error {
 	// TODO-Klaytn Add internal status check routine
 	if bc.db.InMigration() {
 		return errors.New("migration already started")
+	}
+
+	for _, f := range migrationPrerequisites {
+		err := f(bc.db.MigrationBlockNumber())
+
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := bc.db.CreateMigrationDBAndSetStatus(number); err != nil {

--- a/reward/staking_info_db.go
+++ b/reward/staking_info_db.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 )
 
+var ErrStakingDBNotSet = errors.New("stakingInfoDB is not set")
+
 type stakingInfoDB interface {
 	ReadStakingInfo(blockNum uint64) ([]byte, error)
 	WriteStakingInfo(blockNum uint64, stakingInfo []byte) error
@@ -28,7 +30,7 @@ type stakingInfoDB interface {
 
 func getStakingInfoFromDB(blockNum uint64) (*StakingInfo, error) {
 	if stakingManager.stakingInfoDB == nil {
-		return nil, errors.New("stakingInfoDB is not set")
+		return nil, ErrStakingDBNotSet
 	}
 
 	jsonByte, err := stakingManager.stakingInfoDB.ReadStakingInfo(blockNum)
@@ -47,7 +49,7 @@ func getStakingInfoFromDB(blockNum uint64) (*StakingInfo, error) {
 
 func addStakingInfoToDB(stakingInfo *StakingInfo) error {
 	if stakingManager.stakingInfoDB == nil {
-		return errors.New("stakingInfoDB is not set")
+		return ErrStakingDBNotSet
 	}
 
 	marshaledStakingInfo, err := json.Marshal(stakingInfo)

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -117,7 +117,9 @@ func (sm *StakingManager) GetStakingInfo(blockNum uint64) *StakingInfo {
 
 // updateStakingInfo updates staking info in cache and db created from given block number.
 func (sm *StakingManager) updateStakingInfo(blockNum uint64) (*StakingInfo, error) {
-	stakingInfo, err := sm.addressBookConnector.getStakingInfoFromAddressBook(blockNum)
+	stakingBlockNumber := params.CalcStakingBlockNumber(blockNum)
+
+	stakingInfo, err := sm.addressBookConnector.getStakingInfoFromAddressBook(stakingBlockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +130,7 @@ func (sm *StakingManager) updateStakingInfo(blockNum uint64) (*StakingInfo, erro
 		return stakingInfo, err
 	}
 
-	logger.Info("Add a new stakingInfo to stakingInfoCache and stakingInfoDB", "blockNum", blockNum)
+	logger.Info("Add a new stakingInfo to stakingInfoCache and stakingInfoDB", "blockNum", blostakingBlockNumberckNum)
 	logger.Debug("Added stakingInfo", "stakingInfo", stakingInfo)
 	return stakingInfo, nil
 }

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -66,7 +66,11 @@ func NewStakingManager(bc blockChain, gh governanceHelper, db database.DBManager
 		migrationCheck:       migrationCheck(db),
 	}
 
-	// Staking info of current and before need to be stored in DB before migration
+	// Before migration, staking information of current and before should be stored in DB.
+	//
+	// Staking information from block of StakingUpdateInterval ahead is needed to create a block.
+	// If there is no staking info in either cache, db or state trie, the node cannot make a block.
+	// The information in state trie is deleted after state trie migration.
 	blockchain.RegisterMigrationPrerequisites(func(blockNum uint64) error {
 		if _, err := sm.updateStakingInfo(blockNum); err != nil {
 			return err

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -75,7 +75,7 @@ func NewStakingManager(bc blockChain, gh governanceHelper, db database.DBManager
 		if _, err := sm.updateStakingInfo(blockNum); err != nil {
 			return err
 		}
-		_, err := sm.updateStakingInfo(blockNum - params.StakingUpdateInterval())
+		_, err := sm.updateStakingInfo(blockNum + params.StakingUpdateInterval())
 		return err
 	})
 

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -137,12 +137,15 @@ func GetStakingInfo(blockNum uint64) *StakingInfo {
 	calcStakingInfo, _ := updateStakingInfo(stakingBlockNumber)
 	if calcStakingInfo == nil {
 		if stakingManager.migrationCheck.InMigration() {
-			logger.Error("YOU MUST NOT RESTART NODE", "action", "if you want to restart the node, you should wait a day after the migration completed", "reason", "failed to store staking info while migration")
+			logger.Warn("YOU MUST NOT RESTART NODE",
+				"desc", "restarting leads to node failure; if you want to restart the node, you should wait a day after the migration completed",
+				"reason", "enough data should be stored to calculate staking info after the state migration is done")
 		}
 		logger.Error("failed to update stakingInfo", "blockNum", blockNum, "staking block number", stakingBlockNumber)
 
 		return nil
 	}
+	stakingManager.stakingInfoCache.add(calcStakingInfo)
 
 	logger.Debug("Get stakingInfo from header.", "blockNum", blockNum, "staking block number", stakingBlockNumber, "stakingInfo", calcStakingInfo)
 	return calcStakingInfo

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -138,7 +138,7 @@ func GetStakingInfo(blockNum uint64) *StakingInfo {
 	calcStakingInfo, _ := updateStakingInfo(stakingBlockNumber)
 	if calcStakingInfo == nil {
 		if stakingManager.migrationCheck.InMigration() {
-			logger.Error("YOU MUST NOT RESTART NODE", "action", "if you want to restart the node, you should wait a day after the migration completes", "reason", "failed to store staking info while migration")
+			logger.Error("YOU MUST NOT RESTART NODE", "action", "if you want to restart the node, you should wait a day after the migration completed", "reason", "failed to store staking info while migration")
 		}
 		logger.Error("failed to update stakingInfo", "blockNum", blockNum, "staking block number", stakingBlockNumber)
 

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -177,8 +177,7 @@ func updateStakingInfo(blockNum uint64) (*StakingInfo, error) {
 // CheckStakingInfoStored makes sure the given staking info is stored in cache and DB
 func CheckStakingInfoStored(blockNum uint64) error {
 	if stakingManager == nil {
-		logger.Error("unable to GetStakingInfo", "err", ErrStakingManagerNotSet)
-		return nil
+		return ErrStakingManagerNotSet
 	}
 
 	stakingBlockNumber := params.CalcStakingBlockNumber(blockNum)

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -145,7 +145,6 @@ func GetStakingInfo(blockNum uint64) *StakingInfo {
 
 		return nil
 	}
-	stakingManager.stakingInfoCache.add(calcStakingInfo)
 
 	logger.Debug("Get stakingInfo from header.", "blockNum", blockNum, "staking block number", stakingBlockNumber, "stakingInfo", calcStakingInfo)
 	return calcStakingInfo

--- a/reward/staking_manager_test.go
+++ b/reward/staking_manager_test.go
@@ -21,13 +21,12 @@ import (
 	"testing"
 )
 
-// checking calculate blockNumber of stakingInfo and return the stakingInfo with the blockNumber correct when stakingInfo is stored in cache
-func TestStakingManager_getStakingInfoFromStakingCache(t *testing.T) {
-	stakingInterval := uint64(86400)
-	testData := []uint64{
+var (
+	stakingInterval = uint64(86400)
+	testData        = []uint64{
 		0, 1, 2, 3,
 	}
-	testCases := []struct {
+	testCases = []struct {
 		stakingNumber  uint64
 		expectedNumber uint64
 	}{
@@ -45,6 +44,27 @@ func TestStakingManager_getStakingInfoFromStakingCache(t *testing.T) {
 		{345601, 259200},
 		{400000, 259200},
 	}
+)
+
+func TestStakingManager_NewStakingManager(t *testing.T) {
+	// test if nil
+	assert.Nil(t, GetStakingManager())
+	assert.Nil(t, GetStakingInfo(123))
+
+	st, err := updateStakingInfo(456)
+	assert.Nil(t, st)
+	assert.EqualError(t, err, ErrStakingManagerNotSet.Error())
+
+	assert.EqualError(t, CheckStakingInfoStored(789), ErrStakingManagerNotSet.Error())
+
+	// test if get same
+	stNew := NewStakingManager(newTestBlockChain(), newDefaultTestGovernance(), nil)
+	stGet := GetStakingManager()
+	assert.Equal(t, stGet, stNew)
+}
+
+// checking calculate blockNumber of stakingInfo and return the stakingInfo with the blockNumber correct when stakingInfo is stored in cache
+func TestStakingManager_getStakingInfoFromStakingCache(t *testing.T) {
 	stakingManager := NewStakingManager(newTestBlockChain(), newDefaultTestGovernance(), nil)
 
 	for i := 0; i < len(testData); i++ {


### PR DESCRIPTION
## Proposed changes

- Before migration, staking information of current and before is stored to DB. If it fails, the migration will not start.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related PR

- [PR#508](https://github.com/klaytn/klaytn/pull/508) : store staking info to DB
- [PR#513](https://github.com/klaytn/klaytn/pull/513) : state trie migration

## Further comments

- `migrationPrerequisites` is created due to cyclic import.
- ~~This PR has conflict with [PR#515](https://github.com/klaytn/klaytn/pull/515)~~ -> confict resolved