### PR TITLE
[CIRCLECI] RC RPM publish / RC binary link to PR comment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,14 +223,14 @@ commands:
       - run:
           name: "notify slack when job success"
           command : |
-            curl --data '{"text": "✅ Job **'$CIRCLE_JOB'** succeeded on **'$CIRCLE_BRANCH''$CIRCLE_TAG'**. Please see '$CIRCLE_BUILD_URL' for details."}' "$SLACK_WEBHOOK_URL"
+            curl --data '{"text": "✅ Job *'$CIRCLE_JOB'* succeeded on *'$CIRCLE_BRANCH''$CIRCLE_TAG'*. Please see '$CIRCLE_BUILD_URL' for details."}' "$SLACK_WEBHOOK_URL"
           when: on_success
   notify-failure:
     steps:
       - run:
           name: "notify slack when job fail"
           command : |
-            curl --data '{"text": "❌ Job **'$CIRCLE_JOB'** failed on **'$CIRCLE_BRANCH'**. Please see '$CIRCLE_BUILD_URL' for details."}' "$SLACK_WEBHOOK_URL"
+            curl --data '{"text": "❌ Job *'$CIRCLE_JOB'* failed on *'$CIRCLE_BRANCH'*. Please see '$CIRCLE_BUILD_URL' for details."}' "$SLACK_WEBHOOK_URL"
           when: on_fail
 
 jobs:
@@ -553,3 +553,23 @@ workflows:
           filters:
             branches:
               only: master
+
+  nightly-coverage:
+    triggers:
+      - schedule:
+          cron: "0 18 * * *"
+          filters:
+            branches:
+              only: dev
+    jobs:
+      - coverage
+
+  nightly-linters:
+    triggers:
+      - schedule:
+          cron: "0 19 * * *"
+          filters:
+            branches:
+              only: dev
+    jobs:
+      - linters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,9 @@ commands:
                 echo "hub pull-request -m "[Master] release/$CIRCLE_TAG QA Signoff" -b $CIRCLE_PROJECT_USERNAME:master -h $CIRCLE_PROJECT_USERNAME:${CIRCLE_TAG%-*}"
                 echo -e "[Master] release/${CIRCLE_TAG%-*} QA Sign-off\n\nThis PR is automatically created by CI to release a new official version of $CIRCLE_PROJECT_REPONAME.\n\nWhen this PR is approved by QA team, a new version will be released." | hub pull-request -b $CIRCLE_PROJECT_USERNAME:master -h $CIRCLE_PROJECT_USERNAME:release/${CIRCLE_TAG%-*} -r $GITHUB_reviewer -l circleci -F-
               fi
+      - run:
+          name: "build announce"
+          command: .circleci/scripts/build_announce.sh
   tagging-delete-branch:
     steps:
       - run:
@@ -478,6 +481,7 @@ workflows:
             - test-others
             - tag-verify
             - tagger-verify
+            - test-linter
           filters: *filter-version-not-release
 
       - tag-verify:
@@ -491,11 +495,7 @@ workflows:
             - packaging-linux-baobab
             - packaging-darwin
             - packaging-darwin-baobab
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
-            branches:
-              ignore: /.*/
+          filters: *filter-only-version-tag
 
       - release-PR:
           requires:
@@ -553,23 +553,3 @@ workflows:
           filters:
             branches:
               only: master
-
-  nightly-coverage:
-    triggers:
-      - schedule:
-          cron: "0 18 * * *"
-          filters:
-            branches:
-              only: dev
-    jobs:
-      - coverage
-
-  nightly-linters:
-    triggers:
-      - schedule:
-          cron: "0 19 * * *"
-          filters:
-            branches:
-              only: dev
-    jobs:
-      - linters

--- a/.circleci/scripts/build_announce.sh
+++ b/.circleci/scripts/build_announce.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euox
+
+VERSION=$(go run build/rpm/main.go version)~${CIRCLE_TAG##*-}
+
+SHORT_SHA1=${CIRCLE_SHA1:0:7}
+CIRCLE_PR_NUMBER=$(hub pr list -s open -L 10 -f "%I")
+
+PACKAGES="kcn kpn ken kscn kspn ksen kbn kgen homi"
+BAOBAB_PACKAGES="kcn kpn ken"
+#PACKAGE_PREFIX="http://packages.klaytn.net/klaytn/${VERSION}"
+PACKAGE_PREFIX="http://package-dev.klaytn.net/klaytn/${VERSION}"
+
+LINUX_PACKAGE_LINKS=""
+DARWIN_PACKAGE_LINKS=""
+BAOBAB_LINUX_PACKAGE_LINKS=""
+BAOBAB_DARWIN_PACKAGE_LINKS=""
+
+for i in ${PACKAGES}
+do
+    LINUX_PACKAGE_LINKS+="<a href="${PACKAGE_PREFIX}/$i-${VERSION}-0-linux-amd64.tar.gz">$i</a>"
+    LINUX_PACKAGE_LINKS+=" "
+    DARWIN_PACKAGE_LINKS+="<a href="${PACKAGE_PREFIX}/$i-${VERSION}-0-darwin-10.10-amd64.tar.gz">$i</a>"
+    DARWIN_PACKAGE_LINKS+=" "
+done
+
+for i in ${BAOBAB_PACKAGES}
+do
+    BAOBAB_LINUX_PACKAGE_LINKS+="<a href="${PACKAGE_PREFIX}/$i-${VERSION}-0-linux-amd64.tar.gz">$i</a>"
+    BAOBAB_LINUX_PACKAGE_LINKS+=" "
+    BAOBAB_DARWIN_PACKAGE_LINKS+="<a href="${PACKAGE_PREFIX}/$i-${VERSION}-0-darwin-10.10-amd64.tar.gz">$i</a>"
+    BAOBAB_DARWIN_PACKAGE_LINKS+=" "
+done
+
+COMMENT_ROWS="<ul><li>Linux: ${LINUX_PACKAGE_LINKS}</li><li>Darwin: ${DARWIN_PACKAGE_LINKS}</li><li>Baobab-linux: ${BAOBAB_LINUX_PACKAGE_LINKS}</li><li>Baobab-darwin: ${BAOBAB_DARWIN_PACKAGE_LINKS}</li></ul>"
+
+COMMENT_HEAD="Builds ready [${SHORT_SHA1}]"
+COMMENT_BODY="<details><summary>${COMMENT_HEAD}</summary>${COMMENT_ROWS}</details>"
+
+#POST_COMMENT_URI="https://api.github.com/repos/klaytn/klaytn/issues/${CIRCLE_PR_NUMBER}/comments"
+POST_COMMENT_URI="https://api.github.com/repos/whoisxx/klaytn-1/issues/${CIRCLE_PR_NUMBER}/comments"
+
+curl -i --request POST ${POST_COMMENT_URI} \
+-H 'Content-Type: application/json' \
+-H 'User-Agent: klaytnbot' \
+-H 'Authorization: token '"${GITHUB_TOKEN}"'' \
+--data '{"body": "'"${COMMENT_BODY}"'"}'

--- a/.circleci/scripts/build_announce.sh
+++ b/.circleci/scripts/build_announce.sh
@@ -8,8 +8,7 @@ CIRCLE_PR_NUMBER=$(hub pr list -s open -L 10 -f "%I")
 
 PACKAGES="kcn kpn ken kscn kspn ksen kbn kgen homi"
 BAOBAB_PACKAGES="kcn kpn ken"
-#PACKAGE_PREFIX="http://packages.klaytn.net/klaytn/${VERSION}"
-PACKAGE_PREFIX="http://package-dev.klaytn.net/klaytn/${VERSION}"
+PACKAGE_PREFIX="http://packages.klaytn.net/klaytn/${VERSION}"
 
 LINUX_PACKAGE_LINKS=""
 DARWIN_PACKAGE_LINKS=""
@@ -37,8 +36,7 @@ COMMENT_ROWS="<ul><li>Linux: ${LINUX_PACKAGE_LINKS}</li><li>Darwin: ${DARWIN_PAC
 COMMENT_HEAD="Builds ready [${SHORT_SHA1}]"
 COMMENT_BODY="<details><summary>${COMMENT_HEAD}</summary>${COMMENT_ROWS}</details>"
 
-#POST_COMMENT_URI="https://api.github.com/repos/klaytn/klaytn/issues/${CIRCLE_PR_NUMBER}/comments"
-POST_COMMENT_URI="https://api.github.com/repos/whoisxx/klaytn-1/issues/${CIRCLE_PR_NUMBER}/comments"
+POST_COMMENT_URI="https://api.github.com/repos/klaytn/klaytn/issues/${CIRCLE_PR_NUMBER}/comments"
 
 curl -i --request POST ${POST_COMMENT_URI} \
 -H 'Content-Type: application/json' \

--- a/.circleci/scripts/build_announce.sh
+++ b/.circleci/scripts/build_announce.sh
@@ -25,9 +25,9 @@ done
 
 for i in ${BAOBAB_PACKAGES}
 do
-    BAOBAB_LINUX_PACKAGE_LINKS+="<a href="${PACKAGE_PREFIX}/$i-${VERSION}-0-linux-amd64.tar.gz">$i</a>"
+    BAOBAB_LINUX_PACKAGE_LINKS+="<a href="${PACKAGE_PREFIX}/$i-baobab-${VERSION}-0-linux-amd64.tar.gz">$i</a>"
     BAOBAB_LINUX_PACKAGE_LINKS+=" "
-    BAOBAB_DARWIN_PACKAGE_LINKS+="<a href="${PACKAGE_PREFIX}/$i-${VERSION}-0-darwin-10.10-amd64.tar.gz">$i</a>"
+    BAOBAB_DARWIN_PACKAGE_LINKS+="<a href="${PACKAGE_PREFIX}/$i-baobab-${VERSION}-0-darwin-10.10-amd64.tar.gz">$i</a>"
     BAOBAB_DARWIN_PACKAGE_LINKS+=" "
 done
 


### PR DESCRIPTION
## Proposed changes

- RC RPM publish: It's hard to install RC version by yum cause RPM publish job run after release major version. By adding job publish RPM when it comes to RC, it could be much easier to install/upgrade to RC version.
- RC binary link: circleci will make comment under release PR with each binary link every RC version. So that anyone interested could install by check release PR. It could be like image below
![image](https://user-images.githubusercontent.com/19515733/89139254-1814d900-d579-11ea-99e0-7a599c2eea7b.png)

- and small changes: add linter test under test-pass job, remove ** to * on slack notification

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
