### PR TITLE
[State Migration Testcode] Start Migration By MiscDB

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -23,6 +23,7 @@ package common
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"math/rand"
 )
 
 // ToHex returns the hex representation of b, prefixed with '0x'.
@@ -134,6 +135,12 @@ func LeftPadBytes(slice []byte, l int) []byte {
 	copy(padded[l-len(slice):], slice)
 
 	return padded
+}
+
+func MakeRandomByte(n int) []byte {
+	s := make([]byte, n)
+	rand.Read(s)
+	return s
 }
 
 // IntToByteLittleEndian encodes a number as little endian uint64

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/stretchr/testify/assert"
-	"math/rand"
 	"testing"
 )
 
@@ -124,19 +123,13 @@ func TestDatabase_SecureKey(t *testing.T) {
 	assert.Equal(t, secKey1, secKey2)         // secKey1 has changed into secKey2 as they are created from the same buffer
 }
 
-func makeRandomByte(n int) []byte {
-	s := make([]byte, n)
-	rand.Read(s)
-	return s
-}
-
 func TestCache(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
 	cacheSizeMB := 10
 	db := NewDatabaseWithCache(memDB, cacheSizeMB)
 
 	for i := 0; i < 100; i++ {
-		key, value := makeRandomByte(256), makeRandomByte(63*1024) // fastcache can store entrie under 64KB
+		key, value := common.MakeRandomByte(256), common.MakeRandomByte(63*1024) // fastcache can store entrie under 64KB
 		db.trieNodeCache.Set(key, value)
 		rValue, found := db.trieNodeCache.HasGet(nil, key)
 


### PR DESCRIPTION
## Proposed changes

**Tescode**
`TestMigration_StartMigrationByMiscDB` : state trie DB should be determined by the values of miscDB
1. Use the default `statetrie` DB if state DB is not set on miscDB.
2. Use the created DB after migration.
3. Use the state trie DB that is specified in miscDB.

**Minor Changes**
- `makeRandomByte` is moved to common package
- Added error logs in test codes

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments
