### PR TITLE
fdlimit, rpc: update fdlimit related codes

### DIFF
--- a/common/fdlimit/fdlimit_test.go
+++ b/common/fdlimit/fdlimit_test.go
@@ -24,7 +24,7 @@ import (
 // TestFileDescriptorLimits simply tests whether the file descriptor allowance
 // per this process can be retrieved.
 func TestFileDescriptorLimits(t *testing.T) {
-	target := 4096
+	target := 20000
 	hardlimit, err := Maximum()
 	if err != nil {
 		t.Fatal(err)

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -58,7 +58,7 @@ const (
 // pendingRequestCount is a total number of concurrent RPC method calls
 var pendingRequestCount int64 = 0
 
-// checkAndRaiseFDLimit checks the filed descriptor limit and
+// checkAndRaiseFDLimit checks the file descriptor limit and
 // increases the file descriptor limit if the process has a small limit
 func checkAndRaiseFDLimit() {
 	limit, err := fdlimit.Current()

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -23,13 +23,14 @@ package rpc
 import (
 	"context"
 	"fmt"
-	"github.com/klaytn/klaytn/common/fdlimit"
-	"gopkg.in/fatih/set.v0"
 	"reflect"
 	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/klaytn/klaytn/common/fdlimit"
+	"gopkg.in/fatih/set.v0"
 )
 
 const MetadataApi = "rpc"
@@ -57,21 +58,44 @@ const (
 // pendingRequestCount is a total number of concurrent RPC method calls
 var pendingRequestCount int64 = 0
 
-// NewServer will create a new server instance with no registered handlers.
-func NewServer() *Server {
-	// increase the file descriptor limit if the process has a small limit
+// checkAndRaiseFDLimit checks the filed descriptor limit and
+// increases the file descriptor limit if the process has a small limit
+func checkAndRaiseFDLimit() {
 	limit, err := fdlimit.Current()
 	if err != nil {
-		logger.Warn("fail to read fd limit. you may suffer fd exhaustion", "err", err)
-	} else {
-		if limit < minFDLimit {
-			err := fdlimit.Raise(uint64(limit + minFDLimit))
-			if err != nil {
-				logger.Warn("fail to increase fd limit. you may suffer fd exhaustion", "err", err)
-			}
-			logger.Warn("Increase the file descriptor limit of the process for RPC servers", "oldLimit", limit, "newLimit", limit+minFDLimit)
-		}
+		logger.Error("fail to read fd limit. you may suffer fd exhaustion", "err", err)
+		return
 	}
+	// if it has enough file descriptor limit, do nothing
+	if limit >= minFDLimit {
+		return
+	}
+	// try increasing file descriptor limit
+	targetLimit := limit + minFDLimit
+	if err := fdlimit.Raise(uint64(targetLimit)); err != nil {
+		logger.Error("fail to increase fd limit. you may suffer fd exhaustion", "err", err)
+		return
+	}
+	// check if new fd limit is applied
+	newLimit, err := fdlimit.Current()
+	if err != nil {
+		logger.Error("fail to read fd limit after increasing fd limit, current limit may not be accurate",
+			"err", err, "oldLimit", limit, "newLimit", limit+minFDLimit)
+		return
+	}
+	// if the retrieved limit does not match the expected one, leave an error log
+	if newLimit != targetLimit {
+		logger.Error("Tried increasing the file descriptor limit of the process for RPC servers, but it didn't work",
+			"oldLimit", limit, "targetLimit", targetLimit, "actualLimit", newLimit)
+	} else {
+		logger.Warn("Increase the file descriptor limit of the process for RPC servers",
+			"oldLimit", limit, "newLimit", newLimit)
+	}
+}
+
+// NewServer will create a new server instance with no registered handlers.
+func NewServer() *Server {
+	checkAndRaiseFDLimit()
 
 	server := &Server{
 		services: make(serviceRegistry),

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -73,7 +73,7 @@ func checkAndRaiseFDLimit() {
 	// try increasing file descriptor limit
 	targetLimit := limit + minFDLimit
 	if err := fdlimit.Raise(uint64(targetLimit)); err != nil {
-		logger.Error("fail to increase fd limit. you may suffer fd exhaustion", "err", err)
+		logger.Warn("fail to increase fd limit. you may suffer fd exhaustion", "err", err)
 		return
 	}
 	// check if new fd limit is applied
@@ -85,7 +85,7 @@ func checkAndRaiseFDLimit() {
 	}
 	// if the retrieved limit does not match the expected one, leave an error log
 	if newLimit != targetLimit {
-		logger.Error("Tried increasing the file descriptor limit of the process for RPC servers, but it didn't work",
+		logger.Warn("Tried increasing the file descriptor limit of the process for RPC servers, but it didn't work",
 			"oldLimit", limit, "targetLimit", targetLimit, "actualLimit", newLimit)
 	} else {
 		logger.Warn("Increase the file descriptor limit of the process for RPC servers",


### PR DESCRIPTION
## Proposed changes

- Added an independent function to check and raise file descriptor limit 
- It will leave an error log if the retrieved file descriptor limit does not match the expected one
- Target value of `TestFileDescriptorLimits` is raised from 4,000 to 20,000

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
