### PR TITLE
Remove unused cache(cachedStateObjects) and related configs

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -562,7 +562,6 @@ func (bc *BlockChain) TryGetCachedStateDB(rootHash common.Hash) (*state.StateDB,
 				"lastUpdatedRootHash", bc.lastUpdatedRootHash.String())
 			bc.lastUpdatedRootHash = common.Hash{}
 		}
-		cacheGetStateDBMissMeter.Mark(1)
 		return bc.StateAtWithCache(rootHash)
 	}
 
@@ -571,10 +570,8 @@ func (bc *BlockChain) TryGetCachedStateDB(rootHash common.Hash) (*state.StateDB,
 	if rootHash != bc.lastUpdatedRootHash {
 		logger.Trace("Given rootHash is different from lastUpdatedRootHash",
 			"givenRootHash", rootHash, "lastUpdatedRootHash", bc.lastUpdatedRootHash)
-		cacheGetStateDBMissMeter.Mark(1)
 		return bc.StateAt(rootHash)
 	}
-	cacheGetStateDBHitMeter.Mark(1)
 	return bc.StateAtWithCache(rootHash)
 }
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -532,21 +532,6 @@ func (bc *BlockChain) StateCache() state.Database {
 	return bc.stateCache
 }
 
-// StateAtWithCache returns a new mutable state based on a particular point in time.
-// If different from StateAt() in that it uses state object caching.
-func (bc *BlockChain) StateAtWithCache(root common.Hash) (*state.StateDB, error) {
-	return state.NewWithCache(root, bc.stateCache, state.NewCachedStateObjects())
-}
-
-// TryGetCachedStateDB tries to get cachedStateDB, if StateDBCaching flag is true and it exists.
-func (bc *BlockChain) TryGetCachedStateDB(rootHash common.Hash) (*state.StateDB, error) {
-	if !bc.cacheConfig.StateDBCaching {
-		return bc.StateAt(rootHash)
-	}
-
-	return bc.StateAtWithCache(rootHash)
-}
-
 // Reset purges the entire blockchain, restoring it to its genesis state.
 func (bc *BlockChain) Reset() error {
 	return bc.ResetWithGenesisBlock(bc.genesisBlock)
@@ -1607,7 +1592,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 			parent = chain[i-1]
 		}
 
-		stateDB, err := bc.TryGetCachedStateDB(parent.Root())
+		stateDB, err := bc.StateAt(parent.Root())
 		if err != nil {
 			return i, events, coalescedLogs, err
 		}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -85,7 +85,6 @@ const (
 // 2) trie caching/pruning resident in a blockchain.
 type CacheConfig struct {
 	// TODO-Klaytn-Issue1666 Need to check the benefit of trie caching.
-	StateDBCaching       bool                        // Enables caching of state objects in stateDB
 	TxPoolStateCache     bool                        // Enables caching of nonce and balance for txpool
 	ArchiveMode          bool                        // If true, state trie is not pruned and always written to database
 	CacheSize            int                         // Size of in-memory cache of a trie (MiB) to flush matured singleton trie nodes to disk
@@ -183,7 +182,6 @@ type BlockChain struct {
 func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig *params.ChainConfig, engine consensus.Engine, vmConfig vm.Config) (*BlockChain, error) {
 	if cacheConfig == nil {
 		cacheConfig = &CacheConfig{
-			StateDBCaching:      false,
 			ArchiveMode:         false,
 			CacheSize:           512,
 			BlockInterval:       DefaultBlockInterval,

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1590,7 +1590,6 @@ func TestBlockChain_SetCanonicalBlock(t *testing.T) {
 	// Archive mode is given to avoid mismatching between the given starting block number and
 	// the actual block number where the blockchain has been rolled back to due to 128 blocks interval commit.
 	cacheConfig := &CacheConfig{
-		StateDBCaching:      false,
 		ArchiveMode:         true,
 		CacheSize:           512,
 		BlockInterval:       DefaultBlockInterval,

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -171,7 +171,6 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		// TODO(karalabe): This is needed for clique, which depends on multiple blocks.
 		// It's nonetheless ugly to spin up a blockchain here. Get rid of this somehow.
 		cacheConfig := &CacheConfig{
-			StateDBCaching:      false,
 			ArchiveMode:         false,
 			CacheSize:           512,
 			BlockInterval:       DefaultBlockInterval,

--- a/blockchain/metrics.go
+++ b/blockchain/metrics.go
@@ -31,9 +31,6 @@ var (
 	cacheGetBadBlockMissMeter = metrics.NewRegisteredMeter("klay/cache/get/badblock/miss", nil)
 	cacheGetBadBlockHitMeter  = metrics.NewRegisteredMeter("klay/cache/get/badblock/hit", nil)
 
-	cacheGetStateDBMissMeter = metrics.NewRegisteredMeter("klay/cache/get/statedb/miss", nil)
-	cacheGetStateDBHitMeter  = metrics.NewRegisteredMeter("klay/cache/get/statedb/hit", nil)
-
 	headBlockNumberGauge = metrics.NewRegisteredGauge("blockchain/head/blocknumber", nil)
 	blockTxCountsGauge   = metrics.NewRegisteredGauge("blockchain/block/tx/gauge", nil)
 	blockTxCountsCounter = metrics.NewRegisteredCounter("blockchain/block/tx/counter", nil)

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -52,9 +52,6 @@ var (
 	logger = log.NewModuleLogger(log.BlockchainState)
 )
 
-// TODO-Klaytn-StateDB Need to consider setting this value by command line option.
-const maxCachedStateObjects = 40960
-
 // StateDBs within the Klaytn protocol are used to cache stateObjects from Merkle Patricia Trie
 // and mediate the operations to them.
 type StateDB struct {
@@ -65,9 +62,6 @@ type StateDB struct {
 	stateObjects             map[common.Address]*stateObject
 	stateObjectsDirty        map[common.Address]struct{}
 	stateObjectsDirtyStorage map[common.Address]struct{}
-
-	// cachedStateObjects stores the most recent finalized stateObjects.
-	cachedStateObjects common.Cache
 
 	// DB error.
 	// State objects are used by the consensus core and VM which are
@@ -93,11 +87,6 @@ type StateDB struct {
 	nextRevisionId int
 }
 
-// NewCachedStateObjects returns a new Common.Cache object for cachedStateObjects.
-func NewCachedStateObjects() common.Cache {
-	return common.NewCache(common.LRUConfig{CacheSize: maxCachedStateObjects, IsScaled: true})
-}
-
 // Create a new state from a given trie.
 func New(root common.Hash, db Database) (*StateDB, error) {
 	tr, err := db.OpenTrie(root)
@@ -110,21 +99,10 @@ func New(root common.Hash, db Database) (*StateDB, error) {
 		stateObjects:             make(map[common.Address]*stateObject),
 		stateObjectsDirtyStorage: make(map[common.Address]struct{}),
 		stateObjectsDirty:        make(map[common.Address]struct{}),
-		cachedStateObjects:       nil,
 		logs:                     make(map[common.Hash][]*types.Log),
 		preimages:                make(map[common.Hash][]byte),
 		journal:                  newJournal(),
 	}, nil
-}
-
-// NewWithCache creates a new state from a given trie with state object caching enabled.
-func NewWithCache(root common.Hash, db Database, cachedStateObjects common.Cache) (*StateDB, error) {
-	if stateDB, err := New(root, db); err != nil {
-		return nil, err
-	} else {
-		stateDB.cachedStateObjects = cachedStateObjects
-		return stateDB, nil
-	}
 }
 
 // RLockGCCachedNode locks the GC lock of CachedNode.
@@ -158,7 +136,6 @@ func (self *StateDB) Reset(root common.Hash) error {
 	self.trie = tr
 	self.stateObjects = make(map[common.Address]*stateObject)
 	self.stateObjectsDirty = make(map[common.Address]struct{})
-	self.cachedStateObjects = NewCachedStateObjects()
 	self.thash = common.Hash{}
 	self.bhash = common.Hash{}
 	self.txIndex = 0
@@ -167,14 +144,6 @@ func (self *StateDB) Reset(root common.Hash) error {
 	self.preimages = make(map[common.Hash][]byte)
 	self.clearJournalAndRefund()
 	return nil
-}
-
-// ResetExceptCachedStateObjects clears out all ephemeral state objects from the state db,
-// but keeps 1) underlying state trie and 2) cachedStateObjects to avoid reloading data.
-func (self *StateDB) ResetExceptCachedStateObjects(root common.Hash) {
-	cachedStateObjects := self.cachedStateObjects
-	self.Reset(root)
-	self.cachedStateObjects = cachedStateObjects
 }
 
 // UpdateTxPoolStateCache updates the caches used in TxPool.
@@ -193,40 +162,6 @@ func (self *StateDB) UpdateTxPoolStateCache(nonceCache common.Cache, balanceCach
 			balanceCache.Add(addr, stateObj.Balance())
 		}
 	}
-}
-
-// UpdateCachedStateObjects copies stateObjects to cachedStateObjects.
-// And then, call ResetExceptCachedStateObjects() to clear out all ephemeral state objects,
-// except for 1) underlying state trie and 2) cachedStateObjects.
-func (self *StateDB) UpdateCachedStateObjects(root common.Hash) {
-	if !self.UseCachedStateObjects() {
-		logger.ErrorWithStack("UpdateCachedStateObjects should not be called! It is disabled!")
-		return
-	}
-	for addr, stateObj := range self.stateObjects {
-		if stateObj.suicided || stateObj.deleted || stateObj.dbErr != nil {
-			self.cachedStateObjects.Add(addr, nil)
-		} else {
-			// TODO-Klaytn-StateDB cachedStorage also can be reused, but needs to be tested.
-			newObj := newObject(self, addr, stateObj.account)
-			newObj.storageTrie = stateObj.storageTrie
-			newObj.code = stateObj.code
-			self.cachedStateObjects.Add(addr, newObj)
-		}
-	}
-
-	// Reset all member variables except for cachedStateObjects.
-	self.ResetExceptCachedStateObjects(root)
-}
-
-// GetCachedStateObjects returns its cachedStateObjects.
-func (self *StateDB) GetCachedStateObjects() common.Cache {
-	return self.cachedStateObjects
-}
-
-// UseCachedStateObjects returns if it uses cachedStateObjects or not.
-func (self *StateDB) UseCachedStateObjects() bool {
-	return self.cachedStateObjects != nil
 }
 
 func (self *StateDB) AddLog(log *types.Log) {
@@ -557,21 +492,7 @@ func (self *StateDB) getStateObject(addr common.Address) *stateObject {
 		return obj
 	}
 
-	// Second, if not found in stateObjects, check cachedStateObjects.
-	if self.UseCachedStateObjects() {
-		if obj, exist := self.cachedStateObjects.Get(addr); exist && obj != nil {
-			stateObj, ok := obj.(*stateObject)
-			if !ok {
-				logger.Error("cached state object is not *stateObject type!", "addr", addr.String())
-				return nil
-			}
-
-			self.stateObjects[addr] = stateObj.deepCopy(self)
-			return self.stateObjects[addr]
-		}
-	}
-
-	// Third, the object for given address is not cached.
+	// Second, the object for given address is not cached.
 	// Load the object from the database.
 	enc, err := self.trie.TryGet(addr[:])
 	if len(enc) == 0 {
@@ -587,10 +508,6 @@ func (self *StateDB) getStateObject(addr common.Address) *stateObject {
 	// Insert into the live set.
 	obj := newObject(self, addr, data)
 	self.setStateObject(obj)
-
-	if self.UseCachedStateObjects() {
-		self.cachedStateObjects.Add(addr, obj.deepCopy(self))
-	}
 
 	return obj
 }
@@ -732,16 +649,15 @@ func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common
 func (self *StateDB) Copy() *StateDB {
 	// Copy all the basic fields, initialize the memory ones
 	state := &StateDB{
-		db:                 self.db,
-		trie:               self.db.CopyTrie(self.trie),
-		stateObjects:       make(map[common.Address]*stateObject, len(self.journal.dirties)),
-		stateObjectsDirty:  make(map[common.Address]struct{}, len(self.journal.dirties)),
-		cachedStateObjects: nil,
-		refund:             self.refund,
-		logs:               make(map[common.Hash][]*types.Log, len(self.logs)),
-		logSize:            self.logSize,
-		preimages:          make(map[common.Hash][]byte),
-		journal:            newJournal(),
+		db:                self.db,
+		trie:              self.db.CopyTrie(self.trie),
+		stateObjects:      make(map[common.Address]*stateObject, len(self.journal.dirties)),
+		stateObjectsDirty: make(map[common.Address]struct{}, len(self.journal.dirties)),
+		refund:            self.refund,
+		logs:              make(map[common.Hash][]*types.Log, len(self.logs)),
+		logSize:           self.logSize,
+		preimages:         make(map[common.Hash][]byte),
+		journal:           newJournal(),
 	}
 	// Copy the dirty states, logs, and preimages
 	for addr := range self.journal.dirties {
@@ -764,19 +680,12 @@ func (self *StateDB) Copy() *StateDB {
 		}
 	}
 
-	// NOTE-Klaytn-StateDB cachedStateObject is cache, so not copied to copied StateDB.
-
 	deepCopyLogs(self, state)
 
 	for hash, preimage := range self.preimages {
 		state.preimages[hash] = preimage
 	}
 
-	// Use cachedStateObjects only if original StateDB uses.
-	// However, cached values are not copied.
-	if self.cachedStateObjects != nil {
-		state.cachedStateObjects = NewCachedStateObjects()
-	}
 	return state
 }
 

--- a/blockchain/state/statedb_test.go
+++ b/blockchain/state/statedb_test.go
@@ -24,13 +24,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/klaytn/klaytn/blockchain/types"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/params"
-	"github.com/klaytn/klaytn/storage/database"
-	"github.com/klaytn/klaytn/storage/statedb"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/check.v1"
 	"math"
 	"math/big"
 	"math/rand"
@@ -38,6 +31,14 @@ import (
 	"strings"
 	"testing"
 	"testing/quick"
+
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/storage/database"
+	"github.com/klaytn/klaytn/storage/statedb"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/check.v1"
 )
 
 // Updating a state statedb without commit must not affect persistent DB.
@@ -191,208 +192,21 @@ func TestSnapshotRandom(t *testing.T) {
 	}
 }
 
-// TestCachedStateObjects tests basic functional operations of cachedStateObjects.
+// TestStateObjects tests basic functional operations of StateObjects.
 // It will be updated by StateDB.Commit() with state objects in StateDB.stateObjects.
-func TestCachedStateObjects(t *testing.T) {
-	stateDB, _ := NewWithCache(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), NewCachedStateObjects())
-
-	// Update each account, it will only update StateDB.stateObjects.
-	for i := byte(0); i < 128; i++ {
-		addr := common.BytesToAddress([]byte{i})
-		stateObj := stateDB.GetOrNewStateObject(addr)
-
-		stateObj.AddBalance(big.NewInt(int64(i)))
-		stateDB.updateStateObject(stateObj)
-	}
-
-	// Before call StateDB.Commit(), cachedStateObjects is empty.
-	for i := byte(0); i < 128; i++ {
-		addr := common.BytesToAddress([]byte{i})
-		stateObj := stateDB.GetOrNewStateObject(addr)
-		cachedStateObj, ok := stateDB.cachedStateObjects.Get(addr)
-
-		assert.Equal(t, uint64(i), stateObj.Balance().Uint64())
-		assert.Equal(t, false, ok)
-		assert.Equal(t, (interface{})(nil), cachedStateObj)
-	}
-
-	assert.Equal(t, 128, len(stateDB.stateObjects))
-
-	if root, err := stateDB.Commit(false); err != nil {
-		t.Fatal(err)
-	} else {
-		stateDB.UpdateCachedStateObjects(root)
-	}
-
-	// After call StateDB.Commit(), now cachedStateObjects has latest data,
-	// whereas stateObjects is empty.
-	assert.Equal(t, 0, len(stateDB.stateObjects))
-
-	for i := byte(0); i < 128; i++ {
-		addr := common.BytesToAddress([]byte{i})
-		obj := stateDB.GetOrNewStateObject(addr)
-		cachedStateObj, ok := stateDB.cachedStateObjects.Get(addr)
-		cachedObj := cachedStateObj.(*stateObject)
-
-		assert.Equal(t, uint64(i), obj.Balance().Uint64())
-		assert.Equal(t, true, ok)
-		assert.Equal(t, uint64(i), cachedObj.Balance().Uint64())
-	}
-
-	// Update each account, it will only update StateDB.stateObjects.
-	for i := byte(0); i < 128; i++ {
-		addr := common.BytesToAddress([]byte{i})
-		stateObj := stateDB.GetOrNewStateObject(addr)
-
-		stateObj.AddBalance(big.NewInt(int64(i)))
-		stateDB.updateStateObject(stateObj)
-	}
-
-	// Before call StateDB.Commit(), cachedStateObjects has out-dated data.
-	assert.Equal(t, 128, len(stateDB.stateObjects))
-
-	for i := byte(0); i < 128; i++ {
-		addr := common.BytesToAddress([]byte{i})
-		obj := stateDB.GetOrNewStateObject(addr)
-		cachedStateObj, ok := stateDB.cachedStateObjects.Get(addr)
-		cachedObj := cachedStateObj.(*stateObject)
-
-		assert.Equal(t, 2*uint64(i), obj.Balance().Uint64())
-		assert.Equal(t, true, ok)
-		assert.Equal(t, uint64(i), cachedObj.Balance().Uint64())
-	}
-
-	if root, err := stateDB.Commit(false); err != nil {
-		t.Fatal(err)
-	} else {
-		stateDB.UpdateCachedStateObjects(root)
-	}
-
-	// After call StateDB.Commit(), now cachedStateObjects has latest data.
-	assert.Equal(t, 0, len(stateDB.stateObjects))
-
-	for i := byte(0); i < 128; i++ {
-		addr := common.BytesToAddress([]byte{i})
-		obj := stateDB.GetOrNewStateObject(addr)
-		cachedStateObj, ok := stateDB.cachedStateObjects.Get(addr)
-		cachedObj := cachedStateObj.(*stateObject)
-
-		assert.Equal(t, true, ok)
-		assert.Equal(t, obj.Balance().Uint64(), cachedObj.Balance().Uint64())
-	}
-
-	assert.Equal(t, 128, len(stateDB.stateObjects))
-
-	// Update new accounts, it will only update StateDB.stateObjects.
-	// Please note that below loop starts from byte(128).
-	for i := byte(128); i < 255; i++ {
-		addr := common.BytesToAddress([]byte{i})
-		stateObj := stateDB.GetOrNewStateObject(addr)
-
-		stateObj.AddBalance(big.NewInt(int64(i)))
-		stateDB.updateStateObject(stateObj)
-	}
-
-	assert.Equal(t, 255, len(stateDB.stateObjects))
-
-	// Before call StateDB.Commit(), cachedStateObjects does not have data of new accounts.
-	for i := byte(128); i < 255; i++ {
-		addr := common.BytesToAddress([]byte{i})
-		obj := stateDB.GetOrNewStateObject(addr)
-		cachedStateObj, ok := stateDB.cachedStateObjects.Get(addr)
-
-		assert.Equal(t, uint64(i), obj.Balance().Uint64())
-		assert.Equal(t, false, ok)
-		assert.Equal(t, (interface{})(nil), cachedStateObj)
-	}
-	assert.Equal(t, 255, len(stateDB.stateObjects))
-
-	if root, err := stateDB.Commit(false); err != nil {
-		t.Fatal(err)
-	} else {
-		stateDB.UpdateCachedStateObjects(root)
-	}
-
-	// After call StateDB.Commit(), stateObjects is empty.
-	assert.Equal(t, 0, len(stateDB.stateObjects))
-}
-
-// TestCachedStateObjectsEviction is to ensure that cachedStateObjects does not affect
-// the functionality of stateDB. If a stateObject is evicted from the cachedStateObjects,
-// it should be loaded from underlying state trie or persistent database.
-func TestCachedStateObjectsEviction(t *testing.T) {
+func TestStateObjects(t *testing.T) {
 	stateDB, _ := New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
-	stateDB.cachedStateObjects = common.NewCache(common.LRUConfig{CacheSize: 1})
 
-	// Update an account with addr1.
-	i1 := byte(1)
-	addr1 := common.BytesToAddress([]byte{i1})
-	stateObj := stateDB.GetOrNewStateObject(addr1)
-	stateObj.AddBalance(big.NewInt(int64(i1)))
-	stateDB.updateStateObject(stateObj)
+	// Update each account, it will update StateDB.stateObjects.
+	for i := byte(0); i < 128; i++ {
+		addr := common.BytesToAddress([]byte{i})
+		stateObj := stateDB.GetOrNewStateObject(addr)
 
-	if root, err := stateDB.Commit(true); err != nil {
-		t.Fatal(err)
-	} else {
-		stateDB.UpdateCachedStateObjects(root)
+		stateObj.AddBalance(big.NewInt(int64(i)))
+		stateDB.updateStateObject(stateObj)
 	}
 
-	// After call StateDB.Commit(), now cachedStateObjects has latest data,
-	// whereas stateObjects is empty.
-	assert.Equal(t, 0, len(stateDB.stateObjects))
-
-	// We can find stateObject of addr1 from cachedStateObjects.
-	cachedStateObj, ok := stateDB.cachedStateObjects.Get(addr1)
-	assert.Equal(t, true, ok)
-
-	cachedObj := cachedStateObj.(*stateObject)
-	assert.Equal(t, uint64(i1), cachedObj.Balance().Uint64())
-
-	// Let's update a new account with addr2 to evict addr1 from cachedStateObjects.
-	i2 := byte(2)
-	addr2 := common.BytesToAddress([]byte{i2})
-	stateObj = stateDB.GetOrNewStateObject(addr2)
-
-	stateObj.AddBalance(big.NewInt(int64(i2)))
-	stateDB.updateStateObject(stateObj)
-
-	if root, err := stateDB.Commit(true); err != nil {
-		t.Fatal(err)
-	} else {
-		stateDB.UpdateCachedStateObjects(root)
-	}
-
-	// Below lines are disabled due to cacheScale() changes the size of cache.
-	// stateObject of addr1 should be evicted.
-	// Failed to find stateObject of addr1 from cachedStateObjects since it is evicted.
-	//cachedStateObj, ok = stateDB.cachedStateObjects.Get(addr1)
-	//assert.Equal(t, false, ok)
-	//assert.Equal(t, (interface{})(nil), cachedStateObj)
-
-	// However, stateObject of addr1 can be accessed by StateDB.getStateObject.
-	stateObj = stateDB.getStateObject(addr1)
-	assert.Equal(t, uint64(i1), stateObj.Balance().Uint64())
-
-	// Below lines are disabled due to cacheScale() changes the size of cache.
-	// However, stateObject of addr1 can't be found in cachedStateObjects,
-	// since StateDB.Commit() is not called yet. Only StateDB.Commit() ensures
-	// the finalization of stateObjects.
-	//cachedStateObj, ok = stateDB.cachedStateObjects.Get(addr1)
-	//assert.Equal(t, false, ok)
-	//assert.Equal(t, (interface{})(nil), cachedStateObj)
-
-	if root, err := stateDB.Commit(true); err != nil {
-		t.Fatal(err)
-	} else {
-		stateDB.UpdateCachedStateObjects(root)
-	}
-
-	// Now we can find stateObject of add1 from cachedStateObjects.
-	cachedStateObj, ok = stateDB.cachedStateObjects.Get(addr1)
-	assert.Equal(t, true, ok)
-
-	cachedObj = cachedStateObj.(*stateObject)
-	assert.Equal(t, uint64(i1), cachedObj.Balance().Uint64())
+	assert.Equal(t, 128, len(stateDB.stateObjects))
 }
 
 // A snapshotTest checks that reverting StateDB snapshots properly undoes all changes

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -23,11 +23,14 @@ package blockchain
 import (
 	"errors"
 	"fmt"
-	"github.com/klaytn/klaytn/kerrors"
 	"math"
 	"math/big"
 	"sync"
 	"time"
+
+	"github.com/klaytn/klaytn/kerrors"
+
+	"sort"
 
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -36,7 +39,6 @@ import (
 	"github.com/klaytn/klaytn/params"
 	"github.com/rcrowley/go-metrics"
 	"gopkg.in/karalabe/cookiejar.v2/collections/prque"
-	"sort"
 )
 
 const (
@@ -95,7 +97,6 @@ type blockChain interface {
 	CurrentBlock() *types.Block
 	GetBlock(hash common.Hash, number uint64) *types.Block
 	StateAt(root common.Hash) (*state.StateDB, error)
-	TryGetCachedStateDB(root common.Hash) (*state.StateDB, error)
 
 	SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) event.Subscription
 
@@ -411,7 +412,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	if newHead == nil {
 		newHead = pool.chain.CurrentBlock().Header() // Special case during testing
 	}
-	stateDB, err := pool.chain.TryGetCachedStateDB(newHead.Root)
+	stateDB, err := pool.chain.StateAt(newHead.Root)
 	if err != nil {
 		logger.Error("Failed to reset txpool state", "err", err)
 		return

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -23,6 +23,13 @@ package blockchain
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"io/ioutil"
+	"math/big"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -31,12 +38,6 @@ import (
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"math/big"
-	"math/rand"
-	"os"
-	"testing"
-	"time"
 )
 
 // testTxPoolConfig is a transaction pool configuration without stateful disk
@@ -63,10 +64,6 @@ func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block
 }
 
 func (bc *testBlockChain) StateAt(common.Hash) (*state.StateDB, error) {
-	return bc.statedb, nil
-}
-
-func (bc *testBlockChain) TryGetCachedStateDB(common.Hash) (*state.StateDB, error) {
 	return bc.statedb, nil
 }
 

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -163,7 +163,6 @@ var FlagGroups = []FlagGroup{
 	{
 		Name: "STATE",
 		Flags: []cli.Flag{
-			StateDBCachingFlag,
 			TrieMemoryCacheSizeFlag,
 			TrieBlockIntervalFlag,
 			TriesInMemoryFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -202,11 +202,6 @@ var (
 		Name:  "kes.nodetype.service",
 		Usage: "Run as a KES Service Node (Disable fetcher, downloader, and worker)",
 	}
-	// Performance tuning settings
-	StateDBCachingFlag = cli.BoolFlag{
-		Name:  "statedb.use-cache",
-		Usage: "Enables caching of state objects in stateDB",
-	}
 	SingleDBFlag = cli.BoolFlag{
 		Name:  "db.single",
 		Usage: "Create a single persistent storage. MiscDB, headerDB and etc are stored in one DB.",
@@ -1470,7 +1465,6 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 
 	cfg.SenderTxHashIndexing = ctx.GlobalIsSet(SenderTxHashIndexingFlag.Name)
 	cfg.ParallelDBWrite = !ctx.GlobalIsSet(NoParallelDBWriteFlag.Name)
-	cfg.StateDBCaching = ctx.GlobalIsSet(StateDBCachingFlag.Name)
 	cfg.TrieNodeCacheConfig = statedb.TrieNodeCacheConfig{
 		CacheType: statedb.TrieNodeCacheType(ctx.GlobalString(TrieNodeCacheTypeFlag.
 			Name)).ToValid(),

--- a/cmd/utils/nodecmd/flags_test.go
+++ b/cmd/utils/nodecmd/flags_test.go
@@ -198,10 +198,6 @@ var flagsWithValues = []struct {
 		errors:      []int{ErrorInvalidValue, ErrorInvalidValue, ErrorInvalidValue},
 	},
 	{
-		flag:     "--statedb.use-cache",
-		flagType: FlagTypeBoolean,
-	},
-	{
 		flag:     "--db.single",
 		flagType: FlagTypeBoolean,
 	},

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -53,7 +53,6 @@ var CommonNodeFlags = []cli.Flag{
 	utils.SyncModeFlag,
 	utils.GCModeFlag,
 	utils.LightKDFFlag,
-	utils.StateDBCachingFlag,
 	utils.SingleDBFlag,
 	utils.NumStateTrieShardsFlag,
 	utils.LevelDBCompressionTypeFlag,

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -248,7 +248,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	}
 	var (
 		vmConfig    = config.getVMConfig()
-		cacheConfig = &blockchain.CacheConfig{StateDBCaching: config.StateDBCaching,
+		cacheConfig = &blockchain.CacheConfig{
 			ArchiveMode: config.NoPruning, CacheSize: config.TrieCacheSize, BlockInterval: config.TrieBlockInterval,
 			TriesInMemory: config.TriesInMemory, TxPoolStateCache: config.TxPoolStateCache,
 			TrieNodeCacheConfig: config.TrieNodeCacheConfig, SenderTxHashIndexing: config.SenderTxHashIndexing}

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -118,7 +118,6 @@ type Config struct {
 	TriesInMemory        uint64
 	SenderTxHashIndexing bool
 	ParallelDBWrite      bool
-	StateDBCaching       bool
 	TxPoolStateCache     bool
 	TrieNodeCacheConfig  statedb.TrieNodeCacheConfig
 

--- a/node/cn/gen_config.go
+++ b/node/cn/gen_config.go
@@ -43,7 +43,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TriesInMemory           uint64
 		SenderTxHashIndexing    bool
 		ParallelDBWrite         bool
-		StateDBCaching          bool
 		TxPoolStateCache        bool
 		TrieNodeCacheConfig     statedb.TrieNodeCacheConfig
 		ServiceChainSigner      common.Address `toml:",omitempty"`
@@ -89,7 +88,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TriesInMemory = c.TriesInMemory
 	enc.SenderTxHashIndexing = c.SenderTxHashIndexing
 	enc.ParallelDBWrite = c.ParallelDBWrite
-	enc.StateDBCaching = c.StateDBCaching
 	enc.TxPoolStateCache = c.TxPoolStateCache
 	enc.TrieNodeCacheConfig = c.TrieNodeCacheConfig
 	enc.ServiceChainSigner = c.ServiceChainSigner
@@ -139,7 +137,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TriesInMemory           *uint64
 		SenderTxHashIndexing    *bool
 		ParallelDBWrite         *bool
-		StateDBCaching          *bool
 		TxPoolStateCache        *bool
 		TrieNodeCacheConfig     *statedb.TrieNodeCacheConfig
 		ServiceChainSigner      *common.Address `toml:",omitempty"`
@@ -231,9 +228,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.ParallelDBWrite != nil {
 		c.ParallelDBWrite = *dec.ParallelDBWrite
-	}
-	if dec.StateDBCaching != nil {
-		c.StateDBCaching = *dec.StateDBCaching
 	}
 	if dec.TxPoolStateCache != nil {
 		c.TxPoolStateCache = *dec.TxPoolStateCache

--- a/tests/pregenerated_data_execution_test.go
+++ b/tests/pregenerated_data_execution_test.go
@@ -19,11 +19,12 @@ package tests
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"runtime/pprof"
+	"testing"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
-	"runtime/pprof"
-	"testing"
 )
 
 const txPoolSize = 32768
@@ -55,7 +56,6 @@ func BenchmarkDataExecution_CandidateLevelDB(b *testing.B) {
 	tc := getExecutionTestDefaultTC()
 	tc.testName = "BenchmarkDataExecution_CandidateLevelDB"
 	tc.originalDataDir = candidate500LevelDB_orig
-	tc.cacheConfig.StateDBCaching = false
 	tc.cacheConfig.TxPoolStateCache = false
 
 	tc.dbc, tc.levelDBOption = genCandidateLevelDBOptions()
@@ -86,7 +86,6 @@ func BenchmarkDataExecution_Baobab_ControlGroup(b *testing.B) {
 
 	// ControlGroup specific setting
 	tc.numReceiversPerRun = 10000
-	tc.cacheConfig.StateDBCaching = false
 	tc.cacheConfig.TxPoolStateCache = false
 
 	dataExecutionTest(b, tc)

--- a/tests/pregenerated_data_generation_test.go
+++ b/tests/pregenerated_data_generation_test.go
@@ -20,14 +20,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"github.com/klaytn/klaytn/blockchain"
-	"github.com/klaytn/klaytn/blockchain/state"
-	"github.com/klaytn/klaytn/blockchain/types"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/params"
-	"github.com/klaytn/klaytn/storage/database"
-	"github.com/otiai10/copy"
-	"github.com/syndtr/goleveldb/leveldb/opt"
 	"math/big"
 	"math/rand"
 	"os"
@@ -37,6 +29,15 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/state"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/storage/database"
+	"github.com/otiai10/copy"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
 func init() {
@@ -217,7 +218,6 @@ func BenchmarkDataGeneration_CandidateLevelDB(b *testing.B) {
 	tc := getGenerationTestDefaultTC()
 	tc.testName = "BenchmarkDataGeneration_CandidateLevelDB"
 	tc.originalDataDir = candidate500LevelDB_orig
-	tc.cacheConfig.StateDBCaching = false
 	tc.cacheConfig.TxPoolStateCache = false
 
 	tc.cacheConfig = defaultCacheConfig()

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -270,7 +270,7 @@ func (bcdata *BCData) GenABlockWithTxPoolWithoutAccountMap(txPool *blockchain.Tx
 		return err
 	}
 
-	stateDB, err := bcdata.bc.TryGetCachedStateDB(bcdata.bc.CurrentBlock().Root())
+	stateDB, err := bcdata.bc.StateAt(bcdata.bc.CurrentBlock().Root())
 	if err != nil {
 		return err
 	}

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -471,7 +471,6 @@ func getChainConfig(chainDB database.DBManager) (*params.ChainConfig, error) {
 // defaultCacheConfig returns cache config for data generation tests.
 func defaultCacheConfig() *blockchain.CacheConfig {
 	return &blockchain.CacheConfig{
-		StateDBCaching:   true,
 		TxPoolStateCache: true,
 		ArchiveMode:      false,
 		CacheSize:        512,

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -959,21 +959,6 @@ func (mr *MockBlockChainMockRecorder) TrieNode(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrieNode", reflect.TypeOf((*MockBlockChain)(nil).TrieNode), arg0)
 }
 
-// TryGetCachedStateDB mocks base method
-func (m *MockBlockChain) TryGetCachedStateDB(arg0 common.Hash) (*state.StateDB, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TryGetCachedStateDB", arg0)
-	ret0, _ := ret[0].(*state.StateDB)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TryGetCachedStateDB indicates an expected call of TryGetCachedStateDB
-func (mr *MockBlockChainMockRecorder) TryGetCachedStateDB(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryGetCachedStateDB", reflect.TypeOf((*MockBlockChain)(nil).TryGetCachedStateDB), arg0)
-}
-
 // Validator mocks base method
 func (m *MockBlockChain) Validator() blockchain.Validator {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -287,7 +287,6 @@ type BlockChain interface {
 	HasBadBlock(hash common.Hash) bool
 	WriteBlockWithState(block *types.Block, receipts []*types.Receipt, stateDB *state.StateDB) (blockchain.WriteStatus, error)
 	PostChainEvents(events []interface{}, logs []*types.Log)
-	TryGetCachedStateDB(rootHash common.Hash) (*state.StateDB, error)
 	ApplyTransaction(config *params.ChainConfig, author *common.Address, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg *vm.Config) (*types.Receipt, uint64, *vm.InternalTxTrace, error)
 
 	// State Migration

--- a/work/worker.go
+++ b/work/worker.go
@@ -21,6 +21,11 @@
 package work
 
 import (
+	"math/big"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -31,10 +36,6 @@ import (
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/rcrowley/go-metrics"
-	"math/big"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 const (
@@ -457,7 +458,7 @@ func (self *worker) push(work *Task) {
 
 // makeCurrent creates a new environment for the current cycle.
 func (self *worker) makeCurrent(parent *types.Block, header *types.Header) error {
-	stateDB, err := self.chain.TryGetCachedStateDB(parent.Root())
+	stateDB, err := self.chain.StateAt(parent.Root())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

The belows are removed from Klaytn:
- [[f78493a]](https://github.com/klaytn/klaytn/pull/730/commits/f78493a8542758e2ca6f6420ac51262ddda511f6)`stateDB.cachedStateObjects`: not used in default and `Database.trieNodeCache`, or Fastcache, is used instead
- [[8e26811]](https://github.com/klaytn/klaytn/pull/730/commits/8e268116599012469cc04c7c292063b46e686618) `StateDBCachingFlag`: was used to set `stateDB.cachedStateObjects`
- [[4190c91]](https://github.com/klaytn/klaytn/pull/730/commits/4190c91cdd75f4938ec08997c60bcfc05b5623c1) `Blockchain.cachedStateDB `: was used to store the current cache `cachedStateObjects` from last block. But, the data is stored in Fastcache, too.
- [[0fffbad]](https://github.com/klaytn/klaytn/pull/730/commits/0fffbadb3c5b8579a912a39ef74519050e5ab467) `Blockchain.lastUpdatedRootHash `: was used to check if the current hash is stored in `Blockchain.cachedStateDB` 
- [[d14e0da]](https://github.com/klaytn/klaytn/pull/730/commits/d14e0da2c9632a60e0ba07f1da5e51e7037991cf)`cacheGetStateDBMissMeter`: was to measure cache miss of `Blockchain.lastUpdatedRootHash `

- [[99b4a68]](https://github.com/klaytn/klaytn/pull/730/commits/99b4a688ee47189f43ccd0b378c86af5247076d6) [[c195de3]](https://github.com/klaytn/klaytn/pull/730/commits/c195de35c78fe94a8148ccffc81dd3ad745b3909) `TryGetCachedStateDB` and `StateAtWithCache`: are used to call `StateDB` with `cachedStateObjects`. Now, `TryGetCachedStateDB` is replaced with `StateAt`.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
