### PR TITLE
Remove expiration time of redis set time

### DIFF
--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -84,7 +84,7 @@ func (cache *RedisCache) Get(k []byte) []byte {
 }
 
 func (cache *RedisCache) Set(k, v []byte) {
-	if err := cache.client.Set(hexutil.Encode(k), v, redisCacheTimeout).Err(); err != nil {
+	if err := cache.client.Set(hexutil.Encode(k), v, 0).Err(); err != nil {
 		logger.Error("failed to set an item on redis cache", "err", err, "key", hexutil.Encode(k))
 	}
 }


### PR DESCRIPTION
## Proposed changes

- The third parameter of `cache.client.Set` is expiration time, but timeout value was set. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
