### PR TITLE
Modified internal transaction filtering logic and added testcases

### DIFF
--- a/datasync/chaindatafetcher/kas/repository_test.go
+++ b/datasync/chaindatafetcher/kas/repository_test.go
@@ -2,6 +2,12 @@ package kas
 
 import (
 	"fmt"
+	"math/big"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/jinzhu/gorm"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -14,11 +20,6 @@ import (
 	"github.com/klaytn/klaytn/ser/rlp"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/stretchr/testify/suite"
-	"math/big"
-	"math/rand"
-	"strings"
-	"testing"
-	"time"
 )
 
 var models = []interface{}{
@@ -46,9 +47,10 @@ type SuiteRepository struct {
 	repo *repository
 }
 
-func genRandomAddress() common.Address {
+func genRandomAddress() *common.Address {
 	key, _ := crypto.GenerateKey()
-	return crypto.PubkeyToAddress(key.PublicKey)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	return &addr
 }
 
 func genRandomHash() (h common.Hash) {

--- a/datasync/chaindatafetcher/kas/repository_traces.go
+++ b/datasync/chaindatafetcher/kas/repository_traces.go
@@ -27,6 +27,8 @@ import (
 	"github.com/klaytn/klaytn/common"
 )
 
+const selfDestructType = "SELFDESTRUCT"
+
 var emptyTraceResult = &vm.InternalTxTrace{
 	Value: "0x0",
 	Calls: []*vm.InternalTxTrace{},
@@ -54,7 +56,7 @@ func getEntryTx(block *types.Block, txIdx int, tx *types.Transaction) *Tx {
 func transformToInternalTx(trace *vm.InternalTxTrace, offset *int64, entryTx *Tx, isFirstCall bool) ([]*Tx, error) {
 	if trace.Type == "" {
 		return nil, noOpcodeError
-	} else if trace.Type == "SELFDESTRUCT" {
+	} else if trace.Type == selfDestructType {
 		// TODO-ChainDataFetcher currently, skip it when self-destruct is encountered.
 		return nil, nil
 	}
@@ -68,7 +70,7 @@ func transformToInternalTx(trace *vm.InternalTxTrace, offset *int64, entryTx *Tx
 	}
 
 	var txs []*Tx
-	if !isFirstCall && trace.Value != "0x0" { // filter the internal tx if the value is 0
+	if !isFirstCall && trace.Value != "" && trace.Value != "0x0" { // filter the internal tx if the value is 0
 		*offset++ // adding 1 to calculate the transaction id in the order of internal transactions
 		txs = append(txs, &Tx{
 			TransactionId:   entryTx.TransactionId + *offset,


### PR DESCRIPTION
## Proposed changes

- It is possible to have empty value for internal tracing result, but it wasn't filtering the case.
- This change fix this problem, and added the test cases .

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
