### PR TITLE
api_tracer: fix tracer GC which accidentally pruned the metaroot

### DIFF
--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -322,7 +322,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				database.TrieDB().Reference(root, common.Hash{})
 			}
 			// Dereference all past tries we ourselves are done working with
-			if proot != (common.Hash{}) {
+			if !common.EmptyHash(proot) {
 				database.TrieDB().Dereference(proot)
 			}
 			proot = root
@@ -555,7 +555,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 // be one filename per transaction traced.
 func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block *types.Block, config *StdTraceConfig) ([]string, error) {
 	// If we're tracing a single transaction, make sure it's present
-	if config != nil && config.TxHash != (common.Hash{}) {
+	if config != nil && !common.EmptyHash(config.TxHash) {
 		var exists bool
 		for _, tx := range block.Transactions() {
 			if exists = (tx.Hash() == config.TxHash); exists {
@@ -619,7 +619,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		)
 
 		// If the transaction needs tracing, swap out the configs
-		if tx.Hash() == txHash || txHash == (common.Hash{}) {
+		if tx.Hash() == txHash || common.EmptyHash(txHash) {
 			// Generate a unique temporary file to dump it into
 			prefix := fmt.Sprintf("block_%#x-%d-%#x-", block.Hash().Bytes()[:4], i, tx.Hash().Bytes()[:4])
 
@@ -715,7 +715,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 			return nil, fmt.Errorf("state reset after block %d failed: %v", block.NumberU64(), err)
 		}
 		database.TrieDB().Reference(root, common.Hash{})
-		if proot != (common.Hash{}) {
+		if !common.EmptyHash(proot) {
 			database.TrieDB().Dereference(proot)
 		}
 		proot = root

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -556,13 +556,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block *types.Block, config *StdTraceConfig) ([]string, error) {
 	// If we're tracing a single transaction, make sure it's present
 	if config != nil && !common.EmptyHash(config.TxHash) {
-		var exists bool
-		for _, tx := range block.Transactions() {
-			if exists = (tx.Hash() == config.TxHash); exists {
-				break
-			}
-		}
-		if !exists {
+		if !containsTx(block, config.TxHash) {
 			return nil, fmt.Errorf("transaction %#x not found in block", config.TxHash)
 		}
 	}

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -322,7 +322,9 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				database.TrieDB().Reference(root, common.Hash{})
 			}
 			// Dereference all past tries we ourselves are done working with
-			database.TrieDB().Dereference(proot)
+			if proot != (common.Hash{}) {
+				database.TrieDB().Dereference(proot)
+			}
 			proot = root
 		}
 	}()

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -677,6 +677,12 @@ func (db *Database) Dereference(root common.Hash) {
 	db.gcLock.Lock()
 	defer db.gcLock.Unlock()
 
+	// Sanity check to ensure that the meta-root is not removed
+	if root == (common.Hash{}) {
+		logger.Error("Attempted to dereference the trie cache meta root")
+		return
+	}
+
 	db.lock.Lock()
 	defer db.lock.Unlock()
 

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -678,7 +678,7 @@ func (db *Database) Dereference(root common.Hash) {
 	defer db.gcLock.Unlock()
 
 	// Sanity check to ensure that the meta-root is not removed
-	if root == (common.Hash{}) {
+	if common.EmptyHash(root) {
 		logger.Error("Attempted to dereference the trie cache meta root")
 		return
 	}

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -674,14 +674,14 @@ func (db *Database) reference(child common.Hash, parent common.Hash) {
 
 // Dereference removes an existing reference from a root node.
 func (db *Database) Dereference(root common.Hash) {
-	db.gcLock.Lock()
-	defer db.gcLock.Unlock()
-
 	// Sanity check to ensure that the meta-root is not removed
 	if common.EmptyHash(root) {
 		logger.Error("Attempted to dereference the trie cache meta root")
 		return
 	}
+
+	db.gcLock.Lock()
+	defer db.gcLock.Unlock()
 
 	db.lock.Lock()
 	defer db.lock.Unlock()


### PR DESCRIPTION
## Proposed changes

- This PR is derived from https://github.com/ethereum/go-ethereum/pull/17357.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/ethereum/go-ethereum/issues/17355

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
