### PR TITLE
Refine KAS Anchor log and Service chain

### DIFF
--- a/node/sc/api_bridge.go
+++ b/node/sc/api_bridge.go
@@ -236,7 +236,7 @@ func (sb *SubBridgeAPI) KASAnchor(blkNum uint64) error {
 	block := sb.subBridge.blockchain.GetBlockByNumber(blkNum)
 	if block != nil {
 		if err := sb.subBridge.kasAnchor.AnchorBlock(block); err != nil {
-			logger.Error("Failed to anchor a block via KAS", "blkNum", block.NumberU64())
+			logger.Error("Failed to anchor a block via KAS", "blkNum", block.NumberU64(), "err", err)
 			return err
 		}
 		return nil

--- a/node/sc/bridge_manager.go
+++ b/node/sc/bridge_manager.go
@@ -636,7 +636,7 @@ func (bm *BridgeManager) SetBridgeInfo(addr common.Address, bridge *bridgecontra
 // RestoreBridges setups bridge subscription by using the journal cache.
 func (bm *BridgeManager) RestoreBridges() error {
 	if bm.subBridge.peers.Len() < 1 {
-		logger.Error("check peer connections to restore bridges")
+		logger.Debug("check peer connections to restore bridges")
 		return ErrBridgeRestore
 	}
 

--- a/node/sc/kas/anchor.go
+++ b/node/sc/kas/anchor.go
@@ -129,9 +129,8 @@ func (anchor *Anchor) AnchorBlock(block *types.Block) error {
 	if err != nil || res.Code != codeOK {
 		if res != nil {
 			result, _ := json.MarshalIndent(res, "", "	")
-			logger.Warn(fmt.Sprintf(`AnchorBlock returns below http raw result
-%v
-`, string(result)))
+			logger.Warn(fmt.Sprintf(`AnchorBlock returns below http raw result with the error(%v) :
+%v`, err, string(result)))
 		}
 		return err
 	}

--- a/node/sc/kas/anchor_test.go
+++ b/node/sc/kas/anchor_test.go
@@ -103,6 +103,7 @@ func TestSendRequest(t *testing.T) {
 		}
 		bodyBytes, _ := json.Marshal(expectedRespBody)
 		expectedRes.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
+		expectedRes.StatusCode = http.StatusOK
 
 		m.EXPECT().Do(gomock.Any()).Times(1).Return(&expectedRes, nil)
 		resp, err := anchor.sendRequest(pl)

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -591,7 +591,7 @@ func (sb *SubBridge) restoreBridgeLoop() {
 			return
 		case <-ticker.C:
 			if err := sb.bridgeManager.RestoreBridges(); err != nil {
-				logger.Error("failed to sb.bridgeManager.RestoreBridges()", "err", err)
+				logger.Debug("failed to sb.bridgeManager.RestoreBridges()", "err", err)
 				continue
 			}
 			return


### PR DESCRIPTION
## Proposed changes

This PR refined the logs of KAS Anchor below.
- Removed error log related with Service chain bridge restoring.
- Add raw response log like below. This can help a user to find the reason why the anchoring was failed.
```
WARN[09/01,17:58:01 +09] [53] AnchorBlock returns below http raw result
{
	"code": 1072101,
	"result": null,
	"message": "all configured accounts have insufficient funds"
}

WARN[09/01,17:58:01 +09] [53] Failed to anchor a block via KAS          blkNum=7911 err="http status : 400 Bad Request"
```


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
