### PR TITLE
[StateMigration]Flush referenced trie nodes to new stateTrieDB

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1086,11 +1086,11 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 				return err
 			}
 
-			bc.checkStartStateMigration(block.NumberU64(), root)
-
-			// flush referenced trie nodes out to new stateTrieDB
-			if err := trieDB.Cap(0); err != nil {
-				logger.Error("Error from trieDB.Cap by state migration", "err", err)
+			if bc.checkStartStateMigration(block.NumberU64(), root) {
+				// flush referenced trie nodes out to new stateTrieDB
+				if err := trieDB.Cap(0); err != nil {
+					logger.Error("Error from trieDB.Cap by state migration", "err", err)
+				}
 			}
 		}
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1076,7 +1076,7 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 			// NOTE-Klaytn Not to change the original behavior, error is not returned.
 			// Error should be returned if it is thought to be safe in the future.
 			if err := trieDB.Cap(nodesSizeLimit - database.IdealBatchSize); err != nil {
-				logger.Error("Error from trieDB.Cap", "limit", nodesSizeLimit-database.IdealBatchSize)
+				logger.Error("Error from trieDB.Cap", "err", err, "limit", nodesSizeLimit-database.IdealBatchSize)
 			}
 		}
 
@@ -1088,8 +1088,9 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 
 			bc.checkStartStateMigration(block.NumberU64(), root)
 
+			// flush referenced trie nodes out to new stateTrieDB
 			if err := trieDB.Cap(0); err != nil {
-				logger.Error("Error from trieDB.Cap by state migration" )
+				logger.Error("Error from trieDB.Cap by state migration", "err", err)
 			}
 		}
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1087,6 +1087,10 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 			}
 
 			bc.checkStartStateMigration(block.NumberU64(), root)
+
+			if err := trieDB.Cap(0); err != nil {
+				logger.Error("Error from trieDB.Cap by state migration" )
+			}
 		}
 
 		bc.chBlock <- gcBlock{root, block.NumberU64()}

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -264,7 +264,7 @@ func (bc *BlockChain) PrepareStateMigration() error {
 	return nil
 }
 
-func (bc *BlockChain) checkStartStateMigration(number uint64, root common.Hash) {
+func (bc *BlockChain) checkStartStateMigration(number uint64, root common.Hash) bool {
 	if bc.prepareStateMigration {
 		logger.Info("State migration is started", "block", number, "root", root)
 
@@ -273,7 +273,11 @@ func (bc *BlockChain) checkStartStateMigration(number uint64, root common.Hash) 
 		}
 
 		bc.prepareStateMigration = false
+
+		return true
 	}
+
+	return false
 }
 
 // migrationPrerequisites is a collection of functions that needs to be run

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -691,7 +691,6 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	}
 	// Keep committing nodes from the flush-list until we're below allowance
 	oldest := db.oldest
-	// TODO-Klaytn What kind of batch should be used below?
 	batch := db.diskDB.NewBatch(database.StateTrieDB)
 	for size > limit && oldest != (common.Hash{}) {
 		// Fetch the oldest referenced node and push into the batch
@@ -749,7 +748,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	memcacheFlushSizeGauge.Update(int64(nodeSize - db.nodesSize))
 	memcacheFlushNodesGauge.Update(int64(nodes - len(db.nodes)))
 
-	logger.Debug("Persisted nodes from memory database", "nodes", nodes-len(db.nodes), "size", nodeSize-db.nodesSize, "time", time.Since(start),
+	logger.Info("Persisted nodes from memory database by Cap", "nodes", nodes-len(db.nodes), "size", nodeSize-db.nodesSize, "time", time.Since(start),
 		"flushnodes", db.flushnodes, "flushsize", db.flushsize, "flushtime", db.flushtime, "livenodes", len(db.nodes), "livesize", db.nodesSize)
 
 	return nil


### PR DESCRIPTION
## Proposed changes

This PR added the routine to flush reference trie nodes to new stateTrieDB when state trie migration is started.

This can prevent trie nodes lost in old stateTrieDB.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
