### PR TITLE
Added debug.startCollectingTrieStats

### DIFF
--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -572,13 +572,10 @@ func (bc *BlockChain) StartCollectingTrieStats(contractAddr common.Address) erro
 	return nil
 }
 
-// errFinishedCollecting is used to indicate that a collectChildrenStats call is finished.
-var errFinishedCollecting = errors.New("finished collecting stats")
-
 // collectChildrenStats wraps CollectChildrenStats, in order to send finish signal to resultCh.
 func collectChildrenStats(db state.Database, child common.Hash, resultCh chan<- statedb.NodeInfo) {
 	db.TrieDB().CollectChildrenStats(child, 2, resultCh)
-	resultCh <- statedb.NodeInfo{Err: errFinishedCollecting}
+	resultCh <- statedb.NodeInfo{Finished: true}
 }
 
 // collectTrieStats is the main function of collecting trie statistics.
@@ -604,7 +601,7 @@ func collectTrieStats(db state.Database, startNode common.Hash) {
 	for {
 		select {
 		case result := <-resultCh:
-			if result.Err == errFinishedCollecting {
+			if result.Finished {
 				numGoRoutines--
 				if numGoRoutines == 0 {
 					logger.Info("Finished collecting trie statistics", "elapsed", time.Since(begin),

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -24,6 +24,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/blockchain/types/account"
+
 	"github.com/VictoriaMetrics/fastcache"
 
 	"github.com/alecthomas/units"
@@ -117,7 +120,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 	srcState := bc.StateCache()
 	dstState := state.NewDatabase(&stateTrieMigrationDB{bc.db})
 
-	// NOTE: lruCache is mendatory when state migration and block processing are executed simultaneously
+	// NOTE: lruCache is mandatory when state migration and block processing are executed simultaneously
 	lruCache, _ := lru.New(int(2 * units.Giga / common.HashLength)) // 2GB for 62,500,000 common.Hash key values
 	trieSync := state.NewStateSync(rootHash, dstState.TrieDB().DiskDB(), nil, lruCache)
 	var queue []common.Hash
@@ -527,4 +530,142 @@ func (bc *BlockChain) StopWarmUp() error {
 	close(bc.quitWarmUp)
 
 	return nil
+}
+
+// StartCollectingTrieStats collects state or storage trie statistics.
+func (bc *BlockChain) StartCollectingTrieStats(contractAddr common.Address) error {
+	block := bc.GetBlockByNumber(bc.lastCommittedBlock)
+	if block == nil {
+		return fmt.Errorf("Block #%d not found", bc.lastCommittedBlock)
+	}
+
+	mainTrieDB := bc.StateCache().TrieDB()
+	cache := mainTrieDB.TrieNodeCache()
+	if cache == nil {
+		return fmt.Errorf("target cache is nil")
+	}
+	db := state.NewDatabaseWithExistingCache(bc.db, cache)
+
+	startNode := block.Root()
+	// If the contractAddr is given, start collecting stats from the root of storage trie
+	if !common.EmptyAddress(contractAddr) {
+		var err error
+		startNode, err = bc.GetContractStorageRoot(block, db, contractAddr)
+		if err != nil {
+			logger.Error("Failed to get the contract storage root",
+				"contractAddr", contractAddr.String(), "rootHash", block.Root().String(),
+				"err", err)
+			return err
+		}
+	}
+
+	children, err := db.TrieDB().NodeChildren(startNode)
+	if err != nil {
+		logger.Error("Failed to retrieve the children of start node", "err", err)
+		return err
+	}
+
+	logger.Info("Started collecting trie statistics",
+		"blockNum", block.NumberU64(), "root", block.Root().String(), "len(children)", len(children))
+	go collectTrieStats(db, startNode)
+
+	return nil
+}
+
+// errFinishedCollecting is used to indicate that a collectChildrenStats call is finished.
+var errFinishedCollecting = errors.New("finished collecting stats")
+
+// collectChildrenStats wraps CollectChildrenStats, in order to send finish signal to resultCh.
+func collectChildrenStats(db state.Database, child common.Hash, resultCh chan<- statedb.NodeInfo) {
+	db.TrieDB().CollectChildrenStats(child, 2, resultCh)
+	resultCh <- statedb.NodeInfo{Err: errFinishedCollecting}
+}
+
+// collectTrieStats is the main function of collecting trie statistics.
+// It spawns goroutines for the upper-most children and
+func collectTrieStats(db state.Database, startNode common.Hash) {
+	children, err := db.TrieDB().NodeChildren(startNode)
+	if err != nil {
+		logger.Error("Failed to retrieve the children of start node", "err", err)
+	}
+
+	// collecting statistics by running individual goroutines for each child
+	resultCh := make(chan statedb.NodeInfo, 10000)
+	for _, child := range children {
+		go collectChildrenStats(db, child, resultCh)
+	}
+
+	numGoRoutines := len(children)
+	ticker := time.NewTicker(1 * time.Minute)
+
+	numNodes, numLeafNodes, maxDepth := 0, 0, 0
+	depthCounter := make(map[int]int)
+	begin := time.Now()
+	for {
+		select {
+		case result := <-resultCh:
+			if result.Err == errFinishedCollecting {
+				numGoRoutines--
+				continue
+			}
+			numNodes++
+			// if a leaf node, collect the depth data
+			if result.Depth != 0 {
+				numLeafNodes++
+				depthCounter[result.Depth]++
+				if result.Depth > maxDepth {
+					maxDepth = result.Depth
+				}
+			}
+		case <-ticker.C:
+			// leave a periodic log
+			logger.Info("Collecting trie statistics is in progress...", "elapsed", time.Since(begin),
+				"numGoRoutines", numGoRoutines, "numNodes", numNodes, "numLeafNodes", numLeafNodes, "maxDepth", maxDepth)
+			printDepthStats(depthCounter)
+		default:
+			if numGoRoutines != 0 {
+				continue
+			}
+			logger.Info("Finished collecting trie statistics", "elapsed", time.Since(begin),
+				"numNodes", numNodes, "numLeafNodes", numLeafNodes, "maxDepth", maxDepth)
+			printDepthStats(depthCounter)
+			return
+		}
+	}
+}
+
+// printDepthStats leaves logs containing the depth and the number of nodes in the depth.
+func printDepthStats(depthCounter map[int]int) {
+	// max depth 20 is set by heuristically
+	for depth := 2; depth < 20; depth++ {
+		if depthCounter[depth] == 0 {
+			continue
+		}
+		logger.Info("number of leaf nodes in a depth",
+			"depth", depth, "numNodes", depthCounter[depth])
+	}
+}
+
+var errNotExistingAddress = fmt.Errorf("there is no account corresponding to the given address")
+var errNotContractAddress = fmt.Errorf("given address is not a contract address")
+
+// GetContractStorageRoot returns the storage root of a contract based on the given block.
+func (bc *BlockChain) GetContractStorageRoot(block *types.Block, db state.Database, contractAddr common.Address) (common.Hash, error) {
+	stateDB, err := state.New(block.Root(), db)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to get StateDB - %w", err)
+	}
+
+	acc := stateDB.GetAccount(contractAddr)
+	if acc == nil {
+		return common.Hash{}, errNotExistingAddress
+	}
+	if acc.Type() != account.SmartContractAccountType {
+		return common.Hash{}, errNotContractAddress
+	}
+	contract, true := acc.(*account.SmartContractAccount)
+	if !true {
+		return common.Hash{}, errNotContractAddress
+	}
+	return contract.GetStorageRoot(), nil
 }

--- a/common/types.go
+++ b/common/types.go
@@ -25,11 +25,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/klaytn/klaytn/common/hexutil"
-	"github.com/klaytn/klaytn/crypto/sha3"
 	"math/big"
 	"math/rand"
 	"reflect"
+
+	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/crypto/sha3"
 )
 
 const (
@@ -161,6 +162,10 @@ func (h UnprefixedHash) MarshalText() ([]byte, error) {
 
 // Address represents the 20 byte address of a Klaytn account.
 type Address [AddressLength]byte
+
+func EmptyAddress(a Address) bool {
+	return a == Address{}
+}
 
 // BytesToAddress returns Address with value b.
 // If b is larger than len(h), b will be cropped from the left.

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -360,6 +360,11 @@ web3._extend({
 			call: 'debug_stopWarmUp',
 		}),
 		new web3._extend.Method({
+			name: 'startCollectingTrieStats',
+			call: 'debug_startCollectingTrieStats',
+			params: 1,
+		}),
+		new web3._extend.Method({
 			name: 'chaindbProperty',
 			call: 'debug_chaindbProperty',
 			params: 1,

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -287,6 +287,7 @@ func (api *PublicDebugAPI) StopWarmUp() error {
 	return api.cn.blockchain.StopWarmUp()
 }
 
+// StartCollectingTrieStats  collects state/storage trie statistics and print in the log.
 func (api *PublicDebugAPI) StartCollectingTrieStats(contractAddr common.Address) error {
 	return api.cn.blockchain.StartCollectingTrieStats(contractAddr)
 }

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -287,6 +287,10 @@ func (api *PublicDebugAPI) StopWarmUp() error {
 	return api.cn.blockchain.StopWarmUp()
 }
 
+func (api *PublicDebugAPI) StartCollectingTrieStats(contractAddr common.Address) error {
+	return api.cn.blockchain.StartCollectingTrieStats(contractAddr)
+}
+
 // PrivateDebugAPI is the collection of CN full node APIs exposed over
 // the private debugging endpoint.
 type PrivateDebugAPI struct {

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -1141,8 +1141,8 @@ func (db *Database) SaveTrieNodeCacheToFile(filePath string) error {
 
 // NodeInfo is a struct used for collecting trie statistics
 type NodeInfo struct {
-	Depth int // 0 if not a leaf node
-	Err   error
+	Depth    int  // 0 if not a leaf node
+	Finished bool // true if the uppermost call is finished
 }
 
 // CollectChildrenStats collects the depth of the trie recursively
@@ -1156,7 +1156,6 @@ func (db *Database) CollectChildrenStats(node common.Hash, depth int, resultCh c
 	if err != nil {
 		logger.Error("failed to retrieve the children nodes",
 			"node", node.String(), "err", err)
-		resultCh <- NodeInfo{Err: err}
 		return
 	}
 	// write the depth of the node only if the node is a leaf node, otherwise set 0

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -697,6 +697,20 @@ func (mr *MockBlockChainMockRecorder) SetUseGiniCoeff(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUseGiniCoeff", reflect.TypeOf((*MockBlockChain)(nil).SetUseGiniCoeff), arg0)
 }
 
+// StartCollectingTrieStats mocks base method
+func (m *MockBlockChain) StartCollectingTrieStats(arg0 common.Address) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartCollectingTrieStats", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartCollectingTrieStats indicates an expected call of StartCollectingTrieStats
+func (mr *MockBlockChainMockRecorder) StartCollectingTrieStats(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartCollectingTrieStats", reflect.TypeOf((*MockBlockChain)(nil).StartCollectingTrieStats), arg0)
+}
+
 // StartStateMigration mocks base method
 func (m *MockBlockChain) StartStateMigration(arg0 uint64, arg1 common.Hash) error {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -297,7 +297,7 @@ type BlockChain interface {
 	StartWarmUp() error
 	StopWarmUp() error
 
-	// Collect state/storage trie statistics
+	// Collect state/sgetModifiedAccountsByNumbetorage trie statistics
 	StartCollectingTrieStats(contractAddr common.Address) error
 
 	// Save trie node cache to this

--- a/work/work.go
+++ b/work/work.go
@@ -297,7 +297,7 @@ type BlockChain interface {
 	StartWarmUp() error
 	StopWarmUp() error
 
-	// Collect state/sgetModifiedAccountsByNumbetorage trie statistics
+	// Collect state/storage trie statistics
 	StartCollectingTrieStats(contractAddr common.Address) error
 
 	// Save trie node cache to this

--- a/work/work.go
+++ b/work/work.go
@@ -297,6 +297,9 @@ type BlockChain interface {
 	StartWarmUp() error
 	StopWarmUp() error
 
+	// Collect state/storage trie statistics
+	StartCollectingTrieStats(contractAddr common.Address) error
+
 	// Save trie node cache to this
 	SaveTrieNodeCacheToDisk() error
 


### PR DESCRIPTION
## Proposed changes

- Added `debug.startCollectingTrieStats` API to collect statistics of a state or storage trie
- **If an empty address**(=`0x0000000000000000000000000000000000000000`) is given,
 it will collect the statistics of a state trie of the latest block.
- **If an address is given**, it will collect the statistics of a storage trie, if it is a contract address. 
- It will collect the stats in the background goroutine and periodically leave the logs.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
