### PR TITLE
abi: support closing a SimulatedBackend

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -109,6 +109,12 @@ func (b *SimulatedBackend) PendingBlock() *types.Block {
 	return b.pendingBlock
 }
 
+// Close terminates the underlying blockchain's update loop.
+func (b *SimulatedBackend) Close() error {
+	b.blockchain.Stop()
+	return nil
+}
+
 // Commit imports all the pending transactions as a single block and starts a
 // fresh new state.
 func (b *SimulatedBackend) Commit() {

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -40,6 +40,7 @@ func TestSimulatedBackend(t *testing.T) {
 	genAlloc[auth.From] = blockchain.GenesisAccount{Balance: big.NewInt(9223372036854775807)}
 
 	sim := NewSimulatedBackend(genAlloc)
+	defer sim.Close()
 
 	// should return an error if the tx is not found
 	txHash := common.HexToHash("2")

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -22,7 +22,6 @@ package bind
 
 import (
 	"fmt"
-	"github.com/klaytn/klaytn/common"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -30,6 +29,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/klaytn/klaytn/common"
 )
 
 var bindTests = []struct {
@@ -261,7 +262,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			// Deploy an interaction tester contract
 			_, _, interactor, err := DeployInteractor(auth, sim, "Deploy string")
@@ -313,7 +316,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			// Deploy a tuple tester contract and execute a structured call on it
 			_, _, getter, err := DeployGetter(auth, sim)
@@ -353,7 +358,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			// Deploy a tuple tester contract and execute a structured call on it
 			_, _, tupler, err := DeployTupler(auth, sim)
@@ -405,7 +412,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			// Deploy a slice tester contract and execute a n array call on it
 			_, _, slicer, err := DeploySlicer(auth, sim)
@@ -447,7 +456,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			// Deploy a default method invoker contract 
 			_, _, defaulter, err := DeployDefaulter(auth, sim)
@@ -488,6 +499,7 @@ var bindTests = []struct {
 		`
 			// Create a simulator and wrap a non-deployed contract
 			sim := backends.NewSimulatedBackend(nil)
+			defer sim.Close()
 
 			nonexistent, err := NewNonExistent(common.Address{}, sim)
 			if err != nil {
@@ -531,7 +543,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			// Deploy a funky gas pattern contract
 			_, _, limiter, err := DeployFunkyGasPattern(auth, sim)
@@ -575,7 +589,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			// Deploy a sender tester contract and execute a structured call on it
 			_, _, callfrom, err := DeployCallFrom(auth, sim)
@@ -644,7 +660,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			// Deploy a underscorer tester contract and execute a structured call on it
 			_, _, underscorer, err := DeployUnderscorer(auth, sim)
@@ -724,7 +742,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			// Deploy an eventer contract
 			_, _, eventer, err := DeployEventer(auth, sim)
@@ -881,7 +901,9 @@ var bindTests = []struct {
 			// Generate a new random account and a funded simulator
 			key, _ := crypto.GenerateKey()
 			auth := bind.NewKeyedTransactor(key)
+
 			sim := backends.NewSimulatedBackend(blockchain.GenesisAlloc{auth.From: {Balance: big.NewInt(10000000000)}})
+			defer sim.Close()
 
 			//deploy the test contract
 			_, _, testContract, err := DeployDeeplyNestedArray(auth, sim)

--- a/accounts/abi/bind/util_test.go
+++ b/accounts/abi/bind/util_test.go
@@ -22,6 +22,10 @@ package bind_test
 
 import (
 	"context"
+	"math/big"
+	"testing"
+	"time"
+
 	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
 	"github.com/klaytn/klaytn/blockchain"
@@ -29,9 +33,6 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/params"
-	"math/big"
-	"testing"
-	"time"
 )
 
 var testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
@@ -96,5 +97,6 @@ func TestWaitDeployed(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Errorf("test %q: timeout", name)
 		}
+		defer backend.Close()
 	}
 }

--- a/contracts/reward/contract/KlaytnReward_test.go
+++ b/contracts/reward/contract/KlaytnReward_test.go
@@ -43,6 +43,7 @@ func TestSmartContract(t *testing.T) {
 
 	alloc := blockchain.GenesisAlloc{auth.From: {Balance: initialValue}, auth2.From: {Balance: initialValue}}
 	sim := backends.NewSimulatedBackend(alloc)
+	defer sim.Close()
 
 	// Deploy a token contract on the simulated blockchain
 	_, _, reward, err := DeployKlaytnReward(auth, sim)

--- a/node/sc/bridge_test.go
+++ b/node/sc/bridge_test.go
@@ -134,6 +134,7 @@ func TestBridgeDeployWithKLAY(t *testing.T) {
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KLAY)}}
 	backend := backends.NewSimulatedBackend(alloc)
+	defer backend.Close()
 
 	chargeAmount := big.NewInt(10000000)
 	bridgeAccount.Value = chargeAmount
@@ -168,6 +169,7 @@ func TestBridgeRequestValueTransferNonce(t *testing.T) {
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KLAY)}}
 	backend := backends.NewSimulatedBackend(alloc)
+	defer backend.Close()
 
 	chargeAmount := big.NewInt(10000000)
 	bridgeAccount.Value = chargeAmount
@@ -233,6 +235,7 @@ func TestBridgeHandleValueTransferNonceAndBlockNumber(t *testing.T) {
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KLAY)}}
 	backend := backends.NewSimulatedBackend(alloc)
+	defer backend.Close()
 
 	chargeAmount := big.NewInt(10000000)
 	bridgeAccount.Value = chargeAmount
@@ -326,6 +329,7 @@ func TestBridgePublicVariables(t *testing.T) {
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KLAY)}}
 	backend := backends.NewSimulatedBackend(alloc)
+	defer backend.Close()
 
 	chargeAmount := big.NewInt(10000000)
 	bridgeAccount.Value = chargeAmount
@@ -394,6 +398,7 @@ func TestExtendedBridgeAndCallbackERC20(t *testing.T) {
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KLAY)}}
 	backend := backends.NewSimulatedBackend(alloc)
+	defer backend.Close()
 
 	// Deploy extBridge
 	bridgeAddr, tx, eb, err := extbridge.DeployExtBridge(bridgeAccount, backend, true)
@@ -539,6 +544,7 @@ func TestExtendedBridgeAndCallbackERC721(t *testing.T) {
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KLAY)}}
 	backend := backends.NewSimulatedBackend(alloc)
+	defer backend.Close()
 
 	// Deploy extBridge
 	bridgeAddr, tx, eb, err := extbridge.DeployExtBridge(bridgeAccount, backend, true)
@@ -750,6 +756,8 @@ func generateBridgeTokenTestEnv(t *testing.T) *bridgeTokenTestENV {
 // - DeregisterToken works well
 func TestBridgeContract_RegisterToken(t *testing.T) {
 	env := generateBridgeTokenTestEnv(t)
+	defer env.backend.Close()
+
 	backend := env.backend
 	operator := env.operator
 	b := env.bridge
@@ -828,6 +836,8 @@ func TestBridgeContract_RegisterToken(t *testing.T) {
 // TestBridgeContract_InitStatus checks initial lock status.
 func TestBridgeContract_InitStatus(t *testing.T) {
 	env := generateBridgeTokenTestEnv(t)
+	defer env.backend.Close()
+
 	b := env.bridge
 	erc20Addr := env.erc20Addr
 	erc721Addr := env.erc721Addr
@@ -850,6 +860,8 @@ func TestBridgeContract_InitStatus(t *testing.T) {
 // - the request value transfer can be allowed after registering it.
 func TestBridgeContract_InitRequest(t *testing.T) {
 	env := generateBridgeTokenTestEnv(t)
+	defer env.backend.Close()
+
 	backend := env.backend
 	operator := env.operator
 	tester := env.tester
@@ -880,6 +892,8 @@ func TestBridgeContract_InitRequest(t *testing.T) {
 // - the token can be lock to prevent value transfer requests.
 func TestBridgeContract_TokenLock(t *testing.T) {
 	env := generateBridgeTokenTestEnv(t)
+	defer env.backend.Close()
+
 	backend := env.backend
 	operator := env.operator
 	tester := env.tester
@@ -941,6 +955,8 @@ func TestBridgeContract_TokenLock(t *testing.T) {
 // - testing the case locking token is fail.
 func TestBridgeContract_TokenLockFail(t *testing.T) {
 	env := generateBridgeTokenTestEnv(t)
+	defer env.backend.Close()
+
 	backend := env.backend
 	operator := env.operator
 	tester := env.tester
@@ -1007,6 +1023,8 @@ func TestBridgeContract_TokenLockFail(t *testing.T) {
 // - testing the case unlocking token is fail.
 func TestBridgeContract_TokenUnlockFail(t *testing.T) {
 	env := generateBridgeTokenTestEnv(t)
+	defer env.backend.Close()
+
 	backend := env.backend
 	operator := env.operator
 	b := env.bridge
@@ -1041,6 +1059,8 @@ func TestBridgeContract_TokenUnlockFail(t *testing.T) {
 // - the token can be unlock to allow value transfer requests.
 func TestBridgeContract_CheckValueTransferAfterUnLock(t *testing.T) {
 	env := generateBridgeTokenTestEnv(t)
+	defer env.backend.Close()
+
 	backend := env.backend
 	operator := env.operator
 	tester := env.tester
@@ -1134,6 +1154,7 @@ func TestBridgeRequestHandleGasUsed(t *testing.T) {
 		auth.From:  {Balance: big.NewInt(params.KLAY)},
 	}
 	sim := backends.NewSimulatedBackend(alloc)
+	defer sim.Close()
 
 	var err error
 
@@ -1234,6 +1255,7 @@ func TestBridgeMaxOperatorHandleTxGasUsed(t *testing.T) {
 		auth.From:  {Balance: big.NewInt(params.KLAY)},
 	}
 	sim := backends.NewSimulatedBackend(alloc)
+	defer sim.Close()
 
 	var err error
 
@@ -1315,6 +1337,7 @@ func TestBridgeThresholdLimit(t *testing.T) {
 		auth.From: {Balance: big.NewInt(params.KLAY)},
 	}
 	sim := backends.NewSimulatedBackend(alloc)
+	defer sim.Close()
 
 	var err error
 

--- a/node/sc/multi_bridge_test.go
+++ b/node/sc/multi_bridge_test.go
@@ -17,6 +17,10 @@
 package sc
 
 import (
+	"math/big"
+	"testing"
+	"time"
+
 	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
 	"github.com/klaytn/klaytn/blockchain"
@@ -28,9 +32,6 @@ import (
 	"github.com/klaytn/klaytn/event"
 	"github.com/klaytn/klaytn/params"
 	"github.com/stretchr/testify/assert"
-	"math/big"
-	"testing"
-	"time"
 )
 
 type bridgeTestInfo struct {
@@ -113,6 +114,8 @@ func prepareMultiBridgeEventTest(t *testing.T) *multiBridgeTestInfo {
 // - the specified operator is deregistered by the contract method DeregisterOperator.
 func TestRegisterDeregisterOperator(t *testing.T) {
 	info := prepareMultiBridgeTest(t)
+	defer info.sim.Close()
+
 	testAddrs := []common.Address{{10}, {20}}
 
 	opts := &bind.TransactOpts{From: info.acc.From, Signer: info.acc.Signer, GasLimit: DefaultBridgeTxGasLimit}
@@ -173,6 +176,7 @@ func TestRegisterDeregisterOperator(t *testing.T) {
 // - the bridge contract method Stop.
 func TestStartStop(t *testing.T) {
 	info := prepareMultiBridgeTest(t)
+	defer info.sim.Close()
 
 	opts := &bind.TransactOpts{From: info.acc.From, Signer: info.acc.Signer, GasLimit: DefaultBridgeTxGasLimit}
 	tx, err := info.b.Start(opts, true)
@@ -199,6 +203,8 @@ func TestStartStop(t *testing.T) {
 // - the bridge contract method TestSetCounterPartBridge.
 func TestSetCounterPartBridge(t *testing.T) {
 	info := prepareMultiBridgeTest(t)
+	defer info.sim.Close()
+
 	dummy := common.Address{10}
 
 	opts := &bind.TransactOpts{From: info.acc.From, Signer: info.acc.Signer, GasLimit: DefaultBridgeTxGasLimit}
@@ -216,6 +222,8 @@ func TestSetCounterPartBridge(t *testing.T) {
 // - the bridge contract method RegisterToken and DeregisterToken.
 func TestRegisterDeregisterToken(t *testing.T) {
 	info := prepareMultiBridgeTest(t)
+	defer info.sim.Close()
+
 	dummy1 := common.Address{10}
 	dummy2 := common.Address{20}
 
@@ -259,6 +267,8 @@ func TestRegisterDeregisterToken(t *testing.T) {
 // - successful value transfer with proper transaction counts.
 func TestMultiBridgeKLAYTransfer1(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -303,6 +313,8 @@ func TestMultiBridgeKLAYTransfer1(t *testing.T) {
 // - timeout is expected since operator threshold will not be satisfied.
 func TestMultiBridgeKLAYTransfer2(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -339,6 +351,8 @@ func TestMultiBridgeKLAYTransfer2(t *testing.T) {
 // - no double spending is made due to additional tx.
 func TestMultiBridgeKLAYTransfer3(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -382,6 +396,8 @@ func TestMultiBridgeKLAYTransfer3(t *testing.T) {
 // - successful value transfer with proper transaction counts.
 func TestMultiBridgeERC20Transfer(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -450,6 +466,8 @@ func TestMultiBridgeERC20Transfer(t *testing.T) {
 // - successful value transfer with proper transaction counts.
 func TestMultiBridgeERC721Transfer(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -511,6 +529,8 @@ func TestMultiBridgeERC721Transfer(t *testing.T) {
 // - successfully setting KLAY fee
 func TestMultiBridgeSetKLAYFee(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	const confThreshold = uint8(2)
 	const fee = 1000
@@ -548,6 +568,8 @@ func TestMultiBridgeSetKLAYFee(t *testing.T) {
 // - successfully setting ERC20 fee
 func TestMultiBridgeSetERC20Fee(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	const confThreshold = uint8(2)
 	const fee = 1000
@@ -586,6 +608,8 @@ func TestMultiBridgeSetERC20Fee(t *testing.T) {
 // - the bridge contract method SetFeeReceiver.
 func TestSetFeeReceiver(t *testing.T) {
 	info := prepareMultiBridgeTest(t)
+	defer info.sim.Close()
+
 	dummy := common.Address{10}
 
 	opts := &bind.TransactOpts{From: info.acc.From, Signer: info.acc.Signer, GasLimit: DefaultBridgeTxGasLimit}
@@ -604,8 +628,9 @@ func TestSetFeeReceiver(t *testing.T) {
 // - non-operator failed to handle value transfer.
 func TestMultiBridgeErrNotOperator1(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
-	to := common.Address{100}
+	defer info.sim.Close()
 
+	to := common.Address{100}
 	nonceOffset := uint64(17)
 	sentNonce := nonceOffset
 	transferAmount := uint64(100)
@@ -625,6 +650,8 @@ func TestMultiBridgeErrNotOperator1(t *testing.T) {
 // - non-operator fails to handle value transfer.
 func TestMultiBridgeErrNotOperator2(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	to := common.Address{100}
 	acc := info.accounts[0]
 
@@ -657,6 +684,8 @@ func TestMultiBridgeErrNotOperator2(t *testing.T) {
 // - second operator fails to handle value transfer with invalid tx.
 func TestMultiBridgeErrInvalTx(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	to := common.Address{100}
 	acc := info.accounts[0]
 
@@ -698,6 +727,8 @@ func TestMultiBridgeErrInvalTx(t *testing.T) {
 // - the last operator fails to handle value transfer because of vote closing.
 func TestMultiBridgeErrOverSign(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	to := common.Address{100}
 	acc := info.accounts[0]
 
@@ -734,6 +765,8 @@ func TestMultiBridgeErrOverSign(t *testing.T) {
 // - another operator (different auth) fails to handle value transfer because of vote closing (duplicated).
 func TestMultiOperatorKLAYTransferDup(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	to := common.Address{100}
 	acc := info.accounts[0]
 
@@ -766,6 +799,8 @@ func TestMultiOperatorKLAYTransferDup(t *testing.T) {
 // - failed to set KLAY fee because of the wrong nonce.
 func TestMultiBridgeSetKLAYFeeErrNonce(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	const confThreshold = uint8(2)
 	const fee = 1000
@@ -808,6 +843,8 @@ func TestMultiBridgeSetKLAYFeeErrNonce(t *testing.T) {
 // - jump 100 nonce and successfully handle value transfer.
 func TestMultiBridgeKLAYTransferNonceJump(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -854,6 +891,8 @@ func TestMultiBridgeKLAYTransferNonceJump(t *testing.T) {
 // - two different value transfers succeed to handle the value transfer.
 func TestMultiBridgeKLAYTransferParallel(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	to := common.Address{100}
 	acc := info.accounts[0]
 
@@ -916,6 +955,8 @@ func TestMultiBridgeKLAYTransferParallel(t *testing.T) {
 // - the second operator successfully handles the value transfer.
 func TestMultiBridgeKLAYTransferMixConfig1(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -965,6 +1006,8 @@ func TestMultiBridgeKLAYTransferMixConfig1(t *testing.T) {
 // - remain operators successfully handle the value transfer.
 func TestMultiBridgeKLAYTransferMixConfig2(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -1019,6 +1062,8 @@ func TestMultiBridgeKLAYTransferMixConfig2(t *testing.T) {
 // - the first operator successfully handles the value transfer if retry.
 func TestMultiBridgeKLAYTransferMixConfig3(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -1066,6 +1111,8 @@ func TestMultiBridgeKLAYTransferMixConfig3(t *testing.T) {
 // - the second transfer is done and check nonces and block number (req 1, blk 100100)
 func TestNoncesAndBlockNumber(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 
@@ -1133,6 +1180,8 @@ func TestNoncesAndBlockNumber(t *testing.T) {
 // - check if reversed request nonce from 2 to 0 fail.
 func TestNoncesAndBlockNumberUnordered(t *testing.T) {
 	info := prepareMultiBridgeEventTest(t)
+	defer info.sim.Close()
+
 	acc := info.accounts[0]
 	to := common.Address{100}
 

--- a/node/sc/vt_contract_test.go
+++ b/node/sc/vt_contract_test.go
@@ -17,16 +17,17 @@
 package sc
 
 import (
-	"github.com/klaytn/klaytn/accounts/abi/bind"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/contracts/sc_erc20"
-	"github.com/klaytn/klaytn/contracts/sc_erc721"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"math/big"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/common"
+	sctoken "github.com/klaytn/klaytn/contracts/sc_erc20"
+	scnft "github.com/klaytn/klaytn/contracts/sc_erc721"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestTokenPublicVariables checks the results of the public variables.
@@ -44,6 +45,7 @@ func TestTokenPublicVariables(t *testing.T) {
 			ops[KLAY].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
 
 	initSupply, err := info.tokenLocalBridge.INITIALSUPPLY(nil)
 	assert.NoError(t, err)
@@ -90,6 +92,7 @@ func TestNFTPublicVariables(t *testing.T) {
 			ops[KLAY].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
 
 	_, tx, _, err := scnft.DeployServiceChainNFT(info.nodeAuth, info.sim, common.Address{0})
 	assert.NoError(t, err)

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -17,17 +17,6 @@
 package sc
 
 import (
-	"github.com/klaytn/klaytn/accounts/abi/bind"
-	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
-	"github.com/klaytn/klaytn/blockchain"
-	"github.com/klaytn/klaytn/blockchain/types"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/contracts/sc_erc20"
-	"github.com/klaytn/klaytn/contracts/sc_erc721"
-	"github.com/klaytn/klaytn/crypto"
-	"github.com/klaytn/klaytn/params"
-	"github.com/klaytn/klaytn/storage/database"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
 	"math/big"
@@ -35,6 +24,18 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	sctoken "github.com/klaytn/klaytn/contracts/sc_erc20"
+	scnft "github.com/klaytn/klaytn/contracts/sc_erc721"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/storage/database"
+	"github.com/stretchr/testify/assert"
 )
 
 type testInfo struct {
@@ -114,6 +115,7 @@ func TestBasicKLAYTransferRecovery(t *testing.T) {
 			ops[KLAY].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
 
 	// 2. Update recovery hint.
@@ -186,6 +188,7 @@ func TestKLAYTransferLongRangeRecovery(t *testing.T) {
 			}
 		}
 	})
+	defer info.sim.Close()
 	// TODO-Klaytn need to remove sleep
 	time.Sleep(1 * time.Second)
 	info.sim.Commit()
@@ -249,6 +252,7 @@ func TestBasicTokenTransferRecovery(t *testing.T) {
 			ops[ERC20].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
 	err = vtr.updateRecoveryHint()
@@ -288,6 +292,7 @@ func TestBasicNFTTransferRecovery(t *testing.T) {
 			ops[ERC721].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
 	err = vtr.updateRecoveryHint()
@@ -326,6 +331,8 @@ func TestMethodRecover(t *testing.T) {
 			ops[KLAY].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
+
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
 	err = vtr.updateRecoveryHint()
 	if err != nil {
@@ -362,6 +369,8 @@ func TestMethodStop(t *testing.T) {
 			ops[KLAY].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
+
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 1}, info.localInfo, info.remoteInfo)
 	err = vtr.updateRecoveryHint()
 	if err != nil {
@@ -397,6 +406,7 @@ func TestFlagVTRecovery(t *testing.T) {
 			ops[KLAY].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 60}, info.localInfo, info.remoteInfo)
 	vtr.Start()
@@ -423,6 +433,7 @@ func TestAlreadyStartedVTRecovery(t *testing.T) {
 			ops[KLAY].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 60}, info.localInfo, info.remoteInfo)
 	err = vtr.Start()
@@ -450,6 +461,7 @@ func TestScenarioMainChainRecovery(t *testing.T) {
 			ops[KLAY].request(info, info.remoteInfo)
 		}
 	})
+	defer info.sim.Close()
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
 	err = vtr.updateRecoveryHint()
@@ -487,6 +499,8 @@ func TestScenarioAutomaticRecovery(t *testing.T) {
 			ops[KLAY].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
+
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 1}, info.localInfo, info.remoteInfo)
 	err = vtr.updateRecoveryHint()
 	if err != nil {
@@ -526,6 +540,7 @@ func TestMultiOperatorRequestRecovery(t *testing.T) {
 			ops[KLAY].request(info, info.localInfo)
 		}
 	})
+	defer info.sim.Close()
 
 	// 2. Set multi-operator.
 	cAcc := info.nodeAuth


### PR DESCRIPTION
## Proposed changes

- It fixes goroutine memory leak caused by not freeing `SimulatedBackend`. The problem is solved by adding and calling `Close` function which frees `SimulatedBackend`. 
- Most of the cases, it is not a problem. However, there is an issue reported when CI/CD running ( https://github.com/ethereum/go-ethereum/issues/19892 )
- It is cherry-picked from https://github.com/ethereum/go-ethereum/commit/140a7e91778447e058c1811103037437b2091c6e, and added more `Close` calls because there are more test cases which uses `NewSimulatedBackend`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
