### PR TITLE
abi: add NewKeyStoreTransactor

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -23,14 +23,15 @@ package bind
 import (
 	"crypto/ecdsa"
 	"errors"
+	"io"
+	"io/ioutil"
+	"math/big"
+
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/accounts/keystore"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/crypto"
-	"io"
-	"io/ioutil"
-	"math/big"
 )
 
 // NewTransactor is a utility method to easily create a transaction signer from
@@ -45,6 +46,24 @@ func NewTransactor(keyin io.Reader, passphrase string) (*TransactOpts, error) {
 		return nil, err
 	}
 	return NewKeyedTransactor(key.GetPrivateKey()), nil
+}
+
+// NewKeystoreTransactor is a utility method to easily create a transaction signer from
+// an decrypted key from a keystore
+func NewKeyStoreTransactor(keystore *keystore.KeyStore, account accounts.Account) (*TransactOpts, error) {
+	return &TransactOpts{
+		From: account.Address,
+		Signer: func(signer types.Signer, address common.Address, tx *types.Transaction) (*types.Transaction, error) {
+			if address != account.Address {
+				return nil, errors.New("not authorized to sign this account")
+			}
+			signature, err := keystore.SignHash(account, signer.Hash(tx).Bytes())
+			if err != nil {
+				return nil, err
+			}
+			return tx.WithSignature(signer, signature)
+		},
+	}, nil
 }
 
 // NewKeyedTransactor is a utility method to easily create a transaction signer


### PR DESCRIPTION
## Proposed changes

- This PR adds `NewKeyStoreTransactor`. It is a utility method to easily create a transaction signer from an decrypted key from a keystore.
- It is cherry-picked from go-ethereum 
https://github.com/ethereum/go-ethereum/commit/6f80629383b2e725fb882c345ae4221574643a32
https://github.com/ethereum/go-ethereum/commit/b3f7609d7d887657af3c06e9ac74e38276e7fe87
- This is the re-opened PR of https://github.com/klaytn/klaytn/pull/799.
## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
