### PR TITLE
abi: fix panic in MethodById lookup

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -137,6 +137,9 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 // MethodById looks up a method by the 4-byte id
 // returns nil if none found
 func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
+	if len(sigdata) < 4 {
+		return nil, fmt.Errorf("data too short (% bytes) for abi method lookup", len(sigdata))
+	}
 	for _, method := range abi.Methods {
 		if bytes.Equal(method.Id(), sigdata[:4]) {
 			return &method, nil

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -138,7 +138,7 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 // returns nil if none found
 func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 	if len(sigdata) < 4 {
-		return nil, fmt.Errorf("data too short (% bytes) for abi method lookup", len(sigdata))
+		return nil, fmt.Errorf("data too short (%d bytes) for abi method lookup", len(sigdata))
 	}
 	for _, method := range abi.Methods {
 		if bytes.Equal(method.Id(), sigdata[:4]) {

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -715,19 +715,17 @@ func TestABI_MethodById(t *testing.T) {
 			t.Errorf("Method %v (id %v) not 'findable' by id in ABI", name, common.ToHex(m.Id()))
 		}
 	}
-	// TODO-Klaytn-FailedTest Enable follow tests after updating abi.go
-	/*
-		// Also test empty
-		if _, err := abi.MethodById([]byte{0x00}); err == nil {
-			t.Errorf("Expected error, too short to decode data")
-		}
-		if _, err := abi.MethodById([]byte{}); err == nil {
-			t.Errorf("Expected error, too short to decode data")
-		}
-		if _, err := abi.MethodById(nil); err == nil {
-			t.Errorf("Expected error, nil is short to decode data")
-		}
-	*/
+
+	// Also test empty
+	if _, err := abi.MethodById([]byte{0x00}); err == nil {
+		t.Errorf("Expected error, too short to decode data")
+	}
+	if _, err := abi.MethodById([]byte{}); err == nil {
+		t.Errorf("Expected error, too short to decode data")
+	}
+	if _, err := abi.MethodById(nil); err == nil {
+		t.Errorf("Expected error, nil is short to decode data")
+	}
 }
 
 func TestMaliciousABIStrings(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

- It fixes `MethodById` lookup error when tx.data is too short(ex. "0x0")
- Also, it enables some tests which were disabled due to above reason.
- It is cherry-picked from go-ethereum
https://github.com/klaytn/klaytn/commit/42d4a0ef0b4a00e69b98afac1ebee04526e88c50: https://github.com/ethereum/go-ethereum/commit/96fd50be10885c9b3033404df698177fdb63d036
https://github.com/klaytn/klaytn/commit/9dac6e17bddb6c65d74fa5106fa77fdcfd395492: https://github.com/ethereum/go-ethereum/commit/4a090a1bab8896e8b4715058931fd23d4166f361
## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
