### PR TITLE
abi: stop using goimports in the binding generator

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/klaytn/klaytn/accounts/abi"
-	"golang.org/x/tools/imports"
+	"go/format"
 	"regexp"
 	"strings"
 	"text/template"
@@ -145,9 +145,9 @@ func Bind(types []string, abis []string, bytecodes []string, runtimebytecodes []
 	if err := tmpl.Execute(buffer, data); err != nil {
 		return "", err
 	}
-	// For Go bindings pass the code through goimports to clean it up and double check
+	// For Go bindings pass the code through gofmt to clean it up
 	if lang == LangGo {
-		code, err := imports.Process(".", buffer.Bytes(), nil)
+		code, err := format.Source(buffer.Bytes())
 		if err != nil {
 			return "", fmt.Errorf("%v\n%s", err, buffer)
 		}

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -70,6 +70,8 @@ const tmplSourceGo = `
 package {{.Package}}
 
 import (
+	"math/big"
+	"strings"
 
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/accounts/abi/bind"
@@ -77,6 +79,18 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = klaytn.NotFound
+	_ = abi.U256
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
 )
 
 {{range $contract := .Contracts}}

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,6 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc
 	golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed
-	golang.org/x/tools v0.0.0-20191126055441-b0650ceb63d9
 	google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c // indirect
 	google.golang.org/grpc v1.23.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15


### PR DESCRIPTION
## Proposed changes

- This PR is derived from https://github.com/ethereum/go-ethereum/pull/17768.
- It stops using goimports in the binding generator.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
