### PR TITLE
TrieSync: Fix short node depth

### DIFF
--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -354,8 +354,7 @@ func (s *TrieSync) commit(req *request) (err error) {
 	// Write the node content to the membatch
 	s.membatch.batch[req.hash] = req.data
 	s.membatch.order = append(s.membatch.order, req.hash)
-	//logger.Warn("add membatch", "hash", req.hash.String(), "depth", req.depth, "depth % shortNodeDepthOffset", req.depth%shortNodeDepthOffset)
-
+	
 	delete(s.requests, req.hash)
 
 	// Check all parents for completion

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -354,7 +354,7 @@ func (s *TrieSync) commit(req *request) (err error) {
 	// Write the node content to the membatch
 	s.membatch.batch[req.hash] = req.data
 	s.membatch.order = append(s.membatch.order, req.hash)
-	
+
 	delete(s.requests, req.hash)
 
 	// Check all parents for completion


### PR DESCRIPTION
## Proposed changes
This PR fixed the short trie node depth value.
Previous depth is extra path. But it is not a physical depth value.
So this PR introduces offset value.

This make same high priority with previous one. 
But with modulus operator it can show the physical right depth.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
