### PR TITLE
statedb, blockchain: save in-memory cache to file for reuse

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -845,6 +845,9 @@ func (bc *BlockChain) Stop() {
 			logger.Error("Dangling trie nodes after full cleanup")
 		}
 	}
+	if err := bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(); err != nil {
+		logger.Error("Failed to save trie node cache to file", "err", err)
+	}
 	logger.Info("Blockchain manager stopped")
 }
 

--- a/storage/statedb/cache.go
+++ b/storage/statedb/cache.go
@@ -36,18 +36,29 @@ type Cache interface {
 	Set(k, v []byte)
 	Get(k []byte) []byte
 	Has(k []byte) ([]byte, bool)
+	SaveToFile(filePath string, concurrency int) error
+}
+
+type CacheConfig struct {
+	Type CacheType
+	// FastCache related configurations
+	CacheFilePath string
+	MaxBytes      int
+	// RedisCache related configurations
+	RedisEndpoints   []string
+	IsClusteredRedis bool
 }
 
 // NewCache creates one type of any supported stateDB caches.
 // TODO-Klaytn: refine input parameters after setting node flags
-func NewCache(cacheType CacheType, maxBytes int, redisEndpoint []string, redisCluster bool) (Cache, error) {
-	switch cacheType {
+func NewCache(c *CacheConfig) (Cache, error) {
+	switch c.Type {
 	case LocalCache:
-		return NewFastCache(maxBytes), nil
+		return NewFastCache(c.CacheFilePath, c.MaxBytes), nil
 	case RemoteCache:
-		return NewRedisCache(redisEndpoint, redisCluster)
+		return NewRedisCache(c.RedisEndpoints, c.IsClusteredRedis)
 	case HybridCache:
-		return NewHybridCache(maxBytes, redisEndpoint, redisCluster)
+		return NewHybridCache(c.CacheFilePath, c.MaxBytes, c.RedisEndpoints, c.IsClusteredRedis)
 	default:
 	}
 	return nil, errNotSupportedCacheType

--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -22,9 +22,9 @@ type FastCache struct {
 	cache *fastcache.Cache
 }
 
-func NewFastCache(maxBytes int) Cache {
+func NewFastCache(filePath string, maxBytes int) Cache {
 	return &FastCache{
-		cache: fastcache.New(maxBytes),
+		cache: fastcache.LoadFromFileOrNew(filePath, maxBytes),
 	}
 }
 
@@ -45,4 +45,8 @@ func (l *FastCache) UpdateStats() fastcache.Stats {
 	l.cache.UpdateStats(&stats)
 
 	return stats
+}
+
+func (l *FastCache) SaveToFile(filePath string, concurrency int) error {
+	return l.cache.SaveToFileConcurrent(filePath, concurrency)
 }

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -17,7 +17,7 @@ var (
 
 // TestHybridCache_Set tests whether a hybrid cache can set an item into both of local and remote caches.
 func _TestHybridCache_Set(t *testing.T) {
-	cache, err := NewHybridCache(testMaxBytes, testRedisEndpoints, testRedisCluster)
+	cache, err := NewHybridCache("", testMaxBytes, testRedisEndpoints, testRedisCluster)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func _TestHybridCache_Set(t *testing.T) {
 // TestHybridCache_Get tests whether a hybrid cache can get an item from both of local and remote caches.
 func _TestHybridCache_Get(t *testing.T) {
 	// Prepare caches to be integrated with a hybrid cache
-	localCache := NewFastCache(testMaxBytes)
+	localCache := NewFastCache("", testMaxBytes)
 	remoteCache, err := NewRedisCache(testRedisEndpoints, testRedisCluster)
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +91,7 @@ func _TestHybridCache_Get(t *testing.T) {
 // TestHybridCache_Has tests whether a hybrid cache can check an item from both of local and remote caches.
 func _TestHybridCache_Has(t *testing.T) {
 	// Prepare caches to be integrated with a hybrid cache
-	localCache := NewFastCache(testMaxBytes)
+	localCache := NewFastCache("", testMaxBytes)
 	remoteCache, err := NewRedisCache(testRedisEndpoints, testRedisCluster)
 	if err != nil {
 		t.Fatal(err)

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -96,3 +96,7 @@ func (cache *RedisCache) Has(k []byte) ([]byte, bool) {
 	}
 	return val, true
 }
+
+func (cache *RedisCache) SaveToFile(filePath string, concurrency int) error {
+	return nil
+}

--- a/storage/statedb/cache_test.go
+++ b/storage/statedb/cache_test.go
@@ -17,8 +17,13 @@
 package statedb
 
 import (
+	"io/ioutil"
+	"os"
 	"reflect"
+	"runtime"
 	"testing"
+
+	"github.com/klaytn/klaytn/common"
 
 	"github.com/docker/docker/pkg/testutil/assert"
 )
@@ -28,17 +33,50 @@ import (
 // TestNewCache tests creating all kinds of supported stateDB caches.
 func _TestNewCache(t *testing.T) {
 	testCases := []struct {
-		cacheType    CacheType
+		config       *CacheConfig
 		expectedType reflect.Type
 	}{
-		{"LocalCache", reflect.TypeOf(&FastCache{})},
-		{"RemoteCache", reflect.TypeOf(&RedisCache{})},
-		{"HybridCache", reflect.TypeOf(&hybridCache{})},
+		{&CacheConfig{"LocalCache", "", testMaxBytes, testRedisEndpoints, testRedisCluster}, reflect.TypeOf(&FastCache{})},
+		{&CacheConfig{"RemoteCache", "", testMaxBytes, testRedisEndpoints, testRedisCluster}, reflect.TypeOf(&RedisCache{})},
+		{&CacheConfig{"HybridCache", "", testMaxBytes, testRedisEndpoints, testRedisCluster}, reflect.TypeOf(&hybridCache{})},
 	}
 
 	for _, tc := range testCases {
-		cache, err := NewCache(tc.cacheType, testMaxBytes, testRedisEndpoints, testRedisCluster)
+		cache, err := NewCache(tc.config)
 		assert.NilError(t, err)
 		assert.Equal(t, reflect.TypeOf(cache), tc.expectedType)
+	}
+}
+
+func TestFastCache_SaveAndLoad(t *testing.T) {
+	// Create test directory
+	dirName, err := ioutil.TempDir(os.TempDir(), "fastcache_saveandload")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dirName)
+
+	// Generate test data
+	var keys [][]byte
+	var vals [][]byte
+	for i := 0; i < 10; i++ {
+		keys = append(keys, common.MakeRandomBytes(128))
+		vals = append(vals, common.MakeRandomBytes(128))
+	}
+
+	// Create a fastcache from the file and save the data to the cache
+	fastCache := NewFastCache(dirName, testMaxBytes)
+	for idx, key := range keys {
+		assert.DeepEqual(t, fastCache.Get(key), []byte(nil))
+		fastCache.Set(key, vals[idx])
+		assert.DeepEqual(t, fastCache.Get(key), vals[idx])
+	}
+	// Save the cache to the file
+	assert.NilError(t, fastCache.SaveToFile(dirName, runtime.NumCPU()))
+
+	// Create a fastcache from the file and check if the data exists
+	fastCacheFromFile := NewFastCache(dirName, testMaxBytes)
+	for idx, key := range keys {
+		assert.DeepEqual(t, fastCacheFromFile.Get(key), vals[idx])
 	}
 }

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -1143,5 +1143,8 @@ func (db *Database) UpdateMetricNodes() {
 
 // SaveTrieNodeCacheToFile saves the current cached trie nodes to file to reuse when it restarts
 func (db *Database) SaveTrieNodeCacheToFile() error {
+	if db.trieNodeCache == nil {
+		return nil
+	}
 	return db.trieNodeCache.SaveToFile(db.diskDB.GetDBConfig().Dir, runtime.NumCPU()/2)
 }


### PR DESCRIPTION
## Proposed changes

- fastcache has a feature to save the cached data to the file for reuse
- This PR uses that feature to reuse the cached data when a node restarts

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
