### PR TITLE
Added a new API debug.getModifiedStorageNodesByNumber

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -588,6 +588,12 @@ web3._extend({
 			inputFormatter:[null, null],
 		}),
 		new web3._extend.Method({
+			name: 'getModifiedStorageNodesByNumber',
+			call: 'debug_getModifiedStorageNodesByNumber',
+			params: 4,
+			inputFormatter: [null, null, null, null],
+		}),
+		new web3._extend.Method({
 			name: 'setVMLogTarget',
 			call: 'debug_setVMLogTarget',
 			params: 1

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -409,10 +409,6 @@ func (api *PrivateDebugAPI) GetModifiedAccountsByHash(startHash common.Hash, end
 }
 
 func (api *PrivateDebugAPI) getModifiedAccounts(startBlock, endBlock *types.Block) ([]common.Address, error) {
-	if startBlock.Number().Uint64() >= endBlock.Number().Uint64() {
-		return nil, fmt.Errorf("start block height (%d) must be less than end block height (%d)", startBlock.Number().Uint64(), endBlock.Number().Uint64())
-	}
-
 	trieDB := api.cn.blockchain.StateCache().TrieDB()
 
 	oldTrie, err := statedb.NewSecureTrie(startBlock.Root(), trieDB)
@@ -460,6 +456,10 @@ func (api *PrivateDebugAPI) getStartAndEndBlock(startNum uint64, endNum *uint64)
 		}
 	}
 
+	if startBlock.Number().Uint64() >= endBlock.Number().Uint64() {
+		return nil, nil, fmt.Errorf("start block height (%d) must be less than end block height (%d)", startBlock.Number().Uint64(), endBlock.Number().Uint64())
+	}
+
 	return startBlock, endBlock, nil
 }
 
@@ -476,10 +476,6 @@ func (api *PrivateDebugAPI) GetModifiedStorageNodesByNumber(contractAddr common.
 }
 
 func (api *PrivateDebugAPI) getModifiedStorageNodes(contractAddr common.Address, startBlock, endBlock *types.Block, returnDiffList *bool) ([]common.Address, error) {
-	if startBlock.Number().Uint64() >= endBlock.Number().Uint64() {
-		return nil, fmt.Errorf("start block height (%d) must be less than end block height (%d)", startBlock.Number().Uint64(), endBlock.Number().Uint64())
-	}
-
 	startBlockRoot, err := api.cn.blockchain.GetContractStorageRoot(startBlock, api.cn.blockchain.StateCache(), contractAddr)
 	if err != nil {
 		return nil, err

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -502,17 +502,15 @@ func (api *PrivateDebugAPI) getModifiedStorageNodes(contractAddr common.Address,
 	logger.Info("Start collecting the modified storage nodes", "contractAddr", contractAddr.String(),
 		"startBlock", startBlock.NumberU64(), "endBlock", endBlock.NumberU64())
 	start := time.Now()
-	var dirty []common.Hash
+	numModifiedNodes := 0
 	for iter.Next() {
-		dirty = append(dirty, common.BytesToHash(iter.Key))
-	}
-	logger.Info("Finished collecting the modified storage nodes", "contractAddr", contractAddr.String(),
-		"startBlock", startBlock.NumberU64(), "endBlock", endBlock.NumberU64(), "numModifiedNodes", len(dirty), "elapsed", time.Since(start))
-	for _, d := range dirty {
+		numModifiedNodes++
 		if printDetail != nil && *printDetail {
-			logger.Info("modified storage trie nodes", "contractAddr", contractAddr.String(), "nodeHash", d.String())
+			logger.Info("modified storage trie nodes", "contractAddr", contractAddr.String(),
+				"nodeHash", common.BytesToHash(iter.Key).String())
 		}
 	}
-
-	return len(dirty), nil
+	logger.Info("Finished collecting the modified storage nodes", "contractAddr", contractAddr.String(),
+		"startBlock", startBlock.NumberU64(), "endBlock", endBlock.NumberU64(), "numModifiedNodes", numModifiedNodes, "elapsed", time.Since(start))
+	return numModifiedNodes, nil
 }

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -296,6 +296,21 @@ func (mr *MockBlockChainMockRecorder) GetBodyRLP(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBodyRLP", reflect.TypeOf((*MockBlockChain)(nil).GetBodyRLP), arg0)
 }
 
+// GetContractStorageRoot mocks base method
+func (m *MockBlockChain) GetContractStorageRoot(arg0 *types.Block, arg1 state.Database, arg2 common.Address) (common.Hash, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContractStorageRoot", arg0, arg1, arg2)
+	ret0, _ := ret[0].(common.Hash)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetContractStorageRoot indicates an expected call of GetContractStorageRoot
+func (mr *MockBlockChainMockRecorder) GetContractStorageRoot(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContractStorageRoot", reflect.TypeOf((*MockBlockChain)(nil).GetContractStorageRoot), arg0, arg1, arg2)
+}
+
 // GetHeader mocks base method
 func (m *MockBlockChain) GetHeader(arg0 common.Hash, arg1 uint64) *types.Header {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -299,6 +299,7 @@ type BlockChain interface {
 
 	// Collect state/storage trie statistics
 	StartCollectingTrieStats(contractAddr common.Address) error
+	GetContractStorageRoot(block *types.Block, db state.Database, contractAddr common.Address) (common.Hash, error)
 
 	// Save trie node cache to this
 	SaveTrieNodeCacheToDisk() error


### PR DESCRIPTION
## Proposed changes

- Added a new debug API, `debug.getModifiedStorageNodesByNumber(contractAddr, startBlockNum, endBlockNum, returnDiffList)` to track the modified contract storage trie nodes between the two blocks specified.
- `endBlockNum` can be omitted and if so, the difference between the `startBlockNum-1` and `startBlockNum` will be calculated. 
- `returnDiffList` can be omitted and if so, the list of the changed nodes will be only printed to the log, not to the console. If it is entered as true, the list of the nodes will be also printed to the console.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
