### PR TITLE
Fix a bad block during sync Baobab

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1063,6 +1063,8 @@ func (bc *BlockChain) writeReceipts(hash common.Hash, number uint64, receipts ty
 // If an archiving node is running, it always flushes state trie to DB.
 // If not, it flushes state trie to DB periodically. (period = bc.cacheConfig.BlockInterval)
 func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) error {
+	state.LockGCCachedNode()
+	defer state.UnlockGCCachedNode()
 	root, err := state.Commit(true)
 	if err != nil {
 		return err

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1065,7 +1065,7 @@ func (bc *BlockChain) writeReceipts(hash common.Hash, number uint64, receipts ty
 func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) error {
 	state.LockGCCachedNode()
 	defer state.UnlockGCCachedNode()
-	
+
 	root, err := state.Commit(true)
 	if err != nil {
 		return err

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1065,6 +1065,7 @@ func (bc *BlockChain) writeReceipts(hash common.Hash, number uint64, receipts ty
 func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) error {
 	state.LockGCCachedNode()
 	defer state.UnlockGCCachedNode()
+	
 	root, err := state.Commit(true)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Proposed changes
Before this PR, bad block can be happened caused by the dereferenced missing trie node in low spec instances.
The missing trie node was dereferenced by the race condition of trieNodeCache reference count.

This PR added GCLock to prevent `dereference` during `commit` and `reference`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
