### PR TITLE
Refine State trie migration 

### DIFF
--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -203,6 +203,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 	}
 
 	stats.stateMigrationReport(true, trieSync.Pending(), trieSync.CalcProgressPercentage())
+	bc.readCnt, bc.committedCnt, bc.pendingCnt, bc.progress = stats.totalRead, stats.totalCommitted, trieSync.Pending(), stats.progress
 
 	// Clear memory of trieSync
 	trieSync = nil

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -638,6 +638,7 @@ func (dbm *databaseManager) CreateMigrationDBAndSetStatus(blockNum uint64) error
 	// Create a new database for migration process.
 	newDB, newDBDir := newStateTrieMigrationDB(dbm.config, blockNum)
 
+	// lock to prevent from a conflict of reading state DB and changing state DB
 	dbm.lockInMigration.Lock()
 	defer dbm.lockInMigration.Unlock()
 

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dgraph-io/badger"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -656,7 +657,7 @@ func (dbm *databaseManager) CreateMigrationDBAndSetStatus(blockNum uint64) error
 // FinishStateMigration updates stateTrieDB and removes the old one.
 // The function should be called only after when state trie migration is finished.
 func (dbm *databaseManager) FinishStateMigration(succeed bool) {
-	// lock to prevent from a conflict of state DB reading and state DB changing
+	// lock to prevent from a conflict of reading state DB and changing state DB
 	dbm.lockInMigration.Lock()
 
 	dbRemoved := StateTrieDB

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -656,6 +656,7 @@ func (dbm *databaseManager) CreateMigrationDBAndSetStatus(blockNum uint64) error
 // FinishStateMigration updates stateTrieDB and removes the old one.
 // The function should be called only after when state trie migration is finished.
 func (dbm *databaseManager) FinishStateMigration(succeed bool) {
+	// lock to prevent from a conflict of state DB reading and state DB changing
 	dbm.lockInMigration.Lock()
 
 	dbRemoved := StateTrieDB

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/dgraph-io/badger"
 	"github.com/klaytn/klaytn/blockchain/types"

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -639,6 +639,7 @@ func (dbm *databaseManager) CreateMigrationDBAndSetStatus(blockNum uint64) error
 	newDB, newDBDir := newStateTrieMigrationDB(dbm.config, blockNum)
 
 	dbm.lockInMigration.Lock()
+	defer dbm.lockInMigration.Unlock()
 
 	// Store migration db path in misc db
 	dbm.setDBDir(StateTrieMigrationDB, newDBDir)
@@ -648,7 +649,6 @@ func (dbm *databaseManager) CreateMigrationDBAndSetStatus(blockNum uint64) error
 
 	// Store the migration status
 	dbm.setStateTrieMigrationStatus(blockNum)
-	dbm.lockInMigration.Unlock()
 
 	return nil
 }
@@ -658,6 +658,7 @@ func (dbm *databaseManager) CreateMigrationDBAndSetStatus(blockNum uint64) error
 func (dbm *databaseManager) FinishStateMigration(succeed bool) {
 	// lock to prevent from a conflict of reading state DB and changing state DB
 	dbm.lockInMigration.Lock()
+	defer dbm.lockInMigration.Unlock()
 
 	dbRemoved := StateTrieDB
 	dbUsed := StateTrieMigrationDB
@@ -682,8 +683,6 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool) {
 
 	dbPathToBeRemoved := filepath.Join(dbm.config.Dir, dbDirToBeRemoved)
 	dbToBeRemoved.Close()
-
-	dbm.lockInMigration.Unlock()
 
 	go removeDB(dbPathToBeRemoved)
 }

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -686,7 +686,7 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool) {
 
 	dbm.lockInMigration.Unlock()
 
-	removeDB(dbPathToBeRemoved)
+	go removeDB(dbPathToBeRemoved)
 }
 
 func removeDB(dbPath string) {

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -30,6 +30,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 var dbManagers []DBManager
@@ -845,7 +846,9 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 			assert.True(t, dirNames[0] == NewMigrationPath || dirNames[1] == NewMigrationPath)
 
 			// check if old db is deleted on migration success
-			dbm.FinishStateMigration(true) // migration success
+			dbm.FinishStateMigration(true)     // migration success
+			time.Sleep(100 * time.Millisecond) // wait for removing DB
+
 			newDirNames := getFilesInDir(t, dbm.GetDBConfig().Dir, "statetrie")
 			assert.Equal(t, 1, len(newDirNames))
 			assert.Equal(t, NewMigrationPath, newDirNames[0], "new DB should remain")
@@ -869,7 +872,9 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 			assert.True(t, dirNames[0] == NewMigrationPath || dirNames[1] == NewMigrationPath)
 
 			// check if new db is deleted on migration fail
-			dbm.FinishStateMigration(false) // migration fail
+			dbm.FinishStateMigration(false)    // migration fail
+			time.Sleep(100 * time.Millisecond) // wait for removing DB
+
 			newDirNames := getFilesInDir(t, dbm.GetDBConfig().Dir, dbm.getDBDir(StateTrieDB))
 			assert.Equal(t, 1, len(newDirNames))
 			assert.Equal(t, initialDirNames[0], newDirNames[0], "old DB should remain")


### PR DESCRIPTION
## Proposed changes

This PR improves state trie migration like below.
- fix a minor bug that `admin_stateMigrationStatus()` shows not 100% progress after state migration.
- expand the lock scope to prevent a conflict of reading/change state db.
- apply concurrent removing database to reduce the delay for big database

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
