### PR TITLE
Introduce bloom filter for state migration

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -320,7 +320,13 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	srcCachedDB := bc.StateCache().TrieDB()
 	targetDB := statedb.NewDatabase(&stateTrieMigrationDB{bc.db})
 
-	trieSync := state.NewStateSync(rootHash, targetDB.DiskDB())
+	// TODO-Klaytn Change NewMemDB to real targetDB for restarting state migration
+	// Present partitionedDB doesn't not support iterator. Therefore targetDB can't not be used.
+	// If state migration is finished without restarting node, this fake empty DB is ok.
+	stateBloom := statedb.NewSyncBloom(uint64(512), database.NewMemDB())
+	defer stateBloom.Close()
+
+	trieSync := state.NewStateSync(rootHash, targetDB.DiskDB(), stateBloom)
 	var queue []common.Hash
 	committedCnt := 0
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -321,7 +321,8 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	targetDB := statedb.NewDatabase(&stateTrieMigrationDB{bc.db})
 
 	// TODO-Klaytn Change NewMemDB to real targetDB for restarting state migration
-	// Present partitionedDB doesn't not support iterator. Therefore targetDB can't not be used.
+	// Present bloom filter for migration.
+	// Since iterator doesn't support partitionedDB, we cannot use targetDB.
 	// If state migration is finished without restarting node, this fake empty DB is ok.
 	stateBloom := statedb.NewSyncBloom(uint64(512), database.NewMemDB())
 	defer stateBloom.Close()

--- a/blockchain/state/sync.go
+++ b/blockchain/state/sync.go
@@ -29,7 +29,7 @@ import (
 )
 
 // NewStateSync create a new state trie download scheduler.
-func NewStateSync(root common.Hash, database statedb.StateTrieReadDB) *statedb.TrieSync {
+func NewStateSync(root common.Hash, database statedb.StateTrieReadDB, bloom *statedb.SyncBloom) *statedb.TrieSync {
 	var syncer *statedb.TrieSync
 	callback := func(leaf []byte, parent common.Hash, parentDepth int) error {
 		serializer := account.NewAccountSerializer()
@@ -43,6 +43,6 @@ func NewStateSync(root common.Hash, database statedb.StateTrieReadDB) *statedb.T
 		}
 		return nil
 	}
-	syncer = statedb.NewTrieSync(root, database, callback)
+	syncer = statedb.NewTrieSync(root, database, callback, bloom)
 	return syncer
 }

--- a/blockchain/state/sync_test.go
+++ b/blockchain/state/sync_test.go
@@ -159,7 +159,7 @@ func checkStateConsistency(db database.DBManager, root common.Hash) error {
 // Tests that an empty state is not scheduled for syncing.
 func TestEmptyStateSync(t *testing.T) {
 	empty := common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
-	if req := NewStateSync(empty, database.NewMemoryDBManager()).Missing(1); len(req) != 0 {
+	if req := NewStateSync(empty, database.NewMemoryDBManager(), statedb.NewSyncBloom(1, database.NewMemDB())).Missing(1); len(req) != 0 {
 		t.Errorf("content requested for empty state: %v", req)
 	}
 }
@@ -175,7 +175,7 @@ func testIterativeStateSync(t *testing.T, count int) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := database.NewMemoryDBManager()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()))
 
 	queue := append([]common.Hash{}, sched.Missing(count)...)
 	for len(queue) > 0 {
@@ -209,7 +209,7 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := database.NewMemoryDBManager()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()))
 
 	queue := append([]common.Hash{}, sched.Missing(0)...)
 	for len(queue) > 0 {
@@ -248,7 +248,7 @@ func testIterativeRandomStateSync(t *testing.T, count int) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := database.NewMemoryDBManager()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()))
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(count) {
@@ -290,7 +290,7 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := database.NewMemoryDBManager()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()))
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(0) {
@@ -339,7 +339,7 @@ func TestIncompleteStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := database.NewMemoryDBManager()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()))
 
 	added := []common.Hash{}
 	queue := append([]common.Hash{}, sched.Missing(1)...)

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -94,7 +94,7 @@ func newTester() *downloadTester {
 	tester.stateDb = database.NewMemoryDBManager()
 	tester.stateDb.GetMemDB().Put(genesis.Root().Bytes(), []byte{0x00})
 
-	tester.downloader = New(FullSync, tester.stateDb, new(event.TypeMux), tester, nil, tester.dropPeer)
+	tester.downloader = New(FullSync, tester.stateDb, statedb.NewSyncBloom(1, tester.stateDb.GetMemDB()), new(event.TypeMux), tester, nil, tester.dropPeer)
 
 	return tester
 }

--- a/datasync/downloader/statesync.go
+++ b/datasync/downloader/statesync.go
@@ -240,7 +240,7 @@ type stateTask struct {
 func newStateSync(d *Downloader, root common.Hash) *stateSync {
 	return &stateSync{
 		d:       d,
-		sched:   state.NewStateSync(root, d.stateDB),
+		sched:   state.NewStateSync(root, d.stateDB, d.stateBloom),
 		keccak:  sha3.NewKeccak256(),
 		tasks:   make(map[common.Hash]*stateTask),
 		deliver: make(chan *stateReq),

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,8 @@ require (
 	github.com/robertkrimen/otto v0.0.0-20180506084358-03d472dc43ab
 	github.com/rs/cors v1.4.0
 	github.com/satori/go.uuid v1.2.0
+	github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570
+	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965
 	github.com/urfave/cli v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,10 @@ github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tL
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570 h1:gIlAHnH1vJb5vwEjIp5kBj/eu99p/bl0Ay2goiPe5xE=
+github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570/go.mod h1:8OR4w3TdeIHIh1g6EMY5p0gVNOovcWC+1vpc7naMuAw=
+github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 h1:njlZPzLwU639dk2kqnCPPv+wNjq7Xb6EfUxe/oX0/NM=
+github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3/go.mod h1:hpGUWaI9xL8pRQCTXQgocU38Qw1g0Us7n5PxxTwTCYU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -294,7 +294,9 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	// Synchronize unitprice
 	cn.txPool.SetGasPrice(big.NewInt(0).SetUint64(governance.UnitPrice()))
 
-	if cn.protocolManager, err = NewProtocolManager(cn.chainConfig, config.SyncMode, config.NetworkId, cn.eventMux, cn.txPool, cn.engine, cn.blockchain, chainDB, ctx.NodeType(), config); err != nil {
+	// Permit the downloader to use the trie cache allowance during fast sync
+	cacheLimit := cacheConfig.TrieCacheLimit
+	if cn.protocolManager, err = NewProtocolManager(cn.chainConfig, config.SyncMode, config.NetworkId, cn.eventMux, cn.txPool, cn.engine, cn.blockchain, chainDB, cacheLimit, ctx.NodeType(), config); err != nil {
 		return nil, err
 	}
 

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -148,7 +148,7 @@ func TestNewProtocolManager(t *testing.T) {
 		mockEngine.EXPECT().Protocol().Return(consensus.Protocol{}).Times(1)
 
 		pm, err := NewProtocolManager(nil, downloader.FastSync, 0, nil, mockTxPool,
-			mockEngine, mockBlockChain, nil, -1, &Config{})
+			mockEngine, mockBlockChain, nil, 1, -1, &Config{})
 
 		assert.Nil(t, pm)
 		assert.Equal(t, errIncompatibleConfig, err)

--- a/storage/database/badger_database.go
+++ b/storage/database/badger_database.go
@@ -163,9 +163,21 @@ func (bg *badgerDB) Delete(key []byte) error {
 	return txn.Commit()
 }
 
-func (bg *badgerDB) NewIterator() *badger.Iterator {
-	txn := bg.db.NewTransaction(false)
-	return txn.NewIterator(badger.DefaultIteratorOptions)
+func (bg *badgerDB) NewIterator() Iterator {
+	//txn := bg.db.NewTransaction(false)
+	//return txn.NewIterator(badger.DefaultIteratorOptions)
+	logger.CritWithStack("badgerDB doesn't support NewIterator")
+	return nil
+}
+
+func (bg *badgerDB) NewIteratorWithStart(start []byte) Iterator {
+	logger.CritWithStack("badgerDB doesn't support NewIteratorWithStart")
+	return nil
+}
+
+func (pdb *badgerDB) NewIteratorWithPrefix(prefix []byte) Iterator {
+	logger.CritWithStack("badgerDB doesn't support NewIteratorWithPrefix")
+	return nil
 }
 
 func (bg *badgerDB) Close() {

--- a/storage/database/interface.go
+++ b/storage/database/interface.go
@@ -66,6 +66,7 @@ type Database interface {
 	NewBatch() Batch
 	Type() DBType
 	Meter(prefix string)
+	Iteratee
 }
 
 // Batch is a write-only database that commits changes to its host database

--- a/storage/database/partitioned_database.go
+++ b/storage/database/partitioned_database.go
@@ -17,6 +17,7 @@
 package database
 
 import (
+	"bytes"
 	"fmt"
 	"path"
 	"strconv"
@@ -147,6 +148,98 @@ func (pdb *partitionedDB) Close() {
 	for _, partition := range pdb.partitions {
 		partition.Close()
 	}
+}
+
+type partitionedDBIterator struct {
+	iterators []Iterator
+	key       []byte
+	value     []byte
+
+	//numBatches uint
+	//
+	//taskCh   chan pdbBatchTask
+	//resultCh chan pdbBatchResult
+}
+
+// NewIterator creates a binary-alphabetical iterator over the entire keyspace
+// contained within the key-value database.
+func (pdb *partitionedDB) NewIterator() Iterator {
+	// TODO-Klaytn implement this later.
+	return nil
+}
+
+// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
+// database content starting at a particular initial key (or after, if it does
+// not exist).
+func (pdb *partitionedDB) NewIteratorWithStart(start []byte) Iterator {
+	iterators := make([]Iterator, 0, pdb.numPartitions)
+	for i := 0; i < int(pdb.numPartitions); i++ {
+		iterators = append(iterators, pdb.partitions[i].NewIteratorWithStart(start))
+	}
+
+	for _, iter := range iterators {
+		if iter != nil {
+			if !iter.Next() {
+				iter = nil
+			}
+		}
+	}
+
+	return &partitionedDBIterator{iterators, nil, nil}
+}
+
+// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix.
+func (pdb *partitionedDB) NewIteratorWithPrefix(prefix []byte) Iterator {
+	// TODO-Klaytn implement this later.
+	return nil
+}
+
+func (pdi *partitionedDBIterator) Next() bool {
+	var minIter Iterator
+	minIdx := -1
+	minKey := []byte{0}
+	minKeyValue := []byte{0}
+
+	for idx, iter := range pdi.iterators {
+		if iter != nil {
+			if bytes.Compare(minKey, iter.Key()) >= 0 {
+				minIdx = idx
+				minIter = iter
+				minKey = iter.Key()
+				minKeyValue = iter.Value()
+			}
+		}
+	}
+
+	if minIter == nil {
+		return false
+	}
+
+	pdi.key = minKey
+	pdi.value = minKeyValue
+
+	if !minIter.Next() {
+		pdi.iterators[minIdx] = nil
+	}
+
+	return false
+}
+
+func (pdi *partitionedDBIterator) Error() error {
+	return nil
+}
+
+func (pdi *partitionedDBIterator) Key() []byte {
+	return nil
+}
+
+func (pdi *partitionedDBIterator) Value() []byte {
+	return nil
+}
+
+func (pdi *partitionedDBIterator) Release() {
+
 }
 
 func (pdb *partitionedDB) NewBatch() Batch {

--- a/storage/database/partitioned_database.go
+++ b/storage/database/partitioned_database.go
@@ -17,7 +17,6 @@
 package database
 
 import (
-	"bytes"
 	"fmt"
 	"path"
 	"strconv"
@@ -151,6 +150,7 @@ func (pdb *partitionedDB) Close() {
 }
 
 type partitionedDBIterator struct {
+	// TODO-Klaytn implement this later.
 	iterators []Iterator
 	key       []byte
 	value     []byte
@@ -172,6 +172,7 @@ func (pdb *partitionedDB) NewIterator() Iterator {
 // database content starting at a particular initial key (or after, if it does
 // not exist).
 func (pdb *partitionedDB) NewIteratorWithStart(start []byte) Iterator {
+	// TODO-Klaytn implement this later.
 	iterators := make([]Iterator, 0, pdb.numPartitions)
 	for i := 0; i < int(pdb.numPartitions); i++ {
 		iterators = append(iterators, pdb.partitions[i].NewIteratorWithStart(start))
@@ -196,50 +197,54 @@ func (pdb *partitionedDB) NewIteratorWithPrefix(prefix []byte) Iterator {
 }
 
 func (pdi *partitionedDBIterator) Next() bool {
-	var minIter Iterator
-	minIdx := -1
-	minKey := []byte{0}
-	minKeyValue := []byte{0}
-
-	for idx, iter := range pdi.iterators {
-		if iter != nil {
-			if bytes.Compare(minKey, iter.Key()) >= 0 {
-				minIdx = idx
-				minIter = iter
-				minKey = iter.Key()
-				minKeyValue = iter.Value()
-			}
-		}
-	}
-
-	if minIter == nil {
-		return false
-	}
-
-	pdi.key = minKey
-	pdi.value = minKeyValue
-
-	if !minIter.Next() {
-		pdi.iterators[minIdx] = nil
-	}
-
-	return false
+	// TODO-Klaytn implement this later.
+	//var minIter Iterator
+	//minIdx := -1
+	//minKey := []byte{0}
+	//minKeyValue := []byte{0}
+	//
+	//for idx, iter := range pdi.iterators {
+	//	if iter != nil {
+	//		if bytes.Compare(minKey, iter.Key()) >= 0 {
+	//			minIdx = idx
+	//			minIter = iter
+	//			minKey = iter.Key()
+	//			minKeyValue = iter.Value()
+	//		}
+	//	}
+	//}
+	//
+	//if minIter == nil {
+	//	return false
+	//}
+	//
+	//pdi.key = minKey
+	//pdi.value = minKeyValue
+	//
+	//if !minIter.Next() {
+	//	pdi.iterators[minIdx] = nil
+	//}
+	//
+	return true
 }
 
 func (pdi *partitionedDBIterator) Error() error {
+	// TODO-Klaytn implement this later.
 	return nil
 }
 
 func (pdi *partitionedDBIterator) Key() []byte {
+	// TODO-Klaytn implement this later.
 	return nil
 }
 
 func (pdi *partitionedDBIterator) Value() []byte {
+	// TODO-Klaytn implement this later.
 	return nil
 }
 
 func (pdi *partitionedDBIterator) Release() {
-
+	// TODO-Klaytn implement this later.
 }
 
 func (pdb *partitionedDB) NewBatch() Batch {

--- a/storage/statedb/sync_bloom.go
+++ b/storage/statedb/sync_bloom.go
@@ -1,0 +1,207 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/steakknife/bloomfilter"
+)
+
+var (
+	bloomAddMeter   = metrics.NewRegisteredMeter("trie/bloom/add", nil)
+	bloomLoadMeter  = metrics.NewRegisteredMeter("trie/bloom/load", nil)
+	bloomTestMeter  = metrics.NewRegisteredMeter("trie/bloom/test", nil)
+	bloomMissMeter  = metrics.NewRegisteredMeter("trie/bloom/miss", nil)
+	bloomFaultMeter = metrics.NewRegisteredMeter("trie/bloom/fault", nil)
+	bloomErrorGauge = metrics.NewRegisteredGauge("trie/bloom/error", nil)
+)
+
+// syncBloomHasher is a wrapper around a byte blob to satisfy the interface API
+// requirements of the bloom library used. It's used to convert a trie hash into
+// a 64 bit mini hash.
+type syncBloomHasher []byte
+
+func (f syncBloomHasher) Write(p []byte) (n int, err error) { panic("not implemented") }
+func (f syncBloomHasher) Sum(b []byte) []byte               { panic("not implemented") }
+func (f syncBloomHasher) Reset()                            { panic("not implemented") }
+func (f syncBloomHasher) BlockSize() int                    { panic("not implemented") }
+func (f syncBloomHasher) Size() int                         { return 8 }
+func (f syncBloomHasher) Sum64() uint64                     { return binary.BigEndian.Uint64(f) }
+
+// SyncBloom is a bloom filter used during fast sync to quickly decide if a trie
+// node already exists on disk or not. It self populates from the provided disk
+// database on creation in a background thread and will only start returning live
+// results once that's finished.
+type SyncBloom struct {
+	bloom  *bloomfilter.Filter
+	inited uint32
+	closer sync.Once
+	closed uint32
+	pend   sync.WaitGroup
+}
+
+// NewSyncBloom creates a new bloom filter of the given size (in megabytes) and
+// initializes it from the database. The bloom is hard coded to use 3 filters.
+func NewSyncBloom(memory uint64, database ethdb.Iteratee) *SyncBloom {
+	// Create the bloom filter to track known trie nodes
+	bloom, err := bloomfilter.New(memory*1024*1024*8, 3)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create bloom: %v", err))
+	}
+	log.Info("Allocated fast sync bloom", "size", common.StorageSize(memory*1024*1024))
+
+	// Assemble the fast sync bloom and init it from previous sessions
+	b := &SyncBloom{
+		bloom: bloom,
+	}
+	b.pend.Add(2)
+	go func() {
+		defer b.pend.Done()
+		b.init(database)
+	}()
+	go func() {
+		defer b.pend.Done()
+		b.meter()
+	}()
+	return b
+}
+
+// init iterates over the database, pushing every trie hash into the bloom filter.
+func (b *SyncBloom) init(database ethdb.Iteratee) {
+	// Iterate over the database, but restart every now and again to avoid holding
+	// a persistent snapshot since fast sync can push a ton of data concurrently,
+	// bloating the disk.
+	//
+	// Note, this is fine, because everything inserted into leveldb by fast sync is
+	// also pushed into the bloom directly, so we're not missing anything when the
+	// iterator is swapped out for a new one.
+	it := database.NewIterator()
+
+	var (
+		start = time.Now()
+		swap  = time.Now()
+	)
+	for it.Next() && atomic.LoadUint32(&b.closed) == 0 {
+		// If the database entry is a trie node, add it to the bloom
+		if key := it.Key(); len(key) == common.HashLength {
+			b.bloom.Add(syncBloomHasher(key))
+			bloomLoadMeter.Mark(1)
+		}
+		// If enough time elapsed since the last iterator swap, restart
+		if time.Since(swap) > 8*time.Second {
+			key := common.CopyBytes(it.Key())
+
+			it.Release()
+			it = database.NewIteratorWithStart(key)
+
+			log.Info("Initializing fast sync bloom", "items", b.bloom.N(), "errorrate", b.errorRate(), "elapsed", common.PrettyDuration(time.Since(start)))
+			swap = time.Now()
+		}
+	}
+	it.Release()
+
+	// Mark the bloom filter inited and return
+	log.Info("Initialized fast sync bloom", "items", b.bloom.N(), "errorrate", b.errorRate(), "elapsed", common.PrettyDuration(time.Since(start)))
+	atomic.StoreUint32(&b.inited, 1)
+}
+
+// meter periodically recalculates the false positive error rate of the bloom
+// filter and reports it in a metric.
+func (b *SyncBloom) meter() {
+	for {
+		// Report the current error ration. No floats, lame, scale it up.
+		bloomErrorGauge.Update(int64(b.errorRate() * 100000))
+
+		// Wait one second, but check termination more frequently
+		for i := 0; i < 10; i++ {
+			if atomic.LoadUint32(&b.closed) == 1 {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+// Close terminates any background initializer still running and releases all the
+// memory allocated for the bloom.
+func (b *SyncBloom) Close() error {
+	b.closer.Do(func() {
+		// Ensure the initializer is stopped
+		atomic.StoreUint32(&b.closed, 1)
+		b.pend.Wait()
+
+		// Wipe the bloom, but mark it "uninited" just in case someone attempts an access
+		log.Info("Deallocated fast sync bloom", "items", b.bloom.N(), "errorrate", b.errorRate())
+
+		atomic.StoreUint32(&b.inited, 0)
+		b.bloom = nil
+	})
+	return nil
+}
+
+// Add inserts a new trie node hash into the bloom filter.
+func (b *SyncBloom) Add(hash []byte) {
+	if atomic.LoadUint32(&b.closed) == 1 {
+		return
+	}
+	b.bloom.Add(syncBloomHasher(hash))
+	bloomAddMeter.Mark(1)
+}
+
+// Contains tests if the bloom filter contains the given hash:
+//   - false: the bloom definitely does not contain hash
+//   - true:  the bloom maybe contains hash
+//
+// While the bloom is being initialized, any query will return true.
+func (b *SyncBloom) Contains(hash []byte) bool {
+	bloomTestMeter.Mark(1)
+	if atomic.LoadUint32(&b.inited) == 0 {
+		// We didn't load all the trie nodes from the previous run of Geth yet. As
+		// such, we can't say for sure if a hash is not present for anything. Until
+		// the init is done, we're faking "possible presence" for everything.
+		return true
+	}
+	// Bloom initialized, check the real one and report any successful misses
+	maybe := b.bloom.Contains(syncBloomHasher(hash))
+	if !maybe {
+		bloomMissMeter.Mark(1)
+	}
+	return maybe
+}
+
+// errorRate calculates the probability of a random containment test returning a
+// false positive.
+//
+// We're calculating it ourselves because the bloom library we used missed a
+// parentheses in the formula and calculates it wrong. And it's discontinued...
+func (b *SyncBloom) errorRate() float64 {
+	k := float64(b.bloom.K())
+	n := float64(b.bloom.N())
+	m := float64(b.bloom.M())
+
+	return math.Pow(1.0-math.Exp((-k)*(n+0.5)/(m-1)), k)
+}

--- a/storage/statedb/sync_test.go
+++ b/storage/statedb/sync_test.go
@@ -100,7 +100,7 @@ func TestEmptyTrieSync(t *testing.T) {
 	emptyB, _ := NewTrie(emptyRoot, dbB)
 
 	for i, trie := range []*Trie{emptyA, emptyB} {
-		if req := NewTrieSync(trie.Hash(), database.NewMemoryDBManager(), nil).Missing(1); len(req) != 0 {
+		if req := NewTrieSync(trie.Hash(), database.NewMemoryDBManager(), nil, NewSyncBloom(1, database.NewMemDB())).Missing(1); len(req) != 0 {
 			t.Errorf("test %d: content requested for empty trie: %v", i, req)
 		}
 	}
@@ -119,7 +119,7 @@ func testIterativeTrieSync(t *testing.T, batch int) {
 	memDBManager := database.NewMemoryDBManager()
 	diskdb := memDBManager.GetMemDB()
 	triedb := NewDatabase(memDBManager)
-	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil)
+	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil, NewSyncBloom(1, diskdb))
 
 	queue := append([]common.Hash{}, sched.Missing(batch)...)
 	for len(queue) > 0 {
@@ -153,7 +153,7 @@ func TestIterativeDelayedTrieSync(t *testing.T) {
 	memDBManager := database.NewMemoryDBManager()
 	diskdb := memDBManager.GetMemDB()
 	triedb := NewDatabase(memDBManager)
-	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil)
+	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil, NewSyncBloom(1, diskdb))
 
 	queue := append([]common.Hash{}, sched.Missing(10000)...)
 	for len(queue) > 0 {
@@ -192,7 +192,7 @@ func testIterativeRandomTrieSync(t *testing.T, batch int) {
 	memDBManager := database.NewMemoryDBManager()
 	diskdb := memDBManager.GetMemDB()
 	triedb := NewDatabase(memDBManager)
-	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil)
+	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil, NewSyncBloom(1, diskdb))
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(batch) {
@@ -234,7 +234,7 @@ func TestIterativeRandomDelayedTrieSync(t *testing.T) {
 	memDBManager := database.NewMemoryDBManager()
 	diskdb := memDBManager.GetMemDB()
 	triedb := NewDatabase(memDBManager)
-	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil)
+	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil, NewSyncBloom(1, diskdb))
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(10000) {
@@ -282,7 +282,7 @@ func TestDuplicateAvoidanceTrieSync(t *testing.T) {
 	memDBManager := database.NewMemoryDBManager()
 	diskdb := memDBManager.GetMemDB()
 	triedb := NewDatabase(memDBManager)
-	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil)
+	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil, NewSyncBloom(1, diskdb))
 
 	queue := append([]common.Hash{}, sched.Missing(0)...)
 	requested := make(map[common.Hash]struct{})
@@ -323,7 +323,7 @@ func TestIncompleteTrieSync(t *testing.T) {
 	memDBManager := database.NewMemoryDBManager()
 	diskdb := memDBManager.GetMemDB()
 	triedb := NewDatabase(memDBManager)
-	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil)
+	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil, NewSyncBloom(1, diskdb))
 
 	added := []common.Hash{}
 	queue := append([]common.Hash{}, sched.Missing(1)...)


### PR DESCRIPTION
## Proposed changes

This PR introduce bloom filter for stateSync to reduce getting trie node from new state trie DB.
This work to getting trie node can prevent duplicated fetch. 

This feature is come from https://github.com/ethereum/go-ethereum/pull/19489.
In the PR, bloom filter is for state sync of fast sync downloader.

This PR applied bloom filter for state migration and fast sync also.
But fast sync is not yet supported feature in Klaytn.
However, this PR applied bloom filter to fast sync for future work.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
