### PR TITLE
CheckStateConsistency use cached source state instead of raw DB for using the cachedNode

### DIFF
--- a/blockchain/state/iterator.go
+++ b/blockchain/state/iterator.go
@@ -27,7 +27,6 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/ser/rlp"
-	"github.com/klaytn/klaytn/storage/database"
 	"github.com/klaytn/klaytn/storage/statedb"
 	"time"
 )
@@ -187,14 +186,14 @@ func (it *NodeIterator) retrieve() bool {
 }
 
 // CheckStateConsistency checks the consistency of all state/storage trie of given two state database.
-func CheckStateConsistency(oldDB database.DBManager, newDB database.DBManager, root common.Hash, mapSize int, quit chan struct{}) error {
+func CheckStateConsistency(oldDB Database, newDB Database, root common.Hash, mapSize int, quit chan struct{}) error {
 	// Create and iterate a state trie rooted in a sub-node
-	oldState, err := New(root, NewDatabase(oldDB))
+	oldState, err := New(root, oldDB)
 	if err != nil {
 		return err
 	}
 
-	newState, err := New(root, NewDatabase(newDB))
+	newState, err := New(root, newDB)
 	if err != nil {
 		return err
 	}

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -104,11 +104,11 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 	start := time.Now()
 
 	srcState := bc.StateCache()
-	targetState := state.NewDatabase(&stateTrieMigrationDB{bc.db})
+	dstState := state.NewDatabase(&stateTrieMigrationDB{bc.db})
 
 	// NOTE: lruCache is mendatory when state migration and block processing are executed simultaneously
 	lruCache, _ := lru.New(int(2 * units.Giga / common.HashLength)) // 2GB for 62,500,000 common.Hash key values
-	trieSync := state.NewStateSync(rootHash, targetState.TrieDB().DiskDB(), nil, lruCache)
+	trieSync := state.NewStateSync(rootHash, dstState.TrieDB().DiskDB(), nil, lruCache)
 	var queue []common.Hash
 	committedCnt := 0
 
@@ -124,7 +124,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 		go bc.concurrentRead(srcState.TrieDB(), quitCh, hashCh, resultCh)
 	}
 
-	stateTrieBatch := targetState.TrieDB().DiskDB().NewBatch(database.StateTrieDB)
+	stateTrieBatch := dstState.TrieDB().DiskDB().NewBatch(database.StateTrieDB)
 	stats := migrationStats{initialStartTime: start, startTime: mclock.Now()}
 
 	// Migration main loop
@@ -202,7 +202,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 		"totalElapsed", elapsed, "committed per second", speed)
 
 	startCheck := time.Now()
-	if err := state.CheckStateConsistency(srcState, targetState, rootHash, bc.committedCnt, bc.quit); err != nil {
+	if err := state.CheckStateConsistency(srcState, dstState, rootHash, bc.committedCnt, bc.quit); err != nil {
 		logger.Error("State migration : copied stateDB is invalid", "err", err)
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

This PR changes from a state without cache (type `DBManager`) to a state with trieNodeCache (type `state.Database` ).
(Nodes are fetched from either fastcache or `srcState` and stored in `dstState`.)
This can help to read tries from old DB with trieNodeCache (fastcache).

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
