### PR TITLE
Reorder validation logic of istanbul messages

### DIFF
--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -79,10 +79,6 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 	}
 
 	//logger.Error("receive handle commit","num", commit.View.Sequence)
-	if !c.valSet.CheckInSubList(msg.Hash, commit.View, src.Address()) {
-		return errNotFromCommittee
-	}
-
 	if err := c.checkMessage(msgCommit, commit.View); err != nil {
 		//logger.Error("### istanbul/commit.go checkMessage","num",commit.View.Sequence,"err",err)
 		return err
@@ -90,6 +86,12 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 
 	if err := c.verifyCommit(commit, src); err != nil {
 		return err
+	}
+
+	if !c.valSet.CheckInSubList(msg.Hash, commit.View, src.Address()) {
+		logger.Warn("received an istanbul commit message from non-committee",
+			"currentSequence", c.current.sequence.Uint64(), "sender", src.Address().String(), "msgView", commit.View.String())
+		return errNotFromCommittee
 	}
 
 	c.acceptCommit(msg, src)

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -58,10 +58,6 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 	}
 
 	//logger.Error("call receive prepare","num",prepare.View.Sequence)
-	if !c.valSet.CheckInSubList(msg.Hash, prepare.View, src.Address()) {
-		return errNotFromCommittee
-	}
-
 	if err := c.checkMessage(msgPrepare, prepare.View); err != nil {
 		return err
 	}
@@ -70,6 +66,12 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 	// Passing verifyPrepare and checkMessage implies it is processing on the locked block since it was verified in the Preprepared state.
 	if err := c.verifyPrepare(prepare, src); err != nil {
 		return err
+	}
+
+	if !c.valSet.CheckInSubList(msg.Hash, prepare.View, src.Address()) {
+		logger.Warn("received an istanbul prepare message from non-committee",
+			"currentSequence", c.current.sequence.Uint64(), "sender", src.Address().String(), "msgView", prepare.View.String())
+		return errNotFromCommittee
 	}
 
 	c.acceptPrepare(msg, src)


### PR DESCRIPTION
## Proposed changes

If an istanbul message is distinguished as a "future message" in `c.checkMessage()`, the message is stored in `backlog`.
Currently, `c.valSet.CheckInSubList()` may invalidate future messages before `c.checkMessage()` is called.
With this PR, future messages will be determined before it is checked in `c.valSet.CheckInSubList()`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
