### PR TITLE
Move cache size checking logic in NewFastCache

### DIFF
--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -28,12 +28,12 @@ type FastCache struct {
 func NewFastCache(cacheSizeMB int) TrieNodeCache {
 	var cacheSizeByte int
 
-	if cacheSizeMB == 0 {
-		return nil
-	}
-
 	if cacheSizeMB == AutoScaling {
 		cacheSizeMB = getTrieNodeCacheSizeMB()
+	}
+
+	if cacheSizeMB <= 0 {
+		return nil
 	}
 
 	if cacheSizeMB > 0 {

--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -26,8 +26,6 @@ type FastCache struct {
 // If you want auto-scaled cache size, set cacheSizeMB to AutoScaling.
 // It returns nil if the cache size is zero.
 func NewFastCache(cacheSizeMB int) TrieNodeCache {
-	var cacheSizeByte int
-
 	if cacheSizeMB == AutoScaling {
 		cacheSizeMB = getTrieNodeCacheSizeMB()
 	}
@@ -36,12 +34,8 @@ func NewFastCache(cacheSizeMB int) TrieNodeCache {
 		return nil
 	}
 
-	if cacheSizeMB > 0 {
-		cacheSizeByte = cacheSizeMB * 1024 * 1024
-	}
-
 	logger.Info("Initialize local trie node cache (fastCache)", "MaxMB", cacheSizeMB)
-	return &FastCache{cache: fastcache.New(cacheSizeByte)}
+	return &FastCache{cache: fastcache.New(cacheSizeMB * 1024 * 1024)} // Covert MB to Byte
 }
 
 func (l *FastCache) Get(k []byte) []byte {

--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -35,7 +35,7 @@ func NewFastCache(cacheSizeMB int) TrieNodeCache {
 	}
 
 	logger.Info("Initialize local trie node cache (fastCache)", "MaxMB", cacheSizeMB)
-	return &FastCache{cache: fastcache.New(cacheSizeMB * 1024 * 1024)} // Covert MB to Byte
+	return &FastCache{cache: fastcache.New(cacheSizeMB * 1024 * 1024)} // Convert MB to Byte
 }
 
 func (l *FastCache) Get(k []byte) []byte {


### PR DESCRIPTION
## Proposed changes

`getTrieNodeCacheSizeMB()` could chagne cache size to 0 which is an invalid fastCache size. 
To validate invalid cache size after `getTrieNodeCacheSizeMB()`, the validation logic is relocated.


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
