### PR TITLE
Added from/to fields to trace result + Added an empty slice of InternalCallTrace

### DIFF
--- a/datasync/chaindatafetcher/kas/repository_traces.go
+++ b/datasync/chaindatafetcher/kas/repository_traces.go
@@ -70,6 +70,8 @@ func transformToInternalTx(trace *vm.InternalTxTrace, offset *int64, entryTx *Tx
 		*offset++
 		newTx := *entryTx
 		newTx.TransactionId += *offset
+		newTx.FromAddr = trace.From.Bytes()
+		newTx.ToAddr = trace.To.Bytes()
 		txs = append(txs, &newTx)
 	}
 

--- a/datasync/chaindatafetcher/kas/repository_traces.go
+++ b/datasync/chaindatafetcher/kas/repository_traces.go
@@ -28,6 +28,7 @@ import (
 
 var emptyTraceResult = &vm.InternalTxTrace{
 	Value: "0x0",
+	Calls: []*vm.InternalTxTrace{},
 }
 
 func isEmptyTraceResult(trace *vm.InternalTxTrace) bool {

--- a/datasync/chaindatafetcher/kas/repository_traces_test.go
+++ b/datasync/chaindatafetcher/kas/repository_traces_test.go
@@ -17,31 +17,24 @@
 package kas
 
 import (
-	"encoding/json"
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-var fastCallTracerResult = []byte(`{
-      "from": "0x0000000000000000000000000000000000000000",
-      "gas": 0,
-      "gasUsed": 0,
-      "input": "",
-      "output": "",
-      "reverted": {
-        "contract": "0x0000000000000000000000000000000000000000",
-        "message": ""
-      },
-      "time": 0,
-      "to": "0x0000000000000000000000000000000000000000",
-      "type": "",
-      "value": "0x0"
-}`)
+// A specific types of transaction returns empty trace result which is defined as a variable `emptyTraceResult`.
+// As a result of the tracing, `reflect.DeepEqual` returns an error while comparing with the not-initialized slice.
+func TestRepository_isEmptyTraceResult(t *testing.T) {
+	// right empty result.
+	data := &vm.InternalTxTrace{
+		Value: "0x0",
+		Calls: []*vm.InternalTxTrace{},
+	}
+	assert.True(t, isEmptyTraceResult(data))
 
-func TestIsInternalTxResult_Success(t *testing.T) {
-	var testResult vm.InternalTxTrace
-	assert.True(t, json.Valid(fastCallTracerResult))
-	assert.NoError(t, json.Unmarshal(fastCallTracerResult, &testResult))
-	assert.True(t, isEmptyTraceResult(&testResult))
+	// wrong empty result.
+	data = &vm.InternalTxTrace{
+		Value: "0x0",
+	}
+	assert.False(t, isEmptyTraceResult(data))
 }


### PR DESCRIPTION
## Proposed changes

- Fixed comparision logic for InternalTrace instead of using `reflect.DeepEqual`.
  - `reflect.DeepEqual` does return `false` for comparison empty slice with `nil` value.
- The `from` and `to` fields are missing to be added. So, they are added.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
