### PR TITLE
Add a cmd flag to allow locally submitted anchor transactions

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -56,7 +56,7 @@ var (
 
 	txPoolIsFullErr = fmt.Errorf("txpool is full")
 
-	errNotAllowedTx = errors.New("not allowed tx")
+	errNotAllowedAnchoringTx = errors.New("locally anchoring chaindata tx is not allowed in this node")
 )
 
 var (
@@ -952,7 +952,7 @@ func (pool *TxPool) handleTxMsg() {
 // pricing constraints.
 func (pool *TxPool) AddLocal(tx *types.Transaction) error {
 	if tx.Type().IsChainDataAnchoring() && !pool.config.AllowLocalAnchorTx {
-		return fmt.Errorf("tx type %v : %w", tx.Type().String(), errNotAllowedTx)
+		return errNotAllowedAnchoringTx
 	}
 
 	poolSize := uint64(len(pool.all))

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -21,6 +21,7 @@
 package blockchain
 
 import (
+	"errors"
 	"fmt"
 	"github.com/klaytn/klaytn/kerrors"
 	"math"
@@ -54,6 +55,8 @@ var (
 	statsReportInterval = 8 * time.Second // Time interval to report transaction pool stats
 
 	txPoolIsFullErr = fmt.Errorf("txpool is full")
+
+	errNotAllowedTx = errors.New("not allowed tx")
 )
 
 var (
@@ -102,9 +105,10 @@ type blockChain interface {
 
 // TxPoolConfig are the configuration parameters of the transaction pool.
 type TxPoolConfig struct {
-	NoLocals        bool          // Whether local transaction handling should be disabled
-	Journal         string        // Journal of local transactions to survive node restarts
-	JournalInterval time.Duration // Time interval to regenerate the local transaction journal
+	NoLocals           bool          // Whether local transaction handling should be disabled
+	AllowLocalAnchorTx bool          // if this is true, the txpool allow locally submitted anchor transactions
+	Journal            string        // Journal of local transactions to survive node restarts
+	JournalInterval    time.Duration // Time interval to regenerate the local transaction journal
 
 	PriceLimit uint64 // Minimum gas price to enforce for acceptance into the pool
 	PriceBump  uint64 // Minimum price bump percentage to replace an already existing transaction (nonce)
@@ -947,6 +951,10 @@ func (pool *TxPool) handleTxMsg() {
 // the sender as a local one in the mean time, ensuring it goes around the local
 // pricing constraints.
 func (pool *TxPool) AddLocal(tx *types.Transaction) error {
+	if tx.Type().IsChainDataAnchoring() && !pool.config.AllowLocalAnchorTx {
+		return fmt.Errorf("tx type %v : %w", tx.Type().String(), errNotAllowedTx)
+	}
+
 	poolSize := uint64(len(pool.all))
 	if poolSize >= pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll {
 		return fmt.Errorf("txpool is full: %d", poolSize)

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -325,7 +325,7 @@ func TestAnchorTransactions(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = pool.AddLocal(tx2)
-		assert.Error(t, errNotAllowedTx, err)
+		assert.Error(t, errNotAllowedAnchoringTx, err)
 	}
 
 	// txPool which allow locally submitted anchor txs

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -278,6 +278,66 @@ func TestInvalidTransactions(t *testing.T) {
 	}
 }
 
+func genAnchorTx(nonce uint64) *types.Transaction {
+	key, _ := crypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
+	from := crypto.PubkeyToAddress(key.PublicKey)
+
+	gasLimit := uint64(1000000)
+	gasPrice := big.NewInt(1)
+
+	data := []byte{0x11, 0x22}
+	values := map[types.TxValueKeyType]interface{}{
+		types.TxValueKeyNonce:        nonce,
+		types.TxValueKeyFrom:         from,
+		types.TxValueKeyGasLimit:     gasLimit,
+		types.TxValueKeyGasPrice:     gasPrice,
+		types.TxValueKeyAnchoredData: data,
+	}
+
+	tx, _ := types.NewTransactionWithMap(types.TxTypeChainDataAnchoring, values)
+
+	signer := types.MakeSigner(params.BFTTestChainConfig, big.NewInt(2))
+	tx.Sign(signer, key)
+
+	return tx
+}
+
+func TestAnchorTransactions(t *testing.T) {
+	t.Parallel()
+
+	pool, _ := setupTxPool()
+	defer pool.Stop()
+
+	poolAllow, _ := setupTxPool()
+	poolAllow.config.AllowLocalAnchorTx = true
+	defer poolAllow.Stop()
+
+	tx1 := genAnchorTx(1)
+	tx2 := genAnchorTx(2)
+
+	from, _ := tx1.From()
+	pool.currentState.AddBalance(from, big.NewInt(10000000))
+	poolAllow.currentState.AddBalance(from, big.NewInt(10000000))
+
+	// default txPool
+	{
+		err := pool.AddRemote(tx1)
+		assert.NoError(t, err)
+
+		err = pool.AddLocal(tx2)
+		assert.Error(t, errNotAllowedTx, err)
+	}
+
+	// txPool which allow locally submitted anchor txs
+	{
+		err := poolAllow.AddRemote(tx1)
+		assert.NoError(t, err)
+
+		err = poolAllow.AddLocal(tx2)
+		assert.NoError(t, err)
+	}
+}
+
 func TestTransactionQueue(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/kcn/main.go
+++ b/cmd/kcn/main.go
@@ -71,6 +71,7 @@ var cnHelpFlagGroups = []utils.FlagGroup{
 		Name: "TXPOOL",
 		Flags: []cli.Flag{
 			utils.TxPoolNoLocalsFlag,
+			utils.TxPoolAllowLocalAnchorTxFlag,
 			utils.TxPoolJournalFlag,
 			utils.TxPoolJournalIntervalFlag,
 			utils.TxPoolPriceLimitFlag,

--- a/cmd/ken/main.go
+++ b/cmd/ken/main.go
@@ -79,6 +79,7 @@ var enHelpFlagGroups = []utils.FlagGroup{
 		Name: "TXPOOL",
 		Flags: []cli.Flag{
 			utils.TxPoolNoLocalsFlag,
+			utils.TxPoolAllowLocalAnchorTxFlag,
 			utils.TxPoolJournalFlag,
 			utils.TxPoolJournalIntervalFlag,
 			utils.TxPoolPriceLimitFlag,

--- a/cmd/kpn/main.go
+++ b/cmd/kpn/main.go
@@ -74,6 +74,7 @@ var pnHelpFlagGroups = []utils.FlagGroup{
 		Name: "TXPOOL",
 		Flags: []cli.Flag{
 			utils.TxPoolNoLocalsFlag,
+			utils.TxPoolAllowLocalAnchorTxFlag,
 			utils.TxPoolJournalFlag,
 			utils.TxPoolJournalIntervalFlag,
 			utils.TxPoolPriceLimitFlag,

--- a/cmd/kscn/main.go
+++ b/cmd/kscn/main.go
@@ -97,6 +97,7 @@ var scnHelpFlagGroups = []utils.FlagGroup{
 		Name: "TXPOOL",
 		Flags: []cli.Flag{
 			utils.TxPoolNoLocalsFlag,
+			utils.TxPoolAllowLocalAnchorTxFlag,
 			utils.TxPoolJournalFlag,
 			utils.TxPoolJournalIntervalFlag,
 			utils.TxPoolPriceLimitFlag,

--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -95,6 +95,7 @@ var senHelpFlagGroups = []utils.FlagGroup{
 		Name: "TXPOOL",
 		Flags: []cli.Flag{
 			utils.TxPoolNoLocalsFlag,
+			utils.TxPoolAllowLocalAnchorTxFlag,
 			utils.TxPoolJournalFlag,
 			utils.TxPoolJournalIntervalFlag,
 			utils.TxPoolPriceLimitFlag,

--- a/cmd/kspn/main.go
+++ b/cmd/kspn/main.go
@@ -98,6 +98,7 @@ var spnHelpFlagGroups = []utils.FlagGroup{
 		Name: "TXPOOL",
 		Flags: []cli.Flag{
 			utils.TxPoolNoLocalsFlag,
+			utils.TxPoolAllowLocalAnchorTxFlag,
 			utils.TxPoolJournalFlag,
 			utils.TxPoolJournalIntervalFlag,
 			utils.TxPoolPriceLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -133,6 +133,10 @@ var (
 		Name:  "txpool.nolocals",
 		Usage: "Disables price exemptions for locally submitted transactions",
 	}
+	TxPoolAllowLocalAnchorTxFlag = cli.BoolFlag{
+		Name:  "txpool.allowlocalanchortx",
+		Usage: "Enable to allow locally submitted anchor transactions",
+	}
 	TxPoolJournalFlag = cli.StringFlag{
 		Name:  "txpool.journal",
 		Usage: "Disk journal for local transaction to survive node restarts",
@@ -1116,6 +1120,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 func setTxPool(ctx *cli.Context, cfg *blockchain.TxPoolConfig) {
 	if ctx.GlobalIsSet(TxPoolNoLocalsFlag.Name) {
 		cfg.NoLocals = ctx.GlobalBool(TxPoolNoLocalsFlag.Name)
+	}
+	if ctx.GlobalIsSet(TxPoolAllowLocalAnchorTxFlag.Name) {
+		cfg.AllowLocalAnchorTx = ctx.GlobalBool(TxPoolAllowLocalAnchorTxFlag.Name)
 	}
 	if ctx.GlobalIsSet(TxPoolJournalFlag.Name) {
 		cfg.Journal = ctx.GlobalString(TxPoolJournalFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -135,7 +135,7 @@ var (
 	}
 	TxPoolAllowLocalAnchorTxFlag = cli.BoolFlag{
 		Name:  "txpool.allowlocalanchortx",
-		Usage: "Enable to allow locally submitted anchor transactions",
+		Usage: "Allow locally submitted anchoring transactions",
 	}
 	TxPoolJournalFlag = cli.StringFlag{
 		Name:  "txpool.journal",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -134,7 +134,7 @@ var (
 		Usage: "Disables price exemptions for locally submitted transactions",
 	}
 	TxPoolAllowLocalAnchorTxFlag = cli.BoolFlag{
-		Name:  "txpool.allowlocalanchortx",
+		Name:  "txpool.allow-local-anchortx",
 		Usage: "Allow locally submitted anchoring transactions",
 	}
 	TxPoolJournalFlag = cli.StringFlag{

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -35,6 +35,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.DataDirFlag,
 	utils.KeyStoreDirFlag,
 	utils.TxPoolNoLocalsFlag,
+	utils.TxPoolAllowLocalAnchorTxFlag,
 	utils.TxPoolJournalFlag,
 	utils.TxPoolJournalIntervalFlag,
 	utils.TxPoolPriceLimitFlag,


### PR DESCRIPTION
## Proposed changes

This PR added `allowlocalanchortx` cmd flag makes txpool to allow locally submitted anchor transctions.
For public endpoint node, it is necessary to prevent anchor transactions. So this option is added.

This PR reverted the feature is removed in https://github.com/klaytn/klaytn/pull/572.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
