### PR TITLE
Changed metrics.Meter to metrics.Timer

### DIFF
--- a/metrics/prometheus/prometheusmetrics.go
+++ b/metrics/prometheus/prometheusmetrics.go
@@ -7,10 +7,11 @@ package prometheusmetrics
 
 import (
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rcrowley/go-metrics"
 	"strings"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rcrowley/go-metrics"
 )
 
 // PrometheusConfig provides a container with config parameters for the Prometheus Exporter
@@ -69,6 +70,9 @@ func (c *PrometheusConfig) UpdatePrometheusMetrics() {
 	}
 }
 
+var pv = []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
+var pv_str = []string{"0.5", "0.75", "0.95", "0.99", "0.999", "0.9999"}
+
 func (c *PrometheusConfig) UpdatePrometheusMetricsOnce() error {
 	c.Registry.Each(func(name string, i interface{}) {
 		switch metric := i.(type) {
@@ -88,8 +92,13 @@ func (c *PrometheusConfig) UpdatePrometheusMetricsOnce() error {
 			lastSample := metric.Snapshot().Rate1()
 			c.gaugeFromNameAndValue(name, float64(lastSample))
 		case metrics.Timer:
-			lastSample := metric.Snapshot().Rate1()
-			c.gaugeFromNameAndValue(name, float64(lastSample))
+			// use mean as a default export value of metrics.Timer
+			c.gaugeFromNameAndValue(name, metric.Mean())
+			// also retrieve and export percentiles
+			ps := metric.Percentiles(pv)
+			for i := range pv {
+				c.gaugeFromNameAndValue(name+pv_str[i], ps[i])
+			}
 		}
 	})
 	return nil

--- a/metrics/prometheus/prometheusmetrics.go
+++ b/metrics/prometheus/prometheusmetrics.go
@@ -71,7 +71,7 @@ func (c *PrometheusConfig) UpdatePrometheusMetrics() {
 }
 
 var pv = []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
-var pv_str = []string{"0.5", "0.75", "0.95", "0.99", "0.999", "0.9999"}
+var pv_str = []string{"_0_5", "_0_75", "_0_95", "_0_99", "_0_999", "_0_9999"}
 
 func (c *PrometheusConfig) UpdatePrometheusMetricsOnce() error {
 	c.Registry.Each(func(name string, i interface{}) {

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -95,8 +95,8 @@ type dynamoDB struct {
 	logger log.Logger // Contextual logger tracking the database path
 
 	// metrics
-	getTimeMeter metrics.Meter
-	putTimeMeter metrics.Meter
+	getTimer metrics.Timer
+	putTimer metrics.Timer
 }
 
 type DynamoData struct {
@@ -284,7 +284,7 @@ func (dynamo *dynamoDB) Put(key []byte, val []byte) error {
 	if dynamo.config.PerfCheck {
 		start := time.Now()
 		err := dynamo.put(key, val)
-		dynamo.putTimeMeter.Mark(int64(time.Since(start)))
+		dynamo.putTimer.Update(time.Since(start))
 		return err
 	}
 	return dynamo.put(key, val)
@@ -336,7 +336,7 @@ func (dynamo *dynamoDB) Get(key []byte) ([]byte, error) {
 	if dynamo.config.PerfCheck {
 		start := time.Now()
 		val, err := dynamo.get(key)
-		dynamo.getTimeMeter.Mark(int64(time.Since(start)))
+		dynamo.getTimer.Update(time.Since(start))
 		return val, err
 	}
 	return dynamo.get(key)
@@ -408,8 +408,8 @@ func (dynamo *dynamoDB) Close() {
 }
 
 func (dynamo *dynamoDB) Meter(prefix string) {
-	dynamo.getTimeMeter = metrics.NewRegisteredMeter(prefix+"get/time", nil)
-	dynamo.putTimeMeter = metrics.NewRegisteredMeter(prefix+"put/time", nil)
+	dynamo.getTimer = metrics.NewRegisteredTimer(prefix+"get/time", nil)
+	dynamo.putTimer = metrics.NewRegisteredTimer(prefix+"put/time", nil)
 	dynamoBatchWriteTimeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/time", nil)
 }
 

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -446,7 +446,7 @@ hasError:
 			currCompRead += s.LevelRead[i]
 			currCompWrite += s.LevelWrite[i]
 		}
-		db.compTimer.Update(time.Duration(currCompTime.Nanoseconds() - prevCompTime.Nanoseconds()))
+		db.compTimer.Update(currCompTime - prevCompTime)
 		db.compReadMeter.Mark(currCompRead - prevCompRead)
 		db.compWriteMeter.Mark(currCompWrite - prevCompWrite)
 		prevCompTime, prevCompRead, prevCompWrite = currCompTime, currCompRead, currCompWrite

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -99,7 +99,7 @@ type levelDB struct {
 	aliveSnapshotsMeter metrics.Meter // Meter for measuring the number of alive snapshots
 	aliveIteratorsMeter metrics.Meter // Meter for measuring the number of alive iterators
 
-	compTimeMeter          metrics.Meter // Meter for measuring the total time spent in database compaction
+	compTimer              metrics.Timer // Meter for measuring the total time spent in database compaction
 	compReadMeter          metrics.Meter // Meter for measuring the data read during compaction
 	compWriteMeter         metrics.Meter // Meter for measuring the data written during compaction
 	diskReadMeter          metrics.Meter // Meter for measuring the effective amount of data read
@@ -111,10 +111,10 @@ type levelDB struct {
 	nonlevel0CompGauge     metrics.Gauge // Gauge for tracking the number of table compaction in non0 level
 	seekCompGauge          metrics.Gauge // Gauge for tracking the number of table compaction caused by read opt
 
-	perfCheck           bool
-	getTimeMeter        metrics.Meter
-	putTimeMeter        metrics.Meter
-	batchWriteTimeMeter metrics.Meter
+	perfCheck       bool
+	getTimer        metrics.Timer
+	putTimer        metrics.Timer
+	batchWriteTimer metrics.Timer
 
 	quitLock sync.Mutex      // Mutex protecting the quit channel access
 	quitChan chan chan error // Quit channel to stop the metrics collection before closing the database
@@ -260,7 +260,7 @@ func (db *levelDB) Put(key []byte, value []byte) error {
 	if db.perfCheck {
 		start := time.Now()
 		err := db.put(key, value)
-		db.putTimeMeter.Mark(int64(time.Since(start)))
+		db.putTimer.Update(time.Since(start))
 		return err
 	}
 	return db.put(key, value)
@@ -279,7 +279,7 @@ func (db *levelDB) Get(key []byte) ([]byte, error) {
 	if db.perfCheck {
 		start := time.Now()
 		val, err := db.get(key)
-		db.getTimeMeter.Mark(int64(time.Since(start)))
+		db.getTimer.Update(time.Since(start))
 		return val, err
 	}
 	return db.get(key)
@@ -353,7 +353,7 @@ func (db *levelDB) Meter(prefix string) {
 	db.writeDelayDurationMeter = metrics.NewRegisteredMeter(prefix+"writedelay/duration", nil)
 	db.aliveSnapshotsMeter = metrics.NewRegisteredMeter(prefix+"snapshots", nil)
 	db.aliveIteratorsMeter = metrics.NewRegisteredMeter(prefix+"iterators", nil)
-	db.compTimeMeter = metrics.NewRegisteredMeter(prefix+"compaction/time", nil)
+	db.compTimer = metrics.NewRegisteredTimer(prefix+"compaction/time", nil)
 	db.compReadMeter = metrics.NewRegisteredMeter(prefix+"compaction/read", nil)
 	db.compWriteMeter = metrics.NewRegisteredMeter(prefix+"compaction/write", nil)
 	db.diskReadMeter = metrics.NewRegisteredMeter(prefix+"disk/read", nil)
@@ -362,9 +362,9 @@ func (db *levelDB) Meter(prefix string) {
 
 	db.openedTablesCountMeter = metrics.NewRegisteredMeter(prefix+"opendedtables", nil)
 
-	db.getTimeMeter = metrics.NewRegisteredMeter(prefix+"get/time", nil)
-	db.putTimeMeter = metrics.NewRegisteredMeter(prefix+"put/time", nil)
-	db.batchWriteTimeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/time", nil)
+	db.getTimer = metrics.NewRegisteredTimer(prefix+"get/time", nil)
+	db.putTimer = metrics.NewRegisteredTimer(prefix+"put/time", nil)
+	db.batchWriteTimer = metrics.NewRegisteredTimer(prefix+"batchwrite/time", nil)
 
 	db.memCompGauge = metrics.NewRegisteredGauge(prefix+"compact/memory", nil)
 	db.level0CompGauge = metrics.NewRegisteredGauge(prefix+"compact/level0", nil)
@@ -446,7 +446,7 @@ hasError:
 			currCompRead += s.LevelRead[i]
 			currCompWrite += s.LevelWrite[i]
 		}
-		db.compTimeMeter.Mark(int64(currCompTime.Seconds() - prevCompTime.Seconds()))
+		db.compTimer.Update(time.Duration(currCompTime.Nanoseconds() - prevCompTime.Nanoseconds()))
 		db.compReadMeter.Mark(currCompRead - prevCompRead)
 		db.compWriteMeter.Mark(currCompWrite - prevCompWrite)
 		prevCompTime, prevCompRead, prevCompWrite = currCompTime, currCompRead, currCompWrite
@@ -503,7 +503,7 @@ func (b *ldbBatch) Write() error {
 	if b.ldb.perfCheck {
 		start := time.Now()
 		err := b.write()
-		b.ldb.batchWriteTimeMeter.Mark(int64(time.Since(start)))
+		b.ldb.batchWriteTimer.Update(time.Since(start))
 		return err
 	}
 	return b.write()


### PR DESCRIPTION
## Proposed changes

- As the result of `metrics.Meter` might be distorted by the rate of data entered, change `metrics.Meter` to `metrics.Timer`, which is designed to collect duration metrics.  
> Timers capture the duration and rate of events. - metrics package description
- `Timer.Mean()` is exported with the original metric name and `0.5, 0.75, 0.95, 0.99, 0.999, 0.9999` percentile metrics are also exported with the suffixes "_0_5", "_0_75", "_0_95", "_0_99", "_0_999", "_0_9999"

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
