### PR TITLE
parameterize triesInMemory

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1213,7 +1213,7 @@ func TestTrieForkGC(t *testing.T) {
 
 	db := database.NewMemoryDBManager()
 	genesis := new(Genesis).MustCommit(db)
-	blocks, _ := GenerateChain(params.TestChainConfig, genesis, engine, db, 2*triesInMemory, func(i int, b *BlockGen) { b.SetRewardbase(common.Address{1}) })
+	blocks, _ := GenerateChain(params.TestChainConfig, genesis, engine, db, 2*DefaultTriesInMemory, func(i int, b *BlockGen) { b.SetRewardbase(common.Address{1}) })
 
 	// Generate a bunch of fork blocks, each side forking from the canonical chain
 	forks := make([]*types.Block, len(blocks))
@@ -1242,7 +1242,7 @@ func TestTrieForkGC(t *testing.T) {
 		}
 	}
 	// Dereference all the recent tries and ensure no past trie is left in
-	for i := 0; i < triesInMemory; i++ {
+	for i := 0; i < DefaultTriesInMemory; i++ {
 		chain.stateCache.TrieDB().Dereference(blocks[len(blocks)-1-i].Root())
 		chain.stateCache.TrieDB().Dereference(forks[len(blocks)-1-i].Root())
 	}
@@ -1263,8 +1263,8 @@ func TestLargeReorgTrieGC(t *testing.T) {
 	genesis := new(Genesis).MustCommit(db)
 
 	shared, _ := GenerateChain(params.TestChainConfig, genesis, engine, db, 64, func(i int, b *BlockGen) { b.SetCoinbase(common.Address{1}) })
-	original, _ := GenerateChain(params.TestChainConfig, shared[len(shared)-1], engine, db, 2*triesInMemory, func(i int, b *BlockGen) { b.SetCoinbase(common.Address{2}) })
-	competitor, _ := GenerateChain(params.TestChainConfig, shared[len(shared)-1], engine, db, 2*triesInMemory+1, func(i int, b *BlockGen) { b.SetCoinbase(common.Address{3}) })
+	original, _ := GenerateChain(params.TestChainConfig, shared[len(shared)-1], engine, db, 2*DefaultTriesInMemory, func(i int, b *BlockGen) { b.SetCoinbase(common.Address{2}) })
+	competitor, _ := GenerateChain(params.TestChainConfig, shared[len(shared)-1], engine, db, 2*DefaultTriesInMemory+1, func(i int, b *BlockGen) { b.SetCoinbase(common.Address{3}) })
 
 	// Import the shared chain and the original canonical one
 	diskdb := database.NewMemoryDBManager()
@@ -1299,7 +1299,7 @@ func TestLargeReorgTrieGC(t *testing.T) {
 	if _, err := chain.InsertChain(competitor[len(competitor)-2:]); err != nil {
 		t.Fatalf("failed to finalize competitor chain: %v", err)
 	}
-	for i, block := range competitor[:len(competitor)-triesInMemory] {
+	for i, block := range competitor[:len(competitor)-DefaultTriesInMemory] {
 		if node, _ := chain.stateCache.TrieDB().Node(block.Root()); node != nil {
 			t.Fatalf("competitor %d: competing chain state missing", i)
 		}

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -173,6 +173,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			ArchiveMode:    false,
 			CacheSize:      512,
 			BlockInterval:  DefaultBlockInterval,
+			TriesInMemory:  DefaultTriesInMemory,
 			TrieCacheLimit: 0,
 		}
 		blockchain, _ := NewBlockChain(db, cacheConfig, config, engine, vm.Config{})

--- a/cmd/kcn/main.go
+++ b/cmd/kcn/main.go
@@ -101,7 +101,7 @@ var cnHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
-			utils.TriesInMemory,
+			utils.TriesInMemoryFlag,
 		},
 	},
 	{

--- a/cmd/kcn/main.go
+++ b/cmd/kcn/main.go
@@ -101,6 +101,7 @@ var cnHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
+			utils.TriesInMemory,
 		},
 	},
 	{

--- a/cmd/ken/main.go
+++ b/cmd/ken/main.go
@@ -112,7 +112,7 @@ var enHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
-			utils.TriesInMemory,
+			utils.TriesInMemoryFlag,
 		},
 	},
 	{

--- a/cmd/ken/main.go
+++ b/cmd/ken/main.go
@@ -112,6 +112,7 @@ var enHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
+			utils.TriesInMemory,
 		},
 	},
 	{

--- a/cmd/kpn/main.go
+++ b/cmd/kpn/main.go
@@ -107,7 +107,7 @@ var pnHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
-			utils.TriesInMemory,
+			utils.TriesInMemoryFlag,
 		},
 	},
 	{

--- a/cmd/kpn/main.go
+++ b/cmd/kpn/main.go
@@ -107,6 +107,7 @@ var pnHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
+			utils.TriesInMemory,
 		},
 	},
 	{

--- a/cmd/kscn/main.go
+++ b/cmd/kscn/main.go
@@ -118,6 +118,7 @@ var scnHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
+			utils.TriesInMemory,
 		},
 	},
 	{

--- a/cmd/kscn/main.go
+++ b/cmd/kscn/main.go
@@ -118,7 +118,7 @@ var scnHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
-			utils.TriesInMemory,
+			utils.TriesInMemoryFlag,
 		},
 	},
 	{

--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -120,6 +120,7 @@ var senHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
+			utils.TriesInMemory,
 		},
 	},
 	{

--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -120,7 +120,7 @@ var senHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
-			utils.TriesInMemory,
+			utils.TriesInMemoryFlag,
 		},
 	},
 	{

--- a/cmd/kspn/main.go
+++ b/cmd/kspn/main.go
@@ -123,7 +123,7 @@ var spnHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
-			utils.TriesInMemory,
+			utils.TriesInMemoryFlag,
 		},
 	},
 	{

--- a/cmd/kspn/main.go
+++ b/cmd/kspn/main.go
@@ -123,6 +123,7 @@ var spnHelpFlagGroups = []utils.FlagGroup{
 			utils.StateDBCachingFlag,
 			utils.TrieMemoryCacheSizeFlag,
 			utils.TrieBlockIntervalFlag,
+			utils.TriesInMemory,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -224,7 +224,7 @@ var (
 		Usage: "An interval in terms of block number to commit the global state to disk",
 		Value: blockchain.DefaultBlockInterval,
 	}
-	TriesInMemory = cli.Uint64Flag{
+	TriesInMemoryFlag = cli.Uint64Flag{
 		Name:  "state.tries-in-memory",
 		Usage: "The number of recent state tries residing in the memory",
 		Value: blockchain.DefaultTriesInMemory,
@@ -1139,7 +1139,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 	cfg.TrieCacheSize = ctx.GlobalInt(TrieMemoryCacheSizeFlag.Name)
 	common.DefaultCacheType = common.CacheType(ctx.GlobalInt(CacheTypeFlag.Name))
 	cfg.TrieBlockInterval = ctx.GlobalUint(TrieBlockIntervalFlag.Name)
-	cfg.TriesInMemory = ctx.GlobalUint64(TriesInMemory.Name)
+	cfg.TriesInMemory = ctx.GlobalUint64(TriesInMemoryFlag.Name)
 
 	if ctx.GlobalIsSet(CacheScaleFlag.Name) {
 		common.CacheScale = ctx.GlobalInt(CacheScaleFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -224,6 +224,11 @@ var (
 		Usage: "An interval in terms of block number to commit the global state to disk",
 		Value: blockchain.DefaultBlockInterval,
 	}
+	TriesInMemory = cli.Uint64Flag{
+		Name:  "state.tries-in-memory",
+		Usage: "The number of recent state tries residing in the memory",
+		Value: blockchain.DefaultTriesInMemory,
+	}
 	CacheTypeFlag = cli.IntFlag{
 		Name:  "cache.type",
 		Usage: "Cache Type: 0=LRUCache, 1=LRUShardCache, 2=FIFOCache",
@@ -1134,6 +1139,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 	cfg.TrieCacheSize = ctx.GlobalInt(TrieMemoryCacheSizeFlag.Name)
 	common.DefaultCacheType = common.CacheType(ctx.GlobalInt(CacheTypeFlag.Name))
 	cfg.TrieBlockInterval = ctx.GlobalUint(TrieBlockIntervalFlag.Name)
+	cfg.TriesInMemory = ctx.GlobalUint64(TriesInMemory.Name)
 
 	if ctx.GlobalIsSet(CacheScaleFlag.Name) {
 		common.CacheScale = ctx.GlobalInt(CacheScaleFlag.Name)

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -58,7 +58,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.SenderTxHashIndexingFlag,
 	utils.TrieMemoryCacheSizeFlag,
 	utils.TrieBlockIntervalFlag,
-	utils.TriesInMemory,
+	utils.TriesInMemoryFlag,
 	utils.CacheTypeFlag,
 	utils.CacheScaleFlag,
 	utils.CacheUsageLevelFlag,

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -58,6 +58,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.SenderTxHashIndexingFlag,
 	utils.TrieMemoryCacheSizeFlag,
 	utils.TrieBlockIntervalFlag,
+	utils.TriesInMemory,
 	utils.CacheTypeFlag,
 	utils.CacheScaleFlag,
 	utils.CacheUsageLevelFlag,

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -250,8 +250,8 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		vmConfig    = vm.Config{EnablePreimageRecording: config.EnablePreimageRecording}
 		cacheConfig = &blockchain.CacheConfig{StateDBCaching: config.StateDBCaching,
 			ArchiveMode: config.NoPruning, CacheSize: config.TrieCacheSize, BlockInterval: config.TrieBlockInterval,
-			TxPoolStateCache: config.TxPoolStateCache, TrieCacheLimit: config.TrieCacheLimit,
-			SenderTxHashIndexing: config.SenderTxHashIndexing}
+			TriesInMemory: config.TriesInMemory, TxPoolStateCache: config.TxPoolStateCache,
+			TrieCacheLimit: config.TrieCacheLimit, SenderTxHashIndexing: config.SenderTxHashIndexing}
 	)
 
 	bc, err := blockchain.NewBlockChain(chainDB, cacheConfig, cn.chainConfig, cn.engine, vmConfig)

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -47,6 +47,7 @@ func GetDefaultConfig() *Config {
 		TrieCacheSize:     512,
 		TrieTimeout:       5 * time.Minute,
 		TrieBlockInterval: blockchain.DefaultBlockInterval,
+		TriesInMemory:     blockchain.DefaultTriesInMemory,
 		GasPrice:          big.NewInt(18 * params.Ston),
 
 		TxPool: blockchain.DefaultTxPoolConfig,
@@ -100,6 +101,7 @@ type Config struct {
 	TrieCacheSize          int
 	TrieTimeout            time.Duration
 	TrieBlockInterval      uint
+	TriesInMemory          uint64
 	SenderTxHashIndexing   bool
 	ParallelDBWrite        bool
 	StateDBCaching         bool

--- a/node/cn/gen_config.go
+++ b/node/cn/gen_config.go
@@ -36,6 +36,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TrieCacheSize           int
 		TrieTimeout             time.Duration
 		TrieBlockInterval       uint
+		TriesInMemory           uint64
 		SenderTxHashIndexing    bool
 		ParallelDBWrite         bool
 		StateDBCaching          bool
@@ -77,6 +78,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TrieCacheSize = c.TrieCacheSize
 	enc.TrieTimeout = c.TrieTimeout
 	enc.TrieBlockInterval = c.TrieBlockInterval
+	enc.TriesInMemory = c.TriesInMemory
 	enc.SenderTxHashIndexing = c.SenderTxHashIndexing
 	enc.ParallelDBWrite = c.ParallelDBWrite
 	enc.StateDBCaching = c.StateDBCaching
@@ -122,6 +124,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TrieCacheSize           *int
 		TrieTimeout             *time.Duration
 		TrieBlockInterval       *uint
+		TriesInMemory           *uint64
 		SenderTxHashIndexing    *bool
 		ParallelDBWrite         *bool
 		StateDBCaching          *bool
@@ -197,6 +200,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.TrieBlockInterval != nil {
 		c.TrieBlockInterval = *dec.TrieBlockInterval
+	}
+	if dec.TriesInMemory != nil {
+		c.TriesInMemory = *dec.TriesInMemory
 	}
 	if dec.SenderTxHashIndexing != nil {
 		c.SenderTxHashIndexing = *dec.SenderTxHashIndexing

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -474,6 +474,7 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 		ArchiveMode:      false,
 		CacheSize:        512,
 		BlockInterval:    blockchain.DefaultBlockInterval,
+		TriesInMemory:    blockchain.DefaultTriesInMemory,
 		TrieCacheLimit:   4096,
 	}
 }


### PR DESCRIPTION
## Proposed changes

- `triesInMemory` can be changed by parameter.
    - parameter name: `state.tries-in-memory`
    - default value: 4

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

Increasing `triesInMemory` can increase memory usage. The below result shows memory usage differences when TPS is 2500. 
CN0: 4 tries, CN1: 64 tries, CN2: 128 tries, CN3: 256 tries
<img width="1162" alt="Screen Shot 2020-06-23 at 10 48 47 AM" src="https://user-images.githubusercontent.com/13597401/85351671-4695a200-b53f-11ea-8872-a1bbe6f9e3ce.png">
<img width="1163" alt="Screen Shot 2020-06-23 at 10 49 06 AM" src="https://user-images.githubusercontent.com/13597401/85351681-4b5a5600-b53f-11ea-847c-6e76f590722d.png">


