### PR TITLE
Introduce timeout for dynamoDB client and increase maxRetries

### DIFF
--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -90,6 +90,10 @@ func (s *SuiteDynamoDB) TestDynamoDB_Put() {
 	s.NoError(returnedErr)
 }
 
+// TestDynamoDB_Timeout tests if a timeout error occurs.
+// When there is no answer from DynamoDB server due to network failure, 
+// a timeout error should occur.
+// A fake server is setup to simulate a server with a response latency.
 func (s *SuiteDynamoDB) TestDynamoDB_Timeout() {
 	// fakeEndpoint allows TCP handshakes, but doesn't answer anything to client.
 	// The fake server is used to produce a network failure scenario.

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -114,6 +114,7 @@ func (s *SuiteDynamoDB) TestDynamoDB_Timeout() {
 
 		for {
 			// Deadline prevents infinite waiting of the fake server
+			// Wait longer than (maxRetries+1) * timeout
 			if err := listen.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
 				s.FailNow(err.Error())
 			}


### PR DESCRIPTION
## Proposed changes

- Introduce timeout (10 seconds) for dynamoDB client to attempt again early. 
- Increase maxRetries from 3 (default) to 5 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
