### PR TITLE
abi: fix nil dereference in abi.JSON

### DIFF
--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -729,3 +729,21 @@ func TestABI_MethodById(t *testing.T) {
 		}
 	*/
 }
+
+func TestMaliciousABIStrings(t *testing.T) {
+	// methods defined in tests are generated from method signatures below
+	//	"func(uint256,uint256,[]uint256)"
+	//	"func(uint256,uint256,uint256,)"
+	//	"func(,uint256,uint256,uint256)"
+	tests := []string{
+		"[{\"name\":\"func\",\"type\":\"function\",\"inputs\":[{\"type\":\"uint256\"},{\"type\":\"uint256\"},{\"type\":\"[]uint256\"}]}]",
+		"[{\"name\":\"func\",\"type\":\"function\",\"inputs\":[{\"type\":\"uint256\"},{\"type\":\"uint256\"},{\"type\":\"uint256\"},{\"type\":\"\"}]}]",
+		"[{\"name\":\"func\",\"type\":\"function\",\"inputs\":[{\"type\":\"\"},{\"type\":\"uint256\"},{\"type\":\"uint256\"},{\"type\":\"uint256\"}]}]",
+	}
+	for i, tt := range tests {
+		_, err := JSON(strings.NewReader(tt))
+		if err == nil {
+			t.Errorf("test %d: expected error from JSON '%v'", i, tt)
+		}
+	}
+}

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -103,7 +103,11 @@ func NewType(t string) (typ Type, err error) {
 		return typ, err
 	}
 	// parse the type and size of the abi-type.
-	parsedType := typeRegex.FindAllStringSubmatch(t, -1)[0]
+	matches := typeRegex.FindAllStringSubmatch(t, -1)
+	if len(matches) == 0 {
+		return Type{}, fmt.Errorf("invalid type '%v'", t)
+	}
+	parsedType := matches[0]
 	// varSize is the size of the variable
 	var varSize int
 	if len(parsedType[3]) > 0 {


### PR DESCRIPTION
## Proposed changes

* This PR is to fix nil dereference in abi.JSON. The related issue is https://github.com/ethereum/go-ethereum/issues/17633, and related fix PR is https://github.com/ethereum/go-ethereum/pull/17653.
* The abi.JSON gets panic when the NewType function returns no error even malicious abi comes in.
* This PR fixes the NewType to return an error when malicious abi comes in, so that abi.JSON not to panic.
* TestMaliciousABIStrings function is added to check this fix works well.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
