### PR TITLE
Skipping local tests when no kafka broker

### DIFF
--- a/datasync/chaindatafetcher/kafka/kafka_test.go
+++ b/datasync/chaindatafetcher/kafka/kafka_test.go
@@ -39,7 +39,7 @@ func (s *KafkaSuite) SetupTest() {
 	config := getDefaultKafkaConfig()
 	config.brokers = []string{"kafka:9094"}
 	kfk, err := NewKafka(config)
-	if err != nil && err == sarama.ErrOutOfBrokers {
+	if err == sarama.ErrOutOfBrokers {
 		s.T().Log("Failed connecting to brokers", config.brokers)
 		s.T().Skip()
 	}

--- a/datasync/chaindatafetcher/kafka/kafka_test.go
+++ b/datasync/chaindatafetcher/kafka/kafka_test.go
@@ -33,10 +33,16 @@ type KafkaSuite struct {
 	topic    string
 }
 
+// In order to test KafkaSuite, any available kafka broker must be connectable with "kafka:9094".
+// If no kafka broker is available, the KafkaSuite tests are skipped.
 func (s *KafkaSuite) SetupTest() {
 	config := getDefaultKafkaConfig()
 	config.brokers = []string{"kafka:9094"}
 	kfk, err := NewKafka(config)
+	if err != nil && err == sarama.ErrOutOfBrokers {
+		s.T().Log("Failed connecting to brokers", config.brokers)
+		s.T().Skip()
+	}
 	s.NoError(err)
 	s.kfk = kfk
 


### PR DESCRIPTION
## Proposed changes

- KafkaSuite fails the test cases if no kafka broker is available.
- This PR prevents local test failure if no kafka broker is available.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
