### PR TITLE
[State Migration] Support stop migration (writing old/new DB)

### DIFF
--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -130,7 +130,6 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 
 	// Migration main loop
 	for trieSync.Pending() > 0 {
-		time.Sleep(time.Second)
 		bc.committedCnt, bc.pendingCnt = committedCnt, trieSync.Pending()
 		queue = append(queue[:0], trieSync.Missing(1024)...)
 		results := make([]statedb.SyncResult, len(queue))

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -96,10 +96,9 @@ func (bc *BlockChain) concurrentRead(db *statedb.Database, quitCh chan struct{},
 // After the migration finish, the original StateTrieDB is removed and StateTrieMigrationDB becomes a new StateTrieDB.
 func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 	bc.wg.Add(1)
-	defer bc.wg.Done()
-
 	defer func() {
 		bc.db.FinishStateMigration(returnErr == nil)
+		bc.wg.Done()
 	}()
 
 	start := time.Now()

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -207,10 +207,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 		return err
 	}
 	checkElapsed := time.Since(startCheck)
-	logger.Info("State migration : Consistency check is done", "elapsed", checkElapsed)
-
-	logger.Info("completed state migration")
-
+	logger.Info("State migration is completed", "copyElapsed", elapsed, "checkElapsed", checkElapsed)
 	return nil
 }
 

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -172,9 +172,7 @@ func (api *PrivateAdminAPI) StartStateMigration() error {
 
 // StopStateMigration stops state migration and removes stateMigrationDB.
 func (api *PrivateAdminAPI) StopStateMigration() error {
-	// TODO-Klaytn need to support stopStateMigration
-	// return api.cn.BlockChain().StopStateMigration()
-	return errors.New("StopStateMigration is not yet supported")
+	return api.cn.BlockChain().StopStateMigration()
 }
 
 // StatusStateMigration returns the status information of state trie migration.

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -522,8 +522,7 @@ func (stdBatch *stateTrieDBBatch) ValueSize() int {
 	return maxSize
 }
 
-// Write passes the list of batch tasks to taskCh so batch can be processed
-// by underlying workers. Write waits until all workers return the result.
+// Write passes the list of batch to WriteBatchesParallel for writing batches.
 func (stdBatch *stateTrieDBBatch) Write() error {
 	_, err := WriteBatchesParallel(stdBatch.batches...)
 	return err

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -525,9 +525,9 @@ func (stdBatch *stateTrieDBBatch) ValueSize() int {
 func (stdBatch *stateTrieDBBatch) Write() error {
 	resultCh := make(chan error, len(stdBatch.batches))
 	for _, batch := range stdBatch.batches {
-		go func() {
+		go func(batch Batch) {
 			resultCh <- batch.Write()
-		}()
+		}(batch)
 	}
 
 	var errResult error

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -479,10 +479,12 @@ func (dbm *databaseManager) NewBatch(dbEntryType DBEntryType) Batch {
 		defer dbm.lockInMigration.RUnlock()
 
 		if dbm.inMigration {
-			newDBBatch := dbm.GetStateTrieMigrationDB().NewBatch()
-			oldDBBatch := dbm.getDatabase(dbEntryType).NewBatch()
+			newDBBatch := dbm.getDatabase(StateTrieMigrationDB).NewBatch()
+			oldDBBatch := dbm.getDatabase(StateTrieDB).NewBatch()
 			return NewStateTrieDBBatch([]Batch{oldDBBatch, newDBBatch})
 		}
+	} else if dbEntryType == StateTrieMigrationDB {
+		return dbm.GetStateTrieMigrationDB().NewBatch()
 	}
 	return dbm.getDatabase(dbEntryType).NewBatch()
 }

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -48,7 +48,7 @@ type DBManager interface {
 	GetMemDB() *MemDB
 	GetDBConfig() *DBConfig
 	CreateMigrationDBAndSetStatus(blockNum uint64) error
-	FinishStateMigration()
+	FinishStateMigration(succeed bool)
 	GetStateTrieDB() Database
 	GetStateTrieMigrationDB() Database
 	GetMiscDB() Database
@@ -479,10 +479,72 @@ func (dbm *databaseManager) NewBatch(dbEntryType DBEntryType) Batch {
 		defer dbm.lockInMigration.RUnlock()
 
 		if dbm.inMigration {
-			return dbm.GetStateTrieMigrationDB().NewBatch()
+			newDBBatch := dbm.GetStateTrieMigrationDB().NewBatch()
+			oldDBBatch := dbm.getDatabase(dbEntryType).NewBatch()
+			return NewStateTrieDBBatch([]Batch{oldDBBatch, newDBBatch})
 		}
 	}
 	return dbm.getDatabase(dbEntryType).NewBatch()
+}
+
+func NewStateTrieDBBatch(batches []Batch) Batch {
+	return &stateTrieDBBatch{batches: batches}
+}
+
+type stateTrieDBBatch struct {
+	batches []Batch
+}
+
+func (stdBatch *stateTrieDBBatch) Put(key []byte, value []byte) error {
+	var errResult error
+	for _, batch := range stdBatch.batches {
+		if err := batch.Put(key, value); err != nil {
+			errResult = err
+		}
+	}
+
+	return errResult
+}
+
+// ValueSize is called to determine whether to write batches when it exceeds
+// certain limit. partitionedDB returns the largest size of its batches to
+// write all batches at once when one of batch exceeds the limit.
+func (stdBatch *stateTrieDBBatch) ValueSize() int {
+	maxSize := 0
+	for _, batch := range stdBatch.batches {
+		if batch.ValueSize() > maxSize {
+			maxSize = batch.ValueSize()
+		}
+	}
+
+	return maxSize
+}
+
+// Write passes the list of batch tasks to taskCh so batch can be processed
+// by underlying workers. Write waits until all workers return the result.
+func (stdBatch *stateTrieDBBatch) Write() error {
+	resultCh := make(chan error, len(stdBatch.batches))
+	for _, batch := range stdBatch.batches {
+		go func() {
+			resultCh <- batch.Write()
+		}()
+	}
+
+	var errResult error
+	for range stdBatch.batches {
+		err := <-resultCh
+		if err != nil {
+			errResult = err
+		}
+	}
+
+	return errResult
+}
+
+func (stdBatch *stateTrieDBBatch) Reset() {
+	for _, batch := range stdBatch.batches {
+		batch.Reset()
+	}
 }
 
 func (dbm *databaseManager) getDBDir(dbEntry DBEntryType) string {
@@ -580,24 +642,31 @@ func (dbm *databaseManager) CreateMigrationDBAndSetStatus(blockNum uint64) error
 
 // FinishStateMigration updates stateTrieDB and removes the old one.
 // The function should be called only after when state trie migration is finished.
-func (dbm *databaseManager) FinishStateMigration() {
-	oldDB := dbm.dbs[StateTrieDB]
-	newDB := dbm.dbs[StateTrieMigrationDB]
-	oldDBDir := dbm.getDBDir(StateTrieDB)
-	newDBDir := dbm.getDBDir(StateTrieMigrationDB)
+func (dbm *databaseManager) FinishStateMigration(succeed bool) {
+	dbRemoved := StateTrieDB
+	dbUsed := StateTrieMigrationDB
+
+	if !succeed {
+		dbRemoved, dbUsed = dbUsed, dbRemoved
+	}
+
+	dbToBeRemoved := dbm.dbs[dbRemoved]
+	dbToBeUsed := dbm.dbs[dbUsed]
+	dbDirToBeRemoved := dbm.getDBDir(dbRemoved)
+	dbDirToBeUsed := dbm.getDBDir(dbUsed)
 
 	// Replace StateTrieDB with new one
-	dbm.setDBDir(StateTrieDB, newDBDir)
-	dbm.dbs[StateTrieDB] = newDB
+	dbm.setDBDir(StateTrieDB, dbDirToBeUsed)
+	dbm.dbs[StateTrieDB] = dbToBeUsed
 
 	dbm.setStateTrieMigrationStatus(0)
 
 	dbm.dbs[StateTrieMigrationDB] = nil
 	dbm.setDBDir(StateTrieMigrationDB, "")
 
-	oldDBPath := filepath.Join(dbm.config.Dir, oldDBDir)
-	oldDB.Close()
-	removeDB(oldDBPath)
+	dbPathToBeRemoved := filepath.Join(dbm.config.Dir, dbDirToBeRemoved)
+	dbToBeRemoved.Close()
+	removeDB(dbPathToBeRemoved)
 }
 
 func removeDB(dbPath string) {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -525,22 +525,8 @@ func (stdBatch *stateTrieDBBatch) ValueSize() int {
 // Write passes the list of batch tasks to taskCh so batch can be processed
 // by underlying workers. Write waits until all workers return the result.
 func (stdBatch *stateTrieDBBatch) Write() error {
-	resultCh := make(chan error, len(stdBatch.batches))
-	for _, batch := range stdBatch.batches {
-		go func(batch Batch) {
-			resultCh <- batch.Write()
-		}(batch)
-	}
-
-	var errResult error
-	for range stdBatch.batches {
-		err := <-resultCh
-		if err != nil {
-			errResult = err
-		}
-	}
-
-	return errResult
+	_, err := WriteBatchesParallel(stdBatch.batches...)
+	return err
 }
 
 func (stdBatch *stateTrieDBBatch) Reset() {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -509,7 +509,7 @@ func (stdBatch *stateTrieDBBatch) Put(key []byte, value []byte) error {
 }
 
 // ValueSize is called to determine whether to write batches when it exceeds
-// certain limit. partitionedDB returns the largest size of its batches to
+// certain limit. stdBatch returns the largest size of its batches to
 // write all batches at once when one of batch exceeds the limit.
 func (stdBatch *stateTrieDBBatch) ValueSize() int {
 	maxSize := 0

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -432,7 +432,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		assert.True(t, hasStateTrieNode)
 		assert.False(t, hasOldStateTrieNode)
 
-		dbm.FinishStateMigration()
+		dbm.FinishStateMigration(true)
 	}
 }
 
@@ -684,7 +684,7 @@ func TestDBManager_StateTrieMigration(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, dbManagers[i].InMigration())
 
-		dbm.FinishStateMigration()
+		dbm.FinishStateMigration(true)
 		assert.False(t, dbManagers[i].InMigration())
 
 		dbm.Close()

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -420,17 +420,17 @@ func TestDBManager_TrieNode(t *testing.T) {
 		cachedNode, _ = dbm.ReadCachedTrieNode(hash2)
 		oldCachedNode, _ = dbm.ReadCachedTrieNodeFromOld(hash2)
 		assert.Equal(t, hash2[:], cachedNode)
-		assert.Nil(t, oldCachedNode)
+		assert.Equal(t, hash2[:], oldCachedNode)
 
 		stateTrieNode, _ = dbm.ReadStateTrieNode(hash2[:])
 		oldStateTrieNode, _ = dbm.ReadStateTrieNodeFromOld(hash2[:])
 		assert.Equal(t, hash2[:], stateTrieNode)
-		assert.Nil(t, oldStateTrieNode)
+		assert.Equal(t, hash2[:], oldStateTrieNode)
 
 		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash2[:])
 		hasOldStateTrieNode, _ = dbm.HasStateTrieNodeFromOld(hash2[:])
 		assert.True(t, hasStateTrieNode)
-		assert.False(t, hasOldStateTrieNode)
+		assert.True(t, hasOldStateTrieNode)
 
 		dbm.FinishStateMigration(true)
 	}

--- a/storage/database/interface.go
+++ b/storage/database/interface.go
@@ -112,17 +112,15 @@ func WriteBatchesParallel(batches ...Batch) (int, error) {
 	}
 
 	var bytes int
-	var errResult error
-
 	for range batches {
 		rst := <-resultCh
 		if rst.err != nil {
-			errResult = rst.err
+			return bytes, rst.err
 		}
 		bytes += rst.bytes
 	}
 
-	return bytes, errResult
+	return bytes, nil
 }
 
 func WriteBatchesOverThreshold(batches ...Batch) (int, error) {


### PR DESCRIPTION
## Proposed changes
This PR introduce the state trie batch write for old/new DB.
This makes users to be able to stop state migration.
Also during migration, if there is an error case, it can recover the old database.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
