### PR TITLE
Reorganize the stop sequence of modules

### DIFF
--- a/node/cn/bloombits.go
+++ b/node/cn/bloombits.go
@@ -56,7 +56,7 @@ func (cn *CN) startBloomHandlers() {
 		go func() {
 			for {
 				select {
-				case <-cn.shutdownChan:
+				case <-cn.closeBloomHandler:
 					return
 
 				case request := <-cn.bloomRequests:


### PR DESCRIPTION
## Proposed changes

When `(*cn) Stop()` is called, it stops blockchain and then stops chainDB.
```
s.blockchain.Stop()
// stop others
s.chainDB.Close()
```

However, blockchain still processes inserted block and tries to write data to `chainDB`. 
Because of this, `chainDB` may closes databases during the data insertion and remains incomplete data in databases.

With this PR, `protocolManger`, which fetch blocks from other nodes, will be closed earlier than others. 

Related PR: https://github.com/ethereum/go-ethereum/pull/20695

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
