### PR TITLE
database: ReadCachedTrieNode leaves a log for the unexpected cases

### DIFF
--- a/storage/database/badger_database.go
+++ b/storage/database/badger_database.go
@@ -18,10 +18,11 @@ package database
 
 import (
 	"fmt"
-	"github.com/dgraph-io/badger"
-	"github.com/klaytn/klaytn/log"
 	"os"
 	"time"
+
+	"github.com/dgraph-io/badger"
+	"github.com/klaytn/klaytn/log"
 )
 
 const gcThreshold = int64(1 << 30) // GB
@@ -141,6 +142,9 @@ func (bg *badgerDB) Get(key []byte) ([]byte, error) {
 	defer txn.Discard()
 	item, err := txn.Get(key)
 	if err != nil {
+		if err == badger.ErrKeyNotFound {
+			return nil, dataNotFoundErr
+		}
 		return nil, err
 	}
 

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -110,8 +110,6 @@ func TestDatabase_NotFoundErr(t *testing.T) {
 }
 
 func testPutGet(db Database, t *testing.T) {
-	t.Parallel()
-
 	// put
 	for _, v := range test_values {
 		err := db.Put([]byte(v), []byte(v))

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -23,7 +23,6 @@ package database
 import (
 	"bytes"
 	"fmt"
-	"github.com/klaytn/klaytn/common"
 	"io/ioutil"
 	"math/big"
 	"os"
@@ -31,9 +30,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/stretchr/testify/assert"
 )
 
-func newTestLDB() (*levelDB, func()) {
+func newTestLDB() (Database, func()) {
 	dirName, err := ioutil.TempDir(os.TempDir(), "klay_leveldb_test_")
 	if err != nil {
 		panic("failed to create test file: " + err.Error())
@@ -49,7 +51,7 @@ func newTestLDB() (*levelDB, func()) {
 	}
 }
 
-func newTestBadgerDB() (*badgerDB, func()) {
+func newTestBadgerDB() (Database, func()) {
 	dirName, err := ioutil.TempDir(os.TempDir(), "klay_badgerdb_test_")
 	if err != nil {
 		panic("failed to create test file: " + err.Error())
@@ -65,24 +67,46 @@ func newTestBadgerDB() (*badgerDB, func()) {
 	}
 }
 
+func newTestMemDB() (Database, func()) {
+	return NewMemDB(), func() {}
+}
+
 var test_values = []string{"a", "1251", "\x00123\x00"}
 
 //var test_values = []string{"", "a", "1251", "\x00123\x00"} original test_values; modified since badgerDB can't store empty key
 
-func TestLDB_PutGet(t *testing.T) {
-	db, remove := newTestLDB()
-	defer remove()
-	testPutGet(db, t)
+// TODO-Klaytn-Database Need to add DynamoDB to the below list.
+var testDatabases = []func() (Database, func()){newTestLDB, newTestBadgerDB, newTestMemDB}
+
+// TestDatabase_PutGet tests the basic put and get operations.
+func TestDatabase_PutGet(t *testing.T) {
+	for _, dbCreateFn := range testDatabases {
+		db, remove := dbCreateFn()
+		defer remove()
+		testPutGet(db, t)
+	}
 }
 
-func TestBadgerDB_PutGet(t *testing.T) {
-	db, remove := newTestBadgerDB()
-	defer remove()
-	testPutGet(db, t)
+// TestDatabase_ParallelPutGet tests the parallel put and get operations.
+func TestDatabase_ParallelPutGet(t *testing.T) {
+	for _, dbCreateFn := range testDatabases {
+		db, remove := dbCreateFn()
+		defer remove()
+		testParallelPutGet(db, t)
+	}
 }
 
-func TestMemoryDB_PutGet(t *testing.T) {
-	testPutGet(NewMemDB(), t)
+// TestDatabase_NotFoundErr checks if an empty database returns
+// dataNotFoundErr for the given  random key.
+func TestDatabase_NotFoundErr(t *testing.T) {
+	for _, dbCreateFn := range testDatabases {
+		db, remove := dbCreateFn()
+		defer remove()
+		val, err := db.Get(randStrBytes(100))
+		assert.Nil(t, val)
+		assert.Error(t, err)
+		assert.Equal(t, dataNotFoundErr, err)
+	}
 }
 
 func testPutGet(db Database, t *testing.T) {
@@ -157,22 +181,6 @@ func testPutGet(db Database, t *testing.T) {
 			t.Fatalf("got deleted value %q", v)
 		}
 	}
-}
-
-func TestLDB_ParallelPutGet(t *testing.T) {
-	db, remove := newTestLDB()
-	defer remove()
-	testParallelPutGet(db, t)
-}
-
-func TestBadgerDB_ParallelPutGet(t *testing.T) {
-	db, remove := newTestBadgerDB()
-	defer remove()
-	testParallelPutGet(db, t)
-}
-
-func TestMemoryDB_ParallelPutGet(t *testing.T) {
-	testParallelPutGet(NewMemDB(), t)
 }
 
 func TestShardDB(t *testing.T) {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1391,13 +1391,13 @@ func (dbm *databaseManager) ReadCachedTrieNode(hash common.Hash) ([]byte, error)
 	if dbm.inMigration {
 		if val, err := dbm.GetStateTrieMigrationDB().Get(hash[:]); err == nil {
 			return val, nil
-		} else if err != leveldb.ErrNotFound {
+		} else if err != dataNotFoundErr {
 			// TODO-Klaytn-Database Need to be properly handled
 			logger.Error("Unexpected error while reading cached trie node from state migration database", "err", err)
 		}
 	}
 	val, err := dbm.ReadCachedTrieNodeFromOld(hash)
-	if err != leveldb.ErrNotFound {
+	if err != dataNotFoundErr {
 		// TODO-Klaytn-Database Need to be properly handled
 		logger.Error("Unexpected error while reading cached trie node", "err", err)
 	}

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1391,9 +1391,17 @@ func (dbm *databaseManager) ReadCachedTrieNode(hash common.Hash) ([]byte, error)
 	if dbm.inMigration {
 		if val, err := dbm.GetStateTrieMigrationDB().Get(hash[:]); err == nil {
 			return val, nil
+		} else if err != leveldb.ErrNotFound {
+			// TODO-Klaytn-Database Need to be properly handled
+			logger.Error("Unexpected error while reading cached trie node from state migration database", "err", err)
 		}
 	}
-	return dbm.ReadCachedTrieNodeFromOld(hash)
+	val, err := dbm.ReadCachedTrieNodeFromOld(hash)
+	if err != leveldb.ErrNotFound {
+		// TODO-Klaytn-Database Need to be properly handled
+		logger.Error("Unexpected error while reading cached trie node", "err", err)
+	}
+	return val, err
 }
 
 // Cached Trie Node Preimage operation.

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -21,10 +21,11 @@
 package database
 
 import (
-	"github.com/klaytn/klaytn/common/fdlimit"
-	metricutils "github.com/klaytn/klaytn/metrics/utils"
 	"sync"
 	"time"
+
+	"github.com/klaytn/klaytn/common/fdlimit"
+	metricutils "github.com/klaytn/klaytn/metrics/utils"
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
@@ -250,6 +251,9 @@ func (db *levelDB) Get(key []byte) ([]byte, error) {
 	// Retrieve the key and increment the miss counter if not found
 	dat, err := db.db.Get(key, nil)
 	if err != nil {
+		if err == leveldb.ErrNotFound {
+			return nil, dataNotFoundErr
+		}
 		return nil, err
 	}
 	return dat, nil

--- a/storage/database/memory_database.go
+++ b/storage/database/memory_database.go
@@ -21,11 +21,11 @@
 package database
 
 import (
-	"errors"
-	"github.com/klaytn/klaytn/common"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/klaytn/klaytn/common"
 )
 
 /*
@@ -75,7 +75,7 @@ func (db *MemDB) Get(key []byte) ([]byte, error) {
 	if entry, ok := db.db[string(key)]; ok {
 		return common.CopyBytes(entry), nil
 	}
-	return nil, errors.New("not found")
+	return nil, dataNotFoundErr
 }
 
 func (db *MemDB) Keys() [][]byte {


### PR DESCRIPTION
## Proposed changes

- When `ReadCachedTrieNode` receives an error except for `dataNotFoundErr`, it leaves an error log
- This is to check the unexpected error cases.
- Now, every Klaytn database returns `nil, dataNotFoundErr` for `val, err` when it fails to find the data

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
