### PR TITLE
database: collect database performance metrics by default

### DIFF
--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -93,6 +93,7 @@ var FlagGroups = []FlagGroup{
 			DynamoDBWriteCapacityFlag,
 			NoParallelDBWriteFlag,
 			SenderTxHashIndexingFlag,
+			DBNoPerformanceMetricsFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -262,6 +262,10 @@ var (
 		Name:  "db.no-parallel-write",
 		Usage: "Disables parallel writes of block data to persistent database",
 	}
+	DBNoPerformanceMetricsFlag = cli.BoolFlag{
+		Name:  "db.no-perf-metrics",
+		Usage: "Disables performance metrics of database's read and write operations",
+	}
 	TrieMemoryCacheSizeFlag = cli.IntFlag{
 		Name:  "state.cache-size",
 		Usage: "Size of in-memory cache of the global state (in MiB) to flush matured singleton trie nodes to disk",
@@ -1417,6 +1421,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 
 	cfg.LevelDBCompression = database.LevelDBCompressionType(ctx.GlobalInt(LevelDBCompressionTypeFlag.Name))
 	cfg.LevelDBBufferPool = !ctx.GlobalIsSet(LevelDBNoBufferPoolFlag.Name)
+	cfg.EnableDBPerfMetrics = !ctx.GlobalIsSet(DBNoPerformanceMetricsFlag.Name)
 	cfg.LevelDBCacheSize = ctx.GlobalInt(LevelDBCacheSizeFlag.Name)
 
 	cfg.DynamoDBConfig.TableName = ctx.GlobalString(DynamoDBTableNameFlag.Name)

--- a/cmd/utils/nodecmd/migrationcmd.go
+++ b/cmd/utils/nodecmd/migrationcmd.go
@@ -120,8 +120,9 @@ func createDBConfigForMigration(ctx *cli.Context) (*database.DBConfig, *database
 		NumStateTrieShards: ctx.GlobalUint(utils.NumStateTrieShardsFlag.Name),
 		OpenFilesLimit:     database.GetOpenFilesLimit(),
 
-		LevelDBCacheSize:   ctx.GlobalInt(utils.LevelDBCacheSizeFlag.Name),
-		LevelDBCompression: database.LevelDBCompressionType(ctx.GlobalInt(utils.LevelDBCompressionTypeFlag.Name)),
+		LevelDBCacheSize:    ctx.GlobalInt(utils.LevelDBCacheSizeFlag.Name),
+		LevelDBCompression:  database.LevelDBCompressionType(ctx.GlobalInt(utils.LevelDBCompressionTypeFlag.Name)),
+		EnableDBPerfMetrics: !ctx.IsSet(utils.DBNoPerformanceMetricsFlag.Name),
 
 		DynamoDBConfig: &database.DynamoDBConfig{
 			TableName:          ctx.GlobalString(utils.DynamoDBTableNameFlag.Name),
@@ -129,6 +130,7 @@ func createDBConfigForMigration(ctx *cli.Context) (*database.DBConfig, *database
 			IsProvisioned:      ctx.GlobalBool(utils.DynamoDBIsProvisionedFlag.Name),
 			ReadCapacityUnits:  ctx.GlobalInt64(utils.DynamoDBReadCapacityFlag.Name),
 			WriteCapacityUnits: ctx.GlobalInt64(utils.DynamoDBWriteCapacityFlag.Name),
+			PerfCheck:          !ctx.IsSet(utils.DBNoPerformanceMetricsFlag.Name),
 		},
 	}
 	if len(srcDBC.DBType) == 0 { // changed to invalid type
@@ -143,8 +145,9 @@ func createDBConfigForMigration(ctx *cli.Context) (*database.DBConfig, *database
 		NumStateTrieShards: ctx.GlobalUint(utils.DstNumStateTrieShardsFlag.Name),
 		OpenFilesLimit:     database.GetOpenFilesLimit(),
 
-		LevelDBCacheSize:   ctx.GlobalInt(utils.DstLevelDBCacheSizeFlag.Name),
-		LevelDBCompression: database.LevelDBCompressionType(ctx.GlobalInt(utils.DstLevelDBCompressionTypeFlag.Name)),
+		LevelDBCacheSize:    ctx.GlobalInt(utils.DstLevelDBCacheSizeFlag.Name),
+		LevelDBCompression:  database.LevelDBCompressionType(ctx.GlobalInt(utils.DstLevelDBCompressionTypeFlag.Name)),
+		EnableDBPerfMetrics: !ctx.IsSet(utils.DBNoPerformanceMetricsFlag.Name),
 
 		DynamoDBConfig: &database.DynamoDBConfig{
 			TableName:          ctx.GlobalString(utils.DstDynamoDBTableNameFlag.Name),
@@ -152,6 +155,7 @@ func createDBConfigForMigration(ctx *cli.Context) (*database.DBConfig, *database
 			IsProvisioned:      ctx.GlobalBool(utils.DstDynamoDBIsProvisionedFlag.Name),
 			ReadCapacityUnits:  ctx.GlobalInt64(utils.DstDynamoDBReadCapacityFlag.Name),
 			WriteCapacityUnits: ctx.GlobalInt64(utils.DstDynamoDBWriteCapacityFlag.Name),
+			PerfCheck:          !ctx.IsSet(utils.DBNoPerformanceMetricsFlag.Name),
 		},
 	}
 	if len(dstDBC.DBType) == 0 { // changed to invalid type

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -58,6 +58,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.NumStateTrieShardsFlag,
 	utils.LevelDBCompressionTypeFlag,
 	utils.LevelDBNoBufferPoolFlag,
+	utils.DBNoPerformanceMetricsFlag,
 	utils.DynamoDBTableNameFlag,
 	utils.DynamoDBRegionFlag,
 	utils.DynamoDBIsProvisionedFlag,

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -424,7 +424,7 @@ func makeExtraData(extra []byte) []byte {
 func CreateDB(ctx *node.ServiceContext, config *Config, name string) database.DBManager {
 	dbc := &database.DBConfig{Dir: name, DBType: config.DBType, ParallelDBWrite: config.ParallelDBWrite, SingleDB: config.SingleDB, NumStateTrieShards: config.NumStateTrieShards,
 		LevelDBCacheSize: config.LevelDBCacheSize, OpenFilesLimit: database.GetOpenFilesLimit(), LevelDBCompression: config.LevelDBCompression,
-		LevelDBBufferPool: config.LevelDBBufferPool, DynamoDBConfig: &config.DynamoDBConfig}
+		LevelDBBufferPool: config.LevelDBBufferPool, EnableDBPerfMetrics: config.EnableDBPerfMetrics, DynamoDBConfig: &config.DynamoDBConfig}
 	return ctx.OpenDatabase(dbc)
 }
 

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -108,6 +108,7 @@ type Config struct {
 	SkipBcVersionCheck   bool `toml:"-"`
 	SingleDB             bool
 	NumStateTrieShards   uint
+	EnableDBPerfMetrics  bool
 	LevelDBCompression   database.LevelDBCompressionType
 	LevelDBBufferPool    bool
 	LevelDBCacheSize     int

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -329,12 +329,13 @@ func NewMemoryDBManager() DBManager {
 // DBConfig handles database related configurations.
 type DBConfig struct {
 	// General configurations for all types of DB.
-	Dir                string
-	DBType             DBType
-	SingleDB           bool // whether dbs (such as MiscDB, headerDB and etc) share one physical DB
-	NumStateTrieShards uint // the number of shards of state trie db
-	ParallelDBWrite    bool
-	OpenFilesLimit     int
+	Dir                 string
+	DBType              DBType
+	SingleDB            bool // whether dbs (such as MiscDB, headerDB and etc) share one physical DB
+	NumStateTrieShards  uint // the number of shards of state trie db
+	ParallelDBWrite     bool
+	OpenFilesLimit      int
+	EnableDBPerfMetrics bool // If true, read and write performance will be logged
 
 	// LevelDB related configurations.
 	LevelDBCacheSize   int // LevelDBCacheSize = BlockCacheCapacity + WriteBuffer

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -48,8 +48,8 @@ import (
 var overSizedDataPrefix = []byte("oversizeditem")
 
 // Performance of batch operations of DynamoDB are collected by default.
-var dynamoBatchWriteTimeMeter metrics.Meter
-var dynamoBatchWriteSizeMeter metrics.Meter
+var dynamoBatchWriteTimeMeter metrics.Meter = &metrics.NilMeter{}
+var dynamoBatchWriteSizeMeter metrics.Meter = &metrics.NilMeter{}
 
 // errors
 var dataNotFoundErr = errors.New("data is not found with the given key")

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -49,7 +49,6 @@ var overSizedDataPrefix = []byte("oversizeditem")
 
 // Performance of batch operations of DynamoDB are collected by default.
 var dynamoBatchWriteTimeMeter metrics.Meter = &metrics.NilMeter{}
-var dynamoBatchWriteSizeMeter metrics.Meter = &metrics.NilMeter{}
 
 // errors
 var dataNotFoundErr = errors.New("data is not found with the given key")
@@ -429,7 +428,6 @@ func (dynamo *dynamoDB) Meter(prefix string) {
 	dynamo.getTimeMeter = metrics.NewRegisteredMeter(prefix+"get/time", nil)
 	dynamo.putTimeMeter = metrics.NewRegisteredMeter(prefix+"put/time", nil)
 	dynamoBatchWriteTimeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/time", nil)
-	dynamoBatchWriteSizeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/size", nil)
 }
 
 func (dynamo *dynamoDB) NewIterator() Iterator {
@@ -537,7 +535,6 @@ func (batch *dynamoBatch) Put(key, val []byte) error {
 	}
 
 	// If the size of the item is larger than the limit, it should be handled in different way
-	dynamoBatchWriteSizeMeter.Mark(int64(dataSize))
 	if dataSize > dynamoWriteSizeLimit {
 		batch.wg.Add(1)
 		go func() {

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -99,6 +99,12 @@ type levelDB struct {
 	diskWriteMeter  metrics.Meter // Meter for measuring the effective amount of data written
 	blockCacheGauge metrics.Gauge // Gauge for measuring the current size of block cache
 
+	perfCheck           bool
+	getTimeMeter        metrics.Meter
+	putTimeMeter        metrics.Meter
+	batchWriteTimeMeter metrics.Meter
+	batchWriteSizeMeter metrics.Meter
+
 	quitLock sync.Mutex      // Mutex protecting the quit channel access
 	quitChan chan chan error // Quit channel to stop the metrics collection before closing the database
 
@@ -135,7 +141,7 @@ func NewLevelDB(dbc *DBConfig, entryType DBEntryType) (*levelDB, error) {
 
 	localLogger.Info("LevelDB configurations",
 		"levelDBCacheSize", (ldbOpts.WriteBuffer+ldbOpts.BlockCacheCapacity)/opt.MiB, "openFilesLimit", ldbOpts.OpenFilesCacheCapacity,
-		"useBufferPool", !ldbOpts.DisableBufferPool, "compressionType", ldbOpts.Compression,
+		"useBufferPool", !ldbOpts.DisableBufferPool, "usePerfCheck", dbc.EnableDBPerfMetrics, "compressionType", ldbOpts.Compression,
 		"compactionTableSize(MB)", ldbOpts.CompactionTableSize/opt.MiB, "compactionTableSizeMultiplier", ldbOpts.CompactionTableSizeMultiplier)
 
 	// Open the db and recover any potential corruptions
@@ -148,9 +154,10 @@ func NewLevelDB(dbc *DBConfig, entryType DBEntryType) (*levelDB, error) {
 		return nil, err
 	}
 	return &levelDB{
-		fn:     dbc.Dir,
-		db:     db,
-		logger: localLogger,
+		fn:        dbc.Dir,
+		db:        db,
+		logger:    localLogger,
+		perfCheck: dbc.EnableDBPerfMetrics,
 	}, nil
 }
 
@@ -238,7 +245,16 @@ func (db *levelDB) Path() string {
 func (db *levelDB) Put(key []byte, value []byte) error {
 	// Generate the data to write to disk, update the meter and write
 	//value = rle.Compress(value)
+	if db.perfCheck {
+		start := time.Now()
+		err := db.put(key, value)
+		db.putTimeMeter.Mark(int64(time.Since(start)))
+		return err
+	}
+	return db.put(key, value)
+}
 
+func (db *levelDB) put(key []byte, value []byte) error {
 	return db.db.Put(key, value, nil)
 }
 
@@ -248,7 +264,17 @@ func (db *levelDB) Has(key []byte) (bool, error) {
 
 // Get returns the given key if it's present.
 func (db *levelDB) Get(key []byte) ([]byte, error) {
-	// Retrieve the key and increment the miss counter if not found
+	if db.perfCheck {
+		start := time.Now()
+		val, err := db.get(key)
+		db.getTimeMeter.Mark(int64(time.Since(start)))
+		return val, err
+	}
+	return db.get(key)
+	//return rle.Decompress(dat)
+}
+
+func (db *levelDB) get(key []byte) ([]byte, error) {
 	dat, err := db.db.Get(key, nil)
 	if err != nil {
 		if err == leveldb.ErrNotFound {
@@ -257,7 +283,6 @@ func (db *levelDB) Get(key []byte) ([]byte, error) {
 		return nil, err
 	}
 	return dat, nil
-	//return rle.Decompress(dat)
 }
 
 // Delete deletes the key from the queue and database
@@ -318,6 +343,11 @@ func (db *levelDB) Meter(prefix string) {
 	db.diskReadMeter = metrics.NewRegisteredMeter(prefix+"disk/read", nil)
 	db.diskWriteMeter = metrics.NewRegisteredMeter(prefix+"disk/write", nil)
 	db.blockCacheGauge = metrics.NewRegisteredGauge(prefix+"blockcache", nil)
+
+	db.getTimeMeter = metrics.NewRegisteredMeter(prefix+"get/time", nil)
+	db.putTimeMeter = metrics.NewRegisteredMeter(prefix+"put/time", nil)
+	db.batchWriteTimeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/time", nil)
+	db.batchWriteSizeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/size", nil)
 
 	// Short circuit metering if the metrics system is disabled
 	// Above meters are initialized by NilMeter if metricutils.Enabled == false
@@ -415,12 +445,12 @@ hasError:
 }
 
 func (db *levelDB) NewBatch() Batch {
-	return &ldbBatch{db: db.db, b: new(leveldb.Batch)}
+	return &ldbBatch{b: new(leveldb.Batch), ldb: db}
 }
 
 type ldbBatch struct {
-	db   *leveldb.DB
 	b    *leveldb.Batch
+	ldb  *levelDB
 	size int
 }
 
@@ -431,7 +461,17 @@ func (b *ldbBatch) Put(key, value []byte) error {
 }
 
 func (b *ldbBatch) Write() error {
-	return b.db.Write(b.b, nil)
+	if b.ldb.perfCheck {
+		start := time.Now()
+		err := b.write()
+		b.ldb.batchWriteTimeMeter.Mark(int64(time.Since(start)))
+		return err
+	}
+	return b.write()
+}
+
+func (b *ldbBatch) write() error {
+	return b.ldb.db.Write(b.b, nil)
 }
 
 func (b *ldbBatch) ValueSize() int {

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -103,7 +103,6 @@ type levelDB struct {
 	getTimeMeter        metrics.Meter
 	putTimeMeter        metrics.Meter
 	batchWriteTimeMeter metrics.Meter
-	batchWriteSizeMeter metrics.Meter
 
 	quitLock sync.Mutex      // Mutex protecting the quit channel access
 	quitChan chan chan error // Quit channel to stop the metrics collection before closing the database
@@ -347,7 +346,6 @@ func (db *levelDB) Meter(prefix string) {
 	db.getTimeMeter = metrics.NewRegisteredMeter(prefix+"get/time", nil)
 	db.putTimeMeter = metrics.NewRegisteredMeter(prefix+"put/time", nil)
 	db.batchWriteTimeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/time", nil)
-	db.batchWriteSizeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/size", nil)
 
 	// Short circuit metering if the metrics system is disabled
 	// Above meters are initialized by NilMeter if metricutils.Enabled == false


### PR DESCRIPTION
## Proposed changes

- Now database's read/write performance metrics are collected by default.
- `--db.no-perf-metrics` can be used to disable collecting the metrics.
- API to disable/enable collecting the metrics will be done in another PR.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
