### PR TITLE
Not support pending block in APIs

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -149,27 +149,20 @@ func (s *PublicBlockChainAPI) GetAccount(ctx context.Context, address common.Add
 // transactions in the block are returned in full detail, otherwise only the transaction hash is returned.
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.BlockByNumber(ctx, blockNr)
-	if block != nil && err == nil {
-		response, err := s.rpcOutputBlock(block, true, fullTx)
-		if err == nil && blockNr == rpc.PendingBlockNumber {
-			// Pending blocks need to nil out a few fields
-			for _, field := range []string{"hash", "nonce", "miner"} {
-				response[field] = nil
-			}
-		}
-		return response, err
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	return s.rpcOutputBlock(block, true, fullTx)
 }
 
 // GetBlockByHash returns the requested block. When fullTx is true all transactions in the block are returned in full
 // detail, otherwise only the transaction hash is returned.
 func (s *PublicBlockChainAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.GetBlock(ctx, blockHash)
-	if block != nil && err == nil {
-		return s.rpcOutputBlock(block, true, fullTx)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	return s.rpcOutputBlock(block, true, fullTx)
 }
 
 // GetCode returns the code stored at the given address in the state for the given block number.

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -24,14 +24,15 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"math/big"
+	"reflect"
+
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/types/accountkey"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/ser/rlp"
-	"math/big"
-	"reflect"
 )
 
 var (

--- a/governance/api.go
+++ b/governance/api.go
@@ -18,13 +18,15 @@ package governance
 
 import (
 	"errors"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/networks/rpc"
-	"github.com/klaytn/klaytn/params"
 	"math/big"
 	"reflect"
 	"strings"
 	"sync/atomic"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/kerrors"
+	"github.com/klaytn/klaytn/networks/rpc"
+	"github.com/klaytn/klaytn/params"
 )
 
 type PublicGovernanceAPI struct {
@@ -59,10 +61,13 @@ var (
 	errInvalidKeyValue        = errors.New("Your vote couldn't be placed. Please check your vote's key and value")
 )
 
+// TODO-Klaytn-Governance: Refine this API and consider the gas price of txpool
 func (api *GovernanceKlayAPI) GasPriceAt(num *rpc.BlockNumber) (*big.Int, error) {
-	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
+	if num == nil || *num == rpc.LatestBlockNumber {
 		ret := api.governance.UnitPrice()
 		return big.NewInt(0).SetUint64(ret), nil
+	} else if *num == rpc.PendingBlockNumber {
+		return nil, kerrors.ErrPendingBlockNotSupported
 	} else {
 		blockNum := num.Int64()
 
@@ -143,8 +148,10 @@ func (api *PublicGovernanceAPI) TotalVotingPower() (float64, error) {
 
 func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interface{}, error) {
 	blockNumber := uint64(0)
-	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
+	if num == nil || *num == rpc.LatestBlockNumber {
 		blockNumber = api.governance.blockChain.CurrentHeader().Number.Uint64()
+	} else if *num == rpc.PendingBlockNumber {
+		return nil, kerrors.ErrPendingBlockNotSupported
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
@@ -172,10 +179,13 @@ func (api *PublicGovernanceAPI) IdxCacheFromDb() []uint64 {
 	return api.governance.IdxCacheFromDb()
 }
 
+// TODO-Klaytn: Return error if invalid input is given such as pending or a too big number
 func (api *PublicGovernanceAPI) ItemCacheFromDb(num *rpc.BlockNumber) map[string]interface{} {
 	blockNumber := uint64(0)
-	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
+	if num == nil || *num == rpc.LatestBlockNumber {
 		blockNumber = api.governance.blockChain.CurrentHeader().Number.Uint64()
+	} else if *num == rpc.PendingBlockNumber {
+		return nil
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
@@ -239,35 +249,36 @@ func (api *GovernanceKlayAPI) GasPriceAtNumber(num int64) (uint64, error) {
 	return val.(uint64), nil
 }
 
-func (api *GovernanceKlayAPI) GetTxGasHumanReadable(num *rpc.BlockNumber) (uint64, error) {
-	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		// If the value hasn't been set in governance, set it with default value
-		if ret := api.governance.GetGovernanceValue(params.ConstTxGasHumanReadable); ret == nil {
-			return api.setDefaultTxGasHumanReadable()
-		} else {
-			return ret.(uint64), nil
-		}
-	} else {
-		blockNum := num.Int64()
-
-		if blockNum > api.chain.CurrentHeader().Number.Int64() {
-			return 0, errUnknownBlock
-		}
-
-		if ret, err := api.governance.GetGovernanceItemAtNumber(uint64(blockNum), GovernanceKeyMapReverse[params.ConstTxGasHumanReadable]); err == nil && ret != nil {
-			return ret.(uint64), nil
-		} else {
-			logger.Error("Failed to retrieve TxGasHumanReadable, sending default value", "err", err)
-			return api.setDefaultTxGasHumanReadable()
-		}
-	}
-}
-
-func (api *GovernanceKlayAPI) setDefaultTxGasHumanReadable() (uint64, error) {
-	err := api.governance.currentSet.SetValue(params.ConstTxGasHumanReadable, params.TxGasHumanReadable)
-	if err != nil {
-		return 0, errSetDefaultFailure
-	} else {
-		return params.TxGasHumanReadable, nil
-	}
-}
+// Disabled APIs
+// func (api *GovernanceKlayAPI) GetTxGasHumanReadable(num *rpc.BlockNumber) (uint64, error) {
+// 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
+// 		// If the value hasn't been set in governance, set it with default value
+// 		if ret := api.governance.GetGovernanceValue(params.ConstTxGasHumanReadable); ret == nil {
+// 			return api.setDefaultTxGasHumanReadable()
+// 		} else {
+// 			return ret.(uint64), nil
+// 		}
+// 	} else {
+// 		blockNum := num.Int64()
+//
+// 		if blockNum > api.chain.CurrentHeader().Number.Int64() {
+// 			return 0, errUnknownBlock
+// 		}
+//
+// 		if ret, err := api.governance.GetGovernanceItemAtNumber(uint64(blockNum), GovernanceKeyMapReverse[params.ConstTxGasHumanReadable]); err == nil && ret != nil {
+// 			return ret.(uint64), nil
+// 		} else {
+// 			logger.Error("Failed to retrieve TxGasHumanReadable, sending default value", "err", err)
+// 			return api.setDefaultTxGasHumanReadable()
+// 		}
+// 	}
+// }
+//
+// func (api *GovernanceKlayAPI) setDefaultTxGasHumanReadable() (uint64, error) {
+// 	err := api.governance.currentSet.SetValue(params.ConstTxGasHumanReadable, params.TxGasHumanReadable)
+// 	if err != nil {
+// 		return 0, errSetDefaultFailure
+// 	} else {
+// 		return params.TxGasHumanReadable, nil
+// 	}
+// }

--- a/kerrors/kerrors.go
+++ b/kerrors/kerrors.go
@@ -51,6 +51,7 @@ var (
 	ErrNestedCompositeType                  = errors.New("nested composite type")
 	ErrLegacyTransactionMustBeWithLegacyKey = errors.New("a legacy transaction must be with a legacy account key")
 
-	ErrDeprecated   = errors.New("deprecated feature")
-	ErrNotSupported = errors.New("not supported")
+	ErrDeprecated               = errors.New("deprecated feature")
+	ErrNotSupported             = errors.New("not supported")
+	ErrPendingBlockNotSupported = errors.New("pending block is not supported")
 )

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -35,6 +35,7 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/ser/rlp"
@@ -215,11 +216,7 @@ func NewPublicDebugAPI(cn *CN) *PublicDebugAPI {
 // DumpBlock retrieves the entire state of the database at a given block.
 func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
 	if blockNr == rpc.PendingBlockNumber {
-		// If we're dumping the pending state, we need to request
-		// both the pending block as well as the pending state from
-		// the miner and operate on those
-		_, stateDb := api.cn.miner.Pending()
-		return stateDb.RawDump(), nil
+		return state.Dump{}, kerrors.ErrPendingBlockNotSupported
 	}
 	var block *types.Block
 	if blockNr == rpc.LatestBlockNumber {

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -34,6 +34,7 @@ import (
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/event"
+	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/node/cn/gasprice"
 	"github.com/klaytn/klaytn/params"
@@ -82,8 +83,7 @@ func (b *CNAPIBackend) SetHead(number uint64) {
 func (b *CNAPIBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error) {
 	// Pending block is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
-		block := b.cn.miner.PendingBlock()
-		return block.Header(), nil
+		return nil, kerrors.ErrPendingBlockNotSupported
 	}
 	// Otherwise resolve and return the block
 	if blockNr == rpc.LatestBlockNumber {
@@ -99,8 +99,7 @@ func (b *CNAPIBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumb
 func (b *CNAPIBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error) {
 	// Pending block is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
-		block := b.cn.miner.PendingBlock()
-		return block, nil
+		return nil, kerrors.ErrPendingBlockNotSupported
 	}
 	// Otherwise resolve and return the block
 	if blockNr == rpc.LatestBlockNumber {
@@ -116,8 +115,7 @@ func (b *CNAPIBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumbe
 func (b *CNAPIBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	// Pending state is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
-		block, state := b.cn.miner.Pending()
-		return state, block.Header(), nil
+		return nil, nil, kerrors.ErrPendingBlockNotSupported
 	}
 	// Otherwise resolve the block number and return its state
 	header, err := b.HeaderByNumber(ctx, blockNr)

--- a/node/cn/api_backend_test.go
+++ b/node/cn/api_backend_test.go
@@ -20,6 +20,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/klaytn/klaytn/kerrors"
+
 	"github.com/golang/mock/gomock"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/state"
@@ -162,13 +164,12 @@ func TestCNAPIBackend_HeaderByNumber(t *testing.T) {
 	block := newBlock(int(blockNum))
 	expectedHeader := block.Header()
 	{
-		mockCtrl, _, mockMiner, api := newCNAPIBackend(t)
-		mockMiner.EXPECT().PendingBlock().Return(block).Times(1)
+		mockCtrl, _, _, api := newCNAPIBackend(t)
 
 		header, err := api.HeaderByNumber(context.Background(), rpc.PendingBlockNumber)
 
-		assert.Equal(t, expectedHeader, header)
-		assert.NoError(t, err)
+		assert.Nil(t, header)
+		assert.Equal(t, kerrors.ErrPendingBlockNotSupported, err)
 
 		mockCtrl.Finish()
 	}
@@ -212,13 +213,12 @@ func TestCNAPIBackend_BlockByNumber(t *testing.T) {
 	block := newBlock(int(blockNum))
 	expectedBlock := block
 	{
-		mockCtrl, _, mockMiner, api := newCNAPIBackend(t)
-		mockMiner.EXPECT().PendingBlock().Return(block).Times(1)
+		mockCtrl, _, _, api := newCNAPIBackend(t)
 
 		block, err := api.BlockByNumber(context.Background(), rpc.PendingBlockNumber)
 
-		assert.Equal(t, expectedBlock, block)
-		assert.NoError(t, err)
+		assert.Nil(t, block)
+		assert.Equal(t, kerrors.ErrPendingBlockNotSupported, err)
 
 		mockCtrl.Finish()
 	}
@@ -270,14 +270,13 @@ func TestCNAPIBackend_StateAndHeaderByNumber(t *testing.T) {
 
 	expectedHeader := block.Header()
 	{
-		mockCtrl, _, mockMiner, api := newCNAPIBackend(t)
-		mockMiner.EXPECT().Pending().Return(block, stateDB).Times(1)
+		mockCtrl, _, _, api := newCNAPIBackend(t)
 
 		returnedStateDB, header, err := api.StateAndHeaderByNumber(context.Background(), rpc.PendingBlockNumber)
 
-		assert.Equal(t, stateDB, returnedStateDB)
-		assert.Equal(t, expectedHeader, header)
-		assert.NoError(t, err)
+		assert.Nil(t, returnedStateDB)
+		assert.Nil(t, header)
+		assert.Equal(t, kerrors.ErrPendingBlockNotSupported, err)
 
 		mockCtrl.Finish()
 	}

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/klaytn/klaytn/log"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -41,6 +40,8 @@ import (
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/kerrors"
+	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/node/cn/tracers"
 	"github.com/klaytn/klaytn/ser/rlp"
@@ -116,7 +117,7 @@ func (api *PrivateDebugAPI) TraceChain(ctx context.Context, start, end rpc.Block
 
 	switch start {
 	case rpc.PendingBlockNumber:
-		from = api.cn.miner.PendingBlock()
+		return nil, kerrors.ErrPendingBlockNotSupported
 	case rpc.LatestBlockNumber:
 		from = api.cn.blockchain.CurrentBlock()
 	default:
@@ -124,7 +125,7 @@ func (api *PrivateDebugAPI) TraceChain(ctx context.Context, start, end rpc.Block
 	}
 	switch end {
 	case rpc.PendingBlockNumber:
-		to = api.cn.miner.PendingBlock()
+		return nil, kerrors.ErrPendingBlockNotSupported
 	case rpc.LatestBlockNumber:
 		to = api.cn.blockchain.CurrentBlock()
 	default:
@@ -365,7 +366,7 @@ func (api *PrivateDebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.B
 
 	switch number {
 	case rpc.PendingBlockNumber:
-		block = api.cn.miner.PendingBlock()
+		return nil, kerrors.ErrPendingBlockNotSupported
 	case rpc.LatestBlockNumber:
 		block = api.cn.blockchain.CurrentBlock()
 	default:

--- a/node/cn/api_tracer_test.go
+++ b/node/cn/api_tracer_test.go
@@ -18,16 +18,18 @@ package cn
 
 import (
 	"context"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common/hexutil"
 	mocks2 "github.com/klaytn/klaytn/consensus/mocks"
+	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/networks/rpc"
 	mocks3 "github.com/klaytn/klaytn/node/cn/mocks"
 	"github.com/klaytn/klaytn/work/mocks"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func createCNMocks(t *testing.T) (*gomock.Controller, *PrivateDebugAPI, *mocks2.MockEngine, *mocks.MockBlockChain, *mocks3.MockMiner) {
@@ -39,14 +41,12 @@ func createCNMocks(t *testing.T) (*gomock.Controller, *PrivateDebugAPI, *mocks2.
 
 func TestPrivateDebugAPI_TraceChain(t *testing.T) {
 	endBlockNumber := rpc.BlockNumber(123)
-	block := newBlock(123)
 	// from == nil
 	{
-		mockCtrl, api, _, _, mockMiner := createCNMocks(t)
-		mockMiner.EXPECT().PendingBlock().Return(nil).Times(2)
+		mockCtrl, api, _, _, _ := createCNMocks(t)
 		sub, err := api.TraceChain(context.Background(), rpc.PendingBlockNumber, rpc.PendingBlockNumber, nil)
 		assert.Nil(t, sub)
-		assert.Error(t, err)
+		assert.Equal(t, kerrors.ErrPendingBlockNotSupported, err)
 		mockCtrl.Finish()
 	}
 	{
@@ -67,22 +67,18 @@ func TestPrivateDebugAPI_TraceChain(t *testing.T) {
 	}
 	// from != nil
 	{
-		mockCtrl, api, _, mockBlockChain, mockMiner := createCNMocks(t)
-		mockMiner.EXPECT().PendingBlock().Return(block).Times(1)
-		mockBlockChain.EXPECT().CurrentBlock().Return(nil).Times(1)
+		mockCtrl, api, _, _, _ := createCNMocks(t)
 		sub, err := api.TraceChain(context.Background(), rpc.PendingBlockNumber, rpc.LatestBlockNumber, nil)
 		assert.Nil(t, sub)
-		assert.Error(t, err)
+		assert.Equal(t, kerrors.ErrPendingBlockNotSupported, err)
 		mockCtrl.Finish()
 	}
 	{
 		endBlockNumber := rpc.BlockNumber(123)
-		mockCtrl, api, _, mockBlockChain, mockMiner := createCNMocks(t)
-		mockMiner.EXPECT().PendingBlock().Return(block).Times(1)
-		mockBlockChain.EXPECT().GetBlockByNumber(uint64(endBlockNumber)).Return(nil).Times(1)
+		mockCtrl, api, _, _, _ := createCNMocks(t)
 		sub, err := api.TraceChain(context.Background(), rpc.PendingBlockNumber, endBlockNumber, nil)
 		assert.Nil(t, sub)
-		assert.Error(t, err)
+		assert.Equal(t, kerrors.ErrPendingBlockNotSupported, err)
 		mockCtrl.Finish()
 	}
 }
@@ -90,11 +86,10 @@ func TestPrivateDebugAPI_TraceChain(t *testing.T) {
 func TestPrivateDebugAPI_TraceBlockByNumber(t *testing.T) {
 	blockNumber := rpc.BlockNumber(123)
 	{
-		mockCtrl, api, _, _, mockMiner := createCNMocks(t)
-		mockMiner.EXPECT().PendingBlock().Return(nil).Times(1)
+		mockCtrl, api, _, _, _ := createCNMocks(t)
 		sub, err := api.TraceBlockByNumber(context.Background(), rpc.PendingBlockNumber, nil)
 		assert.Nil(t, sub)
-		assert.Error(t, err)
+		assert.Equal(t, kerrors.ErrPendingBlockNotSupported, err)
 		mockCtrl.Finish()
 	}
 	{

--- a/node/cn/filters/api.go
+++ b/node/cn/filters/api.go
@@ -25,16 +25,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/event"
+	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/storage/database"
-	"math/big"
-	"sync"
-	"time"
 )
 
 var (
@@ -442,6 +444,14 @@ func (args *FilterCriteria) UnmarshalJSON(data []byte) error {
 	var raw input
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
+	}
+
+	if raw.From != nil && *raw.From == rpc.PendingBlockNumber {
+		return kerrors.ErrPendingBlockNotSupported
+	}
+
+	if raw.ToBlock != nil && *raw.ToBlock == rpc.PendingBlockNumber {
+		return kerrors.ErrPendingBlockNotSupported
 	}
 
 	if raw.From != nil {


### PR DESCRIPTION
## Proposed changes

"pending" keyword is disabled in all APIs except for `klay_getTransactionCount` since EN can't mine blocks. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
