### PR TITLE
Support `admin.saveTrieNodeToDisk` API to save cache to file

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2101,8 +2101,13 @@ func (bc *BlockChain) GetNonceInCache(addr common.Address) (uint64, bool) {
 	return 0, false
 }
 
-func (bc *BlockChain) SaveTrieNodeCacheToDisk(filePath string) {
-	bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(filePath)
+func (bc *BlockChain) SaveTrieNodeCacheToDisk(filePath string) error {
+	if filePath == "" {
+		filePath = bc.db.GetDBConfig().Dir + "/fastcache"
+		logger.Warn("file path is not given, save the cache to the database dir",
+			"filePath", filePath)
+	}
+	return bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(filePath)
 }
 
 // ApplyTransaction attempts to apply a transaction to the given state database

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2101,6 +2101,10 @@ func (bc *BlockChain) GetNonceInCache(addr common.Address) (uint64, bool) {
 	return 0, false
 }
 
+func (bc *BlockChain) SaveTrieNodeCacheToDisk(filePath string) {
+	bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(filePath)
+}
+
 // ApplyTransaction attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1448,6 +1448,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 		CacheType: statedb.TrieNodeCacheType(ctx.GlobalString(TrieNodeCacheTypeFlag.
 			Name)).ToValid(),
 		LocalCacheSizeMB:   ctx.GlobalInt(TrieNodeCacheLimitFlag.Name),
+		FastCacheFileDir:   ctx.GlobalString(DataDirFlag.Name) + "/fastcache",
 		RedisEndpoints:     ctx.GlobalStringSlice(TrieNodeCacheRedisEndpointsFlag.Name),
 		RedisClusterEnable: ctx.GlobalBool(TrieNodeCacheRedisClusterFlag.Name),
 	}

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -292,8 +292,8 @@ web3._extend({
 			call: 'admin_stopStateMigration',
 		}),
 		new web3._extend.Method({
-			name: 'saveTrieNodeToDisk',
-			call: 'admin_saveTrieNodeToDisk',
+			name: 'saveTrieNodeCacheToDisk',
+			call: 'admin_saveTrieNodeCacheToDisk',
 			params: 1,
 		}),
 	],

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -291,6 +291,11 @@ web3._extend({
 			name: 'stopStateMigration',
 			call: 'admin_stopStateMigration',
 		}),
+		new web3._extend.Method({
+			name: 'saveTrieNodeToDisk',
+			call: 'admin_saveTrieNodeToDisk',
+			params: 1,
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/go-redis/redis/v7 v7.4.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/go-stack/stack v1.8.0
-	github.com/golang/mock v1.3.1-0.20190508161146-9fa652df1129
+	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.1
 	github.com/hashicorp/golang-lru v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200j
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1-0.20190508161146-9fa652df1129 h1:tT8iWCYw4uOem71yYA3htfH+LNopJvcqZQshm56G5L4=
 github.com/golang/mock v1.3.1-0.20190508161146-9fa652df1129/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
+github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -196,8 +196,8 @@ func (api *PrivateAdminAPI) StateMigrationStatus() map[string]interface{} {
 	}
 }
 
-func (api *PrivateAdminAPI) SaveTrieNodeToDisk(filePath string) {
-	api.cn.BlockChain().SaveTrieNodeCacheToDisk(filePath)
+func (api *PrivateAdminAPI) SaveTrieNodeCacheToDisk(filePath string) error {
+	return api.cn.BlockChain().SaveTrieNodeCacheToDisk(filePath)
 }
 
 // PublicDebugAPI is the collection of Klaytn full node APIs exposed

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -26,6 +26,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strings"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -36,9 +40,6 @@ import (
 	"github.com/klaytn/klaytn/ser/rlp"
 	"github.com/klaytn/klaytn/storage/statedb"
 	"github.com/klaytn/klaytn/work"
-	"io"
-	"os"
-	"strings"
 )
 
 // PublicKlayAPI provides an API to access Klaytn CN-related
@@ -193,6 +194,10 @@ func (api *PrivateAdminAPI) StateMigrationStatus() map[string]interface{} {
 		"progress":             progress,
 		"err":                  errStr,
 	}
+}
+
+func (api *PrivateAdminAPI) SaveTrieNodeToDisk(filePath string) {
+	api.cn.BlockChain().SaveTrieNodeCacheToDisk(filePath)
 }
 
 // PublicDebugAPI is the collection of Klaytn full node APIs exposed

--- a/storage/statedb/cache.go
+++ b/storage/statedb/cache.go
@@ -27,6 +27,7 @@ type TrieNodeCacheType string
 type TrieNodeCacheConfig struct {
 	CacheType          TrieNodeCacheType
 	LocalCacheSizeMB   int      // Memory allowance (MB) to use for caching trie nodes in fast cache
+	FastCacheFileDir   string   // Directory where the persistent fastcache data is stored
 	RedisEndpoints     []string // Endpoints of redis cache
 	RedisClusterEnable bool     // Enable cluster-enabled mode of redis cache
 }
@@ -37,6 +38,7 @@ type TrieNodeCache interface {
 	Get(k []byte) []byte
 	Has(k []byte) ([]byte, bool)
 	UpdateStats() interface{}
+	SaveToFile(filePath string, concurrency int) error
 }
 
 const (
@@ -82,6 +84,7 @@ func GetEmptyTrieNodeCacheConfig() TrieNodeCacheConfig {
 	return TrieNodeCacheConfig{
 		CacheType:          CacheTypeLocal,
 		LocalCacheSizeMB:   0,
+		FastCacheFileDir:   "",
 		RedisEndpoints:     nil,
 		RedisClusterEnable: false,
 	}

--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -52,8 +52,9 @@ func NewFastCache(config TrieNodeCacheConfig) TrieNodeCache {
 		return nil
 	}
 
-	logger.Info("Initialize local trie node cache (fastCache)", "MaxMB", config.LocalCacheSizeMB)
-	return &FastCache{cache: fastcache.New(config.LocalCacheSizeMB * 1024 * 1024)} // Convert MB to Byte
+	logger.Info("Initialize local trie node cache (fastCache)",
+		"MaxMB", config.LocalCacheSizeMB, "FilePath", config.FastCacheFileDir)
+	return &FastCache{cache: fastcache.LoadFromFileOrNew(config.FastCacheFileDir, config.LocalCacheSizeMB*1024*1024)} // Convert MB to Byte
 }
 
 func (l *FastCache) Get(k []byte) []byte {
@@ -85,4 +86,8 @@ func (l *FastCache) UpdateStats() interface{} {
 	memcacheFastInvalidValueHashErrors.Update(int64(stats.InvalidValueHashErrors))
 
 	return stats
+}
+
+func (l *FastCache) SaveToFile(filePath string, concurrency int) error {
+	return l.cache.SaveToFileConcurrent(filePath, concurrency)
 }

--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -52,9 +52,13 @@ func NewFastCache(config TrieNodeCacheConfig) TrieNodeCache {
 		return nil
 	}
 
+	fc := &FastCache{cache: fastcache.LoadFromFileOrNew(config.FastCacheFileDir, config.LocalCacheSizeMB*1024*1024)} // Convert MB to Byte
+	stats := fc.UpdateStats().(fastcache.Stats)
+
 	logger.Info("Initialize local trie node cache (fastCache)",
-		"MaxMB", config.LocalCacheSizeMB, "FilePath", config.FastCacheFileDir)
-	return &FastCache{cache: fastcache.LoadFromFileOrNew(config.FastCacheFileDir, config.LocalCacheSizeMB*1024*1024)} // Convert MB to Byte
+		"MaxMB", config.LocalCacheSizeMB, "FilePath", config.FastCacheFileDir,
+		"LoadedBytes", stats.BytesSize, "LoadedEntries", stats.EntriesCount)
+	return fc
 }
 
 func (l *FastCache) Get(k []byte) []byte {

--- a/storage/statedb/cache_hybrid.go
+++ b/storage/statedb/cache_hybrid.go
@@ -64,3 +64,12 @@ func (cache *hybridCache) UpdateStats() interface{} {
 
 	return stats{cache.local.UpdateStats(), cache.remote.UpdateStats()}
 }
+
+func (cache *hybridCache) SaveToFile(filePath string, concurrency int) error {
+	if err := cache.local.SaveToFile(filePath, concurrency); err != nil {
+		logger.Error("failed to save local cache to file",
+			"filePath", filePath, "concurrency", concurrency, "err", err)
+		return err
+	}
+	return nil
+}

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -13,6 +13,7 @@ func getTestHybridConfig() TrieNodeCacheConfig {
 	return TrieNodeCacheConfig{
 		CacheType:          CacheTypeHybrid,
 		LocalCacheSizeMB:   1024 * 1024,
+		FastCacheFileDir:   "",
 		RedisEndpoints:     []string{"localhost:6379"},
 		RedisClusterEnable: false,
 	}

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -116,3 +116,7 @@ func (cache *RedisCache) SubscriptionChannel(channel string) <-chan *redis.Messa
 func (cache *RedisCache) UpdateStats() interface{} {
 	return nil
 }
+
+func (cache *RedisCache) SaveToFile(filePath string, concurrency int) error {
+	return nil
+}

--- a/storage/statedb/cache_test.go
+++ b/storage/statedb/cache_test.go
@@ -17,8 +17,13 @@
 package statedb
 
 import (
+	"io/ioutil"
+	"os"
 	"reflect"
+	"runtime"
 	"testing"
+
+	"github.com/klaytn/klaytn/common"
 
 	"github.com/docker/docker/pkg/testutil/assert"
 )
@@ -43,5 +48,41 @@ func _TestNewTrieNodeCache(t *testing.T) {
 		cache, err := NewTrieNodeCache(config)
 		assert.NilError(t, err)
 		assert.Equal(t, reflect.TypeOf(cache), tc.expectedType)
+	}
+}
+
+func TestFastCache_SaveAndLoad(t *testing.T) {
+	// Create test directory
+	dirName, err := ioutil.TempDir(os.TempDir(), "fastcache_saveandload")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dirName)
+
+	// Generate test data
+	var keys [][]byte
+	var vals [][]byte
+	for i := 0; i < 10; i++ {
+		keys = append(keys, common.MakeRandomBytes(128))
+		vals = append(vals, common.MakeRandomBytes(128))
+	}
+
+	config := getTestHybridConfig()
+	config.FastCacheFileDir = dirName
+
+	// Create a fastcache from the file and save the data to the cache
+	fastCache := NewFastCache(config)
+	for idx, key := range keys {
+		assert.DeepEqual(t, fastCache.Get(key), []byte(nil))
+		fastCache.Set(key, vals[idx])
+		assert.DeepEqual(t, fastCache.Get(key), vals[idx])
+	}
+	// Save the cache to the file
+	assert.NilError(t, fastCache.SaveToFile(dirName, runtime.NumCPU()))
+
+	// Create a fastcache from the file and check if the data exists
+	fastCacheFromFile := NewFastCache(config)
+	for idx, key := range keys {
+		assert.DeepEqual(t, fastCacheFromFile.Get(key), vals[idx])
 	}
 }

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -21,8 +21,11 @@
 package statedb
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -1110,12 +1113,27 @@ func (db *Database) UpdateMetricNodes() {
 	}
 }
 
+var errDisabledTrieNodeCache = errors.New("trie node cache is disabled, nothing to save to file")
+var errNonEmptyDirectory = errors.New("target directory should be an empty directory")
+
 // SaveTrieNodeCacheToFile saves the current cached trie nodes to file to reuse when the node restarts
-func (db *Database) SaveTrieNodeCacheToFile(filePath string) {
+func (db *Database) SaveTrieNodeCacheToFile(filePath string) error {
 	if db.trieNodeCache == nil {
-		return
+		return errDisabledTrieNodeCache
 	}
-	filePath = filePath + "/trie_node_cache_backup"
+	// Save the cache only if the given directory is an empty one
+	files, err := ioutil.ReadDir(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		logger.Error("failed to read directory for saving cache to file",
+			"err", err, "filePath", filePath)
+		return err
+	}
+	if len(files) != 0 {
+		logger.Error("target directory should be an empty directory",
+			"filePath", filePath, "numFiles", len(files))
+		return errNonEmptyDirectory
+	}
+
 	start := time.Now()
 	go func() {
 		logger.Info("start saving cache to file", "filePath", filePath)
@@ -1127,4 +1145,5 @@ func (db *Database) SaveTrieNodeCacheToFile(filePath string) {
 				"filePath", filePath, "elapsed", time.Since(start))
 		}
 	}()
+	return nil
 }

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -1115,6 +1115,7 @@ func (db *Database) SaveTrieNodeCacheToFile(filePath string) {
 	if db.trieNodeCache == nil {
 		return
 	}
+	filePath = filePath + "/trie_node_cache_backup"
 	start := time.Now()
 	go func() {
 		logger.Info("start saving cache to file", "filePath", filePath)

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -29,7 +29,7 @@ var parentHash = common.HexToHash("1343A3F") // 20199999 in hexadecimal
 
 func TestDatabase_Reference(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 128, nil, false})
+	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 128, "", nil, false})
 
 	assert.Equal(t, memDB, db.DiskDB())
 	assert.Equal(t, 1, len(db.nodes)) // {} : {}
@@ -57,7 +57,7 @@ func TestDatabase_Reference(t *testing.T) {
 
 func TestDatabase_DeReference(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 128, nil, false})
+	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 128, "", nil, false})
 	assert.Equal(t, 1, len(db.nodes)) // {} : {}
 
 	db.Dereference(parentHash)
@@ -87,7 +87,7 @@ func TestDatabase_DeReference(t *testing.T) {
 
 func TestDatabase_Size(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 128, nil, false})
+	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 128, "", nil, false})
 
 	totalMemorySize, preimagesSize := db.Size()
 	assert.Equal(t, common.StorageSize(0), totalMemorySize)
@@ -112,7 +112,7 @@ func TestDatabase_Size(t *testing.T) {
 
 func TestDatabase_SecureKey(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 128, nil, false})
+	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 128, "", nil, false})
 
 	secKey1 := db.secureKey(childHash[:])
 	copiedSecKey := make([]byte, 0, len(secKey1))
@@ -126,7 +126,7 @@ func TestDatabase_SecureKey(t *testing.T) {
 
 func TestCache(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 10, nil, false})
+	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheTypeLocal, 10, "", nil, false})
 
 	for i := 0; i < 100; i++ {
 		key, value := common.MakeRandomBytes(256), common.MakeRandomBytes(63*1024) // fastcache can store entrie under 64KB

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -480,6 +480,7 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 		TrieNodeCacheConfig: statedb.TrieNodeCacheConfig{
 			CacheType:          statedb.CacheTypeLocal,
 			LocalCacheSizeMB:   4096,
+			FastCacheFileDir:   "",
 			RedisEndpoints:     nil,
 			RedisClusterEnable: false,
 		},

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -5,6 +5,10 @@
 package mocks
 
 import (
+	io "io"
+	big "math/big"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	blockchain "github.com/klaytn/klaytn/blockchain"
 	state "github.com/klaytn/klaytn/blockchain/state"
@@ -15,9 +19,6 @@ import (
 	event "github.com/klaytn/klaytn/event"
 	params "github.com/klaytn/klaytn/params"
 	rlp "github.com/klaytn/klaytn/ser/rlp"
-	io "io"
-	big "math/big"
-	reflect "reflect"
 )
 
 // MockBlockChain is a mock of BlockChain interface
@@ -633,6 +634,18 @@ func (m *MockBlockChain) Rollback(arg0 []common.Hash) {
 func (mr *MockBlockChainMockRecorder) Rollback(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockBlockChain)(nil).Rollback), arg0)
+}
+
+// SaveTrieNodeCacheToDisk mocks base method
+func (m *MockBlockChain) SaveTrieNodeCacheToDisk(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SaveTrieNodeCacheToDisk", arg0)
+}
+
+// SaveTrieNodeCacheToDisk indicates an expected call of SaveTrieNodeCacheToDisk
+func (mr *MockBlockChainMockRecorder) SaveTrieNodeCacheToDisk(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveTrieNodeCacheToDisk", reflect.TypeOf((*MockBlockChain)(nil).SaveTrieNodeCacheToDisk), arg0)
 }
 
 // SetHead mocks base method

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -637,9 +637,11 @@ func (mr *MockBlockChainMockRecorder) Rollback(arg0 interface{}) *gomock.Call {
 }
 
 // SaveTrieNodeCacheToDisk mocks base method
-func (m *MockBlockChain) SaveTrieNodeCacheToDisk(arg0 string) {
+func (m *MockBlockChain) SaveTrieNodeCacheToDisk(arg0 string) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SaveTrieNodeCacheToDisk", arg0)
+	ret := m.ctrl.Call(m, "SaveTrieNodeCacheToDisk", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // SaveTrieNodeCacheToDisk indicates an expected call of SaveTrieNodeCacheToDisk

--- a/work/work.go
+++ b/work/work.go
@@ -301,5 +301,5 @@ type BlockChain interface {
 	StopWarmUp() error
 
 	// Save trie node cache to this
-	SaveTrieNodeCacheToDisk(filePath string)
+	SaveTrieNodeCacheToDisk(filePath string) error
 }

--- a/work/work.go
+++ b/work/work.go
@@ -22,6 +22,11 @@ package work
 
 import (
 	"fmt"
+	"io"
+	"math/big"
+	"sync/atomic"
+	"time"
+
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/state"
@@ -35,10 +40,6 @@ import (
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/ser/rlp"
 	"github.com/klaytn/klaytn/storage/database"
-	"io"
-	"math/big"
-	"sync/atomic"
-	"time"
 )
 
 var logger = log.NewModuleLogger(log.Work)
@@ -298,4 +299,7 @@ type BlockChain interface {
 	// Warm up
 	StartWarmUp() error
 	StopWarmUp() error
+
+	// Save trie node cache to this
+	SaveTrieNodeCacheToDisk(filePath string)
 }


### PR DESCRIPTION
## Proposed changes

- `admin.saveTrieNodeToDisk(filePath string)` is added to support saving trie node cache to file when the node restarts
- Saving works as a background goroutine. It will leave a log if it finishes.
- Saving can be done in the arbitrary directory, however, for loading, data should be located at `fastcache` directory under `--datadir`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
