### PR TITLE
Modify KAS auth flag to basic auth parm flag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -708,9 +708,9 @@ var (
 		Name:  "chaindatafetcher.kas.xchainid",
 		Usage: "KAS specific header x-chain-id in chaindatafetcher",
 	}
-	ChainDataFetcherKASAuthFlag = cli.StringFlag{
-		Name:  "chaindatafetcher.kas.auth",
-		Usage: "KAS specific header authorization in chaindatafetcher",
+	ChainDataFetcherKASBasicAuthParamFlag = cli.StringFlag{
+		Name:  "chaindatafetcher.kas.basic.auth.param",
+		Usage: "KAS specific header basic authorization parameter in chaindatafetcher",
 	}
 
 	// DBSyncer

--- a/cmd/utils/nodecmd/dumpconfigcmd.go
+++ b/cmd/utils/nodecmd/dumpconfigcmd.go
@@ -198,9 +198,9 @@ func makeChainDataFetcherConfig(ctx *cli.Context) chaindatafetcher.ChainDataFetc
 			} else {
 				logger.Crit("The cache invalidation url is not set")
 			}
-			if ctx.GlobalIsSet(utils.ChainDataFetcherKASAuthFlag.Name) {
-				auth := ctx.GlobalString(utils.ChainDataFetcherKASAuthFlag.Name)
-				kasConfig.Authorization = auth
+			if ctx.GlobalIsSet(utils.ChainDataFetcherKASBasicAuthParamFlag.Name) {
+				auth := ctx.GlobalString(utils.ChainDataFetcherKASBasicAuthParamFlag.Name)
+				kasConfig.BasicAuthParam = auth
 			} else {
 				logger.Crit("The authorization is not set")
 			}

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -156,7 +156,7 @@ var KENFlags = []cli.Flag{
 	utils.ChainDataFetcherKASCacheUse,
 	utils.ChainDataFetcherKASCacheURLFlag,
 	utils.ChainDataFetcherKASXChainIdFlag,
-	utils.ChainDataFetcherKASAuthFlag,
+	utils.ChainDataFetcherKASBasicAuthParamFlag,
 	// DBSyncer
 	utils.EnableDBSyncerFlag,
 	utils.DBHostFlag,

--- a/datasync/chaindatafetcher/kas/config.go
+++ b/datasync/chaindatafetcher/kas/config.go
@@ -27,7 +27,7 @@ type KASConfig struct {
 
 	CacheUse             bool
 	XChainId             string
-	Authorization        string
+	BasicAuthParam       string
 	CacheInvalidationURL string
 }
 

--- a/datasync/chaindatafetcher/kas/repository.go
+++ b/datasync/chaindatafetcher/kas/repository.go
@@ -109,6 +109,10 @@ func makeEOAListStr(eoaList map[common.Address]struct{}) string {
 	return eoaStrList[:len(eoaStrList)-1]
 }
 
+func makeBasicAuthWithParam(param string) string {
+	return "Basic " + param
+}
+
 func (r *repository) InvalidateCacheEOAList(eoaList map[common.Address]struct{}) {
 	numEOAs := len(eoaList)
 	logger.Trace("the number of EOA list for KAS cache invalidation", "numEOAs", numEOAs)
@@ -130,7 +134,7 @@ func (r *repository) InvalidateCacheEOAList(eoaList map[common.Address]struct{})
 		return
 	}
 	req.Header.Add("x-chain-id", r.config.XChainId)
-	req.Header.Add("Authorization", r.config.Authorization)
+	req.Header.Add("Authorization", makeBasicAuthWithParam(r.config.BasicAuthParam))
 	req.Header.Add("Content-Type", "text/plain")
 
 	res, err := http.DefaultClient.Do(req)

--- a/datasync/chaindatafetcher/kas/repository_test.go
+++ b/datasync/chaindatafetcher/kas/repository_test.go
@@ -155,7 +155,7 @@ func Test_repository_InvalidateCacheEOAList(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		assert.Equal(t, testXChainId, req.Header.Get("x-chain-id"))
-		assert.Equal(t, testAuth, req.Header.Get("Authorization"))
+		assert.Equal(t, makeBasicAuthWithParam(testAuth), req.Header.Get("Authorization"))
 
 		buffer := make([]byte, 1024)
 		bodyStr := ""
@@ -185,7 +185,7 @@ func Test_repository_InvalidateCacheEOAList(t *testing.T) {
 	r := &repository{
 		config: &KASConfig{
 			XChainId:             testXChainId,
-			Authorization:        testAuth,
+			BasicAuthParam:       testAuth,
 			CacheInvalidationURL: server.URL,
 		},
 	}


### PR DESCRIPTION
## Proposed changes

- `kend` cannot escape a space read from `kend.conf`, so the associated flag is a bit modified.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
