### PR TITLE
work, blockchain, cn: simplify saveTrieNodeCacheToDisk

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2221,12 +2221,8 @@ func (bc *BlockChain) GetNonceInCache(addr common.Address) (uint64, bool) {
 	return 0, false
 }
 
-func (bc *BlockChain) SaveTrieNodeCacheToDisk(filePath string) error {
-	if filePath == "" {
-		filePath = bc.db.GetDBConfig().Dir + "/fastcache"
-		logger.Warn("file path is not given, save the cache to the database dir",
-			"filePath", filePath)
-	}
+func (bc *BlockChain) SaveTrieNodeCacheToDisk() error {
+	filePath := bc.db.GetDBConfig().Dir + "/fastcache"
 	return bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(filePath)
 }
 

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -294,7 +294,6 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'saveTrieNodeCacheToDisk',
 			call: 'admin_saveTrieNodeCacheToDisk',
-			params: 1,
 		}),
 	],
 	properties: [

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -196,8 +196,8 @@ func (api *PrivateAdminAPI) StateMigrationStatus() map[string]interface{} {
 	}
 }
 
-func (api *PrivateAdminAPI) SaveTrieNodeCacheToDisk(filePath string) error {
-	return api.cn.BlockChain().SaveTrieNodeCacheToDisk(filePath)
+func (api *PrivateAdminAPI) SaveTrieNodeCacheToDisk() error {
+	return api.cn.BlockChain().SaveTrieNodeCacheToDisk()
 }
 
 // PublicDebugAPI is the collection of Klaytn full node APIs exposed

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -661,17 +661,17 @@ func (mr *MockBlockChainMockRecorder) Rollback(arg0 interface{}) *gomock.Call {
 }
 
 // SaveTrieNodeCacheToDisk mocks base method
-func (m *MockBlockChain) SaveTrieNodeCacheToDisk(arg0 string) error {
+func (m *MockBlockChain) SaveTrieNodeCacheToDisk() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveTrieNodeCacheToDisk", arg0)
+	ret := m.ctrl.Call(m, "SaveTrieNodeCacheToDisk")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveTrieNodeCacheToDisk indicates an expected call of SaveTrieNodeCacheToDisk
-func (mr *MockBlockChainMockRecorder) SaveTrieNodeCacheToDisk(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockChainMockRecorder) SaveTrieNodeCacheToDisk() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveTrieNodeCacheToDisk", reflect.TypeOf((*MockBlockChain)(nil).SaveTrieNodeCacheToDisk), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveTrieNodeCacheToDisk", reflect.TypeOf((*MockBlockChain)(nil).SaveTrieNodeCacheToDisk))
 }
 
 // SetHead mocks base method

--- a/work/work.go
+++ b/work/work.go
@@ -301,7 +301,7 @@ type BlockChain interface {
 	StopWarmUp() error
 
 	// Save trie node cache to this
-	SaveTrieNodeCacheToDisk(filePath string) error
+	SaveTrieNodeCacheToDisk() error
 
 	// KES
 	BlockSubscriptionLoop(pool *blockchain.TxPool)


### PR DESCRIPTION
## Proposed changes

- Simplified `admin_saveTrieNodeCacheToDisk`, by not receiving `filePath` as its parameter
- Cache will be stored to and loaded from `--datadir + "/fastcache"` 
- If the command is triggered, previous cache data will be deleted

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
