### PR TITLE
Introduce panic recover logic in ProtocolManager.processMsg

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -74,6 +74,7 @@ const (
 // errIncompatibleConfig is returned if the requested protocols and configs are
 // not compatible (low protocol version restrictions and high requirements).
 var errIncompatibleConfig = errors.New("incompatible configuration")
+var errUnknownProcessingError = errors.New("unknown error during the msg processing")
 
 func errResp(code errCode, format string, v ...interface{}) error {
 	return fmt.Errorf("%v - %v", code, fmt.Sprintf(format, v...))
@@ -470,7 +471,7 @@ func (pm *ProtocolManager) processMsg(msgCh <-chan p2p.Msg, p Peer, addr common.
 		if err := recover(); err != nil {
 			logger.Error("stacktrace from panic: \n" + string(debug.Stack()))
 			logger.Warn("the panic is recovered", "panicErr", err)
-			errCh <- errors.New("unknown error during the msg processing")
+			errCh <- errUnknownProcessingError
 		}
 	}()
 

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -19,6 +19,10 @@ package cn
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -34,9 +38,6 @@ import (
 	"github.com/klaytn/klaytn/params"
 	workmocks "github.com/klaytn/klaytn/work/mocks"
 	"github.com/stretchr/testify/assert"
-	"math/big"
-	"testing"
-	"time"
 )
 
 const blockNum1 = 20190902
@@ -277,6 +278,30 @@ func TestProtocolManager_getChainID(t *testing.T) {
 	pm.blockchain = mockBlockChain
 
 	assert.Equal(t, cfg.ChainID, pm.getChainID())
+}
+
+func TestProtocolManager_processMsg_panicRecover(t *testing.T) {
+	pm := &ProtocolManager{}
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	msgCh := make(chan p2p.Msg)
+	errCh := make(chan error)
+	addr := common.Address{}
+
+	mockPeer := NewMockPeer(mockCtrl)
+	mockPeer.EXPECT().GetVersion().Do(
+		func() { panic("panic test") },
+	)
+
+	// pm.processMsg will be panicked byt the mockPeer
+	go pm.processMsg(msgCh, mockPeer, addr, errCh)
+
+	msgCh <- p2p.Msg{Code: NodeDataMsg}
+
+	// panic will be recovered and errCh will received an error
+	err := <-errCh
+	assert.Equal(t, errUnknownProcessingError, err)
 }
 
 func TestSampleSize(t *testing.T) {

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -294,7 +294,7 @@ func TestProtocolManager_processMsg_panicRecover(t *testing.T) {
 		func() { panic("panic test") },
 	)
 
-	// pm.processMsg will be panicked byt the mockPeer
+	// pm.processMsg will be panicked by the mockPeer
 	go pm.processMsg(msgCh, mockPeer, addr, errCh)
 
 	msgCh <- p2p.Msg{Code: NodeDataMsg}

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -299,7 +299,7 @@ func TestProtocolManager_processMsg_panicRecover(t *testing.T) {
 
 	msgCh <- p2p.Msg{Code: NodeDataMsg}
 
-	// panic will be recovered and errCh will received an error
+	// panic will be recovered and errCh will receive an error
 	err := <-errCh
 	assert.Equal(t, errUnknownProcessingError, err)
 }


### PR DESCRIPTION
## Proposed changes

- Introduce a panic recovering logic that mitigates node failure from unknown errors triggered by p2p peers. 
If panic occurred, the message channel delivered an abnormal message will be closed but `ProtocolManager` will work normally. 

Testing log in KES Service node (A panic occurred intentionally with a message "panic-test. newblockmsg")
```
INFO[12/03,05:09:10 Z] [5] inserted a new block                      prevBlockNumber=45322189 blockNumber=45322190 hash=0xa33f50919d8cc1613fe6b131310f574f732059cf468b553d3d01114a130a69b4 stateRoot=0xaafac207fd15431f1f1c5fdf843a9e229565683718fafae61d7ae29520ad32f1
INFO[12/03,05:09:10 Z] [33] [Dial] Add dial candidate from static nodes  id=c5b001f8669b7ae7 NodeType=3 ip=13.124.208.217 port="[32323 32324]"
INFO[12/03,05:09:10 Z] [33] Added a multichannel P2P Peer             id=c5b001f8669b7ae7 conn=staticdial         peerID=c5b001f8669b7ae7
ERROR[12/03,05:09:11 Z] [41] stacktrace from panic:
goroutine 4370 [running]:
runtime/debug.Stack(0xc000a8a3c8, 0x17d7b60, 0x1f22770)
	/usr/local/src/runtime/debug/stack.go:24 +0x9d
github.com/klaytn/klaytn/node/cn.(*ProtocolManager).processMsg.func1(0xc0015c83c0)
	/go/src/github.com/klaytn/klaytn/node/cn/handler.go:471 +0x57
panic(0x17d7b60, 0x1f22770)
	/usr/local/src/runtime/panic.go:969 +0x166
github.com/klaytn/klaytn/node/cn.(*ProtocolManager).handleMsg(0xc0001a8640, 0x1fb7000, 0xc00152bbc0, 0xc78cfd9cad89d815, 0x40f2382f433e1a64, 0xc0fdafe302, 0xb, 0xd26, 0x1f59a40, 0xc0015f6150, ...)
	/go/src/github.com/klaytn/klaytn/node/cn/handler.go:605 +0xafd
github.com/klaytn/klaytn/node/cn.(*ProtocolManager).processMsg(0xc0001a8640, 0xc0015c8300, 0x1fb7000, 0xc00152bbc0, 0xc78cfd9cad89d815, 0x40f2382f433e1a64, 0xc0fdafe302, 0xc0015c83c0)
	/go/src/github.com/klaytn/klaytn/node/cn/handler.go:477 +0x1d0
created by github.com/klaytn/klaytn/node/cn.(*multiChannelPeer).Handle
	/go/src/github.com/klaytn/klaytn/node/cn/peer.go:1067 +0xec7

WARN[12/03,05:09:11 Z] [41] the panic is recovered                    panicErr="panic-test. newblockmsg"
INFO[12/03,05:09:11 Z] [5] inserted a new block                      prevBlockNumber=45322190 blockNumber=45322191 hash=0x33a62323de5b27691eaefbf44523c97c7eba49012d3a6fe86e92e92ef55db17e stateRoot=0x10ff78e5115355749e6d7699a18b724a361d836800224e5f440df93ea2850add
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
