### PR TITLE
blockchain: added SetCanonicalBlock to change starting block number

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -268,7 +268,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 }
 
 // SetCanonicalBlock resets the canonical as the block with the given block number.
-// It works as rewinding the head block the the previous one, but does not delete the data.
+// It works as rewinding the head block to the previous one, but does not delete the data.
 func (bc *BlockChain) SetCanonicalBlock(blockNum uint64) {
 	// If the given block number is zero (it is zero by default), it does nothing
 	if blockNum == 0 {

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -48,6 +48,7 @@ var FlagGroups = []FlagGroup{
 			ExtraDataFlag,
 			ConfigFileFlag,
 			OverwriteGenesisFlag,
+			StartBlockNumberFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -135,6 +135,10 @@ var (
 		Name:  "overwrite-genesis",
 		Usage: "Overwrites genesis block with the given new genesis block for testing purpose",
 	}
+	StartBlockNumberFlag = cli.Uint64Flag{
+		Name:  "start-block-num",
+		Usage: "Starts the node from the given block number. Starting from 0 is not supported.",
+	}
 	// Transaction pool settings
 	TxPoolNoLocalsFlag = cli.BoolFlag{
 		Name:  "txpool.nolocals",
@@ -1409,6 +1413,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 	}
 
 	cfg.OverwriteGenesis = ctx.GlobalBool(OverwriteGenesisFlag.Name)
+	cfg.StartBlockNumber = ctx.GlobalUint64(StartBlockNumberFlag.Name)
 
 	cfg.LevelDBCompression = database.LevelDBCompressionType(ctx.GlobalInt(LevelDBCompressionTypeFlag.Name))
 	cfg.LevelDBBufferPool = !ctx.GlobalIsSet(LevelDBNoBufferPoolFlag.Name)

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -36,6 +36,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.DbTypeFlag,
 	utils.DataDirFlag,
 	utils.OverwriteGenesisFlag,
+	utils.StartBlockNumberFlag,
 	utils.KeyStoreDirFlag,
 	utils.TxPoolNoLocalsFlag,
 	utils.TxPoolAllowLocalAnchorTxFlag,

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -258,6 +258,8 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	if err != nil {
 		return nil, err
 	}
+	bc.SetCanonicalBlock(config.StartBlockNumber)
+
 	cn.blockchain = bc
 	governance.SetBlockchain(cn.blockchain)
 	// Synchronize proposerpolicy & useGiniCoeff

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -101,6 +101,7 @@ type Config struct {
 	//LightPeers int `toml:",omitempty"` // Maximum number of LES client peers
 
 	OverwriteGenesis bool
+	StartBlockNumber uint64
 
 	// Database options
 	DBType               database.DBType


### PR DESCRIPTION
## Proposed changes

- This feature has been added to debug slow blocks in the Cypress network.
- If `--start-block-num` is given, the node will rewind to the given block number when the node starts.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
