### PR TITLE
Use common.EmptyAddress instead of reward.isEmptyAddress

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -25,11 +25,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/klaytn/klaytn/common/hexutil"
-	"github.com/klaytn/klaytn/crypto/sha3"
 	"math/big"
 	"math/rand"
 	"reflect"
+
+	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/crypto/sha3"
 )
 
 const (
@@ -161,6 +162,10 @@ func (h UnprefixedHash) MarshalText() ([]byte, error) {
 
 // Address represents the 20 byte address of a Klaytn account.
 type Address [AddressLength]byte
+
+func EmptyAddress(a Address) bool {
+	return a == Address{}
+}
 
 // BytesToAddress returns Address with value b.
 // If b is larger than len(h), b will be cropped from the left.

--- a/reward/addressbook_connector.go
+++ b/reward/addressbook_connector.go
@@ -19,6 +19,9 @@ package reward
 import (
 	"errors"
 	"fmt"
+	"math/big"
+	"strings"
+
 	"github.com/klaytn/klaytn/accounts/abi"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -26,8 +29,6 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/contracts/reward/contract"
 	"github.com/klaytn/klaytn/params"
-	"math/big"
-	"strings"
 )
 
 // addressType defined in AddressBook
@@ -144,8 +145,8 @@ func (ac *addressBookConnector) parseAllAddresses(result []byte) (nodeIds []comm
 	// validate parsed node information
 	if len(nodeIds) != len(stakingAddrs) ||
 		len(nodeIds) != len(rewardAddrs) ||
-		isEmptyAddress(pocAddr) ||
-		isEmptyAddress(kirAddr) {
+		common.EmptyAddress(pocAddr) ||
+		common.EmptyAddress(kirAddr) {
 		err = errAddressBookIncomplete
 		return
 	}

--- a/reward/reward_distributor.go
+++ b/reward/reward_distributor.go
@@ -17,10 +17,11 @@
 package reward
 
 import (
+	"math/big"
+
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/log"
-	"math/big"
 )
 
 var logger = log.NewModuleLogger(log.Reward)
@@ -35,10 +36,6 @@ type governanceHelper interface {
 	DeferredTxFee() bool
 	ProposerPolicy() uint64
 	StakingUpdateInterval() uint64
-}
-
-func isEmptyAddress(addr common.Address) bool {
-	return addr == common.Address{}
 }
 
 type RewardDistributor struct {
@@ -118,13 +115,13 @@ func (rd *RewardDistributor) distributeBlockReward(b BalanceAdder, header *types
 
 	// Proposer gets PoC incentive and KIR incentive, if there is no PoC/KIR address.
 	// PoC
-	if isEmptyAddress(pocAddr) {
+	if common.EmptyAddress(pocAddr) {
 		pocAddr = proposer
 	}
 	b.AddBalance(pocAddr, pocIncentive)
 
 	// KIR
-	if isEmptyAddress(kirAddr) {
+	if common.EmptyAddress(kirAddr) {
 		kirAddr = proposer
 	}
 	b.AddBalance(kirAddr, kirIncentive)

--- a/reward/reward_distributor_test.go
+++ b/reward/reward_distributor_test.go
@@ -17,11 +17,12 @@
 package reward
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/stretchr/testify/assert"
-	"math/big"
-	"testing"
 )
 
 type testBalanceAdder struct {
@@ -75,7 +76,7 @@ func Test_isEmptyAddress(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.result, isEmptyAddress(testCase.address))
+		assert.Equal(t, testCase.result, common.EmptyAddress(testCase.address))
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

- Use `common.EmptyAddress` instead of `reward.isEmptyAddress` 
- This will be merged after https://github.com/klaytn/klaytn/pull/740

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
