### PR TITLE
In state migration test, give more time for removing dir

### DIFF
--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -18,12 +18,6 @@ package database
 
 import (
 	"crypto/ecdsa"
-	"github.com/klaytn/klaytn/blockchain/types"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/crypto"
-	"github.com/klaytn/klaytn/params"
-	"github.com/klaytn/klaytn/ser/rlp"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"math/big"
 	"os"
@@ -31,6 +25,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/ser/rlp"
+	"github.com/stretchr/testify/assert"
 )
 
 var dbManagers []DBManager
@@ -842,12 +843,11 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 			assert.NoError(t, err)
 			dirNames := getFilesInDir(t, dbm.GetDBConfig().Dir, "statetrie")
 			assert.Equal(t, 2, len(dirNames))
-
 			assert.True(t, dirNames[0] == NewMigrationPath || dirNames[1] == NewMigrationPath)
 
 			// check if old db is deleted on migration success
 			dbm.FinishStateMigration(true)     // migration success
-			time.Sleep(100 * time.Millisecond) // wait for removing DB
+			time.Sleep(200 * time.Millisecond) // wait for removing DB
 
 			newDirNames := getFilesInDir(t, dbm.GetDBConfig().Dir, "statetrie")
 			assert.Equal(t, 1, len(newDirNames))
@@ -873,7 +873,7 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 
 			// check if new db is deleted on migration fail
 			dbm.FinishStateMigration(false)    // migration fail
-			time.Sleep(100 * time.Millisecond) // wait for removing DB
+			time.Sleep(200 * time.Millisecond) // wait for removing DB
 
 			newDirNames := getFilesInDir(t, dbm.GetDBConfig().Dir, dbm.getDBDir(StateTrieDB))
 			assert.Equal(t, 1, len(newDirNames))


### PR DESCRIPTION
## Proposed changes

`TestDBManager_StateMigrationDBPath` rarely failed in CicleCi because it needs more time for removing a directory in a goroutine. 


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
