### PR TITLE
LRU cache for preventing duplicate writing instead of huge map.

### DIFF
--- a/blockchain/state/sync.go
+++ b/blockchain/state/sync.go
@@ -22,6 +22,7 @@ package state
 
 import (
 	"bytes"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/klaytn/klaytn/blockchain/types/account"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/ser/rlp"
@@ -29,7 +30,7 @@ import (
 )
 
 // NewStateSync create a new state trie download scheduler.
-func NewStateSync(root common.Hash, database statedb.StateTrieReadDB, bloom *statedb.SyncBloom) *statedb.TrieSync {
+func NewStateSync(root common.Hash, database statedb.StateTrieReadDB, bloom *statedb.SyncBloom, lruCache *lru.Cache) *statedb.TrieSync {
 	var syncer *statedb.TrieSync
 	callback := func(leaf []byte, parent common.Hash, parentDepth int) error {
 		serializer := account.NewAccountSerializer()
@@ -43,6 +44,6 @@ func NewStateSync(root common.Hash, database statedb.StateTrieReadDB, bloom *sta
 		}
 		return nil
 	}
-	syncer = statedb.NewTrieSync(root, database, callback, bloom)
+	syncer = statedb.NewTrieSync(root, database, callback, bloom, lruCache)
 	return syncer
 }

--- a/blockchain/state/sync.go
+++ b/blockchain/state/sync.go
@@ -30,6 +30,7 @@ import (
 )
 
 // NewStateSync create a new state trie download scheduler.
+// LRU cache is mendatory when state syncing and block processing are executed simultaneously
 func NewStateSync(root common.Hash, database statedb.StateTrieReadDB, bloom *statedb.SyncBloom, lruCache *lru.Cache) *statedb.TrieSync {
 	var syncer *statedb.TrieSync
 	callback := func(leaf []byte, parent common.Hash, parentDepth int) error {

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -103,7 +103,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	// Present bloom filter for migration.
 	// Since iterator doesn't support partitionedDB, we cannot use targetDB.
 	// If state migration is finished without restarting node, this fake empty DB is ok.
-	stateBloom := statedb.NewSyncBloom(uint64(512), database.NewMemDB())
+	stateBloom := statedb.NewSyncBloom(uint64(1000), database.NewMemDB())
 	defer stateBloom.Close()
 
 	trieSync := state.NewStateSync(rootHash, targetDB.DiskDB(), stateBloom)

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -101,7 +101,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	srcCachedDB := bc.StateCache().TrieDB()
 	targetDB := statedb.NewDatabase(&stateTrieMigrationDB{bc.db})
 
-	// NOTE: lruCache is medatory when state migration and block processing are executed simultaneously
+	// NOTE: lruCache is mendatory when state migration and block processing are executed simultaneously
 	lruCache, _ := lru.New(int(2 * units.Giga / common.HashLength)) // 2GB for 62,500,000 common.Hash key values
 	trieSync := state.NewStateSync(rootHash, targetDB.DiskDB(), nil, lruCache)
 	var queue []common.Hash

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -101,6 +101,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	srcCachedDB := bc.StateCache().TrieDB()
 	targetDB := statedb.NewDatabase(&stateTrieMigrationDB{bc.db})
 
+	// NOTE: lruCache is medatory when state migration and block processing are executed simultaneously
 	lruCache, _ := lru.New(int(2 * units.Giga / common.HashLength)) // 2GB for 62,500,000 common.Hash key values
 	trieSync := state.NewStateSync(rootHash, targetDB.DiskDB(), nil, lruCache)
 	var queue []common.Hash

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -186,6 +186,10 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	}
 	bc.committedCnt, bc.pendingCnt, bc.progress = committedCnt, trieSync.Pending(), trieSync.CalcProgressPercentage()
 
+	// Clear memory of bloom filter and trieSync
+	stateBloom.Close()
+	trieSync = nil
+
 	elapsed := time.Since(start)
 	speed := float64(committedCnt) / elapsed.Seconds()
 	logger.Info("State migration : State copied", "committedCnt", committedCnt, "elapsed", elapsed, "committed per second", speed)

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -103,7 +103,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) error {
 	// Present bloom filter for migration.
 	// Since iterator doesn't support partitionedDB, we cannot use targetDB.
 	// If state migration is finished without restarting node, this fake empty DB is ok.
-	stateBloom := statedb.NewSyncBloom(uint64(1000), database.NewMemDB())
+	stateBloom := statedb.NewSyncBloom(uint64(1000), database.NewMemDB()) // 1GiB
 	defer stateBloom.Close()
 
 	trieSync := state.NewStateSync(rootHash, targetDB.DiskDB(), stateBloom)

--- a/datasync/downloader/statesync.go
+++ b/datasync/downloader/statesync.go
@@ -240,7 +240,7 @@ type stateTask struct {
 func newStateSync(d *Downloader, root common.Hash) *stateSync {
 	return &stateSync{
 		d:       d,
-		sched:   state.NewStateSync(root, d.stateDB, d.stateBloom),
+		sched:   state.NewStateSync(root, d.stateDB, d.stateBloom, nil),
 		keccak:  sha3.NewKeccak256(),
 		tasks:   make(map[common.Hash]*stateTask),
 		deliver: make(chan *stateReq),

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.5.7
+	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
 	github.com/aristanetworks/goarista v0.0.0-20191001182449-186a6201b8ef
 	github.com/cespare/cp v1.0.0
 	github.com/clevergo/websocket v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -97,7 +97,7 @@ type TrieSync struct {
 
 // NewTrieSync creates a new trie data download scheduler.
 func NewTrieSync(root common.Hash, database StateTrieReadDB, callback LeafCallback, bloom *SyncBloom) *TrieSync {
-	lruCache, _ := lru.New(int(1*units.Giga/common.HashLength))	// 1GB for common.Hash
+	lruCache, _ := lru.New(int(1*units.Giga/common.HashLength))	// 1GB for 31,250,000 common.Hash key values
 	ts := &TrieSync{
 		database:         database,
 		membatch:         newSyncMemBatch(),
@@ -106,7 +106,6 @@ func NewTrieSync(root common.Hash, database StateTrieReadDB, callback LeafCallba
 		retrievedByDepth: make(map[int]int),
 		committedByDepth: make(map[int]int),
 		bloom:            bloom,
-		// Klaytn-TODO need to limit the size and support low memory machine.
 		exist: lruCache,
 	}
 	ts.AddSubTrie(root, 0, common.Hash{}, callback)

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -97,7 +97,7 @@ type TrieSync struct {
 
 // NewTrieSync creates a new trie data download scheduler.
 func NewTrieSync(root common.Hash, database StateTrieReadDB, callback LeafCallback, bloom *SyncBloom) *TrieSync {
-	lruCache, _ := lru.New(int(1*units.Giga/common.HashLength))	// 1GB for 31,250,000 common.Hash key values
+	lruCache, _ := lru.New(int(1 * units.Giga / common.HashLength)) // 1GB for 31,250,000 common.Hash key values
 	ts := &TrieSync{
 		database:         database,
 		membatch:         newSyncMemBatch(),
@@ -106,7 +106,7 @@ func NewTrieSync(root common.Hash, database StateTrieReadDB, callback LeafCallba
 		retrievedByDepth: make(map[int]int),
 		committedByDepth: make(map[int]int),
 		bloom:            bloom,
-		exist: lruCache,
+		exist:            lruCache,
 	}
 	ts.AddSubTrie(root, 0, common.Hash{}, callback)
 	return ts

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -90,6 +90,7 @@ type TrieSync struct {
 	retrievedByDepth map[int]int              // Retrieved trie node number counted by depth
 	committedByDepth map[int]int              // Committed trie nodes number counted by depth
 	bloom            *SyncBloom               // Bloom filter for fast node existence checks
+	exist            map[common.Hash]struct{} // exist to check if the trie node is already written or not
 }
 
 // NewTrieSync creates a new trie data download scheduler.
@@ -102,6 +103,8 @@ func NewTrieSync(root common.Hash, database StateTrieReadDB, callback LeafCallba
 		retrievedByDepth: make(map[int]int),
 		committedByDepth: make(map[int]int),
 		bloom:            bloom,
+		// Klaytn-TODO need to limit the size and support low memory machine.
+		exist: make(map[common.Hash]struct{}, 100000000),
 	}
 	ts.AddSubTrie(root, 0, common.Hash{}, callback)
 	return ts
@@ -117,9 +120,14 @@ func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, c
 		return
 	}
 	if s.bloom.Contains(root[:]) {
-		key := root.Bytes()
-		blob, _ := s.database.ReadStateTrieNode(key)
-		if local, err := decodeNode(key, blob); local != nil && err == nil {
+		// Bloom filter says this might be a duplicate, double check
+		if s.exist != nil {
+			if _, ok := s.exist[root]; ok {
+				// already written in migration, skip the node
+				return
+			}
+		} else if ok, _ := s.database.HasStateTrieNode(root[:]); ok {
+			logger.Info("skip write node in migration by ReadStateTrieNode", "AddSubTrie", root.String())
 			return
 		}
 		// False positive, bump fault meter
@@ -156,7 +164,13 @@ func (s *TrieSync) AddRawEntry(hash common.Hash, depth int, parent common.Hash) 
 		return
 	}
 	if s.bloom.Contains(hash[:]) {
-		if ok, _ := s.database.HasStateTrieNode(hash.Bytes()); ok {
+		// Bloom filter says this might be a duplicate, double check
+		if s.exist != nil {
+			if _, ok := s.exist[hash]; ok {
+				// already written in migration, skip the node
+				return
+			}
+		} else if ok, _ := s.database.HasStateTrieNode(hash.Bytes()); ok {
 			return
 		}
 		// False positive, bump fault meter
@@ -245,6 +259,10 @@ func (s *TrieSync) Commit(dbw database.Putter) (int, error) {
 			return i, err
 		}
 		s.bloom.Add(key[:])
+
+		if s.exist != nil {
+			s.exist[key] = struct{}{}
+		}
 	}
 	written := len(s.membatch.order)
 
@@ -322,9 +340,15 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 			if _, ok := s.membatch.batch[hash]; ok {
 				continue
 			}
+
 			if s.bloom.Contains(node) {
 				// Bloom filter says this might be a duplicate, double check
-				if ok, _ := s.database.HasStateTrieNode(node); ok {
+				if s.exist != nil {
+					if _, ok := s.exist[hash]; ok {
+						// already written in migration, skip the node
+						continue
+					}
+				} else if ok, _ := s.database.HasStateTrieNode(node); ok {
 					continue
 				}
 				// False positive, bump fault meter

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -95,6 +95,7 @@ type TrieSync struct {
 }
 
 // NewTrieSync creates a new trie data download scheduler.
+// If both bloom and cache are set, only cache is used.
 func NewTrieSync(root common.Hash, database StateTrieReadDB, callback LeafCallback, bloom *SyncBloom, lruCache *lru.Cache) *TrieSync {
 	ts := &TrieSync{
 		database:         database,


### PR DESCRIPTION
## Proposed changes
This PR LRU cache for preventing duplicate writing.

This PR resolves the missing trie node during state migration.
This issue's root cause is skipping the trie node and its child when insertBlock added the trie node during migration.

This PR adds a cache for checking if the trie node is already written by only state migration, not insertBlock.
After this PR, trieSync check the cache instead of checking the target database.
So there is no issue to skip a trie.

We considered whole huge map. (https://github.com/klaytn/klaytn/pull/543) 
But it needs huge memory.
Therefore we applied LRU cache instead of the whold map.

This shows good result (lower memory, lower elapsed) comparing with whole map.
- whole map : 8h46m, 114GB
```
INFO[06/16,00:27:56 +09] [5] State migration is completed              committedCnt=363454052 elapsed=8h46m49.55906327s committed per second=11498.232
```

- LRU : 8h35m, 89.9GB
```
INFO[06/16,00:16:13 +09] [5] State migration is completed              committedCnt=363664086 elapsed=8h35m6.130689239s committed per second=11766.730
```

![image](https://user-images.githubusercontent.com/29390878/84722807-3ae63080-afbf-11ea-8e93-8742d7900073.png)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
