### PR TITLE
Add exist check map for state migration

### DIFF
--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -103,7 +103,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	// Present bloom filter for migration.
 	// Since iterator doesn't support partitionedDB, we cannot use targetDB.
 	// If state migration is finished without restarting node, this fake empty DB is ok.
-	stateBloom := statedb.NewSyncBloom(uint64(512), database.NewMemDB())
+	stateBloom := statedb.NewSyncBloom(uint64(1000), database.NewMemDB())
 	defer stateBloom.Close()
 
 	trieSync := state.NewStateSync(rootHash, targetDB.DiskDB(), stateBloom)

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -185,14 +185,14 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	}
 	bc.committedCnt, bc.pendingCnt, bc.progress = committedCnt, trieSync.Pending(), trieSync.CalcProgressPercentage()
 
+	// Clear memory of bloom filter and trieSync
+	stateBloom.Close()
+	trieSync = nil
+
 	elapsed := time.Since(start)
 	speed := float64(committedCnt) / elapsed.Seconds()
 	logger.Info("State migration is completed", "committedCnt", committedCnt, "elapsed", elapsed, "committed per second", speed)
 
-	// Preimage Copy
-	// TODO-Klaytn consider to copy preimage
-
-	// TODO-Klaytn consider to check Trie contents optionally
 	if err := state.CheckStateConsistency(srcCachedDB.DiskDB(), targetDB.DiskDB(), rootHash); err != nil {
 		logger.Error("State migration : copied stateDB is invalid", "err", err)
 		return err

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -90,6 +90,7 @@ type TrieSync struct {
 	retrievedByDepth map[int]int              // Retrieved trie node number counted by depth
 	committedByDepth map[int]int              // Committed trie nodes number counted by depth
 	bloom            *SyncBloom               // Bloom filter for fast node existence checks
+	exist            map[common.Hash]struct{} // exist to check if the trie node is already written or not
 }
 
 // NewTrieSync creates a new trie data download scheduler.
@@ -102,6 +103,8 @@ func NewTrieSync(root common.Hash, database StateTrieReadDB, callback LeafCallba
 		retrievedByDepth: make(map[int]int),
 		committedByDepth: make(map[int]int),
 		bloom:            bloom,
+		// Klaytn-TODO need to limit the size and support low memory machine.
+		exist: make(map[common.Hash]struct{}, 100000000),
 	}
 	ts.AddSubTrie(root, 0, common.Hash{}, callback)
 	return ts
@@ -117,9 +120,14 @@ func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, c
 		return
 	}
 	if s.bloom.Contains(root[:]) {
-		key := root.Bytes()
-		blob, _ := s.database.ReadStateTrieNode(key)
-		if local, err := decodeNode(key, blob); local != nil && err == nil {
+		// Bloom filter says this might be a duplicate, double check
+		if s.exist != nil {
+			if _, ok := s.exist[root]; ok {
+				// already written in migration, skip the node
+				return
+			}
+		} else if ok, _ := s.database.HasStateTrieNode(root[:]); ok {
+			logger.Info("skip write node in migration by ReadStateTrieNode", "AddSubTrie", root.String())
 			return
 		}
 		// False positive, bump fault meter
@@ -156,7 +164,13 @@ func (s *TrieSync) AddRawEntry(hash common.Hash, depth int, parent common.Hash) 
 		return
 	}
 	if s.bloom.Contains(hash[:]) {
-		if ok, _ := s.database.HasStateTrieNode(hash.Bytes()); ok {
+		// Bloom filter says this might be a duplicate, double check
+		if s.exist != nil {
+			if _, ok := s.exist[hash]; ok {
+				// already written in migration, skip the node
+				return
+			}
+		} else if ok, _ := s.database.HasStateTrieNode(hash.Bytes()); ok {
 			return
 		}
 		// False positive, bump fault meter
@@ -245,6 +259,10 @@ func (s *TrieSync) Commit(dbw database.Putter) (int, error) {
 			return i, err
 		}
 		s.bloom.Add(key[:])
+
+		if s.exist != nil {
+			s.exist[key] = struct{}{}
+		}
 	}
 	written := len(s.membatch.order)
 
@@ -322,9 +340,15 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 			if _, ok := s.membatch.batch[hash]; ok {
 				continue
 			}
+
 			if s.bloom.Contains(node) {
 				// Bloom filter says this might be a duplicate, double check
-				if ok, _ := s.database.HasStateTrieNode(node); ok {
+				if s.exist != nil {
+					if _, ok := s.exist[hash]; ok {
+						// already written in migration, skip the node
+						continue
+					}
+				} else if ok, _ := s.database.HasStateTrieNode(node); ok {
 					continue
 				}
 				// False positive, bump fault meter


### PR DESCRIPTION
## Proposed changes
This PR resolves the missing trie node during state migration.
This issue's root cause is skipping the trie node and its child when `insertBlock` added the trie node during migration.

This PR adds a map for checking if the trie node is already written by only state migration, not `insertBlock`.
After this PR, trieSync check the map instead of checking the target database. 
So there is no issue to skip a trie.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
