### PR TITLE
statedb: fix concurrent usage of secKeyBuf

### DIFF
--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -68,8 +68,11 @@ var (
 // secureKeyPrefix is the database key prefix used to store trie node preimages.
 var secureKeyPrefix = []byte("secure-key-")
 
+// secureKeyPrefixLength is the length of the above prefix
+const secureKeyPrefixLength = 11
+
 // secureKeyLength is the length of the above prefix + 32byte hash.
-const secureKeyLength = 11 + 32
+const secureKeyLength = secureKeyPrefixLength + 32
 
 // commitResultChSizeLimit limits the size of channel used for commitResult.
 const commitResultChSizeLimit = 100 * 10000
@@ -97,7 +100,6 @@ type Database struct {
 	newest common.Hash                 // Newest tracked node, flush-list tail
 
 	preimages map[common.Hash][]byte // Preimages of nodes from the secure trie
-	seckeybuf [secureKeyLength]byte  // Ephemeral buffer for calculating preimage keys
 
 	gctime  time.Duration      // Time spent on garbage collection since last commit
 	gcnodes uint64             // Nodes garbage collected since last commit
@@ -619,15 +621,15 @@ func (db *Database) preimage(hash common.Hash) ([]byte, error) {
 		return preimage, nil
 	}
 	// Content unavailable in memory, attempt to retrieve from disk
-	return db.diskDB.ReadCachedTrieNodePreimage(db.secureKey(hash[:]))
+	return db.diskDB.ReadCachedTrieNodePreimage(secureKey(hash))
 }
 
-// secureKey returns the database key for the preimage of key, as an ephemeral
-// buffer. The caller must not hold onto the return value because it will become
-// invalid on the next call.
-func (db *Database) secureKey(key []byte) []byte {
-	buf := append(db.seckeybuf[:0], secureKeyPrefix...)
-	buf = append(buf, key...)
+// secureKey returns the database key for the preimage of key (as a newly
+// allocated byte-slice)
+func secureKey(hash common.Hash) []byte {
+	buf := make([]byte, secureKeyLength)
+	copy(buf, secureKeyPrefix)
+	copy(buf[secureKeyPrefixLength:], hash[:])
 	return buf
 }
 
@@ -825,9 +827,15 @@ func (db *Database) writeBatchPreimages() error {
 	// TODO-Klaytn What kind of batch should be used below?
 	preimagesBatch := db.diskDB.NewBatch(database.StateTrieDB)
 
+	// We reuse an ephemeral buffer for the keys. The batch Put operation
+	// copies it internally, so we can reuse it.
+	var keyBuf [secureKeyLength]byte
+	copy(keyBuf[:], secureKeyPrefix)
+
 	// Move all of the accumulated preimages into a write batch
 	for hash, preimage := range db.preimages {
-		if err := preimagesBatch.Put(db.secureKey(hash[:]), preimage); err != nil {
+		copy(keyBuf[secureKeyPrefixLength:], hash[:])
+		if err := preimagesBatch.Put(keyBuf[:], preimage); err != nil {
 			logger.Error("Failed to commit preimages from trie database", "err", err)
 			return err
 		}

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -112,13 +112,13 @@ func TestDatabase_Size(t *testing.T) {
 
 func TestDatabase_SecureKey(t *testing.T) {
 	secKey1 := secureKey(childHash)
-	copiedSecKey := make([]byte, 0, len(secKey1))
+	copiedSecKey := make([]byte, len(secKey1))
 	copy(copiedSecKey, secKey1)
 
 	secKey2 := secureKey(parentHash)
 
-	assert.NotEqual(t, secKey1, copiedSecKey) // after the next call of secureKey, secKey1 became different from the copied
-	assert.Equal(t, secKey1, secKey2)         // secKey1 has changed into secKey2 as they are created from the same buffer
+	assert.Equal(t, secKey1, copiedSecKey) // after the next call of secureKey, secKey1 became different from the copied
+	assert.NotEqual(t, secKey1, secKey2)   // secKey1 has changed into secKey2 as they are created from the different buffer
 }
 
 func TestCache(t *testing.T) {

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -111,14 +111,11 @@ func TestDatabase_Size(t *testing.T) {
 }
 
 func TestDatabase_SecureKey(t *testing.T) {
-	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMB: 128})
-
-	secKey1 := db.secureKey(childHash[:])
+	secKey1 := secureKey(childHash)
 	copiedSecKey := make([]byte, 0, len(secKey1))
 	copy(copiedSecKey, secKey1)
 
-	secKey2 := db.secureKey(parentHash[:])
+	secKey2 := secureKey(parentHash)
 
 	assert.NotEqual(t, secKey1, copiedSecKey) // after the next call of secureKey, secKey1 became different from the copied
 	assert.Equal(t, secKey1, secKey2)         // secKey1 has changed into secKey2 as they are created from the same buffer


### PR DESCRIPTION
## Proposed changes

- This PR is derived from https://github.com/ethereum/go-ethereum/pull/20923
- This is to avoid the corruption of shared buffer object when it is accessed concurrently

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
