### PR TITLE
Able to disable fetcher and downloader

### DIFF
--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -48,6 +48,8 @@ var FlagGroups = []FlagGroup{
 			ExtraDataFlag,
 			ConfigFileFlag,
 			OverwriteGenesisFlag,
+			DownloaderDisableFlag,
+			FetcherDisableFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -193,6 +193,17 @@ var (
 		Usage: "Maximum amount of time non-executable transaction are queued",
 		Value: cn.GetDefaultConfig().TxPool.Lifetime,
 	}
+
+	// block processing
+	DownloaderDisableFlag = cli.BoolFlag{
+		Name:  "downloader.disable",
+		Usage: "Disables downloader",
+	}
+	FetcherDisableFlag = cli.BoolFlag{
+		Name:  "fetcher.disable",
+		Usage: "Disables fetcher",
+	}
+
 	// Performance tuning settings
 	StateDBCachingFlag = cli.BoolFlag{
 		Name:  "statedb.use-cache",
@@ -1341,6 +1352,9 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 			log.Fatalf("only syncmode=full can be used for syncmode!")
 		}
 	}
+
+	cfg.DownloaderDisable = ctx.GlobalBool(DownloaderDisableFlag.Name)
+	cfg.FetcherDisable = ctx.GlobalBool(FetcherDisableFlag.Name)
 
 	cfg.NetworkId, cfg.IsPrivate = getNetworkId(ctx)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -193,7 +193,6 @@ var (
 		Usage: "Maximum amount of time non-executable transaction are queued",
 		Value: cn.GetDefaultConfig().TxPool.Lifetime,
 	}
-
 	// block processing
 	DownloaderDisableFlag = cli.BoolFlag{
 		Name:  "downloader.disable",
@@ -203,7 +202,6 @@ var (
 		Name:  "fetcher.disable",
 		Usage: "Disables fetcher",
 	}
-
 	// Performance tuning settings
 	StateDBCachingFlag = cli.BoolFlag{
 		Name:  "statedb.use-cache",

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -108,6 +108,8 @@ var CommonNodeFlags = []cli.Flag{
 	utils.RestartTimeOutFlag,
 	utils.DaemonPathFlag,
 	utils.ConfigFileFlag,
+	utils.DownloaderDisableFlag,
+	utils.FetcherDisableFlag,
 }
 
 // Common RPC flags

--- a/datasync/downloader/downloader_fake.go
+++ b/datasync/downloader/downloader_fake.go
@@ -27,7 +27,10 @@ import (
 // fakeDownloader do nothing
 type FakeDownloader struct{}
 
-func NewFakeDownloader() *FakeDownloader { return &FakeDownloader{} }
+func NewFakeDownloader() *FakeDownloader {
+	logger.Warn("downloader is disabled; no data will be downloaded from peers")
+	return &FakeDownloader{}
+}
 
 func (*FakeDownloader) RegisterPeer(id string, version int, peer Peer) error { return nil }
 func (*FakeDownloader) UnregisterPeer(id string) error                       { return nil }

--- a/datasync/downloader/downloader_fake.go
+++ b/datasync/downloader/downloader_fake.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package downloader
+
+import (
+	"math/big"
+
+	"github.com/klaytn/klaytn"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+)
+
+// fakeDownloader do nothing
+type FakeDownloader struct{}
+
+func NewFakeDownloader() *FakeDownloader { return &FakeDownloader{} }
+
+func (*FakeDownloader) RegisterPeer(id string, version int, peer Peer) error { return nil }
+func (*FakeDownloader) UnregisterPeer(id string) error                       { return nil }
+
+func (*FakeDownloader) DeliverBodies(id string, transactions [][]*types.Transaction) error {
+	return nil
+}
+func (*FakeDownloader) DeliverHeaders(id string, headers []*types.Header) error      { return nil }
+func (*FakeDownloader) DeliverNodeData(id string, data [][]byte) error               { return nil }
+func (*FakeDownloader) DeliverReceipts(id string, receipts [][]*types.Receipt) error { return nil }
+
+func (*FakeDownloader) Terminate() {}
+func (*FakeDownloader) Synchronise(id string, head common.Hash, td *big.Int, mode SyncMode) error {
+	return nil
+}
+func (*FakeDownloader) Progress() klaytn.SyncProgress { return klaytn.SyncProgress{} }

--- a/datasync/fetcher/fetcher_fake.go
+++ b/datasync/fetcher/fetcher_fake.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package fetcher
+
+import (
+	"time"
+
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+)
+
+type FakeFetcher struct{}
+
+func NewFakeFetcher() *FakeFetcher { return &FakeFetcher{} }
+
+func (*FakeFetcher) Enqueue(peer string, block *types.Block) error { return nil }
+func (*FakeFetcher) FilterBodies(peer string, transactions [][]*types.Transaction, time time.Time) [][]*types.Transaction {
+	return nil
+}
+func (*FakeFetcher) FilterHeaders(peer string, headers []*types.Header, time time.Time) []*types.Header {
+	return nil
+}
+func (*FakeFetcher) Notify(peer string, hash common.Hash, number uint64, time time.Time, headerFetcher HeaderRequesterFn, bodyFetcher BodyRequesterFn) error {
+	return nil
+}
+func (*FakeFetcher) Start() {}
+func (*FakeFetcher) Stop()  {}

--- a/datasync/fetcher/fetcher_fake.go
+++ b/datasync/fetcher/fetcher_fake.go
@@ -25,7 +25,10 @@ import (
 
 type FakeFetcher struct{}
 
-func NewFakeFetcher() *FakeFetcher { return &FakeFetcher{} }
+func NewFakeFetcher() *FakeFetcher {
+	logger.Warn("fetcher is disabled; no data will be fetched from peers")
+	return &FakeFetcher{}
+}
 
 func (*FakeFetcher) Enqueue(peer string, block *types.Block) error { return nil }
 func (*FakeFetcher) FilterBodies(peer string, transactions [][]*types.Transaction, time time.Time) [][]*types.Transaction {

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -86,6 +86,10 @@ type Config struct {
 	SyncMode  downloader.SyncMode
 	NoPruning bool
 
+	// block processing options
+	DownloaderDisable bool
+	FetcherDisable    bool
+
 	// Service chain options
 	ParentOperatorAddr *common.Address `toml:",omitempty"` // A hex account address in the parent chain used to sign a child chain transaction.
 	AnchoringPeriod    uint64          // Period when child chain sends an anchoring transaction to the parent chain. Default value is 1.

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -24,6 +24,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -40,12 +47,6 @@ import (
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/klaytn/klaytn/storage/statedb"
 	"github.com/klaytn/klaytn/work"
-	"math"
-	"math/big"
-	"math/rand"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 const (
@@ -233,32 +234,42 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		return nil, errIncompatibleConfig
 	}
 
-	// Construct the downloader (long sync) and its backing state bloom if fast
-	// sync is requested. The downloader is responsible for deallocating the state
+	// Create and set downloader
+	if cnconfig.DownloaderDisable {
+		manager.downloader = downloader.NewFakeDownloader()
+	} else {
+		// Construct the downloader (long sync) and its backing state bloom if fast
+		// sync is requested. The downloader is responsible for deallocating the state
 
-	// bloom when it's done.
-	var stateBloom *statedb.SyncBloom
-	if atomic.LoadUint32(&manager.fastSync) == 1 {
-		stateBloom = statedb.NewSyncBloom(uint64(cacheLimit), chainDB.GetStateTrieDB())
-	}
-	manager.downloader = downloader.New(mode, chainDB, stateBloom, manager.eventMux, blockchain, nil, manager.removePeer)
-
-	validator := func(header *types.Header) error {
-		return engine.VerifyHeader(blockchain, header, true)
-	}
-	heighter := func() uint64 {
-		return blockchain.CurrentBlock().NumberU64()
-	}
-	inserter := func(blocks types.Blocks) (int, error) {
-		// If fast sync is running, deny importing weird blocks
+		// bloom when it's done.
+		var stateBloom *statedb.SyncBloom
 		if atomic.LoadUint32(&manager.fastSync) == 1 {
-			logger.Warn("Discarded bad propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
-			return 0, nil
+			stateBloom = statedb.NewSyncBloom(uint64(cacheLimit), chainDB.GetStateTrieDB())
 		}
-		atomic.StoreUint32(&manager.acceptTxs, 1) // Mark initial sync done on any fetcher import
-		return manager.blockchain.InsertChain(blocks)
+		manager.downloader = downloader.New(mode, chainDB, stateBloom, manager.eventMux, blockchain, nil, manager.removePeer)
 	}
-	manager.fetcher = fetcher.New(blockchain.GetBlockByHash, validator, manager.BroadcastBlock, manager.BroadcastBlockHash, heighter, inserter, manager.removePeer)
+
+	// Create and set fetcher
+	if cnconfig.FetcherDisable {
+		manager.fetcher = fetcher.NewFakeFetcher()
+	} else {
+		validator := func(header *types.Header) error {
+			return engine.VerifyHeader(blockchain, header, true)
+		}
+		heighter := func() uint64 {
+			return blockchain.CurrentBlock().NumberU64()
+		}
+		inserter := func(blocks types.Blocks) (int, error) {
+			// If fast sync is running, deny importing weird blocks
+			if atomic.LoadUint32(&manager.fastSync) == 1 {
+				logger.Warn("Discarded bad propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
+				return 0, nil
+			}
+			atomic.StoreUint32(&manager.acceptTxs, 1) // Mark initial sync done on any fetcher import
+			return manager.blockchain.InsertChain(blocks)
+		}
+		manager.fetcher = fetcher.New(blockchain.GetBlockByHash, validator, manager.BroadcastBlock, manager.BroadcastBlockHash, heighter, inserter, manager.removePeer)
+	}
 
 	if manager.useTxResend() {
 		go manager.txResendLoop(cnconfig.TxResendInterval, cnconfig.TxResendCount)


### PR DESCRIPTION
## Proposed changes

- Able to disable fetcher and downloader
    - Made new structs `FakeFetcher` and `FakeDownloader`
    - Made new flags `fetcher.disable` and `downloader.disable`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

Since this feature disables to receive blocks from peers, it is unable to make blocks.
New features to receive blocks from redis will be implemented.