### PR TITLE
Fixed Memory Slice method

### DIFF
--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -268,8 +268,6 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 		input := ""
 		if int(inOff.Int64()) >= log.memory.Len() {
 			input = ""
-		} else if int(inEnd) >= log.memory.Len() {
-			input = hexutil.Encode(log.memory.Slice(inOff.Int64(), int64(log.memory.Len()-1)))
 		} else {
 			input = hexutil.Encode(log.memory.Slice(inOff.Int64(), inEnd))
 		}

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -265,19 +265,12 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 		inOff := log.stack.Back(2 + off)
 		inEnd := big.NewInt(0).Add(inOff, log.stack.Back(3+off)).Int64()
 
-		input := ""
-		if int(inOff.Int64()) >= log.memory.Len() {
-			input = ""
-		} else {
-			input = hexutil.Encode(log.memory.Slice(inOff.Int64(), inEnd))
-		}
-
 		// Assemble the internal call report and store for completion
 		call := &InternalCall{
 			Type:    op.String(),
 			From:    log.contract.Address(),
 			To:      toAddr,
-			Input:   input,
+			Input:   hexutil.Encode(log.memory.Slice(inOff.Int64(), inEnd)),
 			GasIn:   log.gas,
 			GasCost: log.cost,
 			OutOff:  big.NewInt(log.stack.Back(4 + off).Int64()),

--- a/blockchain/vm/memory.go
+++ b/blockchain/vm/memory.go
@@ -133,6 +133,9 @@ func (m *Memory) Print() {
 }
 
 func (m *Memory) Slice(from, to int64) []byte {
+	if from > int64(m.Len()) {
+		return nil
+	}
 	if to > int64(m.Len()) {
 		to = int64(m.Len())
 	}

--- a/blockchain/vm/memory.go
+++ b/blockchain/vm/memory.go
@@ -133,6 +133,10 @@ func (m *Memory) Print() {
 }
 
 func (m *Memory) Slice(from, to int64) []byte {
+	if to > int64(m.Len()) {
+		to = int64(m.Len())
+	}
+
 	sliced := m.store[from:to]
 	copied := make([]byte, len(sliced))
 	copy(copied, sliced)


### PR DESCRIPTION
## Proposed changes

- The `Slice` method has two parameters: `from` and `to`. When pass `memory.len() - 1` as `to` parameter, the method may truncate the last byte. This PR fixes this issue.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
