### PR TITLE
fix the path for saving trie node cache

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2133,8 +2133,7 @@ func (bc *BlockChain) IsSenderTxHashIndexingEnabled() bool {
 }
 
 func (bc *BlockChain) SaveTrieNodeCacheToDisk() error {
-	filePath := bc.db.GetDBConfig().Dir + "/fastcache"
-	return bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(filePath)
+	return bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(bc.cacheConfig.TrieNodeCacheConfig.FastCacheFileDir)
 }
 
 // ApplyTransaction attempts to apply a transaction to the given state database


### PR DESCRIPTION
## Proposed changes

This change change the path of saving trie node cache to same path with the path for loading.

```
INFO[11/18,17:20:41 +09] [47] start saving cache to file                filePath=/Volumes/Samsung_T5/cypress_migrated/datadir/fastcache
INFO[11/18,17:20:47 +09] [5] Imported new chain segment                number=44040317 hash=703cc5…26aefd blocks=1  txs=4   elapsed=5.708s        trieDBSize=3.39mB   mgas=0.731  mgasps=0.128
INFO[11/18,17:20:48 +09] [5] Imported new chain segment                number=44040318 hash=e76e8a…39faf9 blocks=1  txs=5   elapsed=1.072s        trieDBSize=3.41mB   mgas=0.045  mgasps=0.042  ignored=1
INFO[11/18,17:21:15 +09] [33] [Dial] Add dial candidate from static nodes  id=c378208d4d09e95a NodeType=3 ip=49.50.167.22   port="[32323 32324]"
INFO[11/18,17:21:25 +09] [47] Persisted trie from memory database       blockNum=44040320 updated nodes=7340 updated nodes size=2.87mB time=36.453790522s gcnodes=8571 gcsize=3.76mB gctime=25.292701ms livenodes=222 livesize=92.44kB
INFO[11/18,17:21:25 +09] [5] Imported new chain segment                number=44040320 hash=e46f04…36c1c8 blocks=2  txs=2   elapsed=36.457s       trieDBSize=36.25kB  mgas=0.128  mgasps=0.004
INFO[11/18,17:21:30 +09] [33] [Dial] Try to update dial candidate with a multichannel peer  id=c378208d4d09e95a addr=49.50.167.22   port="[32323 32324]"
INFO[11/18,17:21:42 +09] [5] Imported new chain segment                number=44040322 hash=9d2dd7…c8f039 blocks=2  txs=7   elapsed=17.058s       trieDBSize=155.01kB mgas=0.589  mgasps=0.035
INFO[11/18,17:21:52 +09] [47] successfully saved cache to file          filePath=/Volumes/Samsung_T5/cypress_migrated/datadir/fastcache elapsed=1m11.229373842s
INFO[11/18,17:21:52 +09] [5] Imported new chain segment                number=44040324 hash=c7e088…52b582 blocks=2  txs=4   elapsed=10.230s         trieDBSize=173.20kB mgas=0.825  mgasps=0.081
INFO[11/18,17:21:52 +09] [5] Imported new chain segment                number=44040325 hash=b5a474…311ab9 blocks=1  txs=1   elapsed=69.999ms        trieDBSize=219.60kB mgas=0.230  mgasps=3.279
INFO[11/18,17:21:53 +09] [5] Imported new chain segment                number=44040326 hash=db9b22…741def blocks=1  txs=1   elapsed=2.191ms         trieDBSize=241.90kB mgas=0.064  mgasps=29.279
INFO[11/18,17:21:53 +09] [5] Imported new chain segment                number=44040327 hash=be3c50…ad5372 blocks=1  txs=4   elapsed=84.562ms        trieDBSize

...

INFO[11/18,17:22:41 +09] [47] Initialize local trie node cache (fastCache)  MaxMB=7000 FilePath=/Volumes/Samsung_T5/cypress_migrated/datadir/fastcache LoadedBytes=5300289536 LoadedEntries=14792713
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
