### PR TITLE
Support RPC output with AnchroingTx's json data

### DIFF
--- a/blockchain/types/anchoring_data.go
+++ b/blockchain/types/anchoring_data.go
@@ -17,14 +17,17 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/ser/rlp"
 	"math/big"
 )
 
 const (
-	AnchoringDataType0 uint8 = 0
+	AnchoringDataType0    uint8 = 0
+	AnchoringJSONDataType uint8 = 128
 )
 
 var (
@@ -43,12 +46,12 @@ type AnchoringData struct {
 
 // AnchoringDataLegacy is an old anchoring type that does not support an data type.
 type AnchoringDataLegacy struct {
-	BlockHash     common.Hash
-	TxHash        common.Hash
-	ParentHash    common.Hash
-	ReceiptHash   common.Hash
-	StateRootHash common.Hash
-	BlockNumber   *big.Int
+	BlockHash     common.Hash `json:"blockHash"`
+	TxHash        common.Hash `json:"transactionsRoot"`
+	ParentHash    common.Hash `json:"parentHash"`
+	ReceiptHash   common.Hash `json:"receiptsRoot"`
+	StateRootHash common.Hash `json:"stateRoot"`
+	BlockNumber   *big.Int    `json:"blockNumber"`
 }
 
 func (data *AnchoringDataLegacy) GetBlockHash() common.Hash {
@@ -96,6 +99,14 @@ func NewAnchoringDataType0(block *Block, blockCount uint64, txCount uint64) (*An
 	return &AnchoringData{AnchoringDataType0, encodedCCTxData}, nil
 }
 
+func NewAnchoringJSONDataType(v interface{}) (*AnchoringData, error) {
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return &AnchoringData{AnchoringJSONDataType, encoded}, nil
+}
+
 // DecodeAnchoringData decodes an anchoring data used by main and sub bridges.
 func DecodeAnchoringData(data []byte) (AnchoringDataInternal, error) {
 	anchoringData := new(AnchoringData)
@@ -116,4 +127,31 @@ func DecodeAnchoringData(data []byte) (AnchoringDataInternal, error) {
 		return anchoringDataInternal, nil
 	}
 	return nil, errUnknownAnchoringTxType
+}
+
+// DecodeAnchoringDataToJSON decodes an anchoring data.
+func DecodeAnchoringDataToJSON(data []byte) (interface{}, error) {
+	anchoringData := new(AnchoringData)
+	if err := rlp.DecodeBytes(data, anchoringData); err != nil {
+		anchoringDataLegacy := new(AnchoringDataLegacy)
+		if err := rlp.DecodeBytes(data, anchoringDataLegacy); err != nil {
+			return nil, err
+		}
+		return anchoringDataLegacy, nil
+	}
+	if anchoringData.Type == AnchoringDataType0 {
+		anchoringDataInternal := new(AnchoringDataInternalType0)
+		if err := rlp.DecodeBytes(anchoringData.Data, anchoringDataInternal); err != nil {
+			return nil, err
+		}
+		return anchoringDataInternal, nil
+	}
+	if anchoringData.Type == AnchoringJSONDataType {
+		var v map[string]interface{}
+		if err := json.Unmarshal(anchoringData.Data, &v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	}
+	return nil, fmt.Errorf("%w type=%v", errUnknownAnchoringTxType, anchoringData.Type)
 }

--- a/blockchain/types/anchoring_data_test.go
+++ b/blockchain/types/anchoring_data_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The klaytn Authors
+// Copyright 2020 The klaytn Authors
 // This file is part of the klaytn library.
 //
 // The klaytn library is free software: you can redistribute it and/or modify
@@ -116,7 +116,7 @@ func TestDecodingAnchoringTxType0(t *testing.T) {
 }
 
 func TestDecodingAnchoringTxJSONType(t *testing.T) {
-	orginData := map[string]interface{}{
+	originalData := map[string]interface{}{
 		"int":    1,
 		"string": "string",
 		"bigInt": big.NewInt(100),
@@ -124,7 +124,7 @@ func TestDecodingAnchoringTxJSONType(t *testing.T) {
 		"addr":   genRandomAddress(),
 	}
 
-	anchoringData, err := NewAnchoringJSONDataType(orginData)
+	anchoringData, err := NewAnchoringJSONDataType(originalData)
 	assert.NoError(t, err)
 
 	data, err := rlp.EncodeToBytes(anchoringData)
@@ -134,7 +134,7 @@ func TestDecodingAnchoringTxJSONType(t *testing.T) {
 	decodedDataJSON, err := DecodeAnchoringDataToJSON(data)
 	assert.NoError(t, err)
 
-	expResult, err := json.Marshal(orginData)
+	expResult, err := json.Marshal(originalData)
 	assert.NoError(t, err)
 	actResult, err := json.Marshal(decodedDataJSON)
 	assert.NoError(t, err)

--- a/blockchain/types/anchoring_data_test.go
+++ b/blockchain/types/anchoring_data_test.go
@@ -1,0 +1,140 @@
+// Copyright 2019 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"encoding/json"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/ser/rlp"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"math/rand"
+	"testing"
+)
+
+func genRandomAddress() *common.Address {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	return &addr
+}
+
+func genRandomHash() (h common.Hash) {
+	hasher := sha3.NewKeccak256()
+
+	r := rand.Uint64()
+	rlp.Encode(hasher, r)
+	hasher.Sum(h[:0])
+
+	return h
+}
+
+func TestDecodingLegacyAnchoringTx(t *testing.T) {
+	anchoringData := &AnchoringDataLegacy{
+		BlockHash:     genRandomHash(),
+		TxHash:        genRandomHash(),
+		ParentHash:    genRandomHash(),
+		ReceiptHash:   genRandomHash(),
+		StateRootHash: genRandomHash(),
+		BlockNumber:   new(big.Int).SetUint64(rand.Uint64()),
+	}
+	data, err := rlp.EncodeToBytes(anchoringData)
+	assert.NoError(t, err)
+
+	// Decoding the anchoring tx.
+	decodedData, err := DecodeAnchoringData(data)
+	assert.NoError(t, err)
+	assert.Equal(t, anchoringData, decodedData)
+
+	decodedDataJSON, err := DecodeAnchoringDataToJSON(data)
+	assert.NoError(t, err)
+	assert.Equal(t, anchoringData, decodedDataJSON)
+}
+
+func TestDecodingAnchoringTxType0(t *testing.T) {
+	block := genBlock()
+	blockCnt := rand.Uint64()
+	txCount := rand.Uint64()
+	anchoringData, err := NewAnchoringDataType0(block, blockCnt, txCount)
+	assert.NoError(t, err)
+
+	data, err := rlp.EncodeToBytes(anchoringData)
+	assert.NoError(t, err)
+
+	// Decoding the anchoring tx.
+	decodedData, err := DecodeAnchoringData(data)
+	assert.NoError(t, err)
+	decodedInternalData, ok := decodedData.(*AnchoringDataInternalType0)
+	assert.True(t, ok)
+	assert.Equal(t, txCount, decodedInternalData.TxCount.Uint64())
+	assert.Equal(t, blockCnt, decodedInternalData.BlockCount.Uint64())
+	assert.Equal(t, block.header.Root, decodedInternalData.StateRootHash)
+	assert.Equal(t, block.header.TxHash, decodedInternalData.TxHash)
+	assert.Equal(t, block.header.ReceiptHash, decodedInternalData.ReceiptHash)
+	assert.Equal(t, block.header.Number, decodedInternalData.BlockNumber)
+	assert.Equal(t, block.header.Hash(), decodedInternalData.BlockHash)
+	assert.Equal(t, block.header.ParentHash, decodedInternalData.ParentHash)
+
+	decodedDataJSON, err := DecodeAnchoringDataToJSON(data)
+	assert.NoError(t, err)
+	decodedInternalData, ok = decodedDataJSON.(*AnchoringDataInternalType0)
+	assert.True(t, ok)
+	assert.Equal(t, txCount, decodedInternalData.TxCount.Uint64())
+	assert.Equal(t, blockCnt, decodedInternalData.BlockCount.Uint64())
+	assert.Equal(t, block.header.Root, decodedInternalData.StateRootHash)
+	assert.Equal(t, block.header.TxHash, decodedInternalData.TxHash)
+	assert.Equal(t, block.header.ReceiptHash, decodedInternalData.ReceiptHash)
+	assert.Equal(t, block.header.Number, decodedInternalData.BlockNumber)
+	assert.Equal(t, block.header.Hash(), decodedInternalData.BlockHash)
+	assert.Equal(t, block.header.ParentHash, decodedInternalData.ParentHash)
+
+	var result AnchoringDataInternalType0
+	err = rlp.DecodeBytes(anchoringData.Data, &result)
+	assert.NoError(t, err)
+	expResult, err := json.Marshal(result)
+
+	actResult, err := json.Marshal(decodedInternalData)
+	assert.NoError(t, err)
+	assert.Equal(t, expResult, actResult)
+}
+
+func TestDecodingAnchoringTxJSONType(t *testing.T) {
+	orginData := map[string]interface{}{
+		"int":    1,
+		"string": "string",
+		"bigInt": big.NewInt(100),
+		"hash":   genRandomHash(),
+		"addr":   genRandomAddress(),
+	}
+
+	anchoringData, err := NewAnchoringJSONDataType(orginData)
+	assert.NoError(t, err)
+
+	data, err := rlp.EncodeToBytes(anchoringData)
+	assert.NoError(t, err)
+
+	// Decoding the anchoring tx.
+	decodedDataJSON, err := DecodeAnchoringDataToJSON(data)
+	assert.NoError(t, err)
+
+	expResult, err := json.Marshal(orginData)
+	assert.NoError(t, err)
+	actResult, err := json.Marshal(decodedDataJSON)
+	assert.NoError(t, err)
+	assert.Equal(t, expResult, actResult)
+}

--- a/blockchain/types/anchoring_data_test.go
+++ b/blockchain/types/anchoring_data_test.go
@@ -26,6 +26,7 @@ import (
 	"math/big"
 	"math/rand"
 	"testing"
+	"time"
 )
 
 func genRandomAddress() *common.Address {
@@ -35,6 +36,7 @@ func genRandomAddress() *common.Address {
 }
 
 func genRandomHash() (h common.Hash) {
+	rand.Seed(time.Now().UnixNano())
 	hasher := sha3.NewKeccak256()
 
 	r := rand.Uint64()

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
@@ -60,6 +60,7 @@ type TxInternalDataFeeDelegatedChainDataAnchoringWithRatioJSON struct {
 	GasLimit           hexutil.Uint64   `json:"gas"`
 	From               common.Address   `json:"from"`
 	Payload            hexutil.Bytes    `json:"input"`
+	InputJson          interface{}      `json:"inputJSON"`
 	FeeRatio           hexutil.Uint     `json:"feeRatio"`
 	TxSignatures       TxSignaturesJSON `json:"signatures"`
 	FeePayer           common.Address   `json:"feePayer"`
@@ -339,6 +340,11 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) Execute(sender C
 }
 
 func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MakeRPCOutput() map[string]interface{} {
+	decoded, err := DecodeAnchoringDataToJSON(t.Payload)
+	if err != nil {
+		logger.Error("decode anchor payload", "err", err)
+	}
+
 	return map[string]interface{}{
 		"typeInt":            t.Type(),
 		"type":               t.Type().String(),
@@ -346,6 +352,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MakeRPCOutput() 
 		"gasPrice":           (*hexutil.Big)(t.Price),
 		"nonce":              hexutil.Uint64(t.AccountNonce),
 		"input":              hexutil.Bytes(t.Payload),
+		"inputJSON":          decoded,
 		"feeRatio":           hexutil.Uint(t.FeeRatio),
 		"signatures":         t.TxSignatures.ToJSON(),
 		"feePayer":           t.FeePayer,
@@ -354,6 +361,10 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MakeRPCOutput() 
 }
 
 func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MarshalJSON() ([]byte, error) {
+	decoded, err := DecodeAnchoringDataToJSON(t.Payload)
+	if err != nil {
+		logger.Error("decode anchor payload", "err", err)
+	}
 	return json.Marshal(TxInternalDataFeeDelegatedChainDataAnchoringWithRatioJSON{
 		t.Type(),
 		t.Type().String(),
@@ -362,6 +373,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MarshalJSON() ([
 		(hexutil.Uint64)(t.GasLimit),
 		t.From,
 		t.Payload,
+		decoded,
 		(hexutil.Uint)(t.FeeRatio),
 		t.TxSignatures.ToJSON(),
 		t.FeePayer,


### PR DESCRIPTION
## Proposed changes

This PR supports RPC output with Anchoring Tx's json data in `inputJSON` field like below.
There are 3 types of anchoring Internal data.

- Legacy
```
> klay.getTransaction("0x32241b4c65c11d404925795e81f65c9c5d9920934ef1ab785e7ee10e92b4b45c")
{
  blockHash: "0xba60cab87929d36db90bfaed1b8657e9d9c4911b424bf133505d492a5408c5ac",
  blockNumber: 5000651,
  from: "0x3ce216beeafc62d20547376396e89528e1d778ca",
  gas: 100000,
  gasPrice: 25000000000,
  hash: "0x32241b4c65c11d404925795e81f65c9c5d9920934ef1ab785e7ee10e92b4b45c",
  input: "0xf8a6a0c0f67ae297760292bbbfef1f1574f478abbee9aad0237a55bc5b2757087498f2a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a00000000000000000000000000000000000000000000000000000000000000000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a07ef0679f967fec56203d841f2e7fcb1e31b3ca96001158410d14c90a896b49eb80",
  inputJSON: {
    blockHash: "0xc0f67ae297760292bbbfef1f1574f478abbee9aad0237a55bc5b2757087498f2",
    blockNumber: 0,
    parentHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
    receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    stateRoot: "0x7ef0679f967fec56203d841f2e7fcb1e31b3ca96001158410d14c90a896b49eb",
    transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
  },
  nonce: 0,
  senderTxHash: "0x32241b4c65c11d404925795e81f65c9c5d9920934ef1ab785e7ee10e92b4b45c",
  signatures: [{
      R: "0x34f80dcab9dd4a8d46ff567bb8e17fe625a15fe3d8ed42f1230e6bf19e2944e4",
      S: "0x1ff26e6f13bfbbb0bce1e7286648c9c4577f8c5d0778c5a5684433a2fa5881d",
      V: "0x7f6"
  }],
  transactionIndex: 0,
  type: "TxTypeChainDataAnchoring",
  typeInt: 72,
  value: 0
}
```

- Type 0
```
> klay.getTransaction("0xc761f01ff02ead3c65683d8c614c36b00bee879844ccd895da6335843006f51f")
{
  blockHash: "0x09e4e97fcfc058ad55e33ae25bffc9df04aecdabe8a9585da1e8fcc12b6e0a9e",
  blockNumber: 25288717,
  from: "0x6ca91a27e9dc70d01491a875c41df10ac4a3b0f8",
  gas: 100000,
  gasPrice: 25000000000,
  hash: "0xc761f01ff02ead3c65683d8c614c36b00bee879844ccd895da6335843006f51f",
  input: "0xf8b080b8adf8aba066d094fa7cfe46269103b6fbe99c4ecc3884f0312a4a3de7d6eef143e62cee80a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470a045a7acd07c2c1fb0ec6552f9a2a49f608983e9114d9a9ea1996a211189e6c9e4a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470a03230b089a2d9a815962b3202d1e54de0332551bc90557e1ff5e897217c6af247830569a30180",
  inputJSON: {
    blockCount: 1,
    blockHash: "0x66d094fa7cfe46269103b6fbe99c4ecc3884f0312a4a3de7d6eef143e62cee80",
    blockNumber: 354723,
    parentHash: "0x45a7acd07c2c1fb0ec6552f9a2a49f608983e9114d9a9ea1996a211189e6c9e4",
    receiptsRoot: "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
    stateRoot: "0x3230b089a2d9a815962b3202d1e54de0332551bc90557e1ff5e897217c6af247",
    transactionsRoot: "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
    txCount: 0
  },
  nonce: 378,
  senderTxHash: "0xc761f01ff02ead3c65683d8c614c36b00bee879844ccd895da6335843006f51f",
  signatures: [{
      R: "0xcfa882605adf7ca1ae8f13378069a9f770c9475fe81fdc3884bfe1e78653999",
      S: "0x6702f7d03789260f076333a4db9850ce79d774dc2df77e9305dbc526ee7e5ee2",
      V: "0x7f5"
  }],
  transactionIndex: 378,
  type: "TxTypeChainDataAnchoring",
  typeInt: 72,
  value: 0
}
```

- JSON Type(128)
```
> klay.getTransaction("0xea2c488919dcbf45075bcbad7627bfcdeddd1af226caf3a44aa662c3f3efdcbf")
{
  blockHash: "0x534bbaac45d1f342582d9a8bf1fb5ebd22e54d813d563d3a5989160654ee8719",
  blockNumber: 37973753,
  from: "0x6a3d565c4a2a4cd0fb3df8edfb63a151717ea1d7",
  gas: 90000000,
  gasPrice: 25000000000,
  hash: "0xea2c488919dcbf45075bcbad7627bfcdeddd1af226caf3a44aa662c3f3efdcbf",
  input: "0xf901e68180b901e17b22626c6f636b436f756e74223a31302c22626c6f636b48617368223a22307864386634393936363035633635616462316138653733353939366536336363333633653364623562336261653463316339336166343132663835383939313464222c22626c6f636b4e756d626572223a3538363139302c226964223a22353836313930222c22706172656e7448617368223a22307862623865386431626238613531656162356138316130633134383231306434623637333131346533646563313264646364303163626237326164383633613065222c227265636569707473526f6f74223a22307832333037636263636430616430663938616537623133623131303431366134646661663266306230306361313234336538316362616162383064643161663834222c227374617465526f6f74223a22307864613265336131356132313833393131303763343761313963386565383732616230373438373034346534326662643663633536366361623862393366633265222c227472616e73616374696f6e73526f6f74223a22307832643564333266646566626464313932333562313765323233646130326530326338663931666237663062623638353631646132623637396136663239653463222c227478436f756e74223a37307d",
  inputJSON: {
    blockCount: 10,
    blockHash: "0xd8f4996605c65adb1a8e735996e63cc363e3db5b3bae4c1c93af412f8589914d",
    blockNumber: 586190,
    id: "586190",
    parentHash: "0xbb8e8d1bb8a51eab5a81a0c148210d4b673114e3dec12ddcd01cbb72ad863a0e",
    receiptsRoot: "0x2307cbccd0ad0f98ae7b13b110416a4dfaf2f0b00ca1243e81cbaab80dd1af84",
    stateRoot: "0xda2e3a15a218391107c47a19c8ee872ab07487044e42fbd6cc566cab8b93fc2e",
    transactionsRoot: "0x2d5d32fdefbdd19235b17e223da02e02c8f91fb7f0bb68561da2b679a6f29e4c",
    txCount: 70
  },
  nonce: 20691,
  senderTxHash: "0xea2c488919dcbf45075bcbad7627bfcdeddd1af226caf3a44aa662c3f3efdcbf",
  signatures: [{
      R: "0x3438e5d84c0986521a2f232ea067dde94eda700209116d2e0daa3717bfdfe774",
      S: "0x6dd25cc2f08df0d506f2aa99f2174c8ee7c34b877dfbf085810569fd0e3a3b3b",
      V: "0x7f5"
  }],
  transactionIndex: 0,
  type: "TxTypeChainDataAnchoring",
  typeInt: 72,
  value: 0
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
