### PR TITLE
Support periodic log and quit in state migration check consistency

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -121,7 +121,7 @@ func TestWatchNoDir(t *testing.T) {
 	// ks should see the account.
 	wantAccounts := []accounts.Account{cachetestAccounts[0]}
 	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
-	for d := 200 * time.Millisecond; d < 8*time.Second; d *= 2 {
+	for d := 200 * time.Millisecond; d < log.StatsReportLimit; d *= 2 {
 		list = ks.Accounts()
 		if reflect.DeepEqual(list, wantAccounts) {
 			// ks should have also received change notifications
@@ -305,7 +305,7 @@ func TestCacheFind(t *testing.T) {
 
 func waitForAccounts(wantAccounts []accounts.Account, ks *KeyStore) error {
 	var list []accounts.Account
-	for d := 200 * time.Millisecond; d < 8*time.Second; d *= 2 {
+	for d := 200 * time.Millisecond; d < log.StatsReportLimit; d *= 2 {
 		list = ks.Accounts()
 		if reflect.DeepEqual(list, wantAccounts) {
 			// ks should have also received change notifications

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/log"
 )
 
 var (

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1651,10 +1651,6 @@ type insertStats struct {
 	startTime                  mclock.AbsTime
 }
 
-// statsReportLimit is the time limit during import after which we always print
-// out progress. This avoids the user wondering what's going on.
-const statsReportLimit = 8 * time.Second
-
 // report prints statistics if some number of blocks have been processed
 // or more than a few seconds have passed since the last message.
 func (st *insertStats) report(chain []*types.Block, index int, cache common.StorageSize) {
@@ -1664,7 +1660,7 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 		elapsed = time.Duration(now) - time.Duration(st.startTime)
 	)
 	// If we're at the last block of the batch or report period reached, log
-	if index == len(chain)-1 || elapsed >= statsReportLimit {
+	if index == len(chain)-1 || elapsed >= log.StatsReportLimit {
 		var (
 			end = chain[index]
 			txs = countTransactions(chain[st.lastIndex : index+1])

--- a/blockchain/chain_indexer.go
+++ b/blockchain/chain_indexer.go
@@ -282,7 +282,7 @@ func (c *ChainIndexer) updateLoop() {
 			c.lock.Lock()
 			if c.knownSections > c.storedSections {
 				// Periodically print an upgrade log message to the user
-				if time.Since(updated) > 8*time.Second {
+				if time.Since(updated) > log.StatsReportLimit {
 					if c.knownSections > c.storedSections+1 {
 						updating = true
 						c.logger.Info("Upgrading chain index", "percentage", c.storedSections*100/c.knownSections)

--- a/log/log_modules.go
+++ b/log/log_modules.go
@@ -19,7 +19,12 @@ package log
 import (
 	"strconv"
 	"strings"
+	"time"
 )
+
+// statsReportLimit is the time limit during working after which we always print
+// out progress. This avoids the user wondering what's going on.
+const StatsReportLimit = 10 * time.Second
 
 type ModuleID int
 

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/klaytn/klaytn/log"
 	"io/ioutil"
 	"os"
 	"runtime"
@@ -267,7 +268,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 			default:
 			}
 			// Print progress logs if long enough time elapsed
-			if time.Since(logged) > 8*time.Second {
+			if time.Since(logged) > log.StatsReportLimit {
 				if number > origin {
 					nodeSize, preimageSize := database.TrieDB().Size()
 					logger.Info("Tracing chain segment", "start", origin, "end", end.NumberU64(), "current", number, "transactions", traced, "elapsed", time.Since(begin), "nodeSize", nodeSize, "preimageSize", preimageSize)
@@ -685,7 +686,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 	)
 	for block.NumberU64() < origin {
 		// Print progress logs if long enough time elapsed
-		if time.Since(logged) > 8*time.Second {
+		if time.Since(logged) > log.StatsReportLimit {
 			logger.Info("Regenerating historical state", "block", block.NumberU64()+1, "target", origin, "remaining", origin-block.NumberU64()-1, "elapsed", time.Since(start))
 			logged = time.Now()
 		}

--- a/storage/statedb/sync_bloom.go
+++ b/storage/statedb/sync_bloom.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/rcrowley/go-metrics"
 	"math"
@@ -113,7 +114,7 @@ func (b *SyncBloom) init(database database.Iteratee) {
 			bloomLoadMeter.Mark(1)
 		}
 		// If enough time elapsed since the last iterator swap, restart
-		if time.Since(swap) > 8*time.Second {
+		if time.Since(swap) > log.StatsReportLimit {
 			key := common.CopyBytes(it.Key())
 
 			it.Release()


### PR DESCRIPTION
## Proposed changes

This PR introduce periodic log in check consistency routine.
And Quit channel is added into the `CheckStateConsistency` loop for stopping the node.

**Minor change**
- change timeout 8s -> 10s (10s is easy to calculate the progress)
- change bool -> struct{} of map (to reduce the memory)
- passing the map size (to reduce the elapsed time of the unit test code)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
