### PR TITLE
Change a default parameter of Estimate APIs; PendingBlockNumber -> LatestBlockNumber

### DIFF
--- a/accounts/abi/bind/backend.go
+++ b/accounts/abi/bind/backend.go
@@ -23,10 +23,11 @@ package bind
 import (
 	"context"
 	"errors"
+	"math/big"
+
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
-	"math/big"
 )
 
 var (
@@ -78,7 +79,7 @@ type ContractTransactor interface {
 	// execution of a transaction.
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
 	// EstimateGas tries to estimate the gas needed to execute a specific
-	// transaction based on the current pending state of the backend blockchain.
+	// transaction based on the latest state of the backend blockchain.
 	// There is no guarantee that this is the true gas limit requirement as other
 	// transactions may be added or removed by miners, but it should provide a basis
 	// for setting a reasonable default.

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -24,6 +24,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/blockchain"
@@ -39,9 +43,6 @@ import (
 	"github.com/klaytn/klaytn/node/cn/filters"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
-	"math/big"
-	"sync"
-	"time"
 )
 
 // This nil assignment ensures compile time that SimulatedBackend implements bind.ContractBackend.
@@ -240,8 +241,7 @@ func (b *SimulatedBackend) SuggestGasPrice(ctx context.Context) (*big.Int, error
 	return new(big.Int).SetUint64(b.config.UnitPrice), nil
 }
 
-// EstimateGas executes the requested code against the currently pending block/state and
-// returns the used amount of gas.
+// EstimateGas executes the requested code against the latest block/state and returns the used amount of gas.
 func (b *SimulatedBackend) EstimateGas(ctx context.Context, call klaytn.CallMsg) (uint64, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -263,10 +263,11 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call klaytn.CallMsg)
 	executable := func(gas uint64) bool {
 		call.Gas = gas
 
-		snapshot := b.pendingState.Snapshot()
-		_, _, failed, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
-		b.pendingState.RevertToSnapshot(snapshot)
-
+		state, err := b.blockchain.State()
+		if err != nil {
+			return false
+		}
+		_, _, failed, err := b.callContract(ctx, call, b.blockchain.CurrentBlock(), state)
 		if err != nil || failed {
 			return false
 		}

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -208,11 +208,11 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call klaytn.CallMsg
 	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlock().Number()) != 0 {
 		return nil, errBlockNumberUnsupported
 	}
-	state, err := b.blockchain.State()
+	currentState, err := b.blockchain.State()
 	if err != nil {
 		return nil, err
 	}
-	rval, _, _, err := b.callContract(ctx, call, b.blockchain.CurrentBlock(), state)
+	rval, _, _, err := b.callContract(ctx, call, b.blockchain.CurrentBlock(), currentState)
 	return rval, err
 }
 
@@ -263,11 +263,11 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call klaytn.CallMsg)
 	executable := func(gas uint64) bool {
 		call.Gas = gas
 
-		state, err := b.blockchain.State()
+		currentState, err := b.blockchain.State()
 		if err != nil {
 			return false
 		}
-		_, _, failed, err := b.callContract(ctx, call, b.blockchain.CurrentBlock(), state)
+		_, _, failed, err := b.callContract(ctx, call, b.blockchain.CurrentBlock(), currentState)
 		if err != nil || failed {
 			return false
 		}

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -314,8 +314,7 @@ func (s *PublicBlockChainAPI) EstimateComputationCost(ctx context.Context, args 
 	return (hexutil.Uint64)(computationCost), err
 }
 
-// EstimateGas returns an estimate of the amount of gas needed to execute the
-// given transaction against the current pending block.
+// EstimateGas returns an estimate of the amount of gas needed to execute the given transaction against the latest block.
 func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (hexutil.Uint64, error) {
 	// Binary search the gas requirement, as it may be higher than the amount used
 	var (
@@ -335,7 +334,7 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (h
 	executable := func(gas uint64) bool {
 		args.Gas = hexutil.Uint64(gas)
 
-		_, _, _, failed, err := s.doCall(ctx, args, rpc.PendingBlockNumber, vm.Config{UseOpcodeComputationCost: true}, localTxExecutionTime)
+		_, _, _, failed, err := s.doCall(ctx, args, rpc.LatestBlockNumber, vm.Config{UseOpcodeComputationCost: true}, localTxExecutionTime)
 		if err != nil || failed {
 			return false
 		}

--- a/client/klay_client.go
+++ b/client/klay_client.go
@@ -25,6 +25,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
+
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/api"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -32,7 +34,6 @@ import (
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/ser/rlp"
-	"math/big"
 )
 
 // TODO-Klaytn Needs to separate APIs along with each namespaces.
@@ -445,7 +446,7 @@ func (ec *Client) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 }
 
 // EstimateGas tries to estimate the gas needed to execute a specific transaction based on
-// the current pending state of the backend blockchain. There is no guarantee that this is
+// the latest state of the backend blockchain. There is no guarantee that this is
 // the true gas limit requirement as other transactions may be added or removed by miners,
 // but it should provide a basis for setting a reasonable default.
 func (ec *Client) EstimateGas(ctx context.Context, msg klaytn.CallMsg) (uint64, error) {

--- a/contracts/reward/contract/KlaytnReward_test.go
+++ b/contracts/reward/contract/KlaytnReward_test.go
@@ -18,15 +18,16 @@ package contract
 
 import (
 	"context"
-	"fmt"
+	"log"
+	"math/big"
+	"testing"
+
 	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/params"
-	"log"
-	"math/big"
-	"testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSmartContract(t *testing.T) {
@@ -37,7 +38,10 @@ func TestSmartContract(t *testing.T) {
 	key2, _ := crypto.GenerateKey()
 	auth2 := bind.NewKeyedTransactor(key2)
 
-	alloc := blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(params.KLAY)}, auth2.From: {Balance: big.NewInt(params.KLAY)}}
+	initialValue := big.NewInt(params.KLAY)
+	withdrawValue := big.NewInt(500000000)
+
+	alloc := blockchain.GenesisAlloc{auth.From: {Balance: initialValue}, auth2.From: {Balance: initialValue}}
 	sim := backends.NewSimulatedBackend(alloc)
 
 	// Deploy a token contract on the simulated blockchain
@@ -45,37 +49,33 @@ func TestSmartContract(t *testing.T) {
 	if err != nil {
 		log.Fatalf("Failed to deploy new token contract: %v", err)
 	}
-	// Print the current (non existent) and pending name of the contract
-	tx, err := reward.Reward(&bind.TransactOpts{From: auth.From, Signer: auth.Signer, Value: big.NewInt(500000000)}, auth2.From)
+	sim.Commit()
+
+	// Set reward
+	tx, err := reward.Reward(&bind.TransactOpts{From: auth.From, Signer: auth.Signer,
+		Value: withdrawValue}, auth2.From)
 	if err != nil {
 		log.Fatalf("Failed to call reward : %v", err)
 	}
-	fmt.Println("reward tx.hash :", tx.Hash().Hex())
-
-	// Commit all pending transactions in the simulator and print the names again
 	sim.Commit()
+	assert.Equal(t, uint(1), sim.BlockChain().GetReceiptByTxHash(tx.Hash()).Status)
 
-	balance, _ := reward.BalanceOf((&bind.CallOpts{Pending: true}), auth2.From)
-	fmt.Println("balance :", balance)
+	// Check the balance before withdrawal
+	balance1, err := sim.BalanceAt(context.Background(), auth2.From, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, initialValue, balance1)
 
-	amount, _ := reward.TotalAmount((&bind.CallOpts{Pending: true}))
-	fmt.Println("total amount :", amount)
-
-	balance1, _ := sim.BalanceAt(context.Background(), auth2.From, big.NewInt(1))
-	fmt.Println("before reward, balance :", balance1)
-
-	tx2, err2 := reward.SafeWithdrawal(&bind.TransactOpts{From: auth2.From, Signer: auth2.Signer, Value: big.NewInt(0)})
-	if err2 != nil {
-		log.Fatalf("Failed to call reward : %v", err2)
+	// Withdraw reward
+	tx2, err := reward.SafeWithdrawal(&bind.TransactOpts{From: auth2.From, Signer: auth2.Signer,
+		Value: big.NewInt(0)})
+	if err != nil {
+		log.Fatalf("Failed to call reward : %v", err)
 	}
-	fmt.Println("reward tx.hash :", tx2.Hash().Hex())
-
 	sim.Commit()
+	assert.Equal(t, uint(1), sim.BlockChain().GetReceiptByTxHash(tx2.Hash()).Status)
 
-	balance2, _ := sim.BalanceAt(context.Background(), auth2.From, big.NewInt(2))
-	fmt.Println("after reward, balance :", balance2)
-
-	if balance1.Cmp(balance2) >= 0 {
-		log.Fatalf("Failed to withdraw safely")
-	}
+	// Check the balance after withdrawal
+	balance2, err := sim.BalanceAt(context.Background(), auth2.From, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, new(big.Int).Add(balance1, withdrawValue), balance2)
 }

--- a/go.sum
+++ b/go.sum
@@ -463,6 +463,7 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/interfaces.go
+++ b/interfaces.go
@@ -24,9 +24,10 @@ package klaytn
 import (
 	"context"
 	"errors"
+	"math/big"
+
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
-	"math/big"
 )
 
 // NotFound is returned by API methods if the requested item does not exist.
@@ -197,7 +198,7 @@ type PendingContractCaller interface {
 }
 
 // GasEstimator wraps EstimateGas, which tries to estimate the gas needed to execute a
-// specific transaction based on the pending state. There is no guarantee that this is the
+// specific transaction based on the latest state. There is no guarantee that this is the
 // true gas limit requirement as other transactions may be added or removed by miners, but
 // it should provide a basis for setting a reasonable default.
 type GasEstimator interface {

--- a/node/sc/local_backend.go
+++ b/node/sc/local_backend.go
@@ -83,11 +83,11 @@ func (lb *LocalBackend) CallContract(ctx context.Context, call klaytn.CallMsg, b
 	if blockNumber != nil && blockNumber.Cmp(lb.subbrige.blockchain.CurrentBlock().Number()) != 0 {
 		return nil, errBlockNumberUnsupported
 	}
-	state, err := lb.subbrige.blockchain.State()
+	currentState, err := lb.subbrige.blockchain.State()
 	if err != nil {
 		return nil, err
 	}
-	rval, _, _, err := lb.callContract(ctx, call, lb.subbrige.blockchain.CurrentBlock(), state)
+	rval, _, _, err := lb.callContract(ctx, call, lb.subbrige.blockchain.CurrentBlock(), currentState)
 	return rval, err
 }
 
@@ -174,11 +174,11 @@ func (lb *LocalBackend) EstimateGas(ctx context.Context, call klaytn.CallMsg) (g
 	executable := func(gas uint64) bool {
 		call.Gas = gas
 
-		state, err := lb.subbrige.blockchain.State()
+		currentState, err := lb.subbrige.blockchain.State()
 		if err != nil {
 			return false
 		}
-		_, _, failed, err := lb.callContract(ctx, call, lb.subbrige.blockchain.CurrentBlock(), state)
+		_, _, failed, err := lb.callContract(ctx, call, lb.subbrige.blockchain.CurrentBlock(), currentState)
 		if err != nil || failed {
 			return false
 		}

--- a/node/sc/local_backend.go
+++ b/node/sc/local_backend.go
@@ -24,6 +24,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
+	"time"
+
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/bloombits"
@@ -37,8 +40,6 @@ import (
 	"github.com/klaytn/klaytn/node/cn/filters"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
-	"math/big"
-	"time"
 )
 
 const defaultGasPrice = 50 * params.Ston
@@ -174,6 +175,9 @@ func (lb *LocalBackend) EstimateGas(ctx context.Context, call klaytn.CallMsg) (g
 		call.Gas = gas
 
 		state, err := lb.subbrige.blockchain.State()
+		if err != nil {
+			return false
+		}
 		_, _, failed, err := lb.callContract(ctx, call, lb.subbrige.blockchain.CurrentBlock(), state)
 		if err != nil || failed {
 			return false


### PR DESCRIPTION
## Proposed changes

As EN doesn't generate a block, the pending block is not a proper concept for Klaytn.
Moreover, KES node disabling `worker` cannot serve APIs using `pendingBlock`.
This PR changes a default parameter of Estimate APIs; `PendingBlockNumber` -> `LatestBlockNumber`.
Later, the use of `pendingBlock` will be removed (or disabled) in APIs.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
