### PR TITLE
Enable Testing DynamoDB and S3: use localstack v0.11.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ executors:
     working_directory: /go/src/github.com/klaytn/klaytn
     docker:
       - image: klaytn/build_base:1.1-go1.14.6-solc0.4.24
-      - image: localstack/localstack:0.10.9
+      - image: localstack/localstack:0.11.5
       - image: circleci/mysql:5.7
       - name: zookeeper
         image: wurstmeister/zookeeper

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ jobs:
           name: "Wait until localstack container running"
           command: |
             timeout -t 60 sh -c \
-            'until curl --silent --fail "http://localhost:4566"; do
+            'until nc -z localhost 4566; do
               echo "Waiting for Localstack ..."
               sleep 1
             done'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,10 @@ jobs:
             done'
       - run:
           name: "Run test others"
-          command: make test-others
+          command: |
+            export AWS_ACCESS_KEY_ID=foobar
+            export AWS_SECRET_ACCESS_KEY=foobar
+            make test-others
 
   pass-tests:
     executor: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,15 +338,13 @@ jobs:
           name: "Wait until localstack container running"
           command: |
             timeout -t 60 sh -c \
-            'until curl --silent --fail "http://localhost:4572"; do
-              echo "Waiting for Localstack S3 ..."
+            'until curl --silent --fail "http://localhost:4566"; do
+              echo "Waiting for Localstack ..."
               sleep 1
             done'
       - run:
           name: "Run test others"
           command: |
-            export AWS_ACCESS_KEY_ID=foobar
-            export AWS_SECRET_ACCESS_KEY=foobar
             make test-others
 
   pass-tests:

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -72,6 +72,7 @@ type DynamoDBConfig struct {
 	TableName          string
 	Region             string // AWS region
 	Endpoint           string // Where DynamoDB reside
+	S3Endpoint         string // Where S3 reside
 	IsProvisioned      bool   // Billing mode
 	ReadCapacityUnits  int64  // read capacity when provisioned
 	WriteCapacityUnits int64  // write capacity when provisioned
@@ -129,6 +130,7 @@ func GetTestDynamoConfig() *DynamoDBConfig {
 	return &DynamoDBConfig{
 		Region:             "us-east-1",
 		Endpoint:           "http://localhost:4566",
+		S3Endpoint:         "http://localhost:4566",
 		TableName:          "klaytn-default" + strconv.Itoa(time.Now().Nanosecond()),
 		IsProvisioned:      false,
 		ReadCapacityUnits:  10000,
@@ -156,10 +158,13 @@ func newDynamoDB(config *DynamoDBConfig) (*dynamoDB, error) {
 	if len(config.Endpoint) == 0 {
 		config.Endpoint = "https://dynamodb." + config.Region + ".amazonaws.com"
 	}
+	if len(config.S3Endpoint) == 0 {
+		config.S3Endpoint = "https://s3." + config.Region + ".amazonaws.com"
+	}
 
 	config.TableName = strings.ReplaceAll(config.TableName, "_", "-")
 
-	s3FileDB, err := newS3FileDB(config.Region, "https://s3."+config.Region+".amazonaws.com", config.TableName)
+	s3FileDB, err := newS3FileDB(config.Region, config.S3Endpoint, config.TableName)
 	if err != nil {
 		logger.Error("Unable to create/get S3FileDB", "DB", config.TableName)
 		return nil, err

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -103,16 +103,32 @@ type DynamoData struct {
 	Val []byte `json:"Val" dynamodbav:"Val"`
 }
 
-// TODO-Klaytn: remove the test config when flag setting is completed
-/*
- * Please Run DynamoDB local with docker
- * $ docker pull amazon/dynamodb-local
- * $ docker run -d -p 8000:8000 amazon/dynamodb-local
- */
+// GetTestDynamoConfig gets dynamo config for actual aws DynamoDB test
+//
+// If you use this config, you will be charged for what you use.
+// You need to set AWS credentials to access to dynamoDB.
+//    $ export AWS_ACCESS_KEY_ID=YOUR_ACCESS_KEY
+//    $ export AWS_SECRET_ACCESS_KEY=YOUR_SECRET
 func GetDefaultDynamoDBConfig() *DynamoDBConfig {
 	return &DynamoDBConfig{
 		Region:             "ap-northeast-2",
 		Endpoint:           "https://dynamodb.ap-northeast-2.amazonaws.com",
+		TableName:          "klaytn-default" + strconv.Itoa(time.Now().Nanosecond()),
+		IsProvisioned:      false,
+		ReadCapacityUnits:  10000,
+		WriteCapacityUnits: 10000,
+		ReadOnly:           false,
+	}
+}
+
+// GetTestDynamoConfig gets dynamo config for local test
+//
+// Please Run DynamoDB local with docker
+//    $ docker run -d -p 4566:4566 localstack/localstack:0.11.5
+func GetTestDynamoConfig() *DynamoDBConfig {
+	return &DynamoDBConfig{
+		Region:             "us-east-1",
+		Endpoint:           "http://localhost:4566",
 		TableName:          "klaytn-default" + strconv.Itoa(time.Now().Nanosecond()),
 		IsProvisioned:      false,
 		ReadCapacityUnits:  10000,

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -168,8 +168,9 @@ func newDynamoDB(config *DynamoDBConfig) (*dynamoDB, error) {
 	if dynamoDBClient == nil {
 		dynamoDBClient = dynamodb.New(session.Must(session.NewSessionWithOptions(session.Options{
 			Config: aws.Config{
-				Endpoint: aws.String(config.Endpoint),
-				Region:   aws.String(config.Region),
+				Endpoint:         aws.String(config.Endpoint),
+				Region:           aws.String(config.Region),
+				S3ForcePathStyle: aws.Bool(true),
 			},
 		})))
 	}

--- a/storage/database/dynamodb_readonly_test.go
+++ b/storage/database/dynamodb_readonly_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testDynamoDBReadOnly_Put(t *testing.T) {
-	dynamo, err := newDynamoDBReadOnly(GetDefaultDynamoDBConfig())
+func TestDynamoDBReadOnly_Put(t *testing.T) {
+	dynamo, err := newDynamoDBReadOnly(GetTestDynamoConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -54,8 +54,8 @@ func testDynamoDBReadOnly_Put(t *testing.T) {
 	assert.Equal(t, err.Error(), dataNotFoundErr.Error())
 }
 
-func testDynamoDBReadOnly_Write(t *testing.T) {
-	dynamo, err := newDynamoDBReadOnly(GetDefaultDynamoDBConfig())
+func TestDynamoDBReadOnly_Write(t *testing.T) {
+	dynamo, err := newDynamoDBReadOnly(GetTestDynamoConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -24,13 +24,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/log/term"
 	"github.com/mattn/go-colorable"
 
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func enableLog() {
@@ -47,34 +48,49 @@ func enableLog() {
 	log.Root().SetHandler(glogger)
 }
 
-func TestDynamoDB_Put(t *testing.T) {
-	dynamo, err := newDynamoDB(GetTestDynamoConfig())
-	defer dynamo.deleteDB()
-	if err != nil {
-		t.Fatal(err)
+type SuiteDynamoDB struct {
+	suite.Suite
+	dynamoDBs []*dynamoDB
+}
+
+func (s *SuiteDynamoDB) TearDownSuite() {
+	for _, dynamo := range s.dynamoDBs {
+		dynamo.deleteDB()
 	}
+}
+
+func TestDynamoDB(t *testing.T) {
+	suite.Run(t, new(SuiteDynamoDB))
+}
+
+func (s *SuiteDynamoDB) TestDynamoDB_Put() {
+	dynamo, err := newDynamoDB(GetTestDynamoConfig())
+	if err != nil {
+		s.FailNow("failed to create dynamoDB", err)
+	}
+	s.dynamoDBs = append(s.dynamoDBs, dynamo)
+
 	testKey := common.MakeRandomBytes(32)
 	testVal := common.MakeRandomBytes(500)
 
 	val, err := dynamo.Get(testKey)
 
-	assert.Nil(t, val)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), dataNotFoundErr.Error())
+	s.Nil(val)
+	s.Error(err)
+	s.Equal(err.Error(), dataNotFoundErr.Error())
 
-	assert.NoError(t, dynamo.Put(testKey, testVal))
+	s.NoError(dynamo.Put(testKey, testVal))
 	returnedVal, returnedErr := dynamo.Get(testKey)
-	assert.Equal(t, testVal, returnedVal)
-	assert.NoError(t, returnedErr)
+	s.Equal(testVal, returnedVal)
+	s.NoError(returnedErr)
 }
 
-func TestDynamoBatch_Write(t *testing.T) {
+func (s *SuiteDynamoDB) TestDynamoBatch_Write() {
 	dynamo, err := newDynamoDB(GetTestDynamoConfig())
-	defer dynamo.deleteDB()
 	if err != nil {
-		t.Fatal(err)
+		s.FailNow("failed to create dynamoDB", err)
 	}
-	t.Log("dynamoDB", dynamo.config.TableName)
+	s.dynamoDBs = append(s.dynamoDBs, dynamo)
 
 	var testKeys [][]byte
 	var testVals [][]byte
@@ -88,25 +104,24 @@ func TestDynamoBatch_Write(t *testing.T) {
 		testKeys = append(testKeys, testKey)
 		testVals = append(testVals, testVal)
 
-		assert.NoError(t, batch.Put(testKey, testVal))
+		s.NoError(batch.Put(testKey, testVal))
 	}
-	assert.NoError(t, batch.Write())
+	s.NoError(batch.Write())
 
 	// check if exist
 	for i := 0; i < itemNum; i++ {
 		returnedVal, returnedErr := dynamo.Get(testKeys[i])
-		assert.NoError(t, returnedErr)
-		assert.Equal(t, hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
+		s.NoError(returnedErr)
+		s.Equal(hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
 	}
 }
 
-func TestDynamoBatch_WriteLargeData(t *testing.T) {
+func (s *SuiteDynamoDB) TestDynamoBatch_WriteLargeData() {
 	dynamo, err := newDynamoDB(GetTestDynamoConfig())
-	defer dynamo.deleteDB()
 	if err != nil {
-		t.Fatal(err)
+		s.FailNow("failed to create dynamoDB", err)
 	}
-	t.Log("dynamoDB", dynamo.config.TableName)
+	s.dynamoDBs = append(s.dynamoDBs, dynamo)
 
 	var testKeys [][]byte
 	var testVals [][]byte
@@ -120,25 +135,24 @@ func TestDynamoBatch_WriteLargeData(t *testing.T) {
 		testKeys = append(testKeys, testKey)
 		testVals = append(testVals, testVal)
 
-		assert.NoError(t, batch.Put(testKey, testVal))
+		s.NoError(batch.Put(testKey, testVal))
 	}
-	assert.NoError(t, batch.Write())
+	s.NoError(batch.Write())
 
 	// check if exist
 	for i := 0; i < itemNum; i++ {
 		returnedVal, returnedErr := dynamo.Get(testKeys[i])
-		assert.NoError(t, returnedErr)
-		assert.Equal(t, hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
+		s.NoError(returnedErr)
+		s.Equal(hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
 	}
 }
 
-func TestDynamoBatch_DuplicatedKey(t *testing.T) {
+func (s *SuiteDynamoDB) TestDynamoBatch_DuplicatedKey() {
 	dynamo, err := newDynamoDB(GetTestDynamoConfig())
-	defer dynamo.deleteDB()
 	if err != nil {
-		t.Fatal(err)
+		s.FailNow("failed to create dynamoDB", err)
 	}
-	t.Log("dynamoDB", dynamo.config.TableName)
+	s.dynamoDBs = append(s.dynamoDBs, dynamo)
 
 	var testKeys [][]byte
 	var testVals [][]byte
@@ -152,41 +166,39 @@ func TestDynamoBatch_DuplicatedKey(t *testing.T) {
 		testKeys = append(testKeys, testKey)
 		testVals = append(testVals, testVal)
 
-		assert.NoError(t, batch.Put(testKey, testVal))
-		assert.NoError(t, batch.Put(testKey, testVal))
-		assert.NoError(t, batch.Put(testKey, testVal))
+		s.NoError(batch.Put(testKey, testVal))
+		s.NoError(batch.Put(testKey, testVal))
+		s.NoError(batch.Put(testKey, testVal))
 	}
-	assert.NoError(t, batch.Write())
+	s.NoError(batch.Write())
 
 	// check if exist
 	for i := 0; i < itemNum; i++ {
 		returnedVal, returnedErr := dynamo.Get(testKeys[i])
-		assert.NoError(t, returnedErr)
-		assert.Equal(t, hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
+		s.NoError(returnedErr)
+		s.Equal(hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
 	}
 }
 
 // testDynamoBatch_WriteMutliTables checks if there is no error when working with more than one tables.
 // This also checks if shared workers works as expected.
-func TestDynamoBatch_WriteMutliTables(t *testing.T) {
+func (s *SuiteDynamoDB) TestDynamoBatch_WriteMutliTables() {
 	// this test might end with Crit, enableLog to find out the log
 	//enableLog()
 
 	// create DynamoDB1
 	dynamo, err := newDynamoDB(GetTestDynamoConfig())
-	defer dynamo.deleteDB()
 	if err != nil {
-		t.Fatal(err)
+		s.FailNow("failed to create dynamoDB", err)
 	}
-	t.Log("dynamoDB1", dynamo.config.TableName)
+	s.dynamoDBs = append(s.dynamoDBs, dynamo)
 
 	// create DynamoDB2
 	dynamo2, err := newDynamoDB(GetTestDynamoConfig())
-	defer dynamo2.deleteDB()
 	if err != nil {
-		t.Fatal(err)
+		s.FailNow("failed to create dynamoDB", err)
 	}
-	t.Log("dynamoDB2", dynamo2.config.TableName)
+	s.dynamoDBs = append(s.dynamoDBs, dynamo2)
 
 	var testKeys, testVals [][]byte
 	var testKeys2, testVals2 [][]byte
@@ -205,7 +217,7 @@ func TestDynamoBatch_WriteMutliTables(t *testing.T) {
 			testKeys = append(testKeys, testKey)
 			testVals = append(testVals, testVal)
 
-			assert.NoError(t, batch.Put(testKey, testVal))
+			s.NoError(batch.Put(testKey, testVal))
 
 			// write key2 and val2 to db2
 			testKey2 := common.MakeRandomBytes(10)
@@ -214,29 +226,29 @@ func TestDynamoBatch_WriteMutliTables(t *testing.T) {
 			testKeys2 = append(testKeys2, testKey2)
 			testVals2 = append(testVals2, testVal2)
 
-			assert.NoError(t, batch2.Put(testKey2, testVal2))
+			s.NoError(batch2.Put(testKey2, testVal2))
 		}
 	}
-	assert.NoError(t, batch.Write())
-	assert.NoError(t, batch2.Write())
+	s.NoError(batch.Write())
+	s.NoError(batch2.Write())
 
 	// check if exist
 	for i := 0; i < itemNum; i++ {
 		// dynamodb 1 - check if wrote key and val
 		returnedVal, returnedErr := dynamo.Get(testKeys[i])
-		assert.NoError(t, returnedErr)
-		assert.Equal(t, hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
+		s.NoError(returnedErr)
+		s.Equal(hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
 		// dynamodb 1 - check if not wrote key2 and val2
 		returnedVal, returnedErr = dynamo.Get(testKeys2[i])
-		assert.Nil(t, returnedVal, "the entry should not be put in this table")
+		s.Nil(returnedVal, "the entry should not be put in this table")
 
 		// dynamodb 2 - check if wrote key2 and val2
 		returnedVal, returnedErr = dynamo2.Get(testKeys2[i])
-		assert.NoError(t, returnedErr)
-		assert.Equal(t, hexutil.Encode(testVals2[i]), hexutil.Encode(returnedVal))
+		s.NoError(returnedErr)
+		s.Equal(hexutil.Encode(testVals2[i]), hexutil.Encode(returnedVal))
 		// dynamodb 2 - check if not wrote key and val
 		returnedVal, returnedErr = dynamo2.Get(testKeys[i])
-		assert.Nil(t, returnedVal, "the entry should not be put in this table")
+		s.Nil(returnedVal, "the entry should not be put in this table")
 	}
 }
 

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
 //
-// You need to set AWS credentials to access to dynamoDB.
-//    sh$ export AWS_ACCESS_KEY_ID=YOUR_ACCESS_KEY
-//    sh$ export AWS_SECRET_ACCESS_KEY=YOUR_SECRET
+// For local test, please run the below.
+//    $ docker run -d -p 4566:4566 localstack/localstack:0.11.5
 
 package database
 
@@ -48,8 +47,8 @@ func enableLog() {
 	log.Root().SetHandler(glogger)
 }
 
-func testDynamoDB_Put(t *testing.T) {
-	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
+func TestDynamoDB_Put(t *testing.T) {
+	dynamo, err := newDynamoDB(GetTestDynamoConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -69,8 +68,8 @@ func testDynamoDB_Put(t *testing.T) {
 	assert.NoError(t, returnedErr)
 }
 
-func testDynamoBatch_Write(t *testing.T) {
-	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
+func TestDynamoBatch_Write(t *testing.T) {
+	dynamo, err := newDynamoDB(GetTestDynamoConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -101,8 +100,8 @@ func testDynamoBatch_Write(t *testing.T) {
 	}
 }
 
-func testDynamoBatch_WriteLargeData(t *testing.T) {
-	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
+func TestDynamoBatch_WriteLargeData(t *testing.T) {
+	dynamo, err := newDynamoDB(GetTestDynamoConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -133,8 +132,8 @@ func testDynamoBatch_WriteLargeData(t *testing.T) {
 	}
 }
 
-func testDynamoBatch_DuplicatedKey(t *testing.T) {
-	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
+func TestDynamoBatch_DuplicatedKey(t *testing.T) {
+	dynamo, err := newDynamoDB(GetTestDynamoConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -169,12 +168,12 @@ func testDynamoBatch_DuplicatedKey(t *testing.T) {
 
 // testDynamoBatch_WriteMutliTables checks if there is no error when working with more than one tables.
 // This also checks if shared workers works as expected.
-func testDynamoBatch_WriteMutliTables(t *testing.T) {
+func TestDynamoBatch_WriteMutliTables(t *testing.T) {
 	// this test might end with Crit, enableLog to find out the log
 	//enableLog()
 
 	// create DynamoDB1
-	dynamo, err := newDynamoDB(GetDefaultDynamoDBConfig())
+	dynamo, err := newDynamoDB(GetTestDynamoConfig())
 	defer dynamo.deleteDB()
 	if err != nil {
 		t.Fatal(err)
@@ -182,7 +181,7 @@ func testDynamoBatch_WriteMutliTables(t *testing.T) {
 	t.Log("dynamoDB1", dynamo.config.TableName)
 
 	// create DynamoDB2
-	dynamo2, err := newDynamoDB(GetDefaultDynamoDBConfig())
+	dynamo2, err := newDynamoDB(GetTestDynamoConfig())
 	defer dynamo2.deleteDB()
 	if err != nil {
 		t.Fatal(err)

--- a/storage/database/s3filedb_test.go
+++ b/storage/database/s3filedb_test.go
@@ -13,6 +13,9 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+//
+// For local test, please run the below.
+//    $ docker run -d -p 4566:4566 localstack/localstack:0.11.5
 
 package database
 
@@ -35,8 +38,9 @@ type SuiteS3FileDB struct {
 }
 
 func (s *SuiteS3FileDB) SetupSuite() {
-	region := "ap-northeast-2"
-	endpoint := "https://s3.ap-northeast-2.amazonaws.com"
+	// use local test configs
+	region := "us-east-1"
+	endpoint := "http://localhost:4566"
 	testBucketName := aws.String("test-bucket")
 
 	s3DB, err := newS3FileDB(region, endpoint, *testBucketName)
@@ -63,11 +67,11 @@ func (s *SuiteS3FileDB) TearDownSuite() {
 	}
 }
 
-func testSuiteS3FileDB(t *testing.T) {
+func TestSuiteS3FileDB(t *testing.T) {
 	suite.Run(t, new(SuiteS3FileDB))
 }
 
-func (s *SuiteS3FileDB) testS3FileDB() {
+func (s *SuiteS3FileDB) TestS3FileDB() {
 	testKey := common.MakeRandomBytes(32)
 	testVal := common.MakeRandomBytes(1024 * 1024)
 
@@ -97,7 +101,7 @@ func (s *SuiteS3FileDB) testS3FileDB() {
 	}
 }
 
-func (s *SuiteS3FileDB) testS3FileDB_Overwrite() {
+func (s *SuiteS3FileDB) TestS3FileDB_Overwrite() {
 	testKey := common.MakeRandomBytes(32)
 	var testVals [][]byte
 	for i := 0; i < 10; i++ {
@@ -128,7 +132,7 @@ func (s *SuiteS3FileDB) testS3FileDB_Overwrite() {
 	s.Equal(len(testVals), len(uris))
 }
 
-func (s *SuiteS3FileDB) testS3FileDB_EmptyDelete() {
+func (s *SuiteS3FileDB) TestS3FileDB_EmptyDelete() {
 	testKey := common.MakeRandomBytes(256)
 	s.NoError(s.s3DB.delete(testKey))
 	s.NoError(s.s3DB.delete(testKey))


### PR DESCRIPTION
## Proposed changes

- Enables testing with DynamoDB and S3
    - Upgrade docker image [localstack v0.11.5](https://github.com/localstack/localstack/tree/v0.11.5)
    - Apply test suites for dynamodb (Enable sequenctial and concurrent run of DynamoDB test)
    - Enhance health check logic for localstack
    - Enhance read in S3

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

The new locastack version is not set in CI. I will inform if it is done.