### PR TITLE
Add context timeout for KAS anchor API

### DIFF
--- a/node/sc/kas/anchor.go
+++ b/node/sc/kas/anchor.go
@@ -18,6 +18,7 @@ package kas
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,10 +26,13 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"math/big"
 	"net/http"
+	"time"
 )
 
 const (
 	codeOK = 0
+
+	apiCtxTimeout = 500 * time.Millisecond
 )
 
 var (
@@ -184,7 +188,11 @@ func (anchor *Anchor) sendRequest(payload interface{}) (*respBody, error) {
 
 	body := bytes.NewReader(bodyDataBytes)
 
-	req, err := http.NewRequest("POST", anchor.kasConfig.Url, body)
+	// set up timeout for API call
+	ctx, cancel := context.WithTimeout(context.Background(), apiCtxTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", anchor.kasConfig.Url, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Proposed changes
This PR added context timeout 500ms for KAS anchor API.
Without this, if the server doesn't answer, stuck situation can be happen like below.

```
goroutine 237 [select, 7 minutes]:
net/http.(*persistConn).roundTrip(0xc0102fea20, 0xc01f776840, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.5/libexec/src/net/http/transport.go:2498 +0x756
net/http.(*Transport).roundTrip(0x661bf00, 0xc0126c9300, 0xc01f776570, 0xc00065d428, 0x400f778)
	/usr/local/Cellar/go/1.14.5/libexec/src/net/http/transport.go:565 +0xad9
net/http.(*Transport).RoundTrip(0x661bf00, 0xc0126c9300, 0x661bf00, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.5/libexec/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc0126c9300, 0x58168c0, 0x661bf00, 0x0, 0x0, 0x0, 0xc004a595b0, 0xc000680c00, 0x1, 0x0)
	/usr/local/Cellar/go/1.14.5/libexec/src/net/http/client.go:252 +0x43e
net/http.(*Client).send(0xc000341230, 0xc0126c9300, 0x0, 0x0, 0x0, 0xc004a595b0, 0x0, 0x1, 0xc00393c2c0)
	/usr/local/Cellar/go/1.14.5/libexec/src/net/http/client.go:176 +0xfa
net/http.(*Client).do(0xc000341230, 0xc0126c9300, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.5/libexec/src/net/http/client.go:699 +0x44a
net/http.(*Client).Do(0xc000341230, 0xc0126c9300, 0x54041f6, 0xc, 0xc00393c378)
	/usr/local/Cellar/go/1.14.5/libexec/src/net/http/client.go:567 +0x35
github.com/klaytn/klaytn/node/sc/kas.(*Anchor).sendRequest(0xc00029e780, 0x51f6a60, 0xc003a9b5f0, 0x0, 0x0, 0x0)
	/Users/mini-admin/go/src/github.com/klaytn/klaytn/node/sc/kas/anchor.go:196 +0x548
github.com/klaytn/klaytn/node/sc/kas.(*Anchor).AnchorBlock(0xc00029e780, 0xc000025490, 0x2, 0x1)
	/Users/mini-admin/go/src/github.com/klaytn/klaytn/node/sc/kas/anchor.go:128 +0x82
github.com/klaytn/klaytn/node/sc/kas.(*Anchor).AnchorPeriodicBlock(0xc00029e780, 0xc000025490)
	/Users/mini-admin/go/src/github.com/klaytn/klaytn/node/sc/kas/anchor.go:87 +0x88
github.com/klaytn/klaytn/node/sc.(*SubBridge).loop(0xc0013be680)
	/Users/mini-admin/go/src/github.com/klaytn/klaytn/node/sc/subbridge.go:617 +0xb86
created by github.com/klaytn/klaytn/node/sc.(*SubBridge).SetComponents
	/Users/mini-admin/go/src/github.com/klaytn/klaytn/node/sc/subbridge.go:386 +0x49b
```

After this, context time out resolved it.
```
WARN[09/10,08:21:13 +09] [53] Failed to anchor a block via KAS          blkNum=51277 err="Post \"https://anchor-api.qa-2.klaytn.com/v1/anchor\": context deadline exceeded"
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
