### PR TITLE
Add more field in consensusInfo API to know original proposer

### DIFF
--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -117,6 +117,10 @@ func (h *Header) Size() common.StorageSize {
 	return common.StorageSize(unsafe.Sizeof(*h)) + common.StorageSize(len(h.Extra)+(h.BlockScore.BitLen()+h.Number.BitLen()+h.Time.BitLen())/8)
 }
 
+func (h *Header) Round() byte {
+	return byte(h.Extra[IstanbulExtraVanity-1])
+}
+
 func rlpHash(x interface{}) (h common.Hash) {
 	hw := sha3.NewKeccak256()
 	rlp.Encode(hw, x)

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -324,9 +324,7 @@ func (api *APIExtension) makeRPCBlockOutput(b *types.Block,
 	r["committee"] = cInfo.committee
 	r["proposer"] = cInfo.proposer
 	r["round"] = cInfo.round
-	//if cInfo.round > 0 {
 	r["originProposer"] = cInfo.originProposer
-	//}
 	r["transactions"] = rpcTransactions
 
 	return r

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -214,41 +214,61 @@ func (api *APIExtension) GetCommitteeSize(number *rpc.BlockNumber) (int, error) 
 	}
 }
 
-func (api *APIExtension) getProposerAndValidators(block *types.Block) (common.Address, []common.Address, error) {
+type ConsensusInfo struct {
+	proposer       common.Address
+	originProposal common.Address
+	committee      []common.Address
+	round          byte
+}
+
+func (api *APIExtension) getConsensusInfo(block *types.Block) (ConsensusInfo, error) {
 	blockNumber := block.NumberU64()
 	if blockNumber == 0 {
-		return common.Address{}, []common.Address{}, nil
+		return ConsensusInfo{}, nil
 	}
 
+	round := block.Header().Round()
 	view := &istanbul.View{
 		Sequence: new(big.Int).Set(block.Number()),
-		Round:    new(big.Int).SetInt64(0),
+		Round:    new(big.Int).SetInt64(int64(round)),
 	}
 
 	// get the proposer of this block.
 	proposer, err := ecrecover(block.Header())
 	if err != nil {
-		return common.Address{}, []common.Address{}, err
+		return ConsensusInfo{}, err
 	}
 
 	// get the snapshot of the previous block.
 	parentHash := block.ParentHash()
 	snap, err := api.istanbul.snapshot(api.chain, blockNumber-1, parentHash, nil)
 	if err != nil {
-		return proposer, []common.Address{}, err
+		return ConsensusInfo{}, err
+	}
+
+	// get origin proposer at 0 round.
+	originProposer := common.Address{}
+	lastProposer := common.Address{}
+	// TODO-Klaytn add the logic to get the last proposer for other policy. Weighted round robin doesn't need it.
+	if istanbul.ProposerPolicy(snap.Policy) == istanbul.WeightedRandom {
+		newValSet := snap.ValSet.Copy()
+		newValSet.CalcProposer(lastProposer, 0)
+		originProposer = newValSet.GetProposer().Address()
+	} else {
+		logger.Warn("getConsensusInfo does not support to get origin proposal on", "proposerPolicy", snap.Policy)
 	}
 
 	// get the committee list of this block.
 	committee := snap.ValSet.SubListWithProposer(parentHash, proposer, view)
-	commiteeAddrs := make([]common.Address, len(committee))
+	committeeAddrs := make([]common.Address, len(committee))
 	for i, v := range committee {
-		commiteeAddrs[i] = v.Address()
+		committeeAddrs[i] = v.Address()
 	}
 
 	// verify the committee list of the block using istanbul
 	//proposalSeal := istanbulCore.PrepareCommittedSeal(block.Hash())
 	//extra, err := types.ExtractIstanbulExtra(block.Header())
-	//istanbulAddrs := make([]common.Address, len(commiteeAddrs))
+	//istanbulAddrs := make([]common.Address, len(committeeAddrs))
 	//for i, seal := range extra.CommittedSeal {
 	//	addr, err := istanbul.GetSignatureAddress(proposalSeal, seal)
 	//	istanbulAddrs[i] = addr
@@ -257,23 +277,30 @@ func (api *APIExtension) getProposerAndValidators(block *types.Block) (common.Ad
 	//	}
 	//
 	//	var found bool = false
-	//	for _, v := range commiteeAddrs {
+	//	for _, v := range committeeAddrs {
 	//		if addr == v {
 	//			found = true
 	//			break
 	//		}
 	//	}
 	//	if found == false {
-	//		logger.Trace("validator is different!", "snap", commiteeAddrs, "istanbul", istanbulAddrs)
-	//		return proposer, commiteeAddrs, errors.New("validator set is different from Istanbul engine!!")
+	//		logger.Trace("validator is different!", "snap", committeeAddrs, "istanbul", istanbulAddrs)
+	//		return proposer, committeeAddrs, errors.New("validator set is different from Istanbul engine!!")
 	//	}
 	//}
 
-	return proposer, commiteeAddrs, nil
+	cInfo := ConsensusInfo{
+		proposer:       proposer,
+		originProposal: originProposer,
+		committee:      committeeAddrs,
+		round:          round,
+	}
+
+	return cInfo, nil
 }
 
-func (api *APIExtension) makeRPCOutput(b *types.Block, proposer common.Address, committee []common.Address,
-	transactions types.Transactions, receipts types.Receipts) map[string]interface{} {
+func (api *APIExtension) makeRPCBlockOutput(b *types.Block,
+	cInfo ConsensusInfo, transactions types.Transactions, receipts types.Receipts) map[string]interface{} {
 	head := b.Header() // copies the header once
 	hash := head.Hash()
 
@@ -294,8 +321,12 @@ func (api *APIExtension) makeRPCOutput(b *types.Block, proposer common.Address, 
 		rpcTransactions[i] = klaytnApi.RpcOutputReceipt(tx, hash, head.Number.Uint64(), uint64(i), receipts[i])
 	}
 
-	r["committee"] = committee
-	r["proposer"] = proposer
+	r["committee"] = cInfo.committee
+	r["proposer"] = cInfo.proposer
+	r["round"] = cInfo.round
+	//if cInfo.round > 0 {
+	r["originProposer"] = cInfo.originProposal
+	//}
 	r["transactions"] = rpcTransactions
 
 	return r
@@ -336,7 +367,7 @@ func (api *APIExtension) GetBlockWithConsensusInfoByNumber(number *rpc.BlockNumb
 	}
 	blockHash := block.Hash()
 
-	proposer, committee, err := api.getProposerAndValidators(block)
+	cInfo, err := api.getConsensusInfo(block)
 	if err != nil {
 		logger.Error("Getting the proposer and validators failed.", "blockHash", blockHash, "err", err)
 		return nil, errInternalError
@@ -346,7 +377,8 @@ func (api *APIExtension) GetBlockWithConsensusInfoByNumber(number *rpc.BlockNumb
 	if receipts == nil {
 		receipts = b.GetReceiptsByBlockHash(blockHash)
 	}
-	return api.makeRPCOutput(block, proposer, committee, block.Transactions(), receipts), nil
+
+	return api.makeRPCBlockOutput(block, cInfo, block.Transactions(), receipts), nil
 }
 
 func (api *APIExtension) GetBlockWithConsensusInfoByNumberRange(start *rpc.BlockNumber, end *rpc.BlockNumber) (map[string]interface{}, error) {
@@ -411,7 +443,7 @@ func (api *APIExtension) GetBlockWithConsensusInfoByHash(blockHash common.Hash) 
 		return nil, fmt.Errorf("the block does not exist (block hash: %s)", blockHash.String())
 	}
 
-	proposer, committee, err := api.getProposerAndValidators(block)
+	cInfo, err := api.getConsensusInfo(block)
 	if err != nil {
 		logger.Error("Getting the proposer and validators failed.", "blockHash", blockHash, "err", err)
 		return nil, errInternalError
@@ -422,7 +454,7 @@ func (api *APIExtension) GetBlockWithConsensusInfoByHash(blockHash common.Hash) 
 		receipts = b.GetReceiptsByBlockHash(blockHash)
 	}
 
-	return api.makeRPCOutput(block, proposer, committee, block.Transactions(), receipts), nil
+	return api.makeRPCBlockOutput(block, cInfo, block.Transactions(), receipts), nil
 }
 
 func (api *API) GetTimeout() uint64 {

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -216,7 +216,7 @@ func (api *APIExtension) GetCommitteeSize(number *rpc.BlockNumber) (int, error) 
 
 type ConsensusInfo struct {
 	proposer       common.Address
-	originProposer common.Address
+	originProposer common.Address // the proposal of 0 round at the same block number
 	committee      []common.Address
 	round          byte
 }

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -216,7 +216,7 @@ func (api *APIExtension) GetCommitteeSize(number *rpc.BlockNumber) (int, error) 
 
 type ConsensusInfo struct {
 	proposer       common.Address
-	originProposal common.Address
+	originProposer common.Address
 	committee      []common.Address
 	round          byte
 }
@@ -291,7 +291,7 @@ func (api *APIExtension) getConsensusInfo(block *types.Block) (ConsensusInfo, er
 
 	cInfo := ConsensusInfo{
 		proposer:       proposer,
-		originProposal: originProposer,
+		originProposer: originProposer,
 		committee:      committeeAddrs,
 		round:          round,
 	}
@@ -325,7 +325,7 @@ func (api *APIExtension) makeRPCBlockOutput(b *types.Block,
 	r["proposer"] = cInfo.proposer
 	r["round"] = cInfo.round
 	//if cInfo.round > 0 {
-	r["originProposer"] = cInfo.originProposal
+	r["originProposer"] = cInfo.originProposer
 	//}
 	r["transactions"] = rpcTransactions
 


### PR DESCRIPTION
## Proposed changes
This PR added below fields of getBlockWithConsensusInfo APIs.
- `round` : the consensus round number in which this block was made
- `originProposer` : the proposal of 0 round at the same block number.

The example of the API result with new field is below.
```
> klay.getBlockWithConsensusInfo(0x16e47ae)
{
  blockscore: "0x1",
  committee: ["0xed6ee8a1877f9582858dbe2509abb0ac33e5f24e", "0x16c192585a0ab24b552783b4bf7d8dc9f6855c35", "0x9419fa2e3b9eb1158de31be66c586a52f49c5de7", ..."0x1782834bf8847e235f21f2c1f13fca4d5dff6621"],
  extraData: "0xd883010300846b6c...",
  gasUsed: "0x2e3177",
  governanceData: "0x",
  hash: "0xd2792bb746c6f51f7a2cd6588a315f5d3a0f24971ee951a45c08ada01f1772d5",
  logsBloom: "0x00000...",
  number: "0x16e47ae",
  originProposer: "0xec6c1cede510be308f0fdbbc8dbdf238829bdb34",
  parentHash: "0x3197d7b8fa5100cd49e50daa872fc280b08c35f889b6b9c15313c59070e6fc11",
  proposer: "0xed6ee8a1877f9582858dbe2509abb0ac33e5f24e",
  receiptsRoot: "0x1da9385cc86efbbaea2acf0e3431057d6e20a7d0c16a5d88a2b2a70c0cc00610",
  reward: "0x179679457f93094a4e7186abcb2089661e92fc22",
  round: 1,
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
