### PR TITLE
[DynamoDB] Enables dynamoDB read only function

### DIFF
--- a/cmd/kcn/main.go
+++ b/cmd/kcn/main.go
@@ -99,6 +99,7 @@ var cnHelpFlagGroups = []utils.FlagGroup{
 			utils.DynamoDBIsProvisionedFlag,
 			utils.DynamoDBReadCapacityFlag,
 			utils.DynamoDBWriteCapacityFlag,
+			utils.DynamoDBReadOnlyFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
 		},

--- a/cmd/ken/main.go
+++ b/cmd/ken/main.go
@@ -110,6 +110,7 @@ var enHelpFlagGroups = []utils.FlagGroup{
 			utils.DynamoDBIsProvisionedFlag,
 			utils.DynamoDBReadCapacityFlag,
 			utils.DynamoDBWriteCapacityFlag,
+			utils.DynamoDBReadOnlyFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
 		},

--- a/cmd/kpn/main.go
+++ b/cmd/kpn/main.go
@@ -105,6 +105,7 @@ var pnHelpFlagGroups = []utils.FlagGroup{
 			utils.DynamoDBIsProvisionedFlag,
 			utils.DynamoDBReadCapacityFlag,
 			utils.DynamoDBWriteCapacityFlag,
+			utils.DynamoDBReadOnlyFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
 		},

--- a/cmd/kscn/main.go
+++ b/cmd/kscn/main.go
@@ -124,6 +124,7 @@ var scnHelpFlagGroups = []utils.FlagGroup{
 			utils.DynamoDBIsProvisionedFlag,
 			utils.DynamoDBReadCapacityFlag,
 			utils.DynamoDBWriteCapacityFlag,
+			utils.DynamoDBReadOnlyFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
 		},

--- a/cmd/ksen/main.go
+++ b/cmd/ksen/main.go
@@ -126,6 +126,7 @@ var senHelpFlagGroups = []utils.FlagGroup{
 			utils.DynamoDBIsProvisionedFlag,
 			utils.DynamoDBReadCapacityFlag,
 			utils.DynamoDBWriteCapacityFlag,
+			utils.DynamoDBReadOnlyFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
 		},

--- a/cmd/kspn/main.go
+++ b/cmd/kspn/main.go
@@ -129,6 +129,7 @@ var spnHelpFlagGroups = []utils.FlagGroup{
 			utils.DynamoDBIsProvisionedFlag,
 			utils.DynamoDBReadCapacityFlag,
 			utils.DynamoDBWriteCapacityFlag,
+			utils.DynamoDBReadOnlyFlag,
 			utils.NoParallelDBWriteFlag,
 			utils.SenderTxHashIndexingFlag,
 		},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -243,6 +243,10 @@ var (
 		Usage: "Write capacity unit of dynamoDB. If is-provisioned is not set, this flag will not be applied",
 		Value: database.GetDefaultDynamoDBConfig().WriteCapacityUnits,
 	}
+	DynamoDBReadOnlyFlag = cli.BoolFlag{
+		Name:  "db.dynamo.read-only",
+		Usage: "Disables write to DynamoDB. Only read is possible.",
+	}
 	NoParallelDBWriteFlag = cli.BoolFlag{
 		Name:  "db.no-parallel-write",
 		Usage: "Disables parallel writes of block data to persistent database",
@@ -1283,6 +1287,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 	cfg.DynamoDBConfig.IsProvisioned = ctx.GlobalBool(DynamoDBIsProvisionedFlag.Name)
 	cfg.DynamoDBConfig.ReadCapacityUnits = ctx.GlobalInt64(DynamoDBReadCapacityFlag.Name)
 	cfg.DynamoDBConfig.WriteCapacityUnits = ctx.GlobalInt64(DynamoDBWriteCapacityFlag.Name)
+	cfg.DynamoDBConfig.ReadOnly = ctx.GlobalBool(DynamoDBReadOnlyFlag.Name)
 
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
 		log.Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -53,6 +53,7 @@ var (
 			utils.DynamoDBIsProvisionedFlag,
 			utils.DynamoDBReadCapacityFlag,
 			utils.DynamoDBWriteCapacityFlag,
+			utils.DynamoDBReadOnlyFlag,
 			utils.LevelDBCompressionTypeFlag,
 			utils.DataDirFlag,
 			utils.OverwriteGenesisFlag,

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -60,6 +60,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.DynamoDBIsProvisionedFlag,
 	utils.DynamoDBReadCapacityFlag,
 	utils.DynamoDBWriteCapacityFlag,
+	utils.DynamoDBReadOnlyFlag,
 	utils.LevelDBCacheSizeFlag,
 	utils.NoParallelDBWriteFlag,
 	utils.SenderTxHashIndexingFlag,

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -368,11 +368,13 @@ func (dynamo *dynamoDB) Delete(key []byte) error {
 }
 
 func (dynamo *dynamoDB) Close() {
-	if dynamoOpenedDBNum > 0 {
-		dynamoOpenedDBNum--
-	}
-	if dynamoOpenedDBNum == 0 {
-		close(dynamoWriteCh)
+	if !dynamo.config.ReadOnly {
+		if dynamoOpenedDBNum > 0 {
+			dynamoOpenedDBNum--
+		}
+		if dynamoOpenedDBNum == 0 {
+			close(dynamoWriteCh)
+		}
 	}
 }
 

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -121,6 +121,7 @@ func GetDefaultDynamoDBConfig() *DynamoDBConfig {
 	}
 }
 
+// NewDynamoDB creates either dynamoDB or dynamoDBReadOnly depending on config.ReadOnly.
 func NewDynamoDB(config *DynamoDBConfig) (Database, error) {
 	if config.ReadOnly {
 		return newDynamoDBReadOnly(config)
@@ -128,6 +129,7 @@ func NewDynamoDB(config *DynamoDBConfig) (Database, error) {
 	return newDynamoDB(config)
 }
 
+// newDynamoDB creates dynamoDB. dynamoDB can be used to create dynamoDBReadOnly.
 func newDynamoDB(config *DynamoDBConfig) (*dynamoDB, error) {
 	if config == nil {
 		return nil, nilDynamoConfigErr

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -368,13 +368,11 @@ func (dynamo *dynamoDB) Delete(key []byte) error {
 }
 
 func (dynamo *dynamoDB) Close() {
-	if !dynamo.config.ReadOnly {
-		if dynamoOpenedDBNum > 0 {
-			dynamoOpenedDBNum--
-		}
-		if dynamoOpenedDBNum == 0 {
-			close(dynamoWriteCh)
-		}
+	if dynamoOpenedDBNum > 0 {
+		dynamoOpenedDBNum--
+	}
+	if dynamoOpenedDBNum == 0 {
+		close(dynamoWriteCh)
 	}
 }
 

--- a/storage/database/dynamodb_readonly.go
+++ b/storage/database/dynamodb_readonly.go
@@ -1,0 +1,74 @@
+// Copyright 2020 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+//
+// Database implementation of AWS DynamoDB READ ONLY.
+// Calling put, delete, batch put and batch write does nothing and returns no error.
+// Other functions such as get and has will call functions in DynamoDB.
+//
+// [WARN] Using this DB may cause pricing in your AWS account.
+// [WARN] DynamoDB creates both Dynamo DB table and S3 bucket.
+//
+// You need to set AWS credentials to access to dynamoDB.
+//    $ export AWS_ACCESS_KEY_ID=YOUR_ACCESS_KEY
+//    $ export AWS_SECRET_ACCESS_KEY=YOUR_SECRET
+
+package database
+
+type dynamoDBReadOnly struct {
+	dynamoDB
+}
+
+func newDynamoDBReadOnly(config *DynamoDBConfig) (*dynamoDBReadOnly, error) {
+	config.ReadOnly = true
+	dynamo, err := newDynamoDB(config)
+	if err != nil {
+		return nil, err
+	}
+	return &dynamoDBReadOnly{*dynamo}, nil
+}
+
+func (dynamo *dynamoDBReadOnly) Put(key []byte, val []byte) error {
+	return nil
+}
+
+func (dynamo *dynamoDBReadOnly) Delete(key []byte) error {
+	return nil
+}
+
+func (dynamo *dynamoDBReadOnly) Close() {
+}
+
+func (dynamo *dynamoDBReadOnly) NewBatch() Batch {
+	return &emptyBatch{}
+}
+
+type emptyBatch struct {
+}
+
+func (batch *emptyBatch) Put(key, val []byte) error {
+	return nil
+}
+
+func (batch *emptyBatch) Write() error {
+	return nil
+}
+
+func (batch *emptyBatch) ValueSize() int {
+	return 0
+}
+
+func (batch *emptyBatch) Reset() {
+}

--- a/storage/database/dynamodb_readonly.go
+++ b/storage/database/dynamodb_readonly.go
@@ -41,6 +41,7 @@ func newDynamoDBReadOnly(config *DynamoDBConfig) (*dynamoDBReadOnly, error) {
 	if err != nil {
 		return nil, err
 	}
+	dynamo.logger.Warn("Read only flag is set for dynamoDB. Check for billing method and capacity.")
 	return &dynamoDBReadOnly{*dynamo}, nil
 }
 

--- a/storage/database/dynamodb_readonly.go
+++ b/storage/database/dynamodb_readonly.go
@@ -16,7 +16,7 @@
 //
 // Database implementation of AWS DynamoDB READ ONLY.
 // Calling put, delete, batch put and batch write does nothing and returns no error.
-// Other functions such as get and has will call functions in DynamoDB.
+// Other functions such as get and has will call functions in dynamoDB.
 //
 // [WARN] Using this DB may cause pricing in your AWS account.
 // [WARN] DynamoDB creates both Dynamo DB table and S3 bucket.
@@ -27,10 +27,14 @@
 
 package database
 
+// dynamoDBReadOnly uses dynamoDB.
+// Calling put, delete, batch put and batch write does nothing and returns no error.
+// Other functions such as get and has will call functions in dynamoDB.
 type dynamoDBReadOnly struct {
 	dynamoDB
 }
 
+// newDynamoDBReadOnly creates dynamoDBReadOnly. This uses dynamoDB to create dynamoDBReadOnly.
 func newDynamoDBReadOnly(config *DynamoDBConfig) (*dynamoDBReadOnly, error) {
 	config.ReadOnly = true
 	dynamo, err := newDynamoDB(config)

--- a/storage/database/dynamodb_readonly_test.go
+++ b/storage/database/dynamodb_readonly_test.go
@@ -1,3 +1,23 @@
+// Copyright 2020 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+//
+// You need to set AWS credentials to access to dynamoDB.
+//    sh$ export AWS_ACCESS_KEY_ID=YOUR_ACCESS_KEY
+//    sh$ export AWS_SECRET_ACCESS_KEY=YOUR_SECRET
+
 package database
 
 import (

--- a/storage/database/dynamodb_readonly_test.go
+++ b/storage/database/dynamodb_readonly_test.go
@@ -1,0 +1,68 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func testDynamoDBReadOnly_Put(t *testing.T) {
+	dynamo, err := newDynamoDBReadOnly(GetDefaultDynamoDBConfig())
+	defer dynamo.deleteDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("dynamoDB", dynamo.config.TableName)
+
+	testKey := common.MakeRandomBytes(32)
+	testVal := common.MakeRandomBytes(500)
+
+	// check if not found for not put key, value
+	val, err := dynamo.Get(testKey)
+	assert.Nil(t, val)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), dataNotFoundErr.Error())
+
+	// put key, value
+	assert.NoError(t, dynamo.Put(testKey, testVal))
+
+	// check if not found for put key, value
+	val, err = dynamo.Get(testKey)
+	assert.Nil(t, val)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), dataNotFoundErr.Error())
+}
+
+func testDynamoDBReadOnly_Write(t *testing.T) {
+	dynamo, err := newDynamoDBReadOnly(GetDefaultDynamoDBConfig())
+	defer dynamo.deleteDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("dynamoDB", dynamo.config.TableName)
+
+	var testKeys [][]byte
+	var testVals [][]byte
+	batch := dynamo.NewBatch()
+
+	itemNum := 25
+	for i := 0; i < itemNum; i++ {
+		testKey := common.MakeRandomBytes(32)
+		testVal := common.MakeRandomBytes(500)
+
+		testKeys = append(testKeys, testKey)
+		testVals = append(testVals, testVal)
+
+		assert.NoError(t, batch.Put(testKey, testVal))
+	}
+	assert.NoError(t, batch.Write())
+
+	// check if exist
+	for i := 0; i < itemNum; i++ {
+		val, err := dynamo.Get(testKeys[i])
+		assert.Nil(t, val)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), dataNotFoundErr.Error())
+	}
+}

--- a/storage/database/dynamodb_readonly_test.go
+++ b/storage/database/dynamodb_readonly_test.go
@@ -87,3 +87,9 @@ func testDynamoDBReadOnly_Write(t *testing.T) {
 		assert.Equal(t, err.Error(), dataNotFoundErr.Error())
 	}
 }
+
+func (dynamo *dynamoDBReadOnly) deleteDB() {
+	dynamo.Close()
+	dynamo.deleteTable()
+	dynamo.fdb.deleteBucket()
+}

--- a/storage/database/dynamodb_readonly_test.go
+++ b/storage/database/dynamodb_readonly_test.go
@@ -67,6 +67,7 @@ func testDynamoDBReadOnly_Write(t *testing.T) {
 	batch := dynamo.NewBatch()
 
 	itemNum := 25
+	// put items
 	for i := 0; i < itemNum; i++ {
 		testKey := common.MakeRandomBytes(32)
 		testVal := common.MakeRandomBytes(500)
@@ -78,7 +79,7 @@ func testDynamoDBReadOnly_Write(t *testing.T) {
 	}
 	assert.NoError(t, batch.Write())
 
-	// check if exist
+	// check if not exist
 	for i := 0; i < itemNum; i++ {
 		val, err := dynamo.Get(testKeys[i])
 		assert.Nil(t, val)

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -70,7 +70,7 @@ func testDynamoDB_Put(t *testing.T) {
 }
 
 func testDynamoBatch_Write(t *testing.T) {
-	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
+	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +102,7 @@ func testDynamoBatch_Write(t *testing.T) {
 }
 
 func testDynamoBatch_WriteLargeData(t *testing.T) {
-	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
+	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -134,7 +134,7 @@ func testDynamoBatch_WriteLargeData(t *testing.T) {
 }
 
 func testDynamoBatch_DuplicatedKey(t *testing.T) {
-	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
+	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -174,7 +174,7 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 	//enableLog()
 
 	// create DynamoDB1
-	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
+	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -182,7 +182,7 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 	t.Log("dynamoDB1", dynamo.config.TableName)
 
 	// create DynamoDB2
-	dynamo2, err := NewDynamoDB(GetDefaultDynamoDBConfig())
+	dynamo2, err := newDynamoDB(GetDefaultDynamoDBConfig())
 	defer dynamo2.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -242,7 +242,9 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 }
 
 func (dynamo *dynamoDB) deleteDB() {
-	dynamo.Close()
+	if !dynamo.config.ReadOnly {
+		dynamo.Close()
+	}
 	dynamo.deleteTable()
 	dynamo.fdb.deleteBucket()
 }

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -49,7 +49,7 @@ func enableLog() {
 }
 
 func testDynamoDB_Put(t *testing.T) {
-	dynamo, err := NewDynamoDB(GetDefaultDynamoDBConfig())
+	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -242,9 +242,7 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 }
 
 func (dynamo *dynamoDB) deleteDB() {
-	if !dynamo.config.ReadOnly {
-		dynamo.Close()
-	}
+	dynamo.Close()
 	dynamo.deleteTable()
 	dynamo.fdb.deleteBucket()
 }


### PR DESCRIPTION
## Proposed changes

- If `ReadOnly` is set in DynamoDBConfig, DynamoDB will no longer put, delete or batch write to DynamoDB.
     - Created struct `dynamoDBReadOnly` which do nothing for write operations and uses DynamoDB's functions for read operations.
- A new flag, `DynamoDBReadOnlyFlag`, can be set.
- Add test code for DynamoDBReadOnly

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments
