### PR TITLE
blockchain, cmd, cn: `vm.internaltx` to trace internal tx

### DIFF
--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -180,6 +180,11 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmCon
 		vmConfig.RunningEVM <- evm
 	}
 
+	// If internal transaction tracing is enabled, creates a tracer for a transaction
+	if vmConfig.EnableInternalTxTracing {
+		vmConfig.Tracer = NewInternalTxTracer()
+	}
+
 	evm.interpreter = NewInterpreter(evm, vmConfig)
 	return evm
 }

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -21,12 +21,12 @@
 // This file is derived from eth/tracers/internal/tracers/call_tracer.js (2018/06/04).
 // Modified and improved for the klaytn development.
 
-package tracers
+package vm
 
 import (
 	"encoding/hex"
 	"errors"
-	"github.com/klaytn/klaytn/blockchain/vm"
+	"fmt"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"math/big"
@@ -43,8 +43,6 @@ var emptyAddr = common.Address{}
 // the internal calls made by a transaction, along with any useful information.
 // It is ported to golang from JS, specifically call_tracer.js
 type InternalTxTracer struct {
-	cfg vm.LogConfig
-
 	callStack []*InternalCall
 	output    []byte
 	err       error
@@ -58,14 +56,11 @@ type InternalTxTracer struct {
 	revertString     string
 }
 
-// NewInternalTxLogger returns a new InternalTxTracer
-func NewInternalTxLogger(cfg *vm.LogConfig) *InternalTxTracer {
+// NewInternalTxTracer returns a new InternalTxTracer.
+func NewInternalTxTracer() *InternalTxTracer {
 	logger := &InternalTxTracer{
 		callStack: []*InternalCall{{}},
 		ctx:       map[string]interface{}{},
-	}
-	if cfg != nil {
-		logger.cfg = *cfg
 	}
 	return logger
 }
@@ -158,9 +153,9 @@ type RevertedInfo struct {
 
 // CaptureStart implements the Tracer interface to initialize the tracing operation.
 func (this *InternalTxTracer) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) error {
-	this.ctx["type"] = vm.CALL.String()
+	this.ctx["type"] = CALL.String()
 	if create {
-		this.ctx["type"] = vm.CREATE.String()
+		this.ctx["type"] = CREATE.String()
 	}
 	this.ctx["from"] = from
 	this.ctx["to"] = to
@@ -174,20 +169,29 @@ func (this *InternalTxTracer) CaptureStart(from common.Address, to common.Addres
 // tracerLog is used to help comparing codes between this and call_tracer.js
 // by following the conventions used in call_tracer.js
 type tracerLog struct {
-	env      *vm.EVM
+	env      *EVM
 	pc       uint64
-	op       vm.OpCode
+	op       OpCode
 	gas      uint64
 	cost     uint64
-	memory   *vm.Memory
-	stack    *vm.Stack
-	contract *vm.Contract
+	memory   *Memory
+	stack    *Stack
+	contract *Contract
 	depth    int
 	err      error
 }
 
+func wrapError(context string, err error) error {
+	var message string
+	switch err := err.(type) {
+	default:
+		message = err.Error()
+	}
+	return fmt.Errorf("%v    in server-side tracer function '%v'", message, context)
+}
+
 // CaptureState implements the Tracer interface to trace a single step of VM execution.
-func (this *InternalTxTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, memory *vm.Memory, logStack *vm.Stack, contract *vm.Contract, depth int, err error) error {
+func (this *InternalTxTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, logStack *Stack, contract *Contract, depth int, err error) error {
 	if this.err == nil {
 		// Initialize the context if it wasn't done yet
 		if !this.initialized {
@@ -220,7 +224,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 	sysCall := (log.op & 0xf0) == 0xf0
 	op := log.op
 	// If a new contract is being created, add to the call stack
-	if sysCall && (op == vm.CREATE || op == vm.CREATE2) {
+	if sysCall && (op == CREATE || op == CREATE2) {
 		inOff := log.stack.Back(1)
 		inEnd := big.NewInt(0).Add(inOff, log.stack.Back(2)).Int64()
 
@@ -238,7 +242,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 		return nil
 	}
 	// If a contract is being self destructed, gather that as a subcall too
-	if sysCall && op == vm.SELFDESTRUCT {
+	if sysCall && op == SELFDESTRUCT {
 		left := this.callStackLength()
 		if this.callStack[left-1] == nil {
 			this.callStack[left-1] = &InternalCall{}
@@ -250,7 +254,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 		return nil
 	}
 	// If a new method invocation is being done, add to the call stack
-	if sysCall && (op == vm.CALL || op == vm.CALLCODE || op == vm.DELEGATECALL || op == vm.STATICCALL) {
+	if sysCall && (op == CALL || op == CALLCODE || op == DELEGATECALL || op == STATICCALL) {
 
 		// Skip any pre-compile invocations, those are just fancy opcodes
 		toAddr := common.HexToAddress(log.stack.Back(1).Text(16))
@@ -259,7 +263,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 		}
 
 		off := 1
-		if op == vm.DELEGATECALL || op == vm.STATICCALL {
+		if op == DELEGATECALL || op == STATICCALL {
 			off = 0
 		}
 
@@ -286,7 +290,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 			OutOff:  big.NewInt(log.stack.Back(4 + off).Int64()),
 			OutLen:  big.NewInt(log.stack.Back(5 + off).Int64()),
 		}
-		if op != vm.DELEGATECALL && op != vm.STATICCALL {
+		if op != DELEGATECALL && op != STATICCALL {
 			call.Value = "0x" + log.stack.Back(2).Text(16)
 		}
 		this.callStack = append(this.callStack, call)
@@ -308,7 +312,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 		this.descended = false
 	}
 	// If an existing call is returning, pop off the call stack
-	if sysCall && op == vm.REVERT && this.callStackLength() > 0 {
+	if sysCall && op == REVERT && this.callStackLength() > 0 {
 		this.callStack[this.callStackLength()-1].Error = errExecutionReverted
 		if this.revertedContract == emptyAddr {
 			if this.callStack[this.callStackLength()-1].To == emptyAddr {
@@ -323,7 +327,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 		// Pop off the last call and get the execution results
 		call := this.callStackPop()
 
-		if call.Type == vm.CREATE.String() || call.Type == vm.CREATE2.String() {
+		if call.Type == CREATE.String() || call.Type == CREATE2.String() {
 			// If the call was a CREATE, retrieve the contract address and output code
 			call.GasUsed = call.GasIn - call.GasCost - log.gas
 			call.GasIn, call.GasCost = uint64(0), uint64(0)
@@ -376,7 +380,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 
 // CaptureFault implements the Tracer interface to trace an execution fault
 // while running an opcode.
-func (this *InternalTxTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, memory *vm.Memory, s *vm.Stack, contract *vm.Contract, depth int, err error) error {
+func (this *InternalTxTracer) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, s *Stack, contract *Contract, depth int, err error) error {
 	if this.err == nil {
 		// Apart from the error, everything matches the previous invocation
 		this.errValue = err.Error()

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -182,12 +182,7 @@ type tracerLog struct {
 }
 
 func wrapError(context string, err error) error {
-	var message string
-	switch err := err.(type) {
-	default:
-		message = err.Error()
-	}
-	return fmt.Errorf("%v    in server-side tracer function '%v'", message, context)
+	return fmt.Errorf("%v    in server-side tracer function '%v'", err.Error(), context)
 }
 
 // CaptureState implements the Tracer interface to trace a single step of VM execution.

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -51,6 +51,9 @@ type Config struct {
 
 	// UseOpcodeComputationCost is to enable applying the opcode computation cost limit.
 	UseOpcodeComputationCost bool
+
+	// Enables collecting internal transaction data during processing a block
+	EnableInternalTxTracing bool
 }
 
 // keccakState wraps sha3.state. In addition to the usual hash methods, it also supports

--- a/cmd/kcn/main.go
+++ b/cmd/kcn/main.go
@@ -157,6 +157,7 @@ var cnHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
+			utils.VMTraceInternalTx,
 		},
 	},
 	{

--- a/cmd/kcn/main.go
+++ b/cmd/kcn/main.go
@@ -157,7 +157,7 @@ var cnHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
-			utils.VMTraceInternalTx,
+			utils.VMTraceInternalTxFlag,
 		},
 	},
 	{

--- a/cmd/ken/main.go
+++ b/cmd/ken/main.go
@@ -168,6 +168,7 @@ var enHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
+			utils.VMTraceInternalTx,
 		},
 	},
 	{

--- a/cmd/ken/main.go
+++ b/cmd/ken/main.go
@@ -168,7 +168,7 @@ var enHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
-			utils.VMTraceInternalTx,
+			utils.VMTraceInternalTxFlag,
 		},
 	},
 	{

--- a/cmd/kpn/main.go
+++ b/cmd/kpn/main.go
@@ -157,7 +157,7 @@ var pnHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
-			utils.VMTraceInternalTx,
+			utils.VMTraceInternalTxFlag,
 		},
 	},
 	{

--- a/cmd/kpn/main.go
+++ b/cmd/kpn/main.go
@@ -157,6 +157,7 @@ var pnHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
+			utils.VMTraceInternalTx,
 		},
 	},
 	{

--- a/cmd/kscn/main.go
+++ b/cmd/kscn/main.go
@@ -172,6 +172,7 @@ var scnHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
+			utils.VMTraceInternalTx,
 		},
 	},
 	{

--- a/cmd/kscn/main.go
+++ b/cmd/kscn/main.go
@@ -172,7 +172,7 @@ var scnHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
-			utils.VMTraceInternalTx,
+			utils.VMTraceInternalTxFlag,
 		},
 	},
 	{

--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -174,7 +174,7 @@ var senHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
-			utils.VMTraceInternalTx,
+			utils.VMTraceInternalTxFlag,
 		},
 	},
 	{

--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -174,6 +174,7 @@ var senHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
+			utils.VMTraceInternalTx,
 		},
 	},
 	{

--- a/cmd/kspn/main.go
+++ b/cmd/kspn/main.go
@@ -171,7 +171,7 @@ var spnHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
-			utils.VMTraceInternalTx,
+			utils.VMTraceInternalTxFlag,
 		},
 	},
 	{

--- a/cmd/kspn/main.go
+++ b/cmd/kspn/main.go
@@ -171,6 +171,7 @@ var spnHelpFlagGroups = []utils.FlagGroup{
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,
 			utils.VMLogTargetFlag,
+			utils.VMTraceInternalTx,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -324,6 +324,10 @@ var (
 		Usage: "Set the output target of vmlog precompiled contract (0: no output, 1: file, 2: stdout, 3: both)",
 		Value: 0,
 	}
+	VMTraceInternalTx = cli.BoolFlag{
+		Name:  "vm.internaltx",
+		Usage: "Collect internal transaction data while processing a block",
+	}
 
 	// Logging and debug settings
 	MetricsEnabledFlag = cli.BoolFlag{
@@ -1191,6 +1195,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 			logger.Warn("Incorrect vmlog value", "err", err)
 		}
 	}
+	cfg.EnableInternalTxTracing = ctx.GlobalIsSet(VMTraceInternalTx.Name)
 
 	cfg.AutoRestartFlag = ctx.GlobalBool(AutoRestartFlag.Name)
 	cfg.RestartTimeOutFlag = ctx.GlobalDuration(RestartTimeOutFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -324,7 +324,7 @@ var (
 		Usage: "Set the output target of vmlog precompiled contract (0: no output, 1: file, 2: stdout, 3: both)",
 		Value: 0,
 	}
-	VMTraceInternalTx = cli.BoolFlag{
+	VMTraceInternalTxFlag = cli.BoolFlag{
 		Name:  "vm.internaltx",
 		Usage: "Collect internal transaction data while processing a block",
 	}
@@ -1195,7 +1195,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 			logger.Warn("Incorrect vmlog value", "err", err)
 		}
 	}
-	cfg.EnableInternalTxTracing = ctx.GlobalIsSet(VMTraceInternalTx.Name)
+	cfg.EnableInternalTxTracing = ctx.GlobalIsSet(VMTraceInternalTxFlag.Name)
 
 	cfg.AutoRestartFlag = ctx.GlobalBool(AutoRestartFlag.Name)
 	cfg.RestartTimeOutFlag = ctx.GlobalDuration(RestartTimeOutFlag.Name)

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -82,7 +82,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.NodeKeyHexFlag,
 	utils.VMEnableDebugFlag,
 	utils.VMLogTargetFlag,
-	utils.VMTraceInternalTx,
+	utils.VMTraceInternalTxFlag,
 	utils.NetworkIdFlag,
 	utils.RPCCORSDomainFlag,
 	utils.RPCVirtualHostsFlag,

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -82,6 +82,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.NodeKeyHexFlag,
 	utils.VMEnableDebugFlag,
 	utils.VMLogTargetFlag,
+	utils.VMTraceInternalTx,
 	utils.NetworkIdFlag,
 	utils.RPCCORSDomainFlag,
 	utils.RPCVirtualHostsFlag,

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -792,7 +792,7 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message blockchain.Mess
 
 	case *tracers.Tracer:
 		return tracer.GetResult()
-	case *tracers.InternalTxTracer:
+	case *vm.InternalTxTracer:
 		return tracer.GetResult()
 
 	default:

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -30,7 +30,6 @@ import (
 	"github.com/klaytn/klaytn/blockchain/bloombits"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
-	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/consensus"
@@ -247,7 +246,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		}
 	}
 	var (
-		vmConfig    = vm.Config{EnablePreimageRecording: config.EnablePreimageRecording}
+		vmConfig    = config.getVMConfig()
 		cacheConfig = &blockchain.CacheConfig{StateDBCaching: config.StateDBCaching,
 			ArchiveMode: config.NoPruning, CacheSize: config.TrieCacheSize, BlockInterval: config.TrieBlockInterval,
 			TriesInMemory: config.TriesInMemory, TxPoolStateCache: config.TxPoolStateCache,

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -22,6 +22,7 @@ package cn
 
 import (
 	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/consensus/istanbul"
@@ -124,6 +125,8 @@ type Config struct {
 
 	// Enables tracking of SHA3 preimages in the VM
 	EnablePreimageRecording bool
+	// Enables collecting internal transaction data during processing a block
+	EnableInternalTxTracing bool
 	// Istanbul options
 	Istanbul istanbul.Config
 
@@ -151,4 +154,11 @@ type Config struct {
 
 type configMarshaling struct {
 	ExtraData hexutil.Bytes
+}
+
+func (c *Config) getVMConfig() vm.Config {
+	return vm.Config{
+		EnablePreimageRecording: c.EnablePreimageRecording,
+		EnableInternalTxTracing: c.EnableInternalTxTracing,
+	}
 }

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -206,7 +206,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	}
 }
 
-func covertToCallTrace(t *testing.T, internalTx *InternalTxTrace) *callTrace {
+func covertToCallTrace(t *testing.T, internalTx *vm.InternalTxTrace) *callTrace {
 	// coverts nested InternalTxTraces
 	var nestedCalls []callTrace
 	for _, call := range internalTx.Calls {
@@ -440,7 +440,7 @@ func TestInternalCallTracer(t *testing.T) {
 			statedb := tests.MakePreState(database.NewMemoryDBManager(), test.Genesis.Alloc)
 
 			// Create the tracer, the EVM environment and run it
-			tracer := NewInternalTxLogger(nil)
+			tracer := vm.NewInternalTxTracer()
 			evm := vm.NewEVM(context, statedb, test.Genesis.Config, &vm.Config{Debug: true, Tracer: tracer})
 
 			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())


### PR DESCRIPTION
## Proposed changes

- This PR is to support enabling feature of `InternalTxTracer`
- If `--vm.internaltx` is given, `InternalTxTracer` will collect internal transaction data while processing a block.
- Please note that storing or sending the collected data to designated place is not included in this PR.
- `internaltx_tracer.go` has been moved to `vm` package to avoid cyclic dependency

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
