### PR TITLE
Used local pending count instead of calling the pending function again eth#21263

### DIFF
--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -1113,6 +1113,7 @@ func (d *Downloader) fetchParts(errCancel error, deliveryCh chan dataPack, deliv
 
 			// numTotalPeers means the number of peers satisfying the protocol requirement.
 			idlePeers, numTotalPeers := idlePeers()
+			pendCount := pending()
 
 			for _, peer := range idlePeers {
 				// Short circuit if throttling activated
@@ -1121,7 +1122,7 @@ func (d *Downloader) fetchParts(errCancel error, deliveryCh chan dataPack, deliv
 					break
 				}
 				// Short circuit if there is no more available task.
-				if pending() == 0 {
+				if pendCount = pending(); pendCount == 0 {
 					break
 				}
 				// Reserve a chunk of fetches for a peer. A nil can mean either that
@@ -1158,7 +1159,7 @@ func (d *Downloader) fetchParts(errCancel error, deliveryCh chan dataPack, deliv
 			}
 			// Make sure that we have peers available for fetching. If all peers have been tried
 			// and all failed throw an error
-			if !progressed && !throttled && !running && len(idlePeers) == numTotalPeers && pending() > 0 {
+			if !progressed && !throttled && !running && len(idlePeers) == numTotalPeers && pendCount > 0 {
 				return errPeersUnavailable
 			}
 		}


### PR DESCRIPTION
## Proposed changes

- This PR is a tiny part of the ethereum/go-ethereum#21263.
- This prevents an increase of pending count while escaping on the short cut way.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
