### PR TITLE
Add TrieNodeCacheConfig as a member of Database struct

### DIFF
--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -510,7 +510,7 @@ func (bc *BlockChain) StartWarmUp() error {
 			go bc.concurrentIterateTrie(child, db, resultHashCh, resultErrCh)
 		}
 
-		cacheLimitSize := uint64(mainTrieDB.GetTrieNodeLocalCacheLimit())
+		cacheLimitSize := mainTrieDB.GetTrieNodeLocalCacheByteLimit()
 		bc.warmUpLoop(mainTrieDB.TrieNodeCache(), cacheLimitSize, children, resultHashCh, resultErrCh)
 	}()
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1447,7 +1447,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 	cfg.TrieNodeCacheConfig = statedb.TrieNodeCacheConfig{
 		CacheType: statedb.TrieNodeCacheType(ctx.GlobalString(TrieNodeCacheTypeFlag.
 			Name)).ToValid(),
-		FastCacheSizeMB:    ctx.GlobalInt(TrieNodeCacheLimitFlag.Name),
+		LocalCacheSizeMB:   ctx.GlobalInt(TrieNodeCacheLimitFlag.Name),
 		RedisEndpoints:     ctx.GlobalStringSlice(TrieNodeCacheRedisEndpointsFlag.Name),
 		RedisClusterEnable: ctx.GlobalBool(TrieNodeCacheRedisClusterFlag.Name),
 	}

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -293,7 +293,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	cn.txPool.SetGasPrice(big.NewInt(0).SetUint64(governance.UnitPrice()))
 
 	// Permit the downloader to use the trie cache allowance during fast sync
-	cacheLimit := cacheConfig.TrieNodeCacheConfig.FastCacheSizeMB
+	cacheLimit := cacheConfig.TrieNodeCacheConfig.LocalCacheSizeMB
 	if cn.protocolManager, err = NewProtocolManager(cn.chainConfig, config.SyncMode, config.NetworkId, cn.eventMux, cn.txPool, cn.engine, cn.blockchain, chainDB, cacheLimit, ctx.NodeType(), config); err != nil {
 		return nil, err
 	}

--- a/storage/statedb/cache.go
+++ b/storage/statedb/cache.go
@@ -26,7 +26,7 @@ type TrieNodeCacheType string
 // TrieNodeCacheConfig contains configuration values of all TrieNodeCache.
 type TrieNodeCacheConfig struct {
 	CacheType          TrieNodeCacheType
-	FastCacheSizeMB    int      // Memory allowance (MB) to use for caching trie nodes in fast cache
+	LocalCacheSizeMB   int      // Memory allowance (MB) to use for caching trie nodes in fast cache
 	RedisEndpoints     []string // Endpoints of redis cache
 	RedisClusterEnable bool     // Enable cluster-enabled mode of redis cache
 }
@@ -81,7 +81,7 @@ func NewTrieNodeCache(config TrieNodeCacheConfig) (TrieNodeCache, error) {
 func GetEmptyTrieNodeCacheConfig() TrieNodeCacheConfig {
 	return TrieNodeCacheConfig{
 		CacheType:          CacheTypeLocal,
-		FastCacheSizeMB:    0,
+		LocalCacheSizeMB:   0,
 		RedisEndpoints:     nil,
 		RedisClusterEnable: false,
 	}

--- a/storage/statedb/cache.go
+++ b/storage/statedb/cache.go
@@ -66,9 +66,9 @@ func (cacheType TrieNodeCacheType) ToValid() TrieNodeCacheType {
 func NewTrieNodeCache(config TrieNodeCacheConfig) (TrieNodeCache, error) {
 	switch config.CacheType {
 	case CacheTypeLocal:
-		return NewFastCache(config.FastCacheSizeMB), nil
+		return NewFastCache(config), nil
 	case CacheTypeRedis:
-		return NewRedisCache(config.RedisEndpoints, config.RedisClusterEnable)
+		return NewRedisCache(config)
 	case CacheTypeHybrid:
 		logger.Info("Set hybrid trie node cache using both of localCache (fastCache) and redisCache")
 		return NewHybridCache(config)

--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -41,19 +41,19 @@ type FastCache struct {
 }
 
 // NewFastCache creates a FastCache with given cache size.
-// If you want auto-scaled cache size, set cacheSizeMB to AutoScaling.
+// If you want auto-scaled cache size, set config.FastCacheSizeMB to AutoScaling.
 // It returns nil if the cache size is zero.
-func NewFastCache(cacheSizeMB int) TrieNodeCache {
-	if cacheSizeMB == AutoScaling {
-		cacheSizeMB = getTrieNodeCacheSizeMB()
+func NewFastCache(config TrieNodeCacheConfig) TrieNodeCache {
+	if config.FastCacheSizeMB == AutoScaling {
+		config.FastCacheSizeMB = getTrieNodeCacheSizeMB()
 	}
 
-	if cacheSizeMB <= 0 {
+	if config.FastCacheSizeMB <= 0 {
 		return nil
 	}
 
-	logger.Info("Initialize local trie node cache (fastCache)", "MaxMB", cacheSizeMB)
-	return &FastCache{cache: fastcache.New(cacheSizeMB * 1024 * 1024)} // Convert MB to Byte
+	logger.Info("Initialize local trie node cache (fastCache)", "MaxMB", config.FastCacheSizeMB)
+	return &FastCache{cache: fastcache.New(config.FastCacheSizeMB * 1024 * 1024)} // Convert MB to Byte
 }
 
 func (l *FastCache) Get(k []byte) []byte {

--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -41,19 +41,19 @@ type FastCache struct {
 }
 
 // NewFastCache creates a FastCache with given cache size.
-// If you want auto-scaled cache size, set config.FastCacheSizeMB to AutoScaling.
+// If you want auto-scaled cache size, set config.LocalCacheSizeMB to AutoScaling.
 // It returns nil if the cache size is zero.
 func NewFastCache(config TrieNodeCacheConfig) TrieNodeCache {
-	if config.FastCacheSizeMB == AutoScaling {
-		config.FastCacheSizeMB = getTrieNodeCacheSizeMB()
+	if config.LocalCacheSizeMB == AutoScaling {
+		config.LocalCacheSizeMB = getTrieNodeCacheSizeMB()
 	}
 
-	if config.FastCacheSizeMB <= 0 {
+	if config.LocalCacheSizeMB <= 0 {
 		return nil
 	}
 
-	logger.Info("Initialize local trie node cache (fastCache)", "MaxMB", config.FastCacheSizeMB)
-	return &FastCache{cache: fastcache.New(config.FastCacheSizeMB * 1024 * 1024)} // Convert MB to Byte
+	logger.Info("Initialize local trie node cache (fastCache)", "MaxMB", config.LocalCacheSizeMB)
+	return &FastCache{cache: fastcache.New(config.LocalCacheSizeMB * 1024 * 1024)} // Convert MB to Byte
 }
 
 func (l *FastCache) Get(k []byte) []byte {

--- a/storage/statedb/cache_hybrid.go
+++ b/storage/statedb/cache_hybrid.go
@@ -17,13 +17,13 @@
 package statedb
 
 func NewHybridCache(config TrieNodeCacheConfig) (TrieNodeCache, error) {
-	redis, err := NewRedisCache(config.RedisEndpoints, config.RedisClusterEnable)
+	redis, err := NewRedisCache(config)
 	if err != nil {
 		return nil, err
 	}
 
 	return &hybridCache{
-		local:  NewFastCache(config.FastCacheSizeMB),
+		local:  NewFastCache(config),
 		remote: redis,
 	}, nil
 }

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -12,7 +12,7 @@ import (
 func getTestHybridConfig() TrieNodeCacheConfig {
 	return TrieNodeCacheConfig{
 		CacheType:          CacheTypeHybrid,
-		FastCacheSizeMB:    1024 * 1024,
+		LocalCacheSizeMB:   1024 * 1024,
 		RedisEndpoints:     []string{"localhost:6379"},
 		RedisClusterEnable: false,
 	}

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -45,8 +45,8 @@ func _TestHybridCache_Set(t *testing.T) {
 // TestHybridCache_Get tests whether a hybrid cache can get an item from both of local and remote caches.
 func _TestHybridCache_Get(t *testing.T) {
 	// Prepare caches to be integrated with a hybrid cache
-	localCache := NewFastCache(getTestHybridConfig().FastCacheSizeMB)
-	remoteCache, err := NewRedisCache(getTestHybridConfig().RedisEndpoints, getTestHybridConfig().RedisClusterEnable)
+	localCache := NewFastCache(getTestHybridConfig())
+	remoteCache, err := NewRedisCache(getTestHybridConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,8 +94,8 @@ func _TestHybridCache_Get(t *testing.T) {
 // TestHybridCache_Has tests whether a hybrid cache can check an item from both of local and remote caches.
 func _TestHybridCache_Has(t *testing.T) {
 	// Prepare caches to be integrated with a hybrid cache
-	localCache := NewFastCache(getTestHybridConfig().FastCacheSizeMB)
-	remoteCache, err := NewRedisCache(getTestHybridConfig().RedisEndpoints, getTestHybridConfig().RedisClusterEnable)
+	localCache := NewFastCache(getTestHybridConfig())
+	remoteCache, err := NewRedisCache(getTestHybridConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -64,15 +64,16 @@ func newRedisClient(endpoints []string, isCluster bool) (redis.UniversalClient, 
 	}), nil
 }
 
-func NewRedisCache(endpoints []string, isCluster bool) (*RedisCache, error) {
-	cli, err := newRedisClient(endpoints, isCluster)
+func NewRedisCache(config TrieNodeCacheConfig) (*RedisCache, error) {
+	cli, err := newRedisClient(config.RedisEndpoints, config.RedisClusterEnable)
 	if err != nil {
-		logger.Error("failed to create a redis client", "err", err, "endpoint", endpoints,
-			"isCluster", isCluster)
+		logger.Error("failed to create a redis client", "err", err, "endpoint", config.RedisEndpoints,
+			"isCluster", config.RedisClusterEnable)
 		return nil, err
 	}
 
-	logger.Info("Initialize trie node cache with redis", "endpoint", endpoints, "isCluster", isCluster)
+	logger.Info("Initialize trie node cache with redis", "endpoint", config.RedisEndpoints,
+		"isCluster", config.RedisClusterEnable)
 	return &RedisCache{client: cli}, nil
 }
 

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -28,7 +28,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testHosts = []string{"localhost:6379"}
+func getTestRedisConfig() TrieNodeCacheConfig {
+	return TrieNodeCacheConfig{
+		CacheType:          CacheTypeRedis,
+		FastCacheSizeMB:    1024 * 1024,
+		RedisEndpoints:     []string{"localhost:6379"},
+		RedisClusterEnable: false,
+	}
+}
 
 // TODO-Klaytn: Enable tests when redis is prepared on CI
 
@@ -41,7 +48,7 @@ func _TestSubscription(t *testing.T) {
 	wg.Add(1)
 
 	go func() {
-		cache, err := NewRedisCache(testHosts, false)
+		cache, err := NewRedisCache(getTestRedisConfig())
 		assert.Nil(t, err)
 
 		ch := cache.SubscriptionChannel(channelName)
@@ -56,7 +63,7 @@ func _TestSubscription(t *testing.T) {
 	}()
 	time.Sleep(100 * time.Millisecond)
 
-	cache, err := NewRedisCache(testHosts, false)
+	cache, err := NewRedisCache(getTestRedisConfig())
 	assert.Nil(t, err)
 
 	if err := cache.Publish(channelName, msg1); err != nil {
@@ -78,7 +85,7 @@ func _TestSubscription(t *testing.T) {
 
 // TestNewRedisCache tests basic operations of redis cache
 func _TestNewRedisCache(t *testing.T) {
-	cache, err := NewRedisCache(testHosts, false)
+	cache, err := NewRedisCache(getTestRedisConfig())
 	assert.Nil(t, err)
 
 	key, value := randBytes(32), randBytes(500)
@@ -94,7 +101,7 @@ func _TestNewRedisCache(t *testing.T) {
 
 // TestNewRedisCache_Set_LargeData check whether redis cache can store an large data (5MB).
 func _TestNewRedisCache_Set_LargeData(t *testing.T) {
-	cache, err := NewRedisCache(testHosts, false)
+	cache, err := NewRedisCache(getTestRedisConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -31,7 +31,7 @@ import (
 func getTestRedisConfig() TrieNodeCacheConfig {
 	return TrieNodeCacheConfig{
 		CacheType:          CacheTypeRedis,
-		FastCacheSizeMB:    1024 * 1024,
+		LocalCacheSizeMB:   1024 * 1024,
 		RedisEndpoints:     []string{"localhost:6379"},
 		RedisClusterEnable: false,
 	}

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -111,8 +111,8 @@ type Database struct {
 
 	lock sync.RWMutex
 
-	trieNodeCache           TrieNodeCache // GC friendly memory cache of trie node RLPs
-	trieNodeLocalCacheLimit int           // byte size of local trieNodeCache
+	trieNodeCache       TrieNodeCache       // GC friendly memory cache of trie node RLPs
+	trieNodeCacheConfig TrieNodeCacheConfig // Configuration of trieNodeCache
 }
 
 // rawNode is a simple binary blob used to differentiate between collapsed trie
@@ -311,11 +311,11 @@ func NewDatabaseWithNewCache(diskDB database.DBManager, cacheConfig TrieNodeCach
 	}
 
 	return &Database{
-		diskDB:                  diskDB,
-		nodes:                   map[common.Hash]*cachedNode{{}: {}},
-		preimages:               make(map[common.Hash][]byte),
-		trieNodeCache:           trieNodeCache,
-		trieNodeLocalCacheLimit: cacheConfig.FastCacheSizeMB,
+		diskDB:              diskDB,
+		nodes:               map[common.Hash]*cachedNode{{}: {}},
+		preimages:           make(map[common.Hash][]byte),
+		trieNodeCache:       trieNodeCache,
+		trieNodeCacheConfig: cacheConfig,
 	}
 }
 
@@ -358,9 +358,14 @@ func (db *Database) TrieNodeCache() TrieNodeCache {
 	return db.trieNodeCache
 }
 
-// GetTrieNodeLocalCacheLimit returns the byte size of trie node cache.
-func (db *Database) GetTrieNodeLocalCacheLimit() int {
-	return db.trieNodeLocalCacheLimit
+// GetTrieNodeCacheConfig returns the configuration of TrieNodeCache
+func (db *Database) GetTrieNodeCacheConfig() TrieNodeCacheConfig {
+	return db.trieNodeCacheConfig
+}
+
+// GetTrieNodeLocalCacheByteLimit returns the byte size of trie node cache.
+func (db *Database) GetTrieNodeLocalCacheByteLimit() uint64 {
+	return uint64(db.trieNodeCacheConfig.FastCacheSizeMB) * 1024 * 1024
 }
 
 // RLockGCCachedNode locks the GC lock of CachedNode.

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -358,14 +358,14 @@ func (db *Database) TrieNodeCache() TrieNodeCache {
 	return db.trieNodeCache
 }
 
-// GetTrieNodeCacheConfig returns the configuration of TrieNodeCache
+// GetTrieNodeCacheConfig returns the configuration of TrieNodeCache.
 func (db *Database) GetTrieNodeCacheConfig() TrieNodeCacheConfig {
 	return db.trieNodeCacheConfig
 }
 
 // GetTrieNodeLocalCacheByteLimit returns the byte size of trie node cache.
 func (db *Database) GetTrieNodeLocalCacheByteLimit() uint64 {
-	return uint64(db.trieNodeCacheConfig.FastCacheSizeMB) * 1024 * 1024
+	return uint64(db.trieNodeCacheConfig.LocalCacheSizeMB) * 1024 * 1024
 }
 
 // RLockGCCachedNode locks the GC lock of CachedNode.

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -479,7 +479,7 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 		TriesInMemory:    blockchain.DefaultTriesInMemory,
 		TrieNodeCacheConfig: statedb.TrieNodeCacheConfig{
 			CacheType:          statedb.CacheTypeLocal,
-			FastCacheSizeMB:    4096,
+			LocalCacheSizeMB:   4096,
 			RedisEndpoints:     nil,
 			RedisClusterEnable: false,
 		},


### PR DESCRIPTION
## Proposed changes

`TrieNodeCacheConfig` is added as a member of Database struct. The value will be used later when `Blockchain` publishes/subscribes blocks through redis cache. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

