### PR TITLE
SELFTDESTRUCT opcode internal tx tracer bug fix

### DIFF
--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -259,7 +259,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 		if this.callStack[left-1].Calls == nil {
 			this.callStack[left-1].Calls = []*InternalCall{}
 		}
-		this.callStack = append(this.callStack, &InternalCall{Type: op.String()})
+		this.callStack[left-1].Calls = append(this.callStack[left-1].Calls, &InternalCall{Type: op.String()})
 		return nil
 	}
 	// If a new method invocation is being done, add to the call stack


### PR DESCRIPTION
## Proposed changes

- Fixed a bug for SELFDESTRUCT opcode.
- While testing on baobab network, the result of callTracer and fastCallTracer is found. (1007784)
- SELFDESTRUCT is a call from the last internal call, so it should be added to last call on `callStack`.

```
[{
    from: "0xfc3d5c557c68d70d7cc20843e8077c4d28a828ec",
    gas: 83637274,
    gasUsed: 438,
    input: "0xd4c3eea0",
    output: "0x0000000000000000000000000000000000000000000000000000000000000000",
    time: 0,
    to: "0x948f6e700d12aee8a91e76c151fe7e1e474d11d4",
    type: "STATICCALL",
    value: ""
}]
```

```
[{
    from: "0xfc3d5c557c68d70d7cc20843e8077c4d28a828ec",
    gas: "0x4fc341a",
    gasUsed: "0x1b6",
    input: "0xd4c3eea0",
    output: "0x0000000000000000000000000000000000000000000000000000000000000000",
    to: "0x948f6e700d12aee8a91e76c151fe7e1e474d11d4",
    type: "STATICCALL"
}, {
    calls: [{
        type: "SELFDESTRUCT"
    }],
    from: "0xfc3d5c557c68d70d7cc20843e8077c4d28a828ec",
    gas: "0x7a1200",
    gasUsed: "0x1c35",
    input: "0x",
    output: "0x",
    to: "0x948f6e700d12aee8a91e76c151fe7e1e474d11d4",
    type: "CALL",
    value: "0x0"
}]
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
