### PR TITLE
Fix account validation logic of legacy key to be used as an roleKey

### DIFF
--- a/blockchain/types/accountkey/account_key.go
+++ b/blockchain/types/accountkey/account_key.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 
 	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/log"
 )
 
@@ -110,15 +109,7 @@ func NewAccountKey(t AccountKeyType) (AccountKey, error) {
 }
 
 func ValidateAccountKey(from common.Address, accKey AccountKey, recoveredKeys []*ecdsa.PublicKey, roleType RoleType) error {
-	// Special treatment for AccountKeyLegacy.
-	if accKey.Type().IsLegacyAccountKey() {
-		if len(recoveredKeys) != 1 {
-			return errWrongPubkeyLength
-		}
-		if crypto.PubkeyToAddress(*recoveredKeys[0]) != from {
-			return errInvalidSignature
-		}
-	} else if !accKey.Validate(roleType, recoveredKeys, from) {
+	if !accKey.Validate(roleType, recoveredKeys, from) {
 		return errInvalidSignature
 	}
 	return nil

--- a/blockchain/types/accountkey/account_key.go
+++ b/blockchain/types/accountkey/account_key.go
@@ -109,16 +109,16 @@ func NewAccountKey(t AccountKeyType) (AccountKey, error) {
 	return nil, errUndefinedAccountKeyType
 }
 
-func ValidateAccountKey(from common.Address, accKey AccountKey, recoveredKey []*ecdsa.PublicKey, roleType RoleType) error {
+func ValidateAccountKey(from common.Address, accKey AccountKey, recoveredKeys []*ecdsa.PublicKey, roleType RoleType) error {
 	// Special treatment for AccountKeyLegacy.
 	if accKey.Type().IsLegacyAccountKey() {
-		if len(recoveredKey) != 1 {
+		if len(recoveredKeys) != 1 {
 			return errWrongPubkeyLength
 		}
-		if crypto.PubkeyToAddress(*recoveredKey[0]) != from {
+		if crypto.PubkeyToAddress(*recoveredKeys[0]) != from {
 			return errInvalidSignature
 		}
-	} else if !accKey.Validate(roleType, recoveredKey, from) {
+	} else if !accKey.Validate(roleType, recoveredKeys, from) {
 		return errInvalidSignature
 	}
 	return nil

--- a/blockchain/types/accountkey/account_key_fail.go
+++ b/blockchain/types/accountkey/account_key_fail.go
@@ -18,6 +18,8 @@ package accountkey
 
 import (
 	"crypto/ecdsa"
+
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/kerrors"
 )
 
@@ -47,7 +49,7 @@ func (a *AccountKeyFail) Equal(b AccountKey) bool {
 	return false
 }
 
-func (a *AccountKeyFail) Validate(r RoleType, pubkeys []*ecdsa.PublicKey) bool {
+func (a *AccountKeyFail) Validate(r RoleType, recoveredKeys []*ecdsa.PublicKey, from common.Address) bool {
 	// This type of account key always fails to validate.
 	return false
 }

--- a/blockchain/types/accountkey/account_key_legacy.go
+++ b/blockchain/types/accountkey/account_key_legacy.go
@@ -18,8 +18,10 @@ package accountkey
 
 import (
 	"crypto/ecdsa"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/kerrors"
-	"runtime"
 )
 
 // AccountKeyLegacy is used for accounts having no keys.
@@ -53,12 +55,12 @@ func (a *AccountKeyLegacy) Equal(b AccountKey) bool {
 	return true
 }
 
-func (a *AccountKeyLegacy) Validate(r RoleType, pubkeys []*ecdsa.PublicKey) bool {
-	buf := make([]byte, 1024*1024)
-	buf = buf[:runtime.Stack(buf, false)]
-	logger.Error("this function should not be called. Validation should be done at ValidateSender or ValidateFeePayer",
-		"callstack", buf)
-	return false
+func (a *AccountKeyLegacy) Validate(r RoleType, recoveredKeys []*ecdsa.PublicKey, from common.Address) bool {
+	// A valid legacy key generates only one signature
+	if len(recoveredKeys) != 1 {
+		return false
+	}
+	return from == crypto.PubkeyToAddress(*recoveredKeys[0])
 }
 
 func (a *AccountKeyLegacy) String() string {

--- a/blockchain/types/accountkey/account_key_nil.go
+++ b/blockchain/types/accountkey/account_key_nil.go
@@ -18,9 +18,11 @@ package accountkey
 
 import (
 	"crypto/ecdsa"
+	"io"
+
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/ser/rlp"
-	"io"
 )
 
 // AccountKeyNil represents a key having nothing.
@@ -62,7 +64,7 @@ func (a *AccountKeyNil) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
-func (a *AccountKeyNil) Validate(r RoleType, pubkeys []*ecdsa.PublicKey) bool {
+func (a *AccountKeyNil) Validate(r RoleType, recoveredKeys []*ecdsa.PublicKey, from common.Address) bool {
 	logger.ErrorWithStack("this function should not be called. Validation should be done at ValidateSender or ValidateFeePayer")
 	return false
 }

--- a/blockchain/types/accountkey/account_key_public.go
+++ b/blockchain/types/accountkey/account_key_public.go
@@ -19,6 +19,8 @@ package accountkey
 import (
 	"crypto/ecdsa"
 	"fmt"
+
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 )
@@ -62,13 +64,13 @@ func (a *AccountKeyPublic) Equal(b AccountKey) bool {
 	return a.PublicKeySerializable.Equal(tb.PublicKeySerializable)
 }
 
-func (a *AccountKeyPublic) Validate(r RoleType, pubkeys []*ecdsa.PublicKey) bool {
-	if len(pubkeys) != 1 {
-		// AccountKeyPublic has only one public key.
+func (a *AccountKeyPublic) Validate(r RoleType, recoveredKeys []*ecdsa.PublicKey, from common.Address) bool {
+	// AccountKeyPublic has only one public key.
+	if len(recoveredKeys) != 1 {
 		return false
 	}
 
-	return a.PublicKeySerializable.Equal((*PublicKeySerializable)(pubkeys[0]))
+	return a.PublicKeySerializable.Equal((*PublicKeySerializable)(recoveredKeys[0]))
 }
 
 func (a *AccountKeyPublic) String() string {

--- a/blockchain/types/accountkey/account_key_role_based.go
+++ b/blockchain/types/accountkey/account_key_role_based.go
@@ -20,9 +20,11 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
+	"io"
+
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/ser/rlp"
-	"io"
 )
 
 type RoleType int
@@ -150,11 +152,11 @@ func (a *AccountKeyRoleBased) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (a *AccountKeyRoleBased) Validate(r RoleType, pubkeys []*ecdsa.PublicKey) bool {
+func (a *AccountKeyRoleBased) Validate(r RoleType, recoveredKeys []*ecdsa.PublicKey, from common.Address) bool {
 	if len(*a) > int(r) {
-		return (*a)[r].Validate(r, pubkeys)
+		return (*a)[r].Validate(r, recoveredKeys, from)
 	}
-	return a.getDefaultKey().Validate(r, pubkeys)
+	return a.getDefaultKey().Validate(r, recoveredKeys, from)
 }
 
 func (a *AccountKeyRoleBased) getDefaultKey() AccountKey {

--- a/blockchain/types/accountkey/account_key_weighted_multi_sig.go
+++ b/blockchain/types/accountkey/account_key_weighted_multi_sig.go
@@ -19,6 +19,8 @@ package accountkey
 import (
 	"crypto/ecdsa"
 	"encoding/json"
+
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/ser/rlp"
@@ -73,16 +75,16 @@ func (a *AccountKeyWeightedMultiSig) Equal(b AccountKey) bool {
 		a.Keys.Equal(tb.Keys)
 }
 
-func (a *AccountKeyWeightedMultiSig) Validate(r RoleType, pubkeys []*ecdsa.PublicKey) bool {
+func (a *AccountKeyWeightedMultiSig) Validate(r RoleType, recoveredKeys []*ecdsa.PublicKey, from common.Address) bool {
 	weightedSum := uint(0)
 
 	// To prohibit making a signature with the same key, make a map.
 	// TODO-Klaytn: find another way for better performance
 	pMap := make(map[string]*ecdsa.PublicKey)
-	for _, bk := range pubkeys {
+	for _, bk := range recoveredKeys {
 		b, err := rlp.EncodeToBytes((*PublicKeySerializable)(bk))
 		if err != nil {
-			logger.Warn("Failed to encode public keys in the tx", pubkeys)
+			logger.Warn("Failed to encode public keys in the tx", recoveredKeys)
 			continue
 		}
 		pMap[string(b)] = bk
@@ -104,7 +106,7 @@ func (a *AccountKeyWeightedMultiSig) Validate(r RoleType, pubkeys []*ecdsa.Publi
 		return true
 	}
 
-	logger.Debug("AccountKeyWeightedMultiSig validation is failed", "pubkeys", pubkeys,
+	logger.Debug("AccountKeyWeightedMultiSig validation is failed", "pubkeys", recoveredKeys,
 		"accountKeys", a.String(), "threshold", a.Threshold, "weighted sum", weightedSum)
 
 	return false

--- a/blockchain/types/accountkey/account_key_weighted_multi_sig.go
+++ b/blockchain/types/accountkey/account_key_weighted_multi_sig.go
@@ -84,7 +84,7 @@ func (a *AccountKeyWeightedMultiSig) Validate(r RoleType, recoveredKeys []*ecdsa
 	for _, bk := range recoveredKeys {
 		b, err := rlp.EncodeToBytes((*PublicKeySerializable)(bk))
 		if err != nil {
-			logger.Warn("Failed to encode public keys in the tx", recoveredKeys)
+			logger.Warn("Failed to encode recovered public keys of the tx", "recoveredKeys", recoveredKeys)
 			continue
 		}
 		pMap[string(b)] = bk
@@ -106,7 +106,7 @@ func (a *AccountKeyWeightedMultiSig) Validate(r RoleType, recoveredKeys []*ecdsa
 		return true
 	}
 
-	logger.Debug("AccountKeyWeightedMultiSig validation is failed", "pubkeys", recoveredKeys,
+	logger.Debug("AccountKeyWeightedMultiSig validation is failed", "recoveredKeys", recoveredKeys,
 		"accountKeys", a.String(), "threshold", a.Threshold, "weighted sum", weightedSum)
 
 	return false

--- a/tests/role_based_account_test.go
+++ b/tests/role_based_account_test.go
@@ -19,6 +19,10 @@ package tests
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/types/accountkey"
 	"github.com/klaytn/klaytn/common"
@@ -27,9 +31,6 @@ import (
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/stretchr/testify/assert"
-	"math/big"
-	"testing"
-	"time"
 )
 
 type TestRoleBasedAccountType struct {
@@ -404,6 +405,173 @@ func TestAccountUpdateRoleBasedNil(t *testing.T) {
 		receipt, _, err := applyTransaction(t, bcdata, tx)
 		assert.Equal(t, (*types.Receipt)(nil), receipt)
 		assert.Equal(t, kerrors.ErrAccountKeyNilUninitializable, err)
+	}
+}
+
+// TestAccountUpdateRoleBasedLegacy tests TxInternalDataAccountUpdate with the following scenario:
+// 1. Update key to RoleBasedKey having a LegacyKey for all roles
+// 2. Test RoleTransfer of the RoleBasedKey
+// 3-1. Test RoleUpdate of the RoleBasedKey
+// 3-2. Recover the updated account key to the previously used RoleBasedKey
+// 4. Test RoleFeePayer of the RoleBasedKey
+func TestAccountUpdateRoleBasedLegacy(t *testing.T) {
+	if testing.Verbose() {
+		enableLog()
+	}
+	prof := profile.NewProfiler()
+
+	// Initialize blockchain
+	start := time.Now()
+	bcdata, err := NewBCData(6, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prof.Profile("main_init_blockchain", time.Now().Sub(start))
+	defer bcdata.Shutdown()
+
+	// Initialize address-balance map for verification
+	start = time.Now()
+	accountMap := NewAccountMap()
+	if err := accountMap.Initialize(bcdata); err != nil {
+		t.Fatal(err)
+	}
+	prof.Profile("main_init_accountMap", time.Now().Sub(start))
+
+	// reservoir account
+	reservoir := &TestAccountType{
+		Addr:  *bcdata.addrs[0],
+		Keys:  []*ecdsa.PrivateKey{bcdata.privKeys[0]},
+		Nonce: uint64(0),
+	}
+
+	anon, err := createAnonymousAccount("ed580f5bd71a2ee4dae5cb43e331b7d0318596e561e6add7844271ed94156b20")
+	assert.Equal(t, nil, err)
+
+	if testing.Verbose() {
+		fmt.Println("reservoirAddr = ", reservoir.Addr.String())
+		fmt.Println("anonAddr = ", anon.Addr.String())
+	}
+
+	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
+
+	// RoleBasedKey having LegacyKes for all roles
+	roleBasedKey := accountkey.NewAccountKeyRoleBasedWithValues(accountkey.AccountKeyRoleBased{
+		accountkey.NewAccountKeyLegacy(),
+		accountkey.NewAccountKeyLegacy(),
+		accountkey.NewAccountKeyLegacy(),
+	})
+
+	// 1. Update key to RoleBasedKey having a LegacyKey for all roles
+	{
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:      reservoir.Nonce,
+			types.TxValueKeyFrom:       reservoir.Addr,
+			types.TxValueKeyGasLimit:   gasLimit,
+			types.TxValueKeyGasPrice:   gasPrice,
+			types.TxValueKeyAccountKey: roleBasedKey,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeAccountUpdate, values)
+		assert.Equal(t, nil, err)
+
+		err = tx.SignWithKeys(signer, reservoir.Keys)
+		assert.Equal(t, nil, err)
+
+		if err := bcdata.GenABlockWithTransactions(accountMap, types.Transactions{tx}, prof); err != nil {
+			t.Fatal(err)
+		}
+		reservoir.Nonce += 1
+	}
+
+	// 2. Test RoleTransfer of the RoleBasedKey
+	{
+		amount := new(big.Int).Mul(big.NewInt(3000), new(big.Int).SetUint64(params.KLAY))
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    reservoir.Nonce,
+			types.TxValueKeyFrom:     reservoir.Addr,
+			types.TxValueKeyTo:       anon.Addr,
+			types.TxValueKeyAmount:   amount,
+			types.TxValueKeyGasLimit: gasLimit,
+			types.TxValueKeyGasPrice: gasPrice,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeValueTransfer, values)
+		assert.Equal(t, nil, err)
+
+		err = tx.SignWithKeys(signer, reservoir.Keys)
+		assert.Equal(t, nil, err)
+
+		if err := bcdata.GenABlockWithTransactions(accountMap, types.Transactions{tx}, prof); err != nil {
+			t.Fatal(err)
+		}
+		reservoir.Nonce += 1
+	}
+
+	// 3-1. Test RoleUpdate of the RoleBasedKey
+	{
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:      reservoir.Nonce,
+			types.TxValueKeyFrom:       reservoir.Addr,
+			types.TxValueKeyGasLimit:   gasLimit,
+			types.TxValueKeyGasPrice:   gasPrice,
+			types.TxValueKeyAccountKey: accountkey.NewAccountKeyPublicWithValue(&anon.Keys[0].PublicKey),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeAccountUpdate, values)
+		assert.Equal(t, nil, err)
+
+		err = tx.SignWithKeys(signer, reservoir.Keys)
+		assert.Equal(t, nil, err)
+
+		if err := bcdata.GenABlockWithTransactions(accountMap, types.Transactions{tx}, prof); err != nil {
+			t.Fatal(err)
+		}
+		reservoir.Nonce += 1
+	}
+
+	// 3-2. Recover the updated account key to the previously used RoleBasedKey
+	{
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:      reservoir.Nonce,
+			types.TxValueKeyFrom:       reservoir.Addr,
+			types.TxValueKeyGasLimit:   gasLimit,
+			types.TxValueKeyGasPrice:   gasPrice,
+			types.TxValueKeyAccountKey: roleBasedKey,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeAccountUpdate, values)
+		assert.Equal(t, nil, err)
+
+		err = tx.SignWithKeys(signer, anon.Keys)
+		assert.Equal(t, nil, err)
+
+		if err := bcdata.GenABlockWithTransactions(accountMap, types.Transactions{tx}, prof); err != nil {
+			t.Fatal(err)
+		}
+		reservoir.Nonce += 1
+	}
+
+	// 4. Test RoleFeePayer of the RoleBasedKey
+	{
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    anon.Nonce,
+			types.TxValueKeyFrom:     anon.Addr,
+			types.TxValueKeyTo:       reservoir.Addr,
+			types.TxValueKeyAmount:   new(big.Int).SetUint64(0),
+			types.TxValueKeyGasLimit: gasLimit,
+			types.TxValueKeyGasPrice: gasPrice,
+			types.TxValueKeyFeePayer: reservoir.Addr,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedValueTransfer, values)
+		assert.Equal(t, nil, err)
+
+		err = tx.SignWithKeys(signer, anon.Keys)
+		assert.Equal(t, nil, err)
+
+		err = tx.SignFeePayerWithKeys(signer, reservoir.Keys)
+		assert.Equal(t, nil, err)
+
+		if err := bcdata.GenABlockWithTransactions(accountMap, types.Transactions{tx}, prof); err != nil {
+			t.Fatal(err)
+		}
+		anon.Nonce += 1
 	}
 }
 

--- a/tests/role_based_account_test.go
+++ b/tests/role_based_account_test.go
@@ -457,7 +457,7 @@ func TestAccountUpdateRoleBasedLegacy(t *testing.T) {
 	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
-	// RoleBasedKey having LegacyKes for all roles
+	// RoleBasedKey having LegacyKeys for all roles
 	roleBasedKey := accountkey.NewAccountKeyRoleBasedWithValues(accountkey.AccountKeyRoleBased{
 		accountkey.NewAccountKeyLegacy(),
 		accountkey.NewAccountKeyLegacy(),


### PR DESCRIPTION
## Proposed changes

`(a *AccountKeyLegacy) Validate` can be called when `AccountRoleBased` contains `AccountKeyLegacy` as a role key like `AccountRoleBased{RoleTransaction: AccountKeyLegacy}`, but it always returns `false`.
 This change completes the method for `AccountKeyLegacy` to validate public keys recovered from tx signatures. 

- Complete `(a *AccountKeyLegacy) Validate` for the case when AccountKeyLegacy is used as a roleKey of RoleBasedKey.
- Rename a parameter of `Validate`: `pubkeys` to `recoveredKeys`
- Add a test case `TestAccountUpdateRoleBasedLegacy`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
