### PR TITLE
Remove WriteThroughCaching Flag

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -23,6 +23,9 @@ package api
 import (
 	"context"
 	"fmt"
+	"math/big"
+	"time"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/types/account"
@@ -35,8 +38,6 @@ import (
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/ser/rlp"
-	"math/big"
-	"time"
 )
 
 const defaultGasPrice = 25 * params.Ston
@@ -206,12 +207,6 @@ func (s *PublicBlockChainAPI) GetAccountKey(ctx context.Context, address common.
 	accountKey := state.GetKey(address)
 	serAccKey := accountkey.NewAccountKeySerializerWithAccountKey(accountKey)
 	return serAccKey, state.Error()
-}
-
-// WriteThroughCaching returns if write through caching is enabled or not.
-// If enabled, when data write happens, cache write happens at the same time.
-func (s *PublicBlockChainAPI) WriteThroughCaching() bool {
-	return common.WriteThroughCaching
 }
 
 // IsParallelDBWrite returns if parallel write is enabled or not.

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -147,7 +147,6 @@ var FlagGroups = []FlagGroup{
 			CacheScaleFlag,
 			CacheUsageLevelFlag,
 			MemorySizeFlag,
-			CacheWriteThroughFlag,
 			TxPoolStateCacheFlag,
 			TrieNodeCacheTypeFlag,
 			TrieNodeCacheLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -285,10 +285,6 @@ var (
 		Name:  "cache.memory",
 		Usage: "Set the physical RAM size (GB, Default: 16GB)",
 	}
-	CacheWriteThroughFlag = cli.BoolFlag{
-		Name:  "cache.writethrough",
-		Usage: "Enables write-through writing to database and cache for certain types of cache.",
-	}
 	TxPoolStateCacheFlag = cli.BoolFlag{
 		Name:  "statedb.use-txpool-cache",
 		Usage: "Enables caching of nonce and balance for txpool.",
@@ -1401,7 +1397,6 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 		logger.Debug("Memory settings", "PhysicalMemory(GB)", common.TotalPhysicalMemGB)
 	}
 
-	common.WriteThroughCaching = ctx.GlobalIsSet(CacheWriteThroughFlag.Name)
 	cfg.TxPoolStateCache = ctx.GlobalIsSet(TxPoolStateCacheFlag.Name)
 
 	if ctx.GlobalIsSet(DocRootFlag.Name) {

--- a/cmd/utils/nodecmd/flags_test.go
+++ b/cmd/utils/nodecmd/flags_test.go
@@ -278,10 +278,6 @@ var flagsWithValues = []struct {
 		errors:      []int{ErrorInvalidValue, ErrorInvalidValue},
 	},
 	{
-		flag:     "--cache.writethrough",
-		flagType: FlagTypeBoolean,
-	},
-	{
 		flag:     "--statedb.use-txpool-cache",
 		flagType: FlagTypeBoolean,
 	},

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -73,7 +73,6 @@ var CommonNodeFlags = []cli.Flag{
 	utils.CacheScaleFlag,
 	utils.CacheUsageLevelFlag,
 	utils.MemorySizeFlag,
-	utils.CacheWriteThroughFlag,
 	utils.TxPoolStateCacheFlag,
 	utils.TrieNodeCacheTypeFlag,
 	utils.TrieNodeCacheRedisEndpointsFlag,

--- a/common/cache.go
+++ b/common/cache.go
@@ -18,10 +18,11 @@ package common
 
 import (
 	"errors"
-	"github.com/hashicorp/golang-lru"
+	"math"
+
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/klaytn/klaytn/log"
 	"github.com/pbnjay/memory"
-	"math"
 )
 
 type CacheType int
@@ -66,9 +67,6 @@ func getPhysicalMemorySize() int {
 		return minimumMemorySize
 	}
 }
-
-// TODO-Klaytn-Storage WriteThroughCaching flag should be stored to proper place.
-var WriteThroughCaching = false
 
 type CacheKey interface {
 	getShardIndex(shardMask int) int

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -735,10 +735,6 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, web3._extend.utils.toHex]
 		}),
 		new web3._extend.Method({
-			name: 'writeThroughCaching',
-			call: 'klay_writeThroughCaching',
-		}),
-		new web3._extend.Method({
 			name: 'isParallelDBWrite',
 			call: 'klay_isParallelDBWrite',
 		}),


### PR DESCRIPTION
## Proposed changes

- Remove WriteThroughCaching flag
    - In original code, blockCache, bodyCache, BodyRLPCache was only written when WriteThroughCachingFlag was set. However, not setting the flag is inefficient, since the data is read from db and stored to cache on next block generation.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

![Screen Shot 2020-09-23 at 9 20 05 AM](https://user-images.githubusercontent.com/13597401/93950246-02a07c00-fd7e-11ea-8ee9-0aecbaaf6f00.png)
EN0: WriteThrough disabled
EN1: WriteThrough enabled
EN2: WriteThrough enabled with a go routine

WriteThrough enabled (EN1) is chosen.
EN1 uses 0.3MB less memory.
EN1 creates slightly more go routines.
EN2 is slightly faster than EN1.