### PR TITLE
multi channel update should be redialed right away

### DIFF
--- a/networks/p2p/dial.go
+++ b/networks/p2p/dial.go
@@ -468,7 +468,6 @@ func (s *dialstate) taskDone(t task, now time.Time) {
 	case *dialTask:
 		// Updated dial can be redialed right away
 		if t.err != errUpdateDial {
-			logger.Error("add dialing history", "ID", t.dest.ID, "ip", t.dest.IP)
 			s.hist.add(t.dest.ID, now.Add(dialHistoryExpiration))
 		}
 		t.err = nil

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -577,8 +577,8 @@ func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *disc
 			dialDest.TCPs = append(dialDest.TCPs, uint16(listenPort))
 		}
 		srv.AddPeer(dialDest)
-		logger.Info("[Dial] Try to update dial candidate with a multichannel peer", "id", dialDest.ID, "addr", dialDest.IP, "port", dialDest.TCPs)
-		return nil
+		logger.Info("[Dial] "+errUpdateDial.Error(), "id", dialDest.ID, "addr", dialDest.IP, "port", dialDest.TCPs)
+		return errUpdateDial
 	}
 
 	err = srv.checkpoint(c, srv.addpeer)


### PR DESCRIPTION
## Proposed changes

* The updated dials can be redialed again at once.
* Problem
  * When dialing multi channel server with single port, the actual connection port is found on handshake. 
     In this case, the on-going dial is canceled and a new dial task with new port is generated.
     However, due to the previous dial, the redial task should wait 30 seconds.
     (Normally, redialing to the same node happens every 30 seconds.)
  * It is unable to put subport in `kni` scheme right now.
     Therefore, connecting to nodes in `static-nodes.json` will take at least 30 seconds on node start.
* Node start time is reduced
  * Before this PR: 5sec ~ 40sec
  * After this PR : 5sec ~ 12sec

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

