### PR TITLE
blockchain, api: print block processing summary by default

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1620,8 +1620,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 			validateTime := afterValidate.Sub(procStats.AfterFinalize)
 			logger.Info("Inserted a new block", "number", block.Number(), "hash", block.Hash(),
 				"txs", len(block.Transactions()), "gas", block.GasUsed(), "elapsed", common.PrettyDuration(time.Since(bstart)),
-				"processTxs", processTxsTime, "processFinalize", processFinalizeTime, "validateState", validateTime,
-				"totalWriteTime", writeResult.TotalWriteTime, "trieWriteTime", writeResult.TrieWriteTime)
+				"processTxs", processTxsTime, "finalize", processFinalizeTime, "validateState", validateTime,
+				"totalWrite", writeResult.TotalWriteTime, "trieWrite", writeResult.TrieWriteTime)
 
 			coalescedLogs = append(coalescedLogs, logs...)
 			events = append(events, ChainEvent{

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1746,6 +1746,10 @@ type insertStats struct {
 // report prints statistics if some number of blocks have been processed
 // or more than a few seconds have passed since the last message.
 func (st *insertStats) report(chain []*types.Block, index int, cache common.StorageSize) {
+	// report will leave a log only if inserting two or more blocks at once
+	if len(chain) <= 1 {
+		return
+	}
 	// Fetch the timings for the batch
 	var (
 		now     = mclock.Now()

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -162,7 +162,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 		if err != nil {
 			return err
 		}
-		receipts, _, usedGas, _, err := blockchain.Processor().Process(block, statedb, vm.Config{})
+		receipts, _, usedGas, _, _, err := blockchain.Processor().Process(block, statedb, vm.Config{})
 		if err != nil {
 			blockchain.reportBlock(block, receipts, err)
 			return err

--- a/blockchain/types.go
+++ b/blockchain/types.go
@@ -46,5 +46,5 @@ type Validator interface {
 // of gas used in the process and return an error if any of the internal rules
 // failed.
 type Processor interface {
-	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, []*vm.InternalTxTrace, error)
+	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, []*vm.InternalTxTrace, ProcessStats, error)
 }

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -301,7 +301,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				traced += uint64(len(txs))
 			}
 			// Generate the next state snapshot fast without tracing
-			_, _, _, _, err := api.cn.blockchain.Processor().Process(block, statedb, vm.Config{})
+			_, _, _, _, _, err := api.cn.blockchain.Processor().Process(block, statedb, vm.Config{})
 			if err != nil {
 				failed = err
 				break
@@ -700,7 +700,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 		if block = api.cn.blockchain.GetBlockByNumber(block.NumberU64() + 1); block == nil {
 			return nil, fmt.Errorf("block #%d not found", block.NumberU64()+1)
 		}
-		_, _, _, _, err := api.cn.blockchain.Processor().Process(block, statedb, vm.Config{})
+		_, _, _, _, _, err := api.cn.blockchain.Processor().Process(block, statedb, vm.Config{})
 		if err != nil {
 			return nil, fmt.Errorf("processing block %d failed: %v", block.NumberU64(), err)
 		}

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -297,12 +297,12 @@ func (bcdata *BCData) GenABlockWithTxPoolWithoutAccountMap(txPool *blockchain.Tx
 	}
 
 	// Write the block with state.
-	status, err := bcdata.bc.WriteBlockWithState(b, receipts, stateDB)
+	result, err := bcdata.bc.WriteBlockWithState(b, receipts, stateDB)
 	if err != nil {
 		return fmt.Errorf("err = %s", err)
 	}
 
-	if status == blockchain.SideStatTy {
+	if result.Status == blockchain.SideStatTy {
 		return fmt.Errorf("forked block is generated! number: %v, hash: %v, txs: %v", b.Number(), b.Hash(), len(b.Transactions()))
 	}
 

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -988,10 +988,10 @@ func (mr *MockBlockChainMockRecorder) Validator() *gomock.Call {
 }
 
 // WriteBlockWithState mocks base method
-func (m *MockBlockChain) WriteBlockWithState(arg0 *types.Block, arg1 []*types.Receipt, arg2 *state.StateDB) (blockchain.WriteStatus, error) {
+func (m *MockBlockChain) WriteBlockWithState(arg0 *types.Block, arg1 []*types.Receipt, arg2 *state.StateDB) (blockchain.WriteResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteBlockWithState", arg0, arg1, arg2)
-	ret0, _ := ret[0].(blockchain.WriteStatus)
+	ret0, _ := ret[0].(blockchain.WriteResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/work/work.go
+++ b/work/work.go
@@ -283,7 +283,7 @@ type BlockChain interface {
 	ResetWithGenesisBlock(gb *types.Block) error
 	Validator() blockchain.Validator
 	HasBadBlock(hash common.Hash) bool
-	WriteBlockWithState(block *types.Block, receipts []*types.Receipt, stateDB *state.StateDB) (blockchain.WriteStatus, error)
+	WriteBlockWithState(block *types.Block, receipts []*types.Receipt, stateDB *state.StateDB) (blockchain.WriteResult, error)
 	PostChainEvents(events []interface{}, logs []*types.Log)
 	ApplyTransaction(config *params.ChainConfig, author *common.Address, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg *vm.Config) (*types.Receipt, uint64, *vm.InternalTxTrace, error)
 

--- a/work/worker.go
+++ b/work/worker.go
@@ -378,7 +378,7 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 				log.BlockHash = block.Hash()
 			}
 
-			stat, err := self.chain.WriteBlockWithState(block, work.receipts, work.state)
+			result, err := self.chain.WriteBlockWithState(block, work.receipts, work.state)
 			work.stateMu.Unlock()
 			if err != nil {
 				if err == blockchain.ErrKnownBlock {
@@ -393,7 +393,7 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 			//         Later we may be able to refine below code.
 
 			// check if canon block and write transactions
-			if stat == blockchain.CanonStatTy {
+			if result.Status == blockchain.CanonStatTy {
 				// implicit by posting ChainHeadEvent
 				mustCommitNewWork = false
 			}
@@ -408,7 +408,7 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 			work.stateMu.RUnlock()
 
 			events = append(events, blockchain.ChainEvent{Block: block, Hash: block.Hash(), Logs: logs})
-			if stat == blockchain.CanonStatTy {
+			if result.Status == blockchain.CanonStatTy {
 				events = append(events, blockchain.ChainHeadEvent{Block: block})
 			}
 


### PR DESCRIPTION
## Proposed changes

- This PR is made to make it easier to debug long-running blocks. With this change, block processing summary, which contains detailed block processing time is logged by default for each block.
- 477f88fe20583eb2c5619b1ec755a230a62c3a2f - Leave block processing summary by default for each block
- ~39f2134a1c89e653c253cd3cef53221074e3ad8e - Add `debug_toggleBlockWriteSummary` to enable/disable leaving block processing summary~
- 5dd354fedbc513e37de8c77c53a8755728dd406f - Leave "Imported new chain segment" log only if there are more than 2 blocks

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
