### PR TITLE
Enable setting various DB types on init process

### DIFF
--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -156,7 +156,7 @@ func initGenesis(ctx *cli.Context) error {
 		}
 	}
 
-	for _, name := range []string{"chaindata"} { // Remove "lightchaindata" since Klaytn doesn't use it
+	for _, name := range []string{"chaindata"} { // Removed "lightchaindata" since Klaytn doesn't use it
 		dbc := &database.DBConfig{Dir: name, DBType: dbtype, ParallelDBWrite: parallelDBWrite,
 			SingleDB: singleDB, NumStateTrieShards: numStateTrieShards,
 			LevelDBCacheSize: 0, OpenFilesLimit: 0, DynamoDBConfig: dynamoDBConfig}

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -141,10 +141,25 @@ func initGenesis(ctx *cli.Context) error {
 	singleDB := ctx.GlobalIsSet(utils.SingleDBFlag.Name)
 	numStateTrieShards := ctx.GlobalUint(utils.NumStateTrieShardsFlag.Name)
 	overwriteGenesis := ctx.GlobalBool(utils.OverwriteGenesisFlag.Name)
-	for _, name := range []string{"chaindata", "lightchaindata"} {
-		dbc := &database.DBConfig{Dir: name, DBType: database.LevelDB, ParallelDBWrite: parallelDBWrite,
+	var dynamoDBConfig *database.DynamoDBConfig
+	dbtype := database.DBType(ctx.GlobalString(utils.DbTypeFlag.Name)).ToValid()
+	if len(dbtype) == 0 {
+		logger.Crit("invalid dbtype", "dbtype", ctx.GlobalString(utils.DbTypeFlag.Name))
+	} else if dbtype == database.DynamoDB {
+		dynamoDBConfig = &database.DynamoDBConfig{
+			TableName:          ctx.GlobalString(utils.DynamoDBTableNameFlag.Name),
+			Region:             ctx.GlobalString(utils.DynamoDBRegionFlag.Name),
+			IsProvisioned:      ctx.GlobalBool(utils.DynamoDBIsProvisionedFlag.Name),
+			ReadCapacityUnits:  ctx.GlobalInt64(utils.DynamoDBReadCapacityFlag.Name),
+			WriteCapacityUnits: ctx.GlobalInt64(utils.DynamoDBWriteCapacityFlag.Name),
+			ReadOnly:           ctx.GlobalBool(utils.DynamoDBReadOnlyFlag.Name),
+		}
+	}
+
+	for _, name := range []string{"chaindata"} { // Remove "lightchaindata" since Klaytn doesn't use it
+		dbc := &database.DBConfig{Dir: name, DBType: dbtype, ParallelDBWrite: parallelDBWrite,
 			SingleDB: singleDB, NumStateTrieShards: numStateTrieShards,
-			LevelDBCacheSize: 0, OpenFilesLimit: 0}
+			LevelDBCacheSize: 0, OpenFilesLimit: 0, DynamoDBConfig: dynamoDBConfig}
 		chaindb := stack.OpenDatabase(dbc)
 		// Initialize DeriveSha implementation
 		blockchain.InitDeriveSha(genesis.Config.DeriveShaImpl)

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -373,7 +373,7 @@ func (dynamo *dynamoDB) Close() {
 	if dynamoOpenedDBNum > 0 {
 		dynamoOpenedDBNum--
 	}
-	if dynamoOpenedDBNum == 0 {
+	if dynamoOpenedDBNum == 0 && dynamoWriteCh != nil {
 		close(dynamoWriteCh)
 	}
 }


### PR DESCRIPTION
## Proposed changes

Change the followings during `init` genesis block. 
- Set `dbtype` to option value
- Don't generate "lightchaindata" database which is not used in Klaytn

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
