### PR TITLE
Disable bugs, unused presets in golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ jobs:
       - checkout
       - run:
           name: "Run golangci-lint"
-          command: golangci-lint run --new-from-rev=dev --presets bugs,complexity,format,performance,unused -v --timeout 10m
+          command: golangci-lint run --new-from-rev=dev --presets complexity,format,performance -v --timeout 10m
 
   test-datasync:
     executor: test-others-executor


### PR DESCRIPTION
## Proposed changes

- Since golangci-lint uses too much resource of circle ci, disabled some presets. 
  - Used way more than 1 GB memory frequently
  - Disabled presets may use much resource


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
