### PR TITLE
Terminate services before coreservices

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -578,10 +578,12 @@ func (n *Node) Stop() error {
 	failure := &StopError{
 		Services: make(map[reflect.Type]error),
 	}
+	// subservices are the services which should be terminated before coreservices are terminated.
 	for kind, service := range n.subservices {
 		if err := service.Stop(); err != nil {
 			failure.Services[kind] = err
 		}
+		// delete the already terminated services.
 		delete(n.services, kind)
 	}
 	for kind, service := range n.services {


### PR DESCRIPTION
## Proposed changes

- The services termination order is forced.
- When the node starts, it starts `coreservices` before `services`, but the termination order is not specified.
- This PR terminates the `services` before `coreservices`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules