### PR TITLE
Write governance items during init process

### DIFF
--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -101,7 +101,7 @@ func initGenesis(ctx *cli.Context) error {
 	}
 
 	// Set genesis.Governance and reward intervals
-	govSet := getGovernanceItemSetFromGenesis(genesis)
+	govSet := governance.GetGovernanceItemsFromChainConfig(genesis.Config)
 	govItemBytes, err := json.Marshal(govSet.Items())
 	if err != nil {
 		logger.Crit("Failed to json marshaling governance data", "err", err)
@@ -140,76 +140,26 @@ func initGenesis(ctx *cli.Context) error {
 		dbc := &database.DBConfig{Dir: name, DBType: dbtype, ParallelDBWrite: parallelDBWrite,
 			SingleDB: singleDB, NumStateTrieShards: numStateTrieShards,
 			LevelDBCacheSize: 0, OpenFilesLimit: 0, DynamoDBConfig: dynamoDBConfig}
-		chaindb := stack.OpenDatabase(dbc)
+		chainDB := stack.OpenDatabase(dbc)
+
 		// Initialize DeriveSha implementation
 		blockchain.InitDeriveSha(genesis.Config.DeriveShaImpl)
 
-		_, hash, err := blockchain.SetupGenesisBlock(chaindb, genesis, params.UnusedNetworkId, false, overwriteGenesis)
+		_, hash, err := blockchain.SetupGenesisBlock(chainDB, genesis, params.UnusedNetworkId, false, overwriteGenesis)
 		if err != nil {
-			log.Fatalf("Failed to write genesis block: %v", err)
+			logger.Crit("Failed to write genesis block", "err", err)
 		}
-		logger.Info("Successfully wrote genesis state", "database", name, "hash", hash.String())
 
-		chaindb.Close()
+		// Write governance items to database
+		if err := governance.NewGovernance(genesis.Config, chainDB).WriteGovernance(0, govSet,
+			governance.NewGovernanceSet()); err != nil {
+			logger.Crit("Failed to write governance items", "err", err)
+		}
+
+		logger.Info("Successfully wrote genesis state", "database", name, "hash", hash.String())
+		chainDB.Close()
 	}
 	return nil
-}
-
-func getGovernanceItemSetFromGenesis(genesis *blockchain.Genesis) governance.GovernanceSet {
-	g := governance.NewGovernanceSet()
-
-	if genesis.Config.Governance != nil {
-		governance := genesis.Config.Governance
-		if err := g.SetValue(params.GovernanceMode, governance.GovernanceMode); err != nil {
-			writeFailLog(params.GovernanceMode, err)
-		}
-		if err := g.SetValue(params.GoverningNode, governance.GoverningNode); err != nil {
-			writeFailLog(params.GoverningNode, err)
-		}
-		if err := g.SetValue(params.UnitPrice, genesis.Config.UnitPrice); err != nil {
-			writeFailLog(params.UnitPrice, err)
-		}
-		if err := g.SetValue(params.MintingAmount, governance.Reward.MintingAmount.String()); err != nil {
-			writeFailLog(params.MintingAmount, err)
-		}
-		if err := g.SetValue(params.Ratio, governance.Reward.Ratio); err != nil {
-			writeFailLog(params.Ratio, err)
-		}
-		if err := g.SetValue(params.UseGiniCoeff, governance.Reward.UseGiniCoeff); err != nil {
-			writeFailLog(params.UseGiniCoeff, err)
-		}
-		if err := g.SetValue(params.DeferredTxFee, governance.Reward.DeferredTxFee); err != nil {
-			writeFailLog(params.DeferredTxFee, err)
-		}
-		if err := g.SetValue(params.MinimumStake, governance.Reward.MinimumStake.String()); err != nil {
-			writeFailLog(params.MinimumStake, err)
-		}
-		if err := g.SetValue(params.StakeUpdateInterval, governance.Reward.StakingUpdateInterval); err != nil {
-			writeFailLog(params.StakeUpdateInterval, err)
-		}
-		if err := g.SetValue(params.ProposerRefreshInterval, governance.Reward.ProposerUpdateInterval); err != nil {
-			writeFailLog(params.ProposerRefreshInterval, err)
-		}
-	}
-
-	if genesis.Config.Istanbul != nil {
-		istanbul := genesis.Config.Istanbul
-		if err := g.SetValue(params.Epoch, istanbul.Epoch); err != nil {
-			writeFailLog(params.Epoch, err)
-		}
-		if err := g.SetValue(params.Policy, istanbul.ProposerPolicy); err != nil {
-			writeFailLog(params.Policy, err)
-		}
-		if err := g.SetValue(params.CommitteeSize, istanbul.SubGroupSize); err != nil {
-			writeFailLog(params.CommitteeSize, err)
-		}
-	}
-	return g
-}
-
-func writeFailLog(key int, err error) {
-	msg := "Failed to set " + governance.GovernanceKeyMapReverse[key]
-	logger.Crit(msg, "err", err)
 }
 
 func ValidateGenesisConfig(g *blockchain.Genesis) error {

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -691,7 +691,7 @@ func getTestConfig() *params.ChainConfig {
 
 func getGovernance(dbm database.DBManager) *governance.Governance {
 	config := getTestConfig()
-	return governance.NewGovernance(config, dbm)
+	return governance.NewGovernanceInitialize(config, dbm)
 }
 
 func Benchmark_getTargetReceivers(b *testing.B) {

--- a/governance/default.go
+++ b/governance/default.go
@@ -401,7 +401,7 @@ func (gs *GovernanceSet) Merge(change map[string]interface{}) {
 	}
 }
 
-// NewGovernanceInitialize creates Governance with the given configuration.
+// NewGovernance creates Governance with the given configuration.
 func NewGovernance(chainConfig *params.ChainConfig, dbm database.DBManager) *Governance {
 	return &Governance{
 		ChainConfig:              chainConfig,

--- a/governance/default.go
+++ b/governance/default.go
@@ -401,8 +401,9 @@ func (gs *GovernanceSet) Merge(change map[string]interface{}) {
 	}
 }
 
+// NewGovernanceInitialize creates Governance with the given configuration.
 func NewGovernance(chainConfig *params.ChainConfig, dbm database.DBManager) *Governance {
-	ret := Governance{
+	return &Governance{
 		ChainConfig:              chainConfig,
 		voteMap:                  NewVoteMap(),
 		db:                       dbm,
@@ -414,11 +415,17 @@ func NewGovernance(chainConfig *params.ChainConfig, dbm database.DBManager) *Gov
 		GovernanceVotes:          NewGovernanceVotes(),
 		idxCacheLock:             new(sync.RWMutex),
 	}
+}
+
+// NewGovernanceInitialize creates Governance with the given configuration and read governance state from DB.
+// If any items are not stored in DB, it stores governance items of the genesis block to DB.
+func NewGovernanceInitialize(chainConfig *params.ChainConfig, dbm database.DBManager) *Governance {
+	ret := NewGovernance(chainConfig, dbm)
 	// nil is for testing or simple function usage
 	if dbm != nil {
 		if err := ret.initializeCache(); err != nil {
 			// If this is the first time to run, store governance information for genesis block on database
-			cfg := getGovernanceItemsFromChainConfig(chainConfig)
+			cfg := GetGovernanceItemsFromChainConfig(chainConfig)
 			if err := ret.WriteGovernance(0, cfg, NewGovernanceSet()); err != nil {
 				logger.Crit("Error in writing governance information", "err", err)
 			}
@@ -429,7 +436,7 @@ func NewGovernance(chainConfig *params.ChainConfig, dbm database.DBManager) *Gov
 		}
 		ret.ReadGovernanceState()
 	}
-	return &ret
+	return ret
 }
 
 func (g *Governance) SetNodeAddress(addr common.Address) {
@@ -552,7 +559,7 @@ func (gov *Governance) updateChangeSet(vote GovernanceVote) bool {
 }
 
 func CheckGenesisValues(c *params.ChainConfig) error {
-	gov := NewGovernance(c, nil)
+	gov := NewGovernanceInitialize(c, nil)
 
 	var tstMap = map[string]interface{}{
 		"istanbul.epoch":                c.Istanbul.Epoch,
@@ -917,7 +924,7 @@ func (gov *Governance) SetTxPool(txpool txPool) {
 	gov.TxPool = txpool
 }
 
-func getGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet {
+func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet {
 	g := NewGovernanceSet()
 
 	if config.Governance != nil {
@@ -967,7 +974,7 @@ func writeFailLog(key int, err error) {
 func AddGovernanceCacheForTest(g *Governance, num uint64, config *params.ChainConfig) {
 	// Don't update cache if num (block number) is smaller than the biggest number of cached block number
 
-	data := getGovernanceItemsFromChainConfig(config)
+	data := GetGovernanceItemsFromChainConfig(config)
 	g.addGovernanceCache(num, data)
 }
 

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -128,7 +128,7 @@ func getTestConfig() *params.ChainConfig {
 func getGovernance() *Governance {
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
 	config := getTestConfig()
-	return NewGovernance(config, dbm)
+	return NewGovernanceInitialize(config, dbm)
 }
 
 func TestGetDefaultGovernanceConfig(t *testing.T) {
@@ -684,7 +684,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	config := getTestConfig()
 	config.Governance.GovernanceMode = GovernanceModeBallot
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
-	gov := NewGovernance(config, dbm)
+	gov := NewGovernanceInitialize(config, dbm)
 	gov.nodeAddress.Store(council[len(council)-1])
 
 	votes := make([]GovernanceVote, 0)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -216,7 +216,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	config.GasPrice = new(big.Int).SetUint64(chainConfig.UnitPrice)
 
 	logger.Info("Initialised chain configuration", "config", chainConfig)
-	governance := governance.NewGovernance(chainConfig, chainDB)
+	governance := governance.NewGovernanceInitialize(chainConfig, chainDB)
 
 	cn := &CN{
 		config:            config,

--- a/node/sc/mainbridge_test.go
+++ b/node/sc/mainbridge_test.go
@@ -66,7 +66,7 @@ func testBlockChain(t *testing.T) *blockchain.BlockChain {
 	db := database.NewMemoryDBManager()
 	defer db.Close()
 
-	gov := governance.NewGovernance(&params.ChainConfig{
+	gov := governance.NewGovernanceInitialize(&params.ChainConfig{
 		ChainID:       big.NewInt(2018),
 		UnitPrice:     25000000000,
 		DeriveShaImpl: 0,

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -490,7 +490,7 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 func generateGovernaceDataForTest() *governance.Governance {
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
 
-	return governance.NewGovernance(&params.ChainConfig{
+	return governance.NewGovernanceInitialize(&params.ChainConfig{
 		ChainID:       big.NewInt(2018),
 		UnitPrice:     25000000000,
 		DeriveShaImpl: 0,


### PR DESCRIPTION
## Proposed changes

Currently, governance items of the genesis block are stored when the node started.
This change makes the items to be stored during the init process.
Also, some governance-related code is refactored.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
