### PR TITLE
[DynamoDB] Fix an shared struct error in worker pool while using mutliple tables

### DIFF
--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -397,12 +397,12 @@ func createBatchWriteWorkerPool(endpoint, region string) {
 
 func createBatchWriteWorker(writeCh <-chan *batchWriteWorkerInput) {
 	failCount := 0
-	batchWriteInput := &dynamodb.BatchWriteItemInput{
-		RequestItems: map[string][]*dynamodb.WriteRequest{},
-	}
 	logger.Debug("generate a dynamoDB batchWrite worker")
 
 	for batchInput := range writeCh {
+		batchWriteInput := &dynamodb.BatchWriteItemInput{
+			RequestItems: map[string][]*dynamodb.WriteRequest{},
+		}
 		batchWriteInput.RequestItems[batchInput.tableName] = batchInput.items
 
 		BatchWriteItemOutput, err := dynamoDBClient.BatchWriteItem(batchWriteInput)

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -163,8 +163,9 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 
 	itemNum := WorkerNum * 2
 	for i := 0; i < itemNum; i++ {
-		// write key and val to db1
-		for j := 0; j < 25; j++ {
+		// write batch items to db1 and db2 in turn
+		for j := 0; j < dynamoBatchSize; j++ {
+			// write key and val to db1
 			testKey := common.MakeRandomBytes(10)
 			testVal := common.MakeRandomBytes(20)
 
@@ -172,9 +173,8 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 			testVals = append(testVals, testVal)
 
 			assert.NoError(t, batch.Put(testKey, testVal))
-		}
-		// write key2 and val2 to db2
-		for j := 0; j < 25; j++ {
+
+			// write key2 and val2 to db2
 			testKey2 := common.MakeRandomBytes(10)
 			testVal2 := common.MakeRandomBytes(20)
 

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -50,7 +50,7 @@ func enableLog() {
 
 func testDynamoDB_Put(t *testing.T) {
 	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
-	defer dynamo.deletedDB()
+	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func testDynamoDB_Put(t *testing.T) {
 
 func testDynamoBatch_Write(t *testing.T) {
 	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
-	defer dynamo.deletedDB()
+	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func testDynamoBatch_Write(t *testing.T) {
 
 func testDynamoBatch_WriteLargeData(t *testing.T) {
 	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
-	defer dynamo.deletedDB()
+	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 
 	// creat DynamoDB1
 	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
-	defer dynamo.deletedDB()
+	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 
 	// creat DynamoDB2
 	dynamo2, err := NewDynamoDB(GetDefaultDynamoDBConfig())
-	defer dynamo2.deletedDB()
+	defer dynamo2.deleteDB()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 	}
 }
 
-func (dynamo *dynamoDB) deletedDB() {
+func (dynamo *dynamoDB) deleteDB() {
 	dynamo.Close()
 	dynamo.deleteTable()
 	dynamo.fdb.deleteBucket()

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -133,13 +133,13 @@ func testDynamoBatch_WriteLargeData(t *testing.T) {
 	}
 }
 
-// testDynamoBatch_WriteMutliTables checks there is no error when working with more than on tables.
+// testDynamoBatch_WriteMutliTables checks if there is no error when working with more than one tables.
 // This also checks if shared workers works as expected.
 func testDynamoBatch_WriteMutliTables(t *testing.T) {
 	// this test might end with Crit, enableLog to find out the log
 	//enableLog()
 
-	// creat DynamoDB1
+	// create DynamoDB1
 	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
@@ -147,7 +147,7 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 	}
 	t.Log("dynamoDB1", dynamo.config.TableName)
 
-	// creat DynamoDB2
+	// create DynamoDB2
 	dynamo2, err := NewDynamoDB(GetDefaultDynamoDBConfig())
 	defer dynamo2.deleteDB()
 	if err != nil {


### PR DESCRIPTION
## Proposed changes

DynamoDB makes a following error when working non-singleDB.
```
ValidationException: Too many items requested for the BatchWriteItem call
```
This is due to shared `batchWriteInput` in a worker. (The items are accumulated in map.)
This PR fixs the problem and adds a test code to catch this problem.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments
