### PR TITLE
Resolve state iterator error (empty code hash case)

### DIFF
--- a/blockchain/state/iterator.go
+++ b/blockchain/state/iterator.go
@@ -127,12 +127,12 @@ func (it *NodeIterator) step() error {
 			it.dataIt = nil
 		}
 
-		if !bytes.Equal(pa.GetCodeHash(), emptyCodeHash) {
-			it.codeHash = common.BytesToHash(pa.GetCodeHash())
+		if codeHash := pa.GetCodeHash(); !bytes.Equal(codeHash, emptyCodeHash) {
+			it.codeHash = common.BytesToHash(codeHash)
 			//addrHash := common.BytesToHash(it.stateIt.LeafKey())
-			it.Code, err = it.state.db.ContractCode(common.BytesToHash(pa.GetCodeHash()))
+			it.Code, err = it.state.db.ContractCode(common.BytesToHash(codeHash))
 			if err != nil {
-				return fmt.Errorf("code %x: %v", pa.GetCodeHash(), err)
+				return fmt.Errorf("code %x: %v", codeHash, err)
 			}
 		}
 	}

--- a/blockchain/state/iterator.go
+++ b/blockchain/state/iterator.go
@@ -127,11 +127,13 @@ func (it *NodeIterator) step() error {
 			it.dataIt = nil
 		}
 
-		it.codeHash = common.BytesToHash(pa.GetCodeHash())
-		//addrHash := common.BytesToHash(it.stateIt.LeafKey())
-		it.Code, err = it.state.db.ContractCode(common.BytesToHash(pa.GetCodeHash()))
-		if err != nil {
-			return fmt.Errorf("code %x: %v", pa.GetCodeHash(), err)
+		if !bytes.Equal(pa.GetCodeHash(), emptyCodeHash) {
+			it.codeHash = common.BytesToHash(pa.GetCodeHash())
+			//addrHash := common.BytesToHash(it.stateIt.LeafKey())
+			it.Code, err = it.state.db.ContractCode(common.BytesToHash(pa.GetCodeHash()))
+			if err != nil {
+				return fmt.Errorf("code %x: %v", pa.GetCodeHash(), err)
+			}
 		}
 	}
 	it.accountHash = it.stateIt.Parent()

--- a/blockchain/state/iterator_test.go
+++ b/blockchain/state/iterator_test.go
@@ -48,7 +48,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 		}
 	}
 	for _, hash := range db.TrieDB().Nodes() {
-		if _, ok := hashes[hash]; !ok {
+		if _, ok := hashes[hash]; !ok && hash != emptyCode {
 			t.Errorf("state entry not reported %x", hash)
 		}
 	}

--- a/blockchain/state/sync_test.go
+++ b/blockchain/state/sync_test.go
@@ -61,8 +61,14 @@ func makeTestState(t *testing.T) (Database, common.Hash, []*testAccount) {
 			obj = statedb.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		} else {
 			obj = statedb.GetOrNewSmartContract(common.BytesToAddress([]byte{i}))
+
 			obj.SetCode(crypto.Keccak256Hash([]byte{i, i, i, i, i}), []byte{i, i, i, i, i})
 			acc.code = []byte{i, i, i, i, i}
+			if i == 0 {
+				// to test emptyCodeHash
+				obj.SetCode(crypto.Keccak256Hash([]byte{}), []byte{})
+				acc.code = []byte{}
+			}
 
 			for j := 0; j < int(i)%10; j++ {
 				key := common.Hash{i + byte(j)}


### PR DESCRIPTION
## Proposed changes

This PR resolve the problem that the state iterator stops iteration by an error like below.
```
ERROR[06/09,22:20:12 +09] [5] State migration : copied stateDB is invalid  err="iterator error : oldIt.Error(code c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470: leveldb: not found), newIt.Error(code c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470: leveldb: not found)"
```

Previous code didn't consider the empty code hash.
This PR added the routine to skip the empty code hash and related unit test code.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
