### PR TITLE
KAS Anchor API : excepting already anchored error code

### DIFF
--- a/node/sc/kas/anchor.go
+++ b/node/sc/kas/anchor.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	codeOK              = 0
-	CodeAlreadyAnchored = 1072100
+	codeAlreadyAnchored = 1072100
 
 	apiCtxTimeout = 500 * time.Millisecond
 )
@@ -133,7 +133,7 @@ func (anchor *Anchor) AnchorBlock(block *types.Block) error {
 	res, err := anchor.sendRequest(payload)
 	if err != nil || res.Code != codeOK {
 		if res != nil {
-			if res.Code == CodeAlreadyAnchored {
+			if res.Code == codeAlreadyAnchored {
 				logger.Info("Already anchored a block", "blkNum", block.NumberU64())
 				return nil
 			}

--- a/node/sc/kas/anchor.go
+++ b/node/sc/kas/anchor.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	codeOK = 0
+	codeOK              = 0
+	CodeAlreadyAnchored = 1072100
 
 	apiCtxTimeout = 500 * time.Millisecond
 )
@@ -132,9 +133,14 @@ func (anchor *Anchor) AnchorBlock(block *types.Block) error {
 	res, err := anchor.sendRequest(payload)
 	if err != nil || res.Code != codeOK {
 		if res != nil {
+			if res.Code == CodeAlreadyAnchored {
+				logger.Info("Already anchored a block", "blkNum", block.NumberU64())
+				return nil
+			}
+
 			result, _ := json.MarshalIndent(res, "", "	")
-			logger.Warn(fmt.Sprintf(`AnchorBlock returns below http raw result with the error(%v) :
-%v`, err, string(result)))
+			logger.Warn(fmt.Sprintf(`AnchorBlock returns below http raw result with the error(%v) at the block(%v) :
+%v`, err, block.NumberU64(), string(result)))
 		}
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

This PR added an exception case of already anchored error code of the anchor API.

This means that other node already anchored the data with same id.
Because, it is not a real error situation when multiple nodes are anchoring at the same time for high availability.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
