### PR TITLE
istanbul timeoutEvent embed a view of the next round

### DIFF
--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	SubGroupSize   uint64         `toml:",omitempty"`
 }
 
+// TODO-Klaytn-Istanbul: Do not use DefaultConfig except for assigning new config
 var DefaultConfig = &Config{
 	Timeout:        10000,
 	BlockPeriod:    1,

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -20,6 +20,7 @@ func TestCore_sendCommit(t *testing.T) {
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}
+	defer istCore.Stop()
 
 	lastProposal, lastProposer := mockBackend.LastProposal()
 	proposal, err := genBlock(lastProposal.(*types.Block), validatorKeyMap[validatorAddrs[0]])

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -353,6 +353,7 @@ func (c *core) stopTimer() {
 func (c *core) newRoundChangeTimer() {
 	c.stopTimer()
 
+	// TODO-Klaytn-Istanbul: Replace &istanbul.DefaultConfig.Timeout to c.config.Timeout
 	// set timeout based on the round number
 	timeout := time.Duration(atomic.LoadUint64(&istanbul.DefaultConfig.Timeout)) * time.Millisecond
 	round := c.current.Round().Uint64()
@@ -388,7 +389,10 @@ func (c *core) newRoundChangeTimer() {
 			}
 		}
 
-		c.sendEvent(timeoutEvent{})
+		c.sendEvent(timeoutEvent{&istanbul.View{
+			Sequence: c.current.sequence,
+			Round:    new(big.Int).Add(c.current.round, common.Big1),
+		}})
 	}))
 
 	logger.Debug("New RoundChangeTimer Set", "seq", c.current.Sequence(), "round", round, "timeout", timeout)

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -361,37 +361,42 @@ func (c *core) newRoundChangeTimer() {
 		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second
 	}
 
-	c.roundChangeTimer.Store(time.AfterFunc(timeout, func() {
-		var loc, proposer string
+	current := c.current
+	proposer := c.valSet.GetProposer()
 
-		if c.current.round.Cmp(common.Big0) == 0 {
+	c.roundChangeTimer.Store(time.AfterFunc(timeout, func() {
+		var loc, proposerStr string
+
+		if round == 0 {
 			loc = "startNewRound"
 		} else {
 			loc = "catchUpRound"
 		}
-		if c.valSet.GetProposer() == nil {
-			proposer = ""
+		if proposer == nil {
+			proposerStr = ""
 		} else {
-			proposer = c.valSet.GetProposer().String()
+			proposerStr = proposer.String()
 		}
 
 		if c.backend.NodeType() == common.CONSENSUSNODE {
 			// Write log messages for validator activities analysis
-			preparesSize := c.current.Prepares.Size()
-			commitsSize := c.current.Commits.Size()
-			logger.Warn("[RC] timeoutEvent Sent!", "set by", loc, "sequence", c.current.sequence, "round", c.current.round, "proposer", proposer, "preprepare is nil?", c.current.Preprepare == nil, "len(prepares)", preparesSize, "len(commits)", commitsSize)
+			preparesSize := current.Prepares.Size()
+			commitsSize := current.Commits.Size()
+			logger.Warn("[RC] timeoutEvent Sent!", "set by", loc, "sequence",
+				current.sequence, "round", current.round, "proposer", proposerStr, "preprepare is nil?",
+				current.Preprepare == nil, "len(prepares)", preparesSize, "len(commits)", commitsSize)
 
 			if preparesSize > 0 {
-				logger.Warn("[RC] Prepares:", "messages", c.current.Prepares.GetMessages())
+				logger.Warn("[RC] Prepares:", "messages", current.Prepares.GetMessages())
 			}
 			if commitsSize > 0 {
-				logger.Warn("[RC] Commits:", "messages", c.current.Commits.GetMessages())
+				logger.Warn("[RC] Commits:", "messages", current.Commits.GetMessages())
 			}
 		}
 
 		c.sendEvent(timeoutEvent{&istanbul.View{
-			Sequence: c.current.sequence,
-			Round:    new(big.Int).Add(c.current.round, common.Big1),
+			Sequence: current.sequence,
+			Round:    new(big.Int).Add(current.round, common.Big1),
 		}})
 	}))
 

--- a/consensus/istanbul/core/events.go
+++ b/consensus/istanbul/core/events.go
@@ -22,6 +22,7 @@ package core
 
 import (
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
 )
 
 type backlogEvent struct {
@@ -30,4 +31,6 @@ type backlogEvent struct {
 	Hash common.Hash
 }
 
-type timeoutEvent struct{}
+type timeoutEvent struct {
+	view *istanbul.View
+}

--- a/consensus/istanbul/core/events.go
+++ b/consensus/istanbul/core/events.go
@@ -32,5 +32,5 @@ type backlogEvent struct {
 }
 
 type timeoutEvent struct {
-	view *istanbul.View
+	nextView *istanbul.View
 }

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -123,12 +123,12 @@ func (c *core) handleEvents() {
 			}
 		case ev, ok := <-c.timeoutSub.Chan():
 			if !ok || ev.Data == nil {
-				logger.Warn("Drop an invalid message from timeout channel")
+				logger.Error("Drop an empty message from timeout channel")
 				return
 			}
 			data, ok := ev.Data.(timeoutEvent)
 			if !ok || data.nextView == nil {
-				logger.Warn("Invalid message type from timeout channel", "msg", ev.Data)
+				logger.Error("Invalid message from timeout channel", "msg", ev.Data)
 				return
 			}
 			c.handleTimeoutMsg(data.nextView)

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -123,12 +123,12 @@ func (c *core) handleEvents() {
 			}
 		case ev, ok := <-c.timeoutSub.Chan():
 			if !ok || ev.Data == nil {
-				logger.Warn("Invalid message type from timeout channel")
+				logger.Warn("Invalid message from timeout channel")
 				return
 			}
 			data, ok := ev.Data.(timeoutEvent)
 			if !ok || data.view == nil {
-				logger.Warn("Invalid message from timeout channel", "msg", ev.Data)
+				logger.Warn("Invalid message type from timeout channel", "msg", ev.Data)
 				return
 			}
 			c.handleTimeoutMsg(data.view)
@@ -202,7 +202,7 @@ func (c *core) handleCheckedMsg(msg *message, src istanbul.Validator) error {
 func (c *core) handleTimeoutMsg(view *istanbul.View) {
 	// TODO-Klaytn-Istanbul: Check whether this statement is required. EN/PN should not handle consensus msgs.
 	if c.backend.NodeType() != common.CONSENSUSNODE {
-		logger.Warn("Received an istanbul timeout message from EN or PN",
+		logger.Warn("This is not consensus node, but received an istanbul timeout message",
 			"nodeType", c.backend.NodeType().String())
 		return
 	}

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -228,6 +228,7 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}
+	defer istCore.Stop()
 
 	// Get variables initialized on `newMockBackend()`
 	eventMux := mockBackend.EventMux()
@@ -402,6 +403,7 @@ func TestCore_handlerMsg(t *testing.T) {
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}
+	defer istCore.Stop()
 
 	lastProposal, _ := mockBackend.LastProposal()
 	lastBlock := lastProposal.(*types.Block)
@@ -455,7 +457,7 @@ func TestCore_handlerMsg(t *testing.T) {
 }
 
 // TestCore_handleTimeoutMsg_race tests a race condition between round change triggers.
-// There should be no race condition when and round change message and timeout event are handled simultaneously.
+// There should be no race condition when round change message and timeout event are handled simultaneously.
 func TestCore_handleTimeoutMsg_race(t *testing.T) {
 	// important variables to construct test cases
 	const sleepTime = 200 * time.Millisecond
@@ -505,6 +507,7 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}
+	defer istCore.Stop()
 
 	eventMux := mockBackend.EventMux()
 	lastProposal, _ := mockBackend.LastProposal()
@@ -541,7 +544,7 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 			}
 
 			// wait until the istanbul message have processed
-			time.Sleep(processingTime + 2*sleepTime)
+			time.Sleep(processingTime + sleepTime)
 			roundChangeTimer.Stop()
 
 			// check the result

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -486,14 +486,6 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 			messageRound:  20,
 			expectedRound: 20,
 		},
-		{
-			// if timeoutTime > processingTime && timeoutTime < (processingTime + sleepTime * 2),
-			// (2f+1)th round change message will be processed and then timeout event will not be triggered in the test
-			name:          "reset timeout after processing the (2f+1)th round change message",
-			timeoutTime:   700 * time.Millisecond,
-			messageRound:  30,
-			expectedRound: 30,
-		},
 	}
 
 	validatorAddrs, _ := genValidators(10)

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -488,7 +488,7 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 		},
 		{
 			// if timeoutTime > processingTime && timeoutTime < (processingTime + sleepTime * 2),
-			// (2f+1)th round change message will be process and then timeout event will be reset
+			// (2f+1)th round change message will be processed and then timeout event will not be triggered in the test
 			name:          "reset timeout after processing the (2f+1)th round change message",
 			timeoutTime:   700 * time.Millisecond,
 			messageRound:  30,

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -470,7 +470,7 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 	testCases := []testCase{
 		{
 			// if timeoutTime < sleepTime,
-			// timeout event will be post and then round change message will be processed
+			// timeout event will be posted and then round change message will be processed
 			name:          "timeout before processing the (2f+1)th round change message",
 			timeoutTime:   50 * time.Millisecond,
 			messageRound:  10,
@@ -478,7 +478,7 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 		},
 		{
 			// if timeoutTime > sleepTime && timeoutTime < (processingTime + sleepTime),
-			// timeout event will be post during the processing of (2f+1)th round change message
+			// timeout event will be posted during the processing of (2f+1)th round change message
 			name:          "timeout during processing the (2f+1)th round change message",
 			timeoutTime:   300 * time.Millisecond,
 			messageRound:  20,

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -482,7 +482,7 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 			name:          "timeout during processing the (2f+1)th round change message",
 			timeoutTime:   300 * time.Millisecond,
 			messageRound:  20,
-			expectedRound: 21, // TODO-Klaytn-Istanbul: it should be 20
+			expectedRound: 20,
 		},
 		{
 			// if timeoutTime > processingTime && timeoutTime < (processingTime + sleepTime * 2),

--- a/consensus/istanbul/core/message_set.go
+++ b/consensus/istanbul/core/message_set.go
@@ -22,11 +22,12 @@ package core
 
 import (
 	"fmt"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/consensus/istanbul"
 	"math/big"
 	"strings"
 	"sync"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
 )
 
 // Construct a new message set to accumulate messages for given sequence/view number.

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -20,6 +20,7 @@ func TestCore_sendPrepare(t *testing.T) {
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}
+	defer istCore.Stop()
 
 	lastProposal, lastProposer := mockBackend.LastProposal()
 	proposal, err := genBlock(lastProposal.(*types.Block), validatorKeyMap[validatorAddrs[0]])

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -43,8 +43,7 @@ func (c *core) sendRoundChange(round *big.Int) {
 
 	cv := c.currentView()
 	if cv.Round.Cmp(round) >= 0 {
-		logger.Info("Skip sending out the round change message",
-			"current round", cv.Round, "target round", round)
+		logger.Warn("Skip sending out the round change message", "current round", cv.Round, "target round", round)
 		return
 	}
 

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -43,7 +43,8 @@ func (c *core) sendRoundChange(round *big.Int) {
 
 	cv := c.currentView()
 	if cv.Round.Cmp(round) >= 0 {
-		logger.Error("Cannot send out the round change", "current round", cv.Round, "target round", round)
+		logger.Info("Skip sending out the round change message",
+			"current round", cv.Round, "target round", round)
 		return
 	}
 


### PR DESCRIPTION
## Proposed changes

**Problem Situation**
When the round change of istanbul occurred, some node changes its round successively in a very short time.
The phenomenon can happen when `timeoutEven` is posted handling (2f+1)th round change message. 
When (2f+1)th round change message is handled, Istanbul core resets round change timer triggering `timeoutEvent`.
However, there is a small change the timeout can be reached before resetting the timer.

**Solution**
The problem occurred since Istanbul core just increases the current round to 1 when `timeoutEvent` handled.
This PR makes `timeoutEvent` to embed a target round preventing confusing of the next round. 

- Introduce a test case triggering round change bug
- istanbul timeoutEvent embed a view of the next round
- Detail round change logs

You better see this PR commit by commit. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
