### PR TITLE
Implmeneted data split for kafka message

### DIFF
--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -143,7 +143,7 @@ var FlagGroups = []FlagGroup{
 			ChainDataFetcherKafkaReplicasFlag,
 			ChainDataFetcherKafkaPartitionsFlag,
 			ChainDataFetcherKafkaMaxMessageBytesFlag,
-			ChainDataFetcherKafkaSegmentSizeFlag,
+			ChainDataFetcherKafkaSegmentSizeBytesFlag,
 			ChainDataFetcherKafkaRequiredAcksFlag,
 		},
 	},

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -143,6 +143,7 @@ var FlagGroups = []FlagGroup{
 			ChainDataFetcherKafkaReplicasFlag,
 			ChainDataFetcherKafkaPartitionsFlag,
 			ChainDataFetcherKafkaMaxMessageBytesFlag,
+			ChainDataFetcherKafkaSegmentSizeFlag,
 			ChainDataFetcherKafkaRequiredAcksFlag,
 		},
 	},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -786,6 +786,11 @@ var (
 		Usage: "The max size of a message produced by Kafka producer ",
 		Value: kafka.DefaultMaxMessageBytes,
 	}
+	ChainDataFetcherKafkaSegmentSizeFlag = cli.IntFlag{
+		Name:  "chaindatafetcher.kafka.segment.size",
+		Usage: "The kafka data segment size",
+		Value: kafka.DefaultSegmentSize,
+	}
 	ChainDataFetcherKafkaRequiredAcksFlag = cli.IntFlag{
 		Name:  "chaindatafetcher.kafka.required.acks",
 		Usage: "The level of acknowledgement reliability needed from Kafka broker (0: NoResponse, 1: WaitForLocal, -1: WaitForAll)",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -786,10 +786,10 @@ var (
 		Usage: "The max size of a message produced by Kafka producer ",
 		Value: kafka.DefaultMaxMessageBytes,
 	}
-	ChainDataFetcherKafkaSegmentSizeFlag = cli.IntFlag{
+	ChainDataFetcherKafkaSegmentSizeBytesFlag = cli.IntFlag{
 		Name:  "chaindatafetcher.kafka.segment.size",
-		Usage: "The kafka data segment size",
-		Value: kafka.DefaultSegmentSize,
+		Usage: "The kafka data segment size (in byte)",
+		Value: kafka.DefaultSegmentSizeBytes,
 	}
 	ChainDataFetcherKafkaRequiredAcksFlag = cli.IntFlag{
 		Name:  "chaindatafetcher.kafka.required.acks",

--- a/cmd/utils/nodecmd/dumpconfigcmd.go
+++ b/cmd/utils/nodecmd/dumpconfigcmd.go
@@ -228,6 +228,7 @@ func makeKafkaConfig(ctx *cli.Context) *kafka.KafkaConfig {
 	kafkaConfig.Partitions = int32(ctx.GlobalInt64(utils.ChainDataFetcherKafkaPartitionsFlag.Name))
 	kafkaConfig.Replicas = int16(ctx.GlobalInt64(utils.ChainDataFetcherKafkaReplicasFlag.Name))
 	kafkaConfig.SaramaConfig.Producer.MaxMessageBytes = ctx.GlobalInt(utils.ChainDataFetcherKafkaMaxMessageBytesFlag.Name)
+	kafkaConfig.SegmentSize = ctx.GlobalInt(utils.ChainDataFetcherKafkaSegmentSizeFlag.Name)
 	requiredAcks := sarama.RequiredAcks(ctx.GlobalInt(utils.ChainDataFetcherKafkaRequiredAcksFlag.Name))
 	if requiredAcks != sarama.NoResponse && requiredAcks != sarama.WaitForLocal && requiredAcks != sarama.WaitForAll {
 		logger.Crit("not supported requiredAcks. it must be NoResponse(0), WaitForLocal(1), or WaitForAll(-1)", "given", requiredAcks)

--- a/cmd/utils/nodecmd/dumpconfigcmd.go
+++ b/cmd/utils/nodecmd/dumpconfigcmd.go
@@ -228,7 +228,7 @@ func makeKafkaConfig(ctx *cli.Context) *kafka.KafkaConfig {
 	kafkaConfig.Partitions = int32(ctx.GlobalInt64(utils.ChainDataFetcherKafkaPartitionsFlag.Name))
 	kafkaConfig.Replicas = int16(ctx.GlobalInt64(utils.ChainDataFetcherKafkaReplicasFlag.Name))
 	kafkaConfig.SaramaConfig.Producer.MaxMessageBytes = ctx.GlobalInt(utils.ChainDataFetcherKafkaMaxMessageBytesFlag.Name)
-	kafkaConfig.SegmentSize = ctx.GlobalInt(utils.ChainDataFetcherKafkaSegmentSizeFlag.Name)
+	kafkaConfig.SegmentSizeBytes = ctx.GlobalInt(utils.ChainDataFetcherKafkaSegmentSizeBytesFlag.Name)
 	requiredAcks := sarama.RequiredAcks(ctx.GlobalInt(utils.ChainDataFetcherKafkaRequiredAcksFlag.Name))
 	if requiredAcks != sarama.NoResponse && requiredAcks != sarama.WaitForLocal && requiredAcks != sarama.WaitForAll {
 		logger.Crit("not supported requiredAcks. it must be NoResponse(0), WaitForLocal(1), or WaitForAll(-1)", "given", requiredAcks)

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -175,7 +175,7 @@ var KENFlags = []cli.Flag{
 	utils.ChainDataFetcherKafkaTopicResourceFlag,
 	utils.ChainDataFetcherKafkaTopicEnvironmentFlag,
 	utils.ChainDataFetcherKafkaMaxMessageBytesFlag,
-	utils.ChainDataFetcherKafkaSegmentSizeFlag,
+	utils.ChainDataFetcherKafkaSegmentSizeBytesFlag,
 	utils.ChainDataFetcherKafkaRequiredAcksFlag,
 	// DBSyncer
 	utils.EnableDBSyncerFlag,

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -175,6 +175,7 @@ var KENFlags = []cli.Flag{
 	utils.ChainDataFetcherKafkaTopicResourceFlag,
 	utils.ChainDataFetcherKafkaTopicEnvironmentFlag,
 	utils.ChainDataFetcherKafkaMaxMessageBytesFlag,
+	utils.ChainDataFetcherKafkaSegmentSizeFlag,
 	utils.ChainDataFetcherKafkaRequiredAcksFlag,
 	// DBSyncer
 	utils.EnableDBSyncerFlag,

--- a/datasync/chaindatafetcher/kafka/config.go
+++ b/datasync/chaindatafetcher/kafka/config.go
@@ -40,7 +40,7 @@ const (
 	DefaultTopicResourceName    = "en-0"
 	DefaultMaxMessageBytes      = 1000000
 	DefaultRequiredAcks         = 1
-	DefaultSegmentSize          = 1000000 // 1 MB
+	DefaultSegmentSizeBytes     = 1000000 // 1 MB
 )
 
 type KafkaConfig struct {
@@ -50,7 +50,7 @@ type KafkaConfig struct {
 	TopicResourceName    string
 	Partitions           int32 // Partitions is the number of partitions of a topic.
 	Replicas             int16 // Replicas is a replication factor of kafka settings. This is the number of the replicated partitions in the kafka cluster.
-	SegmentSize          int   // SegmentSize is the size of kafka message segment
+	SegmentSizeBytes     int   // SegmentSizeBytes is the size of kafka message segment
 }
 
 func GetDefaultKafkaConfig() *KafkaConfig {
@@ -68,7 +68,7 @@ func GetDefaultKafkaConfig() *KafkaConfig {
 		TopicResourceName:    DefaultTopicResourceName,
 		Partitions:           DefaultPartitions,
 		Replicas:             DefaultReplicas,
-		SegmentSize:          DefaultSegmentSize,
+		SegmentSizeBytes:     DefaultSegmentSizeBytes,
 	}
 }
 
@@ -78,5 +78,5 @@ func (c *KafkaConfig) getTopicName(event string) string {
 
 func (c *KafkaConfig) String() string {
 	return fmt.Sprintf("brokers: %v, topicEnvironment: %v, topicResourceName: %v, partitions: %v, replicas: %v, maxMessageBytes: %v, requiredAcks: %v, segmentSize: %v",
-		c.Brokers, c.TopicEnvironmentName, c.TopicResourceName, c.Partitions, c.Replicas, c.SaramaConfig.Producer.MaxMessageBytes, c.SaramaConfig.Producer.RequiredAcks, c.SegmentSize)
+		c.Brokers, c.TopicEnvironmentName, c.TopicResourceName, c.Partitions, c.Replicas, c.SaramaConfig.Producer.MaxMessageBytes, c.SaramaConfig.Producer.RequiredAcks, c.SegmentSizeBytes)
 }

--- a/datasync/chaindatafetcher/kafka/config.go
+++ b/datasync/chaindatafetcher/kafka/config.go
@@ -40,6 +40,7 @@ const (
 	DefaultTopicResourceName    = "en-0"
 	DefaultMaxMessageBytes      = 1000000
 	DefaultRequiredAcks         = 1
+	DefaultSegmentSize          = 1000000 // 1 MB
 )
 
 type KafkaConfig struct {
@@ -49,6 +50,7 @@ type KafkaConfig struct {
 	TopicResourceName    string
 	Partitions           int32 // Partitions is the number of partitions of a topic.
 	Replicas             int16 // Replicas is a replication factor of kafka settings. This is the number of the replicated partitions in the kafka cluster.
+	SegmentSize          int   // SegmentSize is the size of kafka message segment
 }
 
 func GetDefaultKafkaConfig() *KafkaConfig {
@@ -66,6 +68,7 @@ func GetDefaultKafkaConfig() *KafkaConfig {
 		TopicResourceName:    DefaultTopicResourceName,
 		Partitions:           DefaultPartitions,
 		Replicas:             DefaultReplicas,
+		SegmentSize:          DefaultSegmentSize,
 	}
 }
 
@@ -74,6 +77,6 @@ func (c *KafkaConfig) getTopicName(event string) string {
 }
 
 func (c *KafkaConfig) String() string {
-	return fmt.Sprintf("brokers: %v, topicEnvironment: %v, topicResourceName: %v, partitions: %v, replicas: %v, maxMessageBytes: %v, requiredAcks: %v",
-		c.Brokers, c.TopicEnvironmentName, c.TopicResourceName, c.Partitions, c.Replicas, c.SaramaConfig.Producer.MaxMessageBytes, c.SaramaConfig.Producer.RequiredAcks)
+	return fmt.Sprintf("brokers: %v, topicEnvironment: %v, topicResourceName: %v, partitions: %v, replicas: %v, maxMessageBytes: %v, requiredAcks: %v, segmentSize: %v",
+		c.Brokers, c.TopicEnvironmentName, c.TopicResourceName, c.Partitions, c.Replicas, c.SaramaConfig.Producer.MaxMessageBytes, c.SaramaConfig.Producer.RequiredAcks, c.SegmentSize)
 }

--- a/datasync/chaindatafetcher/kafka/kafka.go
+++ b/datasync/chaindatafetcher/kafka/kafka.go
@@ -17,7 +17,6 @@
 package kafka
 
 import (
-	"crypto/md5"
 	"encoding/json"
 
 	"github.com/Shopify/sarama"
@@ -30,13 +29,11 @@ var logger = log.NewModuleLogger(log.ChainDataFetcher)
 const (
 	MsgIdxTotalSegments = iota
 	MsgIdxSegmentIdx
-	MsgIdxCheckSum
 )
 
 const (
 	KeyTotalSegments = "totalSegments"
 	KeySegmentIdx    = "segmentIdx"
-	KeyCheckSum      = "checksum"
 )
 
 // Kafka connects to the brokers in an existing kafka cluster.
@@ -102,7 +99,6 @@ func (k *Kafka) split(data []byte) ([][]byte, int) {
 }
 
 func (k *Kafka) makeProducerMessage(topic string, segment []byte, segmentIdx, totalSegments uint64) *sarama.ProducerMessage {
-	checkSum := md5.Sum(segment)
 	return &sarama.ProducerMessage{
 		Topic: topic,
 		Headers: []sarama.RecordHeader{
@@ -113,10 +109,6 @@ func (k *Kafka) makeProducerMessage(topic string, segment []byte, segmentIdx, to
 			{
 				Key:   []byte(KeySegmentIdx),
 				Value: common.Int64ToByteBigEndian(segmentIdx),
-			},
-			{
-				Key:   []byte(KeyCheckSum),
-				Value: checkSum[:],
 			},
 		},
 		Value: sarama.ByteEncoder(segment),

--- a/datasync/chaindatafetcher/kafka/kafka.go
+++ b/datasync/chaindatafetcher/kafka/kafka.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 
 	"github.com/Shopify/sarama"
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/log"
 )
 
@@ -107,11 +108,11 @@ func (k *Kafka) makeProducerMessage(topic string, segment []byte, segmentIdx, to
 		Headers: []sarama.RecordHeader{
 			{
 				Key:   []byte(KeyTotalSegments),
-				Value: intToBytes(totalSegments),
+				Value: common.Int64ToByteBigEndian(totalSegments),
 			},
 			{
 				Key:   []byte(KeySegmentIdx),
-				Value: intToBytes(segmentIdx),
+				Value: common.Int64ToByteBigEndian(segmentIdx),
 			},
 			{
 				Key:   []byte(KeyCheckSum),

--- a/datasync/chaindatafetcher/kafka/kafka_test.go
+++ b/datasync/chaindatafetcher/kafka/kafka_test.go
@@ -19,6 +19,7 @@ package kafka
 import (
 	"context"
 	"crypto/md5"
+	"encoding/binary"
 	"encoding/json"
 	"math/rand"
 	"reflect"
@@ -93,8 +94,8 @@ func (s *KafkaSuite) TestKafka_makeProducerMessage() {
 
 	s.Equal(s.topic, msg.Topic)
 	s.Equal(sarama.ByteEncoder(data), msg.Value)
-	s.Equal(totalSegments, bytesToInt(msg.Headers[MsgIdxTotalSegments].Value))
-	s.Equal(idx, bytesToInt(msg.Headers[MsgIdxSegmentIdx].Value))
+	s.Equal(totalSegments, binary.BigEndian.Uint64(msg.Headers[MsgIdxTotalSegments].Value))
+	s.Equal(idx, binary.BigEndian.Uint64(msg.Headers[MsgIdxSegmentIdx].Value))
 	s.Equal(checksum[:], msg.Headers[MsgIdxCheckSum].Value)
 }
 
@@ -317,8 +318,8 @@ func (s *KafkaSuite) TestKafka_PubSubWithSegments() {
 	var actual []byte
 	for idx, msg := range msgs {
 		actual = append(actual, msg.Value...)
-		s.Equal(uint64(totalSegments), bytesToInt(msg.Headers[MsgIdxTotalSegments].Value))
-		s.Equal(uint64(idx), bytesToInt(msg.Headers[MsgIdxSegmentIdx].Value))
+		s.Equal(uint64(totalSegments), binary.BigEndian.Uint64(msg.Headers[MsgIdxTotalSegments].Value))
+		s.Equal(uint64(idx), binary.BigEndian.Uint64(msg.Headers[MsgIdxSegmentIdx].Value))
 		checksum := md5.Sum(msg.Value)
 		s.Equal(checksum[:], msg.Headers[MsgIdxCheckSum].Value)
 		s.Equal(topic, msg.Topic)

--- a/datasync/chaindatafetcher/kafka/kafka_test.go
+++ b/datasync/chaindatafetcher/kafka/kafka_test.go
@@ -18,7 +18,6 @@ package kafka
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/binary"
 	"encoding/json"
 	"math/rand"
@@ -90,7 +89,6 @@ func (s *KafkaSuite) TestKafka_split() {
 func (s *KafkaSuite) TestKafka_makeProducerMessage() {
 	// make test data
 	data := common.MakeRandomBytes(100)
-	checksum := md5.Sum(data)
 	rand.Seed(time.Now().UnixNano())
 	totalSegments := rand.Uint64()
 	idx := rand.Uint64() % totalSegments
@@ -103,7 +101,6 @@ func (s *KafkaSuite) TestKafka_makeProducerMessage() {
 	s.Equal(sarama.ByteEncoder(data), msg.Value)
 	s.Equal(totalSegments, binary.BigEndian.Uint64(msg.Headers[MsgIdxTotalSegments].Value))
 	s.Equal(idx, binary.BigEndian.Uint64(msg.Headers[MsgIdxSegmentIdx].Value))
-	s.Equal(checksum[:], msg.Headers[MsgIdxCheckSum].Value)
 }
 
 func (s *KafkaSuite) TestKafka_CreateAndDeleteTopic() {
@@ -329,8 +326,6 @@ func (s *KafkaSuite) TestKafka_PubSubWithSegments() {
 		actual = append(actual, msg.Value...)
 		s.Equal(uint64(totalSegments), binary.BigEndian.Uint64(msg.Headers[MsgIdxTotalSegments].Value))
 		s.Equal(uint64(idx), binary.BigEndian.Uint64(msg.Headers[MsgIdxSegmentIdx].Value))
-		checksum := md5.Sum(msg.Value)
-		s.Equal(checksum[:], msg.Headers[MsgIdxCheckSum].Value)
 		s.Equal(topic, msg.Topic)
 	}
 

--- a/datasync/chaindatafetcher/kafka/kafka_test.go
+++ b/datasync/chaindatafetcher/kafka/kafka_test.go
@@ -63,27 +63,27 @@ func (s *KafkaSuite) TearDownTest() {
 }
 
 func (s *KafkaSuite) TestKafka_split() {
-	segmentSize := 3
-	s.kfk.config.SegmentSize = segmentSize
+	segmentSizeBytes := 3
+	s.kfk.config.SegmentSizeBytes = segmentSizeBytes
 
 	// test with the size less than the segment size
-	bytes := common.MakeRandomBytes(segmentSize - 1)
+	bytes := common.MakeRandomBytes(segmentSizeBytes - 1)
 	parts, size := s.kfk.split(bytes)
 	s.Equal(bytes, parts[0])
 	s.Equal(1, size)
 
 	// test with the given segment size
-	bytes = common.MakeRandomBytes(segmentSize)
+	bytes = common.MakeRandomBytes(segmentSizeBytes)
 	parts, size = s.kfk.split(bytes)
 	s.Equal(bytes, parts[0])
 	s.Equal(1, size)
 
 	// test with the size greater than the segment size
-	bytes = common.MakeRandomBytes(2*segmentSize + 2)
+	bytes = common.MakeRandomBytes(2*segmentSizeBytes + 2)
 	parts, size = s.kfk.split(bytes)
-	s.Equal(bytes[:segmentSize], parts[0])
-	s.Equal(bytes[segmentSize:2*segmentSize], parts[1])
-	s.Equal(bytes[2*segmentSize:], parts[2])
+	s.Equal(bytes[:segmentSizeBytes], parts[0])
+	s.Equal(bytes[segmentSizeBytes:2*segmentSizeBytes], parts[1])
+	s.Equal(bytes[2*segmentSizeBytes:], parts[2])
 	s.Equal(3, size)
 }
 
@@ -308,7 +308,7 @@ func (s *KafkaSuite) TestKafka_PubSubWithSegments() {
 	data, _ := json.Marshal(&kafkaData{common.MakeRandomBytes(testBytesSize)})
 	totalSegments := len(data) / segmentSize
 
-	s.kfk.config.SegmentSize = segmentSize
+	s.kfk.config.SegmentSizeBytes = segmentSize
 	topic := "test-message-segments"
 	s.kfk.CreateTopic(topic)
 

--- a/datasync/chaindatafetcher/kafka/utils.go
+++ b/datasync/chaindatafetcher/kafka/utils.go
@@ -17,6 +17,7 @@
 package kafka
 
 import (
+	"encoding/binary"
 	"strings"
 
 	klaytnApi "github.com/klaytn/klaytn/api"
@@ -95,4 +96,14 @@ func makeBlockGroupOutput(blockchain *blockchain.BlockChain, block *types.Block,
 	r["proposer"] = proposer
 	r["transactions"] = rpcTransactions
 	return r
+}
+
+func intToBytes(num uint64) []byte {
+	buffer := make([]byte, 8)
+	binary.BigEndian.PutUint64(buffer, num)
+	return buffer
+}
+
+func bytesToInt(bytes []byte) uint64 {
+	return binary.BigEndian.Uint64(bytes)
 }

--- a/datasync/chaindatafetcher/kafka/utils.go
+++ b/datasync/chaindatafetcher/kafka/utils.go
@@ -17,7 +17,6 @@
 package kafka
 
 import (
-	"encoding/binary"
 	"strings"
 
 	klaytnApi "github.com/klaytn/klaytn/api"
@@ -96,14 +95,4 @@ func makeBlockGroupOutput(blockchain *blockchain.BlockChain, block *types.Block,
 	r["proposer"] = proposer
 	r["transactions"] = rpcTransactions
 	return r
-}
-
-func intToBytes(num uint64) []byte {
-	buffer := make([]byte, 8)
-	binary.BigEndian.PutUint64(buffer, num)
-	return buffer
-}
-
-func bytesToInt(bytes []byte) uint64 {
-	return binary.BigEndian.Uint64(bytes)
 }


### PR DESCRIPTION
## Proposed changes

- Data split is implemented to publish Kafka message
- Key is not implemented for deciding which partition the message is sent to
- Header includes:
  - checksum for the data consistency
  - the number of total segments for a message
  - segment index

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

