### PR TITLE
Updated peer sort algorithm from bubble to quick sort

### DIFF
--- a/datasync/downloader/peer.go
+++ b/datasync/downloader/peer.go
@@ -23,15 +23,16 @@ package downloader
 import (
 	"errors"
 	"fmt"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/event"
-	"github.com/klaytn/klaytn/log"
 	"math"
 	"math/big"
 	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/event"
+	"github.com/klaytn/klaytn/log"
 )
 
 const (
@@ -530,22 +531,20 @@ func (ps *peerSet) idlePeers(minProtocol, maxProtocol int, idleCheck func(*peerC
 	defer ps.lock.RUnlock()
 
 	idlePeers, numTotalPeers := make([]*peerConnection, 0, len(ps.peers)), 0
+	tps := make([]float64, 0, len(ps.peers))
 	for _, p := range ps.peers {
 		if p.version >= minProtocol && p.version <= maxProtocol {
 			if idleCheck(p) {
 				idlePeers = append(idlePeers, p)
+				tps = append(tps, throughput(p))
 			}
 			numTotalPeers++
 		}
 	}
-	for i := 0; i < len(idlePeers); i++ {
-		for j := i + 1; j < len(idlePeers); j++ {
-			if throughput(idlePeers[i]) < throughput(idlePeers[j]) {
-				idlePeers[i], idlePeers[j] = idlePeers[j], idlePeers[i]
-			}
-		}
-	}
-	return idlePeers, numTotalPeers
+	// sort peers in the descending order of throughput
+	sortPeers := &peerThroughputSort{idlePeers, tps}
+	sort.Sort(sortPeers)
+	return sortPeers.p, numTotalPeers
 }
 
 // medianRTT returns the median RTT of the peerset, considering only the tuning
@@ -577,4 +576,25 @@ func (ps *peerSet) medianRTT() time.Duration {
 		median = rttMaxEstimate
 	}
 	return median
+}
+
+// peerThroughputSort implements the Sort interface, and allows for
+// sorting a set of peers by their throughput
+// The sorted data is with the _highest_ throughput first
+type peerThroughputSort struct {
+	p  []*peerConnection
+	tp []float64
+}
+
+func (ps *peerThroughputSort) Len() int {
+	return len(ps.p)
+}
+
+func (ps *peerThroughputSort) Less(i, j int) bool {
+	return ps.tp[i] > ps.tp[j]
+}
+
+func (ps *peerThroughputSort) Swap(i, j int) {
+	ps.p[i], ps.p[j] = ps.p[j], ps.p[i]
+	ps.tp[i], ps.tp[j] = ps.tp[j], ps.tp[i]
 }

--- a/datasync/downloader/peer_test.go
+++ b/datasync/downloader/peer_test.go
@@ -1,0 +1,51 @@
+// Modifications Copyright 2018 The klaytn Authors
+// Copyright 2020 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from eth/downloader/peer_test.go (2020/11/20).
+// Modified and improved for the klaytn development.
+
+package downloader
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPeerThroughputSorting(t *testing.T) {
+	a := &peerConnection{
+		id:               "a",
+		headerThroughput: 1.25,
+	}
+	b := &peerConnection{
+		id:               "b",
+		headerThroughput: 1.21,
+	}
+	c := &peerConnection{
+		id:               "c",
+		headerThroughput: 1.23,
+	}
+
+	peers := []*peerConnection{a, b, c}
+	tps := []float64{a.headerThroughput, b.headerThroughput, c.headerThroughput}
+	sortPeers := &peerThroughputSort{peers, tps}
+	sort.Sort(sortPeers)
+	assert.Equal(t, sortPeers.p[0], a)
+	assert.Equal(t, sortPeers.p[1], c)
+	assert.Equal(t, sortPeers.p[2], b)
+}


### PR DESCRIPTION
## Proposed changes

- Thie PR is a part of ethereum/go-ethereum#21263.
- The bubble sorting algorithm is to updated to quick sort.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

