### PR TITLE
Modified checking precompiled contracts to the one used in call_tracer.js

### DIFF
--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -267,7 +267,7 @@ func (this *InternalTxTracer) step(log *tracerLog) error {
 
 		// Skip any pre-compile invocations, those are just fancy opcodes
 		toAddr := common.HexToAddress(log.stack.Back(1).Text(16))
-		if common.IsPrecompiledContractAddress(toAddr) {
+		if _, ok := PrecompiledContractsCypress[toAddr]; ok {
 			return nil
 		}
 


### PR DESCRIPTION
## Proposed changes

- `isPrecompiledContracts` is modified to the one used in `call_tracer.js`
- https://baobab.scope.klaytn.com/tx/0xda47fd05ece0fc7267f88a5cbcc595603add75b77287c1f3f6c48db0a0250c59?tabId=internalTx
The last two calls weren't collected. This is because of difference between filtering reserved addresses and precompiled addresses. This PR aligns to the original `call_tracer.js`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
