### PR TITLE
[CIRCLECI] Add mysql docker image to datasync test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ executors:
     docker:
       - image: klaytn/build_base:1.1-go1.14.6-solc0.4.24
       - image: localstack/localstack:0.10.9
+      - image: circleci/mysql:5.7
   rpm-executor:
     working_directory: /go/src/github.com/klaytn/klaytn
     docker:
@@ -257,11 +258,22 @@ jobs:
           command: golangci-lint run --new-from-rev=dev --presets format,style -v --timeout 10m
 
   test-datasync:
-    executor: test-executor
+    executor: test-others-executor
     steps:
       - install-ssh-alpine
       - checkout
-      - run: # TODO-ChainDataFetcher launch mysql test database before the test-datasync runs
+      - run:
+        # Our primary container isn't MYSQL so run a sleep command until it's ready.
+            name: "Waiting for MySQL to be ready"
+            command: |
+              for i in `seq 1 10`;
+              do
+                nc -z 127.0.0.1 3306 && echo Success && exit 0
+                echo -n .
+                sleep 1
+              done
+              echo Failed waiting for MySQL && exit 1
+      - run:
           name: "Run test datasync"
           command: make test-datasync
 


### PR DESCRIPTION
## Proposed changes

- Add mysql docker image aside of `test-others-executor`. username should be root and no need, allow empty password. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
