### PR TITLE
added new debug API debug.StartContractWarmUp(common.Address)

### DIFF
--- a/blockchain/state/iterator.go
+++ b/blockchain/state/iterator.go
@@ -22,13 +22,14 @@ package state
 import (
 	"bytes"
 	"fmt"
+	"time"
+
 	"github.com/klaytn/klaytn/blockchain/types/account"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/ser/rlp"
 	"github.com/klaytn/klaytn/storage/statedb"
 	"github.com/pkg/errors"
-	"time"
 )
 
 var (
@@ -116,7 +117,7 @@ func (it *NodeIterator) step() error {
 	if !it.stateIt.Leaf() {
 		return nil
 	}
-	// Otherwise we've reached an account node, initiate data iteration
+	// Otherwise we've reached an account node or a leaf of storage trie, initiate data iteration
 
 	serializer := account.NewAccountSerializer()
 	if err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob()), serializer); err != nil {

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -505,21 +505,21 @@ func (bc *BlockChain) startWarmUp(contractAddr common.Address) error {
 
 	bc.quitWarmUp = make(chan struct{})
 
+	root := block.Root()
+	if !common.EmptyAddress(contractAddr) {
+		var err error
+		root, err = bc.GetContractStorageRoot(block, db, contractAddr)
+		if err != nil {
+			logger.Error("failed to retrieve the storage root",
+				"err", err, "contractAddr", contractAddr.String())
+			return err
+		}
+	}
+
 	go func() {
 		defer func() {
 			bc.quitWarmUp = nil
 		}()
-
-		root := block.Root()
-		if !common.EmptyAddress(contractAddr) {
-			var err error
-			root, err = bc.GetContractStorageRoot(block, db, contractAddr)
-			if err != nil {
-				logger.Error("failed to retrieve the storage root",
-					"err", err, "contractAddr", contractAddr.String())
-				return
-			}
-		}
 
 		children, err := db.TrieDB().NodeChildren(root)
 		if err != nil {

--- a/blockchain/types/account/account_serializer.go
+++ b/blockchain/types/account/account_serializer.go
@@ -18,8 +18,9 @@ package account
 
 import (
 	"encoding/json"
-	"github.com/klaytn/klaytn/ser/rlp"
 	"io"
+
+	"github.com/klaytn/klaytn/ser/rlp"
 )
 
 // AccountSerializer serializes an Account object using RLP/JSON.
@@ -64,14 +65,7 @@ func (ser *AccountSerializer) GetAccount() Account {
 
 func (ser *AccountSerializer) DecodeRLP(s *rlp.Stream) error {
 	if err := s.Decode(&ser.accType); err != nil {
-		// fallback to decoding a LegacyAccount object.
-		acc := newLegacyAccount()
-		if err := s.Decode(acc); err != nil {
-			return err
-		}
-		ser.accType = LegacyAccountType
-		ser.account = acc
-		return nil
+		return err
 	}
 
 	var err error

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -358,6 +358,7 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'startContractWarmUp',
 			call: 'debug_startContractWarmUp',
+			params: 1
 		}),
 		new web3._extend.Method({
 			name: 'stopWarmUp',

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -356,6 +356,10 @@ web3._extend({
 			call: 'debug_startWarmUp',
 		}),
 		new web3._extend.Method({
+			name: 'startContractWarmUp',
+			call: 'debug_startContractWarmUp',
+		}),
+		new web3._extend.Method({
 			name: 'stopWarmUp',
 			call: 'debug_stopWarmUp',
 		}),

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -283,6 +283,10 @@ func (api *PublicDebugAPI) StartWarmUp() error {
 	return api.cn.blockchain.StartWarmUp()
 }
 
+func (api *PublicDebugAPI) StartContractWarmUp(contractAddr common.Address) error {
+	return api.cn.blockchain.StartContractWarmUp(contractAddr)
+}
+
 // StopWarmUp stops the warming up process.
 func (api *PublicDebugAPI) StopWarmUp() error {
 	return api.cn.blockchain.StopWarmUp()

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -726,6 +726,20 @@ func (mr *MockBlockChainMockRecorder) StartCollectingTrieStats(arg0 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartCollectingTrieStats", reflect.TypeOf((*MockBlockChain)(nil).StartCollectingTrieStats), arg0)
 }
 
+// StartContractWarmUp mocks base method
+func (m *MockBlockChain) StartContractWarmUp(arg0 common.Address) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartContractWarmUp", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartContractWarmUp indicates an expected call of StartContractWarmUp
+func (mr *MockBlockChainMockRecorder) StartContractWarmUp(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContractWarmUp", reflect.TypeOf((*MockBlockChain)(nil).StartContractWarmUp), arg0)
+}
+
 // StartStateMigration mocks base method
 func (m *MockBlockChain) StartStateMigration(arg0 uint64, arg1 common.Hash) error {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -295,6 +295,7 @@ type BlockChain interface {
 
 	// Warm up
 	StartWarmUp() error
+	StartContractWarmUp(contractAddr common.Address) error
 	StopWarmUp() error
 
 	// Collect state/storage trie statistics


### PR DESCRIPTION
## Proposed changes

- Added `debug.StartContractWarmUp(common.Address)` to selectively warm up contract storage
- Previous `Blockchain.StartWarmUp()` has been changed to `Blockchain.startWarmUp(common.Address)` and it will iterate all the storage/state trie nodes if an empty address is given.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
