### PR TITLE
blockchain, work: changed gauge to meter and added more metrics

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -53,12 +53,15 @@ import (
 )
 
 var (
-	blockInsertTimeGauge = metrics.NewRegisteredGauge("chain/inserts", nil)
-	ErrNoGenesis         = errors.New("Genesis not found in chain")
-	ErrNotExistNode      = errors.New("the node does not exist in cached node")
-	ErrQuitBySignal      = errors.New("quit by signal")
-	ErrNotInWarmUp       = errors.New("not in warm up")
-	logger               = log.NewModuleLogger(log.Blockchain)
+	blockInsertTimeMeter   = metrics.NewRegisteredMeter("chain/inserts", nil)
+	blockProcessTimeMeter  = metrics.NewRegisteredMeter("chain/process", nil)
+	blockFinalizeTimeMeter = metrics.NewRegisteredMeter("chain/finalize", nil)
+	blockValidateTimeMeter = metrics.NewRegisteredMeter("chain/validate", nil)
+	ErrNoGenesis           = errors.New("Genesis not found in chain")
+	ErrNotExistNode        = errors.New("the node does not exist in cached node")
+	ErrQuitBySignal        = errors.New("quit by signal")
+	ErrNotInWarmUp         = errors.New("not in warm up")
+	logger                 = log.NewModuleLogger(log.Blockchain)
 )
 
 // Below is the list of the constants for cache size.
@@ -1616,13 +1619,19 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 
 		switch writeResult.Status {
 		case CanonStatTy:
-			processTxsTime := procStats.AfterApplyTxs.Sub(procStats.BeforeApplyTxs)
-			processFinalizeTime := procStats.AfterFinalize.Sub(procStats.AfterApplyTxs)
-			validateTime := afterValidate.Sub(procStats.AfterFinalize)
+			processTxsTime := common.PrettyDuration(procStats.AfterApplyTxs.Sub(procStats.BeforeApplyTxs))
+			processFinalizeTime := common.PrettyDuration(procStats.AfterFinalize.Sub(procStats.AfterApplyTxs))
+			validateTime := common.PrettyDuration(afterValidate.Sub(procStats.AfterFinalize))
+			totalTime := common.PrettyDuration(time.Since(bstart))
 			logger.Info("Inserted a new block", "number", block.Number(), "hash", block.Hash(),
-				"txs", len(block.Transactions()), "gas", block.GasUsed(), "elapsed", common.PrettyDuration(time.Since(bstart)),
+				"txs", len(block.Transactions()), "gas", block.GasUsed(), "elapsed", totalTime,
 				"processTxs", processTxsTime, "finalize", processFinalizeTime, "validateState", validateTime,
 				"totalWrite", writeResult.TotalWriteTime, "trieWrite", writeResult.TrieWriteTime)
+
+			blockProcessTimeMeter.Mark(int64(processTxsTime))
+			blockFinalizeTimeMeter.Mark(int64(processFinalizeTime))
+			blockValidateTimeMeter.Mark(int64(validateTime))
+			blockInsertTimeMeter.Mark(int64(totalTime))
 
 			coalescedLogs = append(coalescedLogs, logs...)
 			events = append(events, ChainEvent{
@@ -1640,7 +1649,6 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 
 			events = append(events, ChainSideEvent{block})
 		}
-		blockInsertTimeGauge.Update(int64(time.Since(bstart)))
 		stats.processed++
 		stats.usedGas += usedGas
 

--- a/work/worker.go
+++ b/work/worker.go
@@ -55,18 +55,20 @@ const (
 
 var (
 	// Metrics for miner
-	timeLimitReachedCounter = metrics.NewRegisteredCounter("miner/timelimitreached", nil)
-	tooLongTxCounter        = metrics.NewRegisteredCounter("miner/toolongtx", nil)
-	ResultChGauge           = metrics.NewRegisteredGauge("miner/resultch", nil)
-	resentTxGauge           = metrics.NewRegisteredGauge("miner/tx/resend/gauge", nil)
-	usedAllTxsCounter       = metrics.NewRegisteredCounter("miner/usedalltxs", nil)
-	checkedTxsGauge         = metrics.NewRegisteredGauge("miner/checkedtxs", nil)
-	tCountGauge             = metrics.NewRegisteredGauge("miner/tcount", nil)
-	nonceTooLowTxsGauge     = metrics.NewRegisteredGauge("miner/nonce/low/txs", nil)
-	nonceTooHighTxsGauge    = metrics.NewRegisteredGauge("miner/nonce/high/txs", nil)
-	gasLimitReachedTxsGauge = metrics.NewRegisteredGauge("miner/limitreached/gas/txs", nil)
-	strangeErrorTxsCounter  = metrics.NewRegisteredCounter("miner/strangeerror/txs", nil)
-	blockMiningTimeGauge    = metrics.NewRegisteredGauge("miner/block/mining/time", nil)
+	timeLimitReachedCounter      = metrics.NewRegisteredCounter("miner/timelimitreached", nil)
+	tooLongTxCounter             = metrics.NewRegisteredCounter("miner/toolongtx", nil)
+	ResultChGauge                = metrics.NewRegisteredGauge("miner/resultch", nil)
+	resentTxGauge                = metrics.NewRegisteredGauge("miner/tx/resend/gauge", nil)
+	usedAllTxsCounter            = metrics.NewRegisteredCounter("miner/usedalltxs", nil)
+	checkedTxsGauge              = metrics.NewRegisteredGauge("miner/checkedtxs", nil)
+	tCountGauge                  = metrics.NewRegisteredGauge("miner/tcount", nil)
+	nonceTooLowTxsGauge          = metrics.NewRegisteredGauge("miner/nonce/low/txs", nil)
+	nonceTooHighTxsGauge         = metrics.NewRegisteredGauge("miner/nonce/high/txs", nil)
+	gasLimitReachedTxsGauge      = metrics.NewRegisteredGauge("miner/limitreached/gas/txs", nil)
+	strangeErrorTxsCounter       = metrics.NewRegisteredCounter("miner/strangeerror/txs", nil)
+	blockMiningTimeMeter         = metrics.NewRegisteredMeter("miner/block/mining/time", nil)
+	blockMiningCommitTxTimeMeter = metrics.NewRegisteredMeter("miner/block/committx/time", nil)
+	blockMiningFinalizeTimeMeter = metrics.NewRegisteredMeter("miner/block/finalize/time", nil)
 )
 
 // Agent can register themself with the worker
@@ -532,15 +534,16 @@ func (self *worker) commitNewWork() {
 		// We only care about logging if we're actually mining.
 		if atomic.LoadInt32(&self.mining) == 1 {
 			tCountGauge.Update(int64(work.tcount))
-			blockMiningTime := time.Since(tstart)
-			blockMiningTimeGauge.Update(int64(blockMiningTime))
+			blockMiningTime := common.PrettyDuration(time.Since(tstart))
+			commitTxTime := common.PrettyDuration(finishedCommitTx.Sub(tstart))
+			finalizeTime := common.PrettyDuration(finishedFinalize.Sub(finishedCommitTx))
 
-			commitTxTime := finishedCommitTx.Sub(tstart)
-			finalizeTime := finishedFinalize.Sub(finishedCommitTx)
+			blockMiningTimeMeter.Mark(int64(blockMiningTime))
+			blockMiningCommitTxTimeMeter.Mark(int64(commitTxTime))
+			blockMiningFinalizeTimeMeter.Mark(int64(finalizeTime))
 			logger.Info("Commit new mining work",
 				"number", work.Block.Number(), "hash", work.Block.Hash(),
-				"txs", work.tcount, "elapsed", common.PrettyDuration(blockMiningTime),
-				"commitTime", common.PrettyDuration(commitTxTime), "finalizeTime", common.PrettyDuration(finalizeTime))
+				"txs", work.tcount, "elapsed", blockMiningTime, "commitTime", commitTxTime, "finalizeTime", finalizeTime)
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

- As prometheus exports the collected metrics by every 15 seconds, it is better to use meter instead of gauge to represent that duration, in most cases.
- Added more mining time related metrics and block insert time metrics.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
