### PR TITLE
State Migration: Skip checking staking info if stored in DB

### DIFF
--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -169,7 +169,7 @@ func CheckStakingInfoStored(blockNum uint64) error {
 	stakingBlockNumber := params.CalcStakingBlockNumber(blockNum)
 
 	// skip checking if staking info is stored in DB
-	if stakingInfo, err := getStakingInfoFromDB(stakingBlockNumber); stakingInfo != nil && err == nil {
+	if _, err := getStakingInfoFromDB(stakingBlockNumber); err == nil {
 		return nil
 	}
 

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -167,8 +167,14 @@ func CheckStakingInfoStored(blockNum uint64) error {
 	}
 
 	stakingBlockNumber := params.CalcStakingBlockNumber(blockNum)
-	_, err := updateStakingInfo(stakingBlockNumber)
 
+	// skip checking if staking info is stored in DB
+	if stakingInfo, err := getStakingInfoFromDB(stakingBlockNumber); stakingInfo != nil && err == nil {
+		return nil
+	}
+
+	// update staking info in DB and cache from address book
+	_, err := updateStakingInfo(stakingBlockNumber)
 	return err
 }
 


### PR DESCRIPTION
## Proposed changes

- Fetching staking info from address book is uneccessary if it is stored in DB.
- Because of this, it was unable to migration twice in a row in the original code.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues



## Further comments


