### PR TITLE
Write governance items during init process

### DIFF
--- a/blockchain/vm/runtime/runtime_test.go
+++ b/blockchain/vm/runtime/runtime_test.go
@@ -21,11 +21,11 @@
 package runtime
 
 import (
-	"github.com/klaytn/klaytn/governance"
-	"github.com/klaytn/klaytn/params"
 	"math/big"
 	"strings"
 	"testing"
+
+	"github.com/klaytn/klaytn/params"
 
 	"github.com/klaytn/klaytn/accounts/abi"
 	"github.com/klaytn/klaytn/blockchain/state"
@@ -168,7 +168,7 @@ func benchmarkEVM_Create(bench *testing.B, code string) {
 		Time:        new(big.Int).SetUint64(0),
 		Coinbase:    common.Address{},
 		BlockNumber: new(big.Int).SetUint64(1),
-		ChainConfig: &params.ChainConfig{Istanbul: governance.GetDefaultIstanbulConfig(), Governance: governance.GetDefaultGovernanceConfig(params.UseIstanbul)},
+		ChainConfig: &params.ChainConfig{Istanbul: params.GetDefaultIstanbulConfig(), Governance: params.GetDefaultGovernanceConfig(params.UseIstanbul)},
 		EVMConfig:   vm.Config{},
 	}
 	// Warm up the intpools and stuff

--- a/blockchain/vm/runtime/runtime_test.go
+++ b/blockchain/vm/runtime/runtime_test.go
@@ -25,12 +25,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/klaytn/klaytn/params"
-
 	"github.com/klaytn/klaytn/accounts/abi"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
 )
 

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -90,7 +90,7 @@ func initGenesis(ctx *cli.Context) error {
 	}
 
 	if genesis.Config == nil {
-		logger.Crit("Invalid genesis config")
+		logger.Crit("Genesis config is not set")
 	}
 
 	// Update undefined config with default values and validate config

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -178,6 +178,11 @@ func ValidateGenesisConfig(g *blockchain.Genesis) error {
 		return errors.New("governance and reward policies should be configured")
 	}
 
+	if g.Config.Governance.Reward.ProposerUpdateInterval == 0 || g.Config.Governance.Reward.
+		StakingUpdateInterval == 0 {
+		return errors.New("proposerUpdateInterval and stakingUpdateInterval cannot be zero")
+	}
+
 	if g.Config.GetConsensusEngine() == params.UseIstanbul {
 		if err := governance.CheckGenesisValues(g.Config); err != nil {
 			return err

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -243,12 +243,12 @@ func checkGenesisAndFillDefaultIfNeeded(genesis *blockchain.Genesis) *blockchain
 	if genesis.Config.Istanbul == nil && genesis.Config.Clique != nil {
 		engine = params.UseClique
 		if genesis.Config.Governance == nil {
-			genesis.Config.Governance = governance.GetDefaultGovernanceConfig(engine)
+			genesis.Config.Governance = params.GetDefaultGovernanceConfig(engine)
 		}
 		valueChanged = true
 	} else if genesis.Config.Istanbul == nil && genesis.Config.Clique == nil {
 		engine = params.UseIstanbul
-		genesis.Config.Istanbul = governance.GetDefaultIstanbulConfig()
+		genesis.Config.Istanbul = params.GetDefaultIstanbulConfig()
 		valueChanged = true
 	} else if genesis.Config.Istanbul != nil && genesis.Config.Clique != nil {
 		// Error case. Both istanbul and Clique exists
@@ -257,7 +257,7 @@ func checkGenesisAndFillDefaultIfNeeded(genesis *blockchain.Genesis) *blockchain
 
 	// If we don't have governance config
 	if genesis.Config.Governance == nil {
-		genesis.Config.Governance = governance.GetDefaultGovernanceConfig(engine)
+		genesis.Config.Governance = params.GetDefaultGovernanceConfig(engine)
 		valueChanged = true
 	}
 

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -24,7 +24,13 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/hashicorp/golang-lru"
+	"math/big"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/istanbul"
@@ -36,11 +42,6 @@ import (
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/storage/database"
-	"math/big"
-	"sort"
-	"strings"
-	"testing"
-	"time"
 )
 
 var (
@@ -683,8 +684,8 @@ func getTestVotingPowers(num int) []uint64 {
 
 func getTestConfig() *params.ChainConfig {
 	config := params.TestChainConfig
-	config.Governance = governance.GetDefaultGovernanceConfig(params.UseIstanbul)
-	config.Istanbul = governance.GetDefaultIstanbulConfig()
+	config.Governance = params.GetDefaultGovernanceConfig(params.UseIstanbul)
+	config.Istanbul = params.GetDefaultIstanbulConfig()
 	return config
 }
 

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -691,7 +691,7 @@ func getTestConfig() *params.ChainConfig {
 
 func getGovernance(dbm database.DBManager) *governance.Governance {
 	config := getTestConfig()
-	return governance.NewGovernance(config, dbm)
+	return governance.NewGovernanceInitialize(config, dbm)
 }
 
 func Benchmark_getTargetReceivers(b *testing.B) {

--- a/governance/default.go
+++ b/governance/default.go
@@ -20,6 +20,12 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math/big"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/log"
@@ -27,11 +33,6 @@ import (
 	"github.com/klaytn/klaytn/ser/rlp"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/pkg/errors"
-	"math/big"
-	"reflect"
-	"strings"
-	"sync"
-	"sync/atomic"
 )
 
 var (
@@ -548,42 +549,6 @@ func (gov *Governance) updateChangeSet(vote GovernanceVote) bool {
 		logger.Warn("Unknown key was given", "key", vote.Key)
 	}
 	return false
-}
-
-func GetDefaultGovernanceConfig(engine params.EngineType) *params.GovernanceConfig {
-	gov := &params.GovernanceConfig{
-		GovernanceMode: params.DefaultGovernanceMode,
-		GoverningNode:  common.HexToAddress(params.DefaultGoverningNode),
-		Reward:         GetDefaultRewardConfig(),
-	}
-	return gov
-}
-
-func GetDefaultIstanbulConfig() *params.IstanbulConfig {
-	return &params.IstanbulConfig{
-		Epoch:          params.DefaultEpoch,
-		ProposerPolicy: params.DefaultProposerPolicy,
-		SubGroupSize:   params.DefaultSubGroupSize,
-	}
-}
-
-func GetDefaultRewardConfig() *params.RewardConfig {
-	return &params.RewardConfig{
-		MintingAmount:          big.NewInt(params.DefaultMintingAmount),
-		Ratio:                  params.DefaultRatio,
-		UseGiniCoeff:           params.DefaultUseGiniCoeff,
-		DeferredTxFee:          params.DefaultDefferedTxFee,
-		StakingUpdateInterval:  uint64(86400),
-		ProposerUpdateInterval: uint64(3600),
-		MinimumStake:           big.NewInt(2000000),
-	}
-}
-
-func GetDefaultCliqueConfig() *params.CliqueConfig {
-	return &params.CliqueConfig{
-		Epoch:  params.DefaultEpoch,
-		Period: params.DefaultPeriod,
-	}
 }
 
 func CheckGenesisValues(c *params.ChainConfig) error {

--- a/governance/default.go
+++ b/governance/default.go
@@ -416,6 +416,8 @@ func NewGovernance(chainConfig *params.ChainConfig, dbm database.DBManager) *Gov
 	}
 }
 
+// NewGovernanceInitialize creates Governance with the given configuration and read governance state from DB.
+// It also write governance items of the genesis block to DB if any items are stored in DB.
 func NewGovernanceInitialize(chainConfig *params.ChainConfig, dbm database.DBManager) *Governance {
 	ret := Governance{
 		ChainConfig:              chainConfig,

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -120,8 +120,8 @@ var goodVotes = []voteValue{
 
 func getTestConfig() *params.ChainConfig {
 	config := params.TestChainConfig
-	config.Governance = GetDefaultGovernanceConfig(params.UseIstanbul)
-	config.Istanbul = GetDefaultIstanbulConfig()
+	config.Governance = params.GetDefaultGovernanceConfig(params.UseIstanbul)
+	config.Istanbul = params.GetDefaultIstanbulConfig()
 	return config
 }
 
@@ -132,7 +132,7 @@ func getGovernance() *Governance {
 }
 
 func TestGetDefaultGovernanceConfig(t *testing.T) {
-	tstGovernance := GetDefaultGovernanceConfig(params.UseIstanbul)
+	tstGovernance := params.GetDefaultGovernanceConfig(params.UseIstanbul)
 
 	want := []interface{}{
 		params.DefaultUseGiniCoeff,

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -128,7 +128,7 @@ func getTestConfig() *params.ChainConfig {
 func getGovernance() *Governance {
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
 	config := getTestConfig()
-	return NewGovernance(config, dbm)
+	return NewGovernanceInitialize(config, dbm)
 }
 
 func TestGetDefaultGovernanceConfig(t *testing.T) {
@@ -684,7 +684,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	config := getTestConfig()
 	config.Governance.GovernanceMode = GovernanceModeBallot
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
-	gov := NewGovernance(config, dbm)
+	gov := NewGovernanceInitialize(config, dbm)
 	gov.nodeAddress.Store(council[len(council)-1])
 
 	votes := make([]GovernanceVote, 0)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -216,7 +216,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	config.GasPrice = new(big.Int).SetUint64(chainConfig.UnitPrice)
 
 	logger.Info("Initialised chain configuration", "config", chainConfig)
-	governance := governance.NewGovernance(chainConfig, chainDB)
+	governance := governance.NewGovernanceInitialize(chainConfig, chainDB)
 
 	cn := &CN{
 		config:            config,

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -430,7 +430,7 @@ func CreateDB(ctx *node.ServiceContext, config *Config, name string) database.DB
 func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig *params.ChainConfig, db database.DBManager, gov *governance.Governance, nodetype common.ConnType) consensus.Engine {
 	// Only istanbul  BFT is allowed in the main net. PoA is supported by service chain
 	if chainConfig.Governance == nil {
-		chainConfig.Governance = governance.GetDefaultGovernanceConfig(params.UseIstanbul)
+		chainConfig.Governance = params.GetDefaultGovernanceConfig(params.UseIstanbul)
 	}
 	return istanbulBackend.New(config.Rewardbase, &config.Istanbul, ctx.NodeKey(), db, gov, nodetype)
 }

--- a/node/sc/mainbridge_test.go
+++ b/node/sc/mainbridge_test.go
@@ -75,7 +75,7 @@ func testBlockChain(t *testing.T) *blockchain.BlockChain {
 			ProposerPolicy: uint64(istanbul.DefaultConfig.ProposerPolicy),
 			SubGroupSize:   istanbul.DefaultConfig.SubGroupSize,
 		},
-		Governance: governance.GetDefaultGovernanceConfig(params.UseIstanbul),
+		Governance: params.GetDefaultGovernanceConfig(params.UseIstanbul),
 	}, db)
 
 	prvKey, _ := crypto.GenerateKey()
@@ -84,8 +84,8 @@ func testBlockChain(t *testing.T) *blockchain.BlockChain {
 	var genesis *blockchain.Genesis
 	genesis = blockchain.DefaultGenesisBlock()
 	genesis.BlockScore = big.NewInt(1)
-	genesis.Config.Governance = governance.GetDefaultGovernanceConfig(params.UseIstanbul)
-	genesis.Config.Istanbul = governance.GetDefaultIstanbulConfig()
+	genesis.Config.Governance = params.GetDefaultGovernanceConfig(params.UseIstanbul)
+	genesis.Config.Istanbul = params.GetDefaultIstanbulConfig()
 	genesis.Config.UnitPrice = 25 * params.Ston
 
 	chainConfig, _, err := blockchain.SetupGenesisBlock(db, genesis, params.UnusedNetworkId, false, false)

--- a/node/sc/mainbridge_test.go
+++ b/node/sc/mainbridge_test.go
@@ -66,7 +66,7 @@ func testBlockChain(t *testing.T) *blockchain.BlockChain {
 	db := database.NewMemoryDBManager()
 	defer db.Close()
 
-	gov := governance.NewGovernance(&params.ChainConfig{
+	gov := governance.NewGovernanceInitialize(&params.ChainConfig{
 		ChainID:       big.NewInt(2018),
 		UnitPrice:     25000000000,
 		DeriveShaImpl: 0,

--- a/params/config.go
+++ b/params/config.go
@@ -22,8 +22,9 @@ package params
 
 import (
 	"fmt"
-	"github.com/klaytn/klaytn/common"
 	"math/big"
+
+	"github.com/klaytn/klaytn/common"
 )
 
 // Genesis hashes to enforce below configs on.
@@ -337,4 +338,40 @@ func (c *IstanbulConfig) Copy() *IstanbulConfig {
 	newIC.ProposerPolicy = c.ProposerPolicy
 
 	return newIC
+}
+
+func GetDefaultGovernanceConfig(engine EngineType) *GovernanceConfig {
+	gov := &GovernanceConfig{
+		GovernanceMode: DefaultGovernanceMode,
+		GoverningNode:  common.HexToAddress(DefaultGoverningNode),
+		Reward:         GetDefaultRewardConfig(),
+	}
+	return gov
+}
+
+func GetDefaultIstanbulConfig() *IstanbulConfig {
+	return &IstanbulConfig{
+		Epoch:          DefaultEpoch,
+		ProposerPolicy: DefaultProposerPolicy,
+		SubGroupSize:   DefaultSubGroupSize,
+	}
+}
+
+func GetDefaultRewardConfig() *RewardConfig {
+	return &RewardConfig{
+		MintingAmount:          big.NewInt(DefaultMintingAmount),
+		Ratio:                  DefaultRatio,
+		UseGiniCoeff:           DefaultUseGiniCoeff,
+		DeferredTxFee:          DefaultDefferedTxFee,
+		StakingUpdateInterval:  uint64(86400),
+		ProposerUpdateInterval: uint64(3600),
+		MinimumStake:           big.NewInt(2000000),
+	}
+}
+
+func GetDefaultCliqueConfig() *CliqueConfig {
+	return &CliqueConfig{
+		Epoch:  DefaultEpoch,
+		Period: DefaultPeriod,
+	}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -247,16 +247,14 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 // GetConsensusEngine returns the consensus engine type specified in ChainConfig.
 // It returns Unknown type if none of engine type is configured or more than one type is configured.
 func (c *ChainConfig) GetConsensusEngine() EngineType {
-	if c.Clique != nil {
-		if c.Istanbul != nil {
-			return Unknown
-		}
+	switch {
+	case c.Clique != nil && c.Istanbul == nil:
 		return UseClique
-	}
-	if c.Istanbul != nil {
+	case c.Clique == nil && c.Istanbul != nil:
 		return UseIstanbul
+	default:
+		return Unknown
 	}
-	return Unknown
 }
 
 // Enhance updates consensus and governance related configs to the default values when they are not configured.
@@ -385,6 +383,7 @@ func (c *IstanbulConfig) Copy() *IstanbulConfig {
 	return newIC
 }
 
+// TODO-Klaytn-Governance: Remove input parameter if not needed anymore
 func GetDefaultGovernanceConfig(engine EngineType) *GovernanceConfig {
 	gov := &GovernanceConfig{
 		GovernanceMode: DefaultGovernanceMode,

--- a/params/config.go
+++ b/params/config.go
@@ -20,7 +20,6 @@
 
 package params
 
-import "C"
 import (
 	"fmt"
 	"math/big"

--- a/params/governance_params.go
+++ b/params/governance_params.go
@@ -66,6 +66,7 @@ const (
 	// Engine type
 	UseIstanbul EngineType = iota
 	UseClique
+	Unknown
 )
 
 const (

--- a/tests/klay_test_blockchain_test.go
+++ b/tests/klay_test_blockchain_test.go
@@ -419,8 +419,8 @@ func initBlockChain(db database.DBManager, cacheConfig *blockchain.CacheConfig, 
 		genesis.Config = Forks["Byzantium"]
 		genesis.ExtraData = extraData
 		genesis.BlockScore = big.NewInt(1)
-		genesis.Config.Governance = governance.GetDefaultGovernanceConfig(params.UseIstanbul)
-		genesis.Config.Istanbul = governance.GetDefaultIstanbulConfig()
+		genesis.Config.Governance = params.GetDefaultGovernanceConfig(params.UseIstanbul)
+		genesis.Config.Istanbul = params.GetDefaultIstanbulConfig()
 		genesis.Config.UnitPrice = 25 * params.Ston
 	}
 

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -491,7 +491,7 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 func generateGovernaceDataForTest() *governance.Governance {
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
 
-	return governance.NewGovernance(&params.ChainConfig{
+	return governance.NewGovernanceInitialize(&params.ChainConfig{
 		ChainID:       big.NewInt(2018),
 		UnitPrice:     25000000000,
 		DeriveShaImpl: 0,

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -500,7 +500,7 @@ func generateGovernaceDataForTest() *governance.Governance {
 			ProposerPolicy: uint64(istanbul.DefaultConfig.ProposerPolicy),
 			SubGroupSize:   istanbul.DefaultConfig.SubGroupSize,
 		},
-		Governance: governance.GetDefaultGovernanceConfig(params.UseIstanbul),
+		Governance: params.GetDefaultGovernanceConfig(params.UseIstanbul),
 	}, dbm)
 }
 


### PR DESCRIPTION
## Proposed changes

Currently, governance items of the genesis block are stored when the node started.
This change makes the items to be stored during the init process. 
Also, some governance-related code is refactored. 

- `37b4e1d`: Move default config getters to params package
- `a6cd64a`: Refactor initGenesis
- `75f274a`: Write governance items during init process


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
