### PR TITLE
Redis cache sets items asynchronously

### DIFF
--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -11,7 +11,7 @@ import (
 func getTestHybridConfig() *TrieNodeCacheConfig {
 	return &TrieNodeCacheConfig{
 		CacheType:          CacheTypeHybrid,
-		LocalCacheSizeMB:   1024,
+		LocalCacheSizeMB:   100,
 		FastCacheFileDir:   "",
 		RedisEndpoints:     []string{"localhost:6379"},
 		RedisClusterEnable: false,

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -3,6 +3,7 @@ package statedb
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,6 +28,7 @@ func TestHybridCache_Set(t *testing.T) {
 	// Set an item
 	key, value := randBytes(32), randBytes(500)
 	cache.Set(key, value)
+	time.Sleep(100 * time.Millisecond)
 
 	// Type assertion to check both of local cache and remote cache
 	hybrid, ok := cache.(*HybridCache)
@@ -71,6 +73,7 @@ func TestHybridCache_Get(t *testing.T) {
 		// Store an item into remote cache
 		key, value := randBytes(32), randBytes(500)
 		remoteCache.Set(key, value)
+		time.Sleep(100 * time.Millisecond)
 
 		// Make sure the item is not stored in the local cache.
 		assert.Equal(t, len(localCache.Get(key)), 0)
@@ -89,6 +92,7 @@ func TestHybridCache_Get(t *testing.T) {
 		key, value := randBytes(32), randBytes(500)
 		localCache.Set(key, value)
 		remoteCache.Set(key, []byte{0x11})
+		time.Sleep(100 * time.Millisecond)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal := hybrid.Get(key)
@@ -127,6 +131,7 @@ func TestHybridCache_Has(t *testing.T) {
 		// Store an item into remote cache
 		key, value := randBytes(32), randBytes(500)
 		remoteCache.Set(key, value)
+		time.Sleep(100 * time.Millisecond)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal, returnedExist := hybrid.Has(key)
@@ -140,6 +145,7 @@ func TestHybridCache_Has(t *testing.T) {
 		key, value := randBytes(32), randBytes(500)
 		localCache.Set(key, value)
 		remoteCache.Set(key, []byte{0x11})
+		time.Sleep(100 * time.Millisecond)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal, returnedExist := hybrid.Has(key)

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -11,7 +11,7 @@ import (
 func getTestHybridConfig() *TrieNodeCacheConfig {
 	return &TrieNodeCacheConfig{
 		CacheType:          CacheTypeHybrid,
-		LocalCacheSizeMB:   1024 * 1024,
+		LocalCacheSizeMB:   1024,
 		FastCacheFileDir:   "",
 		RedisEndpoints:     []string{"localhost:6379"},
 		RedisClusterEnable: false,
@@ -28,7 +28,7 @@ func TestHybridCache_Set(t *testing.T) {
 	// Set an item
 	key, value := randBytes(32), randBytes(500)
 	cache.Set(key, value)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(sleepDurationForAsyncBehavior)
 
 	// Type assertion to check both of local cache and remote cache
 	hybrid, ok := cache.(*HybridCache)
@@ -73,7 +73,7 @@ func TestHybridCache_Get(t *testing.T) {
 		// Store an item into remote cache
 		key, value := randBytes(32), randBytes(500)
 		remoteCache.Set(key, value)
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Make sure the item is not stored in the local cache.
 		assert.Equal(t, len(localCache.Get(key)), 0)
@@ -92,7 +92,7 @@ func TestHybridCache_Get(t *testing.T) {
 		key, value := randBytes(32), randBytes(500)
 		localCache.Set(key, value)
 		remoteCache.Set(key, []byte{0x11})
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal := hybrid.Get(key)
@@ -131,7 +131,7 @@ func TestHybridCache_Has(t *testing.T) {
 		// Store an item into remote cache
 		key, value := randBytes(32), randBytes(500)
 		remoteCache.Set(key, value)
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal, returnedExist := hybrid.Has(key)
@@ -145,7 +145,7 @@ func TestHybridCache_Has(t *testing.T) {
 		key, value := randBytes(32), randBytes(500)
 		localCache.Set(key, value)
 		remoteCache.Set(key, []byte{0x11})
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal, returnedExist := hybrid.Has(key)

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -18,6 +18,7 @@ package statedb
 
 import (
 	"errors"
+	"runtime"
 	"time"
 
 	"github.com/go-redis/redis/v7"
@@ -25,6 +26,7 @@ import (
 )
 
 const (
+	redisSetItemChannelSize       = 1024
 	redisSubscriptionChannelSize  = 100 // default value of redis client
 	redisSubscriptionChannelBlock = "latestBlock"
 )
@@ -37,8 +39,14 @@ var (
 )
 
 type RedisCache struct {
-	client redis.UniversalClient
-	pubSub *redis.PubSub
+	client    redis.UniversalClient
+	setItemCh chan setItem
+	pubSub    *redis.PubSub
+}
+
+type setItem struct {
+	key   []byte
+	value []byte
 }
 
 func newRedisClient(endpoints []string, isCluster bool) (redis.UniversalClient, error) {
@@ -68,6 +76,8 @@ func newRedisClient(endpoints []string, isCluster bool) (redis.UniversalClient, 
 	}), nil
 }
 
+// NewRedisCache creates a redis cache containing redis client, setItemCh and pubSub.
+// It generates worker goroutines to process Set commands asynchronously.
 func NewRedisCache(config *TrieNodeCacheConfig) (*RedisCache, error) {
 	cli, err := newRedisClient(config.RedisEndpoints, config.RedisClusterEnable)
 	if err != nil {
@@ -76,15 +86,29 @@ func NewRedisCache(config *TrieNodeCacheConfig) (*RedisCache, error) {
 		return nil, err
 	}
 
-	logger.Info("Initialize trie node cache with redis", "endpoint", config.RedisEndpoints,
+	cache := &RedisCache{
+		client:    cli,
+		setItemCh: make(chan setItem, redisSetItemChannelSize),
+		pubSub:    cli.Subscribe(),
+	}
+
+	workerNum := runtime.NumCPU() / 2
+	for i := 0; i < workerNum; i++ {
+		go func() {
+			for item := range cache.setItemCh {
+				cache.set(item.key, item.value)
+			}
+		}()
+	}
+
+	logger.Info("Initialized trie node cache with redis", "endpoint", config.RedisEndpoints,
 		"isCluster", config.RedisClusterEnable)
-	return &RedisCache{client: cli, pubSub: nil}, nil
+	return cache, nil
 }
 
 func (cache *RedisCache) Get(k []byte) []byte {
 	val, err := cache.client.Get(hexutil.Encode(k)).Bytes()
 	if err != nil {
-		// TODO-Klyatn: Print specific errors if needed
 		logger.Debug("cannot get an item from redis cache", "err", err, "key", hexutil.Encode(k))
 		return nil
 	}
@@ -92,6 +116,15 @@ func (cache *RedisCache) Get(k []byte) []byte {
 }
 
 func (cache *RedisCache) Set(k, v []byte) {
+	item := setItem{key: k, value: v}
+	select {
+	case cache.setItemCh <- item:
+	default:
+		logger.Error("redis setItem channel is full")
+	}
+}
+
+func (cache *RedisCache) set(k, v []byte) {
 	if err := cache.client.Set(hexutil.Encode(k), v, 0).Err(); err != nil {
 		logger.Warn("failed to set an item on redis cache", "err", err, "key", hexutil.Encode(k))
 	}
@@ -112,9 +145,6 @@ func (cache *RedisCache) publish(channel string, msg string) error {
 // subscribe subscribes the redis client to the given channel.
 // It returns an existing *redis.PubSub subscribing previously registered channels also.
 func (cache *RedisCache) subscribe(channel string) *redis.PubSub {
-	if cache.pubSub == nil {
-		cache.pubSub = cache.client.Subscribe()
-	}
 	if err := cache.pubSub.Subscribe(channel); err != nil {
 		logger.Error("failed to subscribe channel", "err", err, "channel", channel)
 	}
@@ -130,9 +160,6 @@ func (cache *RedisCache) SubscribeBlockCh() <-chan *redis.Message {
 }
 
 func (cache *RedisCache) UnsubscribeBlock() error {
-	if cache.pubSub == nil {
-		return nil
-	}
 	return cache.pubSub.Unsubscribe(redisSubscriptionChannelBlock)
 }
 
@@ -145,5 +172,7 @@ func (cache *RedisCache) SaveToFile(filePath string, concurrency int) error {
 }
 
 func (cache *RedisCache) Close() error {
+	cache.pubSub.Close()
+	close(cache.setItemCh)
 	return cache.client.Close()
 }

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -115,6 +115,8 @@ func (cache *RedisCache) Get(k []byte) []byte {
 	return val
 }
 
+// Set writes data asynchronously. Not all data is written if a setItemCh is full.
+// To write data synchronously, use set instead.
 func (cache *RedisCache) Set(k, v []byte) {
 	item := setItem{key: k, value: v}
 	select {
@@ -124,6 +126,8 @@ func (cache *RedisCache) Set(k, v []byte) {
 	}
 }
 
+// set writes data synchronously.
+// To write data asynchronously, use Set instead.
 func (cache *RedisCache) set(k, v []byte) {
 	if err := cache.client.Set(hexutil.Encode(k), v, 0).Err(); err != nil {
 		logger.Warn("failed to set an item on redis cache", "err", err, "key", hexutil.Encode(k))

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -92,7 +92,7 @@ func NewRedisCache(config *TrieNodeCacheConfig) (*RedisCache, error) {
 		pubSub:    cli.Subscribe(),
 	}
 
-	workerNum := runtime.NumCPU() / 2
+	workerNum := runtime.NumCPU()/2 + 1
 	for i := 0; i < workerNum; i++ {
 		go func() {
 			for item := range cache.setItemCh {

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -122,7 +122,7 @@ func (cache *RedisCache) Set(k, v []byte) {
 	select {
 	case cache.setItemCh <- item:
 	default:
-		logger.Error("redis setItem channel is full")
+		logger.Warn("redis setItem channel is full")
 	}
 }
 

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -200,7 +200,7 @@ func TestRedisCache_Timeout(t *testing.T) {
 	key, value := randBytes(32), randBytes(500)
 
 	start := time.Now()
-	redisCache := cache.(*RedisCache) // Because RedisCache.Set item asynchronously, use RedisCache.set
+	redisCache := cache.(*RedisCache) // Because RedisCache.Set writes item asynchronously, use RedisCache.set
 	redisCache.set(key, value)
 	assert.Equal(t, redisCacheTimeout, time.Since(start).Round(redisCacheTimeout/2))
 

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -147,7 +147,7 @@ func TestRedisCache_Set_LargeNumberItems(t *testing.T) {
 	for i := 0; i < itemsLen; i++ {
 		// terminate if test lasts long
 		if time.Since(start) > 5*time.Second {
-			t.Fatal("timeout")
+			t.Fatalf("timeout checking %dth item", i+1)
 		}
 
 		v := cache.Get(items[i].key)

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -161,7 +161,7 @@ func TestRedisCache_Set_LargeNumberItems(t *testing.T) {
 	}
 }
 
-// TestRedisCache_Timeout test timout feature of redis client.
+// TestRedisCache_Timeout tests timout feature of redis client.
 func TestRedisCache_Timeout(t *testing.T) {
 	go func() {
 		tcpAddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:11234")

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -33,7 +33,7 @@ const sleepDurationForAsyncBehavior = 100 * time.Millisecond
 func getTestRedisConfig() *TrieNodeCacheConfig {
 	return &TrieNodeCacheConfig{
 		CacheType:          CacheTypeRedis,
-		LocalCacheSizeMB:   1024,
+		LocalCacheSizeMB:   100,
 		RedisEndpoints:     []string{"localhost:6379"},
 		RedisClusterEnable: false,
 	}

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const sleepDurationForAsyncBehavior = 100 * time.Millisecond
+
 func getTestRedisConfig() *TrieNodeCacheConfig {
 	return &TrieNodeCacheConfig{
 		CacheType:          CacheTypeRedis,
@@ -66,7 +68,7 @@ func TestSubscription(t *testing.T) {
 
 		wg.Done()
 	}()
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(sleepDurationForAsyncBehavior)
 
 	cache, err := NewRedisCache(getTestRedisConfig())
 	assert.Nil(t, err)
@@ -89,7 +91,7 @@ func TestRedisCache(t *testing.T) {
 
 	key, value := randBytes(32), randBytes(500)
 	cache.Set(key, value)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(sleepDurationForAsyncBehavior)
 
 	getValue := cache.Get(key)
 	assert.Equal(t, bytes.Compare(value, getValue), 0)
@@ -108,7 +110,7 @@ func TestRedisCache_Set_LargeData(t *testing.T) {
 
 	key, value := randBytes(32), randBytes(5*1024*1024) // 5MB value
 	cache.Set(key, value)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(sleepDurationForAsyncBehavior)
 
 	retValue := cache.Get(key)
 	assert.Equal(t, bytes.Compare(value, retValue), 0)
@@ -129,7 +131,7 @@ func TestRedisCache_Set_LargeNumberItems(t *testing.T) {
 
 	go func() {
 		// wait for a while to avoid redis setItem channel full
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(sleepDurationForAsyncBehavior)
 
 		for i := 0; i < itemsLen; i++ {
 			if i == redisSetItemChannelSize {
@@ -151,7 +153,7 @@ func TestRedisCache_Set_LargeNumberItems(t *testing.T) {
 		v := cache.Get(items[i].key)
 		if v == nil {
 			// if the item is not set yet, wait and retry
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(sleepDurationForAsyncBehavior)
 			i--
 		} else {
 			assert.Equal(t, v, items[i].value)


### PR DESCRIPTION
## Proposed changes

As redis client sets items synchronously, the node will wait for a while when redis client failed/delayed to set items. 
Even though the timeout duration is very short, it may delay block processing because it happens on the critical time path.

This change introduced worker goroutines to set items asynchronously. 
Also, there are minor changes related to redis. 

- Redis client sets items asynchronously
- Minor changes 
  - pubsub will be created in `NewRedisCache` and will be closed when the cache is closed 
  - In test cases, give a sleep time when redis (asynchronously) set items


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
