### PR TITLE
blockchain: added more info to preCheck and buyGas error

### DIFF
--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -181,7 +181,8 @@ func (st *StateTransition) buyGas() error {
 
 		if st.state.GetBalance(validatedSender).Cmp(senderFee) < 0 {
 			logger.Debug(errInsufficientBalanceForGas.Error(), "sender", validatedSender.String(),
-				"senderBalance", st.state.GetBalance(validatedSender).Uint64(), "senderFee", senderFee.Uint64(), "txHash", st.msg.Hash().String())
+				"senderBalance", st.state.GetBalance(validatedSender).Uint64(), "senderFee", senderFee.Uint64(),
+				"txHash", st.msg.Hash().String())
 			return errInsufficientBalanceForGas
 		}
 
@@ -191,7 +192,8 @@ func (st *StateTransition) buyGas() error {
 		// to make a short circuit, process the special case feeRatio == MaxFeeRatio
 		if st.state.GetBalance(validatedFeePayer).Cmp(mgval) < 0 {
 			logger.Debug(errInsufficientBalanceForGasFeePayer.Error(), "feePayer", validatedFeePayer.String(),
-				"feePayerBalance", st.state.GetBalance(validatedFeePayer).Uint64(), "feePayerFee", mgval.Uint64(), "txHash", st.msg.Hash().String())
+				"feePayerBalance", st.state.GetBalance(validatedFeePayer).Uint64(), "feePayerFee", mgval.Uint64(),
+				"txHash", st.msg.Hash().String())
 			return errInsufficientBalanceForGasFeePayer
 		}
 

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -170,21 +170,30 @@ func (st *StateTransition) buyGas() error {
 	validatedSender := st.msg.ValidatedSender()
 	feeRatio, isRatioTx := st.msg.FeeRatio()
 	if isRatioTx {
-		feePayer, feeSender := types.CalcFeeWithRatio(feeRatio, mgval)
+		feePayerFee, senderFee := types.CalcFeeWithRatio(feeRatio, mgval)
 
-		if st.state.GetBalance(validatedFeePayer).Cmp(feePayer) < 0 {
+		if st.state.GetBalance(validatedFeePayer).Cmp(feePayerFee) < 0 {
+			logger.Error("%w - feePayer: %v, feePayerBalance: %v, feePayerFee: %v, txHash: %v",
+				errInsufficientBalanceForGasFeePayer, validatedFeePayer.String(), st.state.GetBalance(validatedFeePayer).Uint64(),
+				feePayerFee.Uint64(), st.msg.Hash().String())
 			return errInsufficientBalanceForGasFeePayer
 		}
 
-		if st.state.GetBalance(validatedSender).Cmp(feeSender) < 0 {
+		if st.state.GetBalance(validatedSender).Cmp(senderFee) < 0 {
+			logger.Error("%w - sender: %v, senderBalance: %v, senderFee: %v, txHash: %v",
+				errInsufficientBalanceForGas, validatedSender.String(), st.state.GetBalance(validatedSender).Uint64(),
+				senderFee.Uint64(), st.msg.Hash().String())
 			return errInsufficientBalanceForGas
 		}
 
-		st.state.SubBalance(validatedFeePayer, feePayer)
-		st.state.SubBalance(validatedSender, feeSender)
+		st.state.SubBalance(validatedFeePayer, feePayerFee)
+		st.state.SubBalance(validatedSender, senderFee)
 	} else {
 		// to make a short circuit, process the special case feeRatio == MaxFeeRatio
 		if st.state.GetBalance(validatedFeePayer).Cmp(mgval) < 0 {
+			logger.Error("%w - feePayer: %v, feePayerBalance: %v, feePayerFee: %v, txHash: %v",
+				errInsufficientBalanceForGasFeePayer, validatedFeePayer.String(), st.state.GetBalance(validatedFeePayer).Uint64(),
+				mgval.Uint64(), st.msg.Hash().String())
 			return errInsufficientBalanceForGasFeePayer
 		}
 
@@ -202,8 +211,12 @@ func (st *StateTransition) preCheck() error {
 	if st.msg.CheckNonce() {
 		nonce := st.state.GetNonce(st.msg.ValidatedSender())
 		if nonce < st.msg.Nonce() {
+			logger.Error("%w - addr: %v, accountNonce: %v, txNonce: %v, txHash: %v",
+				ErrNonceTooHigh, st.msg.ValidatedSender().String(), nonce, st.msg.Nonce(), st.msg.Hash().String())
 			return ErrNonceTooHigh
 		} else if nonce > st.msg.Nonce() {
+			logger.Error("%w - addr: %v, accountNonce: %v, txNonce: %v, txHash: %v",
+				ErrNonceTooLow, st.msg.ValidatedSender().String(), nonce, st.msg.Nonce(), st.msg.Hash().String())
 			return ErrNonceTooLow
 		}
 	}

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -173,16 +173,15 @@ func (st *StateTransition) buyGas() error {
 		feePayerFee, senderFee := types.CalcFeeWithRatio(feeRatio, mgval)
 
 		if st.state.GetBalance(validatedFeePayer).Cmp(feePayerFee) < 0 {
-			logger.Debug("%w - feePayer: %v, feePayerBalance: %v, feePayerFee: %v, txHash: %v",
-				errInsufficientBalanceForGasFeePayer, validatedFeePayer.String(), st.state.GetBalance(validatedFeePayer).Uint64(),
-				feePayerFee.Uint64(), st.msg.Hash().String())
+			logger.Debug(errInsufficientBalanceForGasFeePayer.Error(), "feePayer", validatedFeePayer.String(),
+				"feePayerBalance", st.state.GetBalance(validatedFeePayer).Uint64(), "feePayerFee", feePayerFee.Uint64(),
+				"txHash", st.msg.Hash().String())
 			return errInsufficientBalanceForGasFeePayer
 		}
 
 		if st.state.GetBalance(validatedSender).Cmp(senderFee) < 0 {
-			logger.Debug("%w - sender: %v, senderBalance: %v, senderFee: %v, txHash: %v",
-				errInsufficientBalanceForGas, validatedSender.String(), st.state.GetBalance(validatedSender).Uint64(),
-				senderFee.Uint64(), st.msg.Hash().String())
+			logger.Debug(errInsufficientBalanceForGas.Error(), "sender", validatedSender.String(),
+				"senderBalance", st.state.GetBalance(validatedSender).Uint64(), "senderFee", senderFee.Uint64(), "txHash", st.msg.Hash().String())
 			return errInsufficientBalanceForGas
 		}
 
@@ -191,9 +190,8 @@ func (st *StateTransition) buyGas() error {
 	} else {
 		// to make a short circuit, process the special case feeRatio == MaxFeeRatio
 		if st.state.GetBalance(validatedFeePayer).Cmp(mgval) < 0 {
-			logger.Debug("%w - feePayer: %v, feePayerBalance: %v, feePayerFee: %v, txHash: %v",
-				errInsufficientBalanceForGasFeePayer, validatedFeePayer.String(), st.state.GetBalance(validatedFeePayer).Uint64(),
-				mgval.Uint64(), st.msg.Hash().String())
+			logger.Debug(errInsufficientBalanceForGasFeePayer.Error(), "feePayer", validatedFeePayer.String(),
+				"feePayerBalance", st.state.GetBalance(validatedFeePayer).Uint64(), "feePayerFee", mgval.Uint64(), "txHash", st.msg.Hash().String())
 			return errInsufficientBalanceForGasFeePayer
 		}
 
@@ -211,12 +209,12 @@ func (st *StateTransition) preCheck() error {
 	if st.msg.CheckNonce() {
 		nonce := st.state.GetNonce(st.msg.ValidatedSender())
 		if nonce < st.msg.Nonce() {
-			logger.Debug("%w - addr: %v, accountNonce: %v, txNonce: %v, txHash: %v",
-				ErrNonceTooHigh, st.msg.ValidatedSender().String(), nonce, st.msg.Nonce(), st.msg.Hash().String())
+			logger.Debug(ErrNonceTooHigh.Error(), "account", st.msg.ValidatedSender().String(),
+				"accountNonce", nonce, "txNonce", st.msg.Nonce(), "txHash", st.msg.Hash().String())
 			return ErrNonceTooHigh
 		} else if nonce > st.msg.Nonce() {
-			logger.Debug("%w - addr: %v, accountNonce: %v, txNonce: %v, txHash: %v",
-				ErrNonceTooLow, st.msg.ValidatedSender().String(), nonce, st.msg.Nonce(), st.msg.Hash().String())
+			logger.Debug(ErrNonceTooLow.Error(), "account", st.msg.ValidatedSender().String(),
+				"accountNonce", nonce, "txNonce", st.msg.Nonce(), "txHash", st.msg.Hash().String())
 			return ErrNonceTooLow
 		}
 	}

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -173,14 +173,14 @@ func (st *StateTransition) buyGas() error {
 		feePayerFee, senderFee := types.CalcFeeWithRatio(feeRatio, mgval)
 
 		if st.state.GetBalance(validatedFeePayer).Cmp(feePayerFee) < 0 {
-			logger.Error("%w - feePayer: %v, feePayerBalance: %v, feePayerFee: %v, txHash: %v",
+			logger.Debug("%w - feePayer: %v, feePayerBalance: %v, feePayerFee: %v, txHash: %v",
 				errInsufficientBalanceForGasFeePayer, validatedFeePayer.String(), st.state.GetBalance(validatedFeePayer).Uint64(),
 				feePayerFee.Uint64(), st.msg.Hash().String())
 			return errInsufficientBalanceForGasFeePayer
 		}
 
 		if st.state.GetBalance(validatedSender).Cmp(senderFee) < 0 {
-			logger.Error("%w - sender: %v, senderBalance: %v, senderFee: %v, txHash: %v",
+			logger.Debug("%w - sender: %v, senderBalance: %v, senderFee: %v, txHash: %v",
 				errInsufficientBalanceForGas, validatedSender.String(), st.state.GetBalance(validatedSender).Uint64(),
 				senderFee.Uint64(), st.msg.Hash().String())
 			return errInsufficientBalanceForGas
@@ -191,7 +191,7 @@ func (st *StateTransition) buyGas() error {
 	} else {
 		// to make a short circuit, process the special case feeRatio == MaxFeeRatio
 		if st.state.GetBalance(validatedFeePayer).Cmp(mgval) < 0 {
-			logger.Error("%w - feePayer: %v, feePayerBalance: %v, feePayerFee: %v, txHash: %v",
+			logger.Debug("%w - feePayer: %v, feePayerBalance: %v, feePayerFee: %v, txHash: %v",
 				errInsufficientBalanceForGasFeePayer, validatedFeePayer.String(), st.state.GetBalance(validatedFeePayer).Uint64(),
 				mgval.Uint64(), st.msg.Hash().String())
 			return errInsufficientBalanceForGasFeePayer
@@ -211,11 +211,11 @@ func (st *StateTransition) preCheck() error {
 	if st.msg.CheckNonce() {
 		nonce := st.state.GetNonce(st.msg.ValidatedSender())
 		if nonce < st.msg.Nonce() {
-			logger.Error("%w - addr: %v, accountNonce: %v, txNonce: %v, txHash: %v",
+			logger.Debug("%w - addr: %v, accountNonce: %v, txNonce: %v, txHash: %v",
 				ErrNonceTooHigh, st.msg.ValidatedSender().String(), nonce, st.msg.Nonce(), st.msg.Hash().String())
 			return ErrNonceTooHigh
 		} else if nonce > st.msg.Nonce() {
-			logger.Error("%w - addr: %v, accountNonce: %v, txNonce: %v, txHash: %v",
+			logger.Debug("%w - addr: %v, accountNonce: %v, txNonce: %v, txHash: %v",
 				ErrNonceTooLow, st.msg.ValidatedSender().String(), nonce, st.msg.Nonce(), st.msg.Hash().String())
 			return ErrNonceTooLow
 		}


### PR DESCRIPTION
## Proposed changes

- When an error is returned from `preCheck` or `buyGas` function, it only returns the type of the error, not the information related to the error
- To help debugging, wrapping an error before returning the error to the caller

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
