### PR TITLE
Iterators for shardedDB

### DIFF
--- a/common/prque/prque_byteSlice.go
+++ b/common/prque/prque_byteSlice.go
@@ -1,0 +1,65 @@
+// CookieJar - A contestant's algorithm toolbox
+// Copyright (c) 2013 Peter Szilagyi. All rights reserved.
+//
+// CookieJar is dual licensed: use of this source code is governed by a BSD
+// license that can be found in the LICENSE file. Alternatively, the CookieJar
+// toolbox may be used in accordance with the terms and conditions contained
+// in a signed written agreement between you and the author(s).
+
+// This is a duplicated and slightly modified version of "gopkg.in/karalabe/cookiejar.v2/collections/prque".
+
+// Package prque implements a priority queue data structure supporting arbitrary
+// value types and int64 priorities.
+//
+// If you would like to use a max-priority queue, pass false for isMinPrque.
+// If you would like to use a min-priority queue, pass false for isMaxPrque.
+//
+// Internally the queue is based on the standard heap package working on a
+// sortable version of the block based stack.
+
+package prque
+
+import "container/heap"
+
+type PrqueByteSlice struct {
+	cont *sstackByte
+}
+
+// New creates a new priority queue.
+// If isMinPrque is false, max-priority queue is created.
+// If isMinPrque is true, min-priority queue is created.
+func NewByteSlice(isMinPrque bool) *PrqueByteSlice {
+	return &PrqueByteSlice{newsstackByte(isMinPrque)}
+}
+
+// Pushes a value with a given priority into the queue, expanding if necessary.
+func (p *PrqueByteSlice) Push(data interface{}, priority []byte) {
+	heap.Push(p.cont, &itemByteSlice{data, priority})
+}
+
+// Pops the value with the greates priority off the stack and returns it.
+// Currently no shrinking is done.
+func (p *PrqueByteSlice) Pop() (interface{}, []byte) {
+	item := heap.Pop(p.cont).(*itemByteSlice)
+	return item.value, item.priority
+}
+
+// Pops only the item from the queue, dropping the associated priority value.
+func (p *PrqueByteSlice) PopItem() interface{} {
+	return heap.Pop(p.cont).(*itemByteSlice).value
+}
+
+// Checks whether the priority queue is empty.
+func (p *PrqueByteSlice) Empty() bool {
+	return p.cont.Len() == 0
+}
+
+// Returns the number of element in the priority queue.
+func (p *PrqueByteSlice) Size() int {
+	return p.cont.Len()
+}
+
+// Clears the contents of the priority queue.
+func (p *PrqueByteSlice) Reset() {
+	*p = *NewByteSlice(p.cont.reverse)
+}

--- a/common/prque/sstack_byteSlice.go
+++ b/common/prque/sstack_byteSlice.go
@@ -1,0 +1,101 @@
+// CookieJar - A contestant's algorithm toolbox
+// Copyright (c) 2013 Peter Szilagyi. All rights reserved.
+//
+// CookieJar is dual licensed: use of this source code is governed by a BSD
+// license that can be found in the LICENSE file. Alternatively, the CookieJar
+// toolbox may be used in accordance with the terms and conditions contained
+// in a signed written agreement between you and the author(s).
+
+// This is a duplicated and slightly modified version of "gopkg.in/karalabe/cookiejar.v2/collections/prque".
+
+package prque
+
+import "bytes"
+
+// A prioritized item in the sorted stack.
+//
+// Note: priorities can "wrap around" the int64 range, a comes before b if bytes.Compare(a.priority - b.priority) > 0.
+// The difference between the lowest and highest priorities in the queue at any point should be less than 2^63.
+type itemByteSlice struct {
+	value    interface{}
+	priority []byte
+}
+
+// Internal sortable stack data structure. Implements the Push and Pop ops for
+// the stack (heap) functionality and the Len, Less and Swap methods for the
+// sortability requirements of the heaps.
+type sstackByte struct {
+	size     int
+	capacity int
+	offset   int
+	reverse  bool // reverse the result of Less()
+
+	blocks [][]*itemByteSlice
+	active []*itemByteSlice
+}
+
+// Creates a new, empty stack.
+func newsstackByte(reverse bool) *sstackByte {
+	result := new(sstackByte)
+	result.active = make([]*itemByteSlice, blockSize)
+	result.blocks = [][]*itemByteSlice{result.active}
+	result.capacity = blockSize
+	result.reverse = reverse
+	return result
+}
+
+// Pushes a value onto the stack, expanding it if necessary. Required by
+// heap.Interface.
+func (s *sstackByte) Push(data interface{}) {
+	if s.size == s.capacity {
+		s.active = make([]*itemByteSlice, blockSize)
+		s.blocks = append(s.blocks, s.active)
+		s.capacity += blockSize
+		s.offset = 0
+	} else if s.offset == blockSize {
+		s.active = s.blocks[s.size/blockSize]
+		s.offset = 0
+	}
+	s.active[s.offset] = data.(*itemByteSlice)
+	s.offset++
+	s.size++
+}
+
+// Pops a value off the stack and returns it. Currently no shrinking is done.
+// Required by heap.Interface.
+func (s *sstackByte) Pop() (res interface{}) {
+	s.size--
+	s.offset--
+	if s.offset < 0 {
+		s.offset = blockSize - 1
+		s.active = s.blocks[s.size/blockSize]
+	}
+	res, s.active[s.offset] = s.active[s.offset], nil
+	return
+}
+
+// Returns the length of the stack. Required by sort.Interface.
+func (s *sstackByte) Len() int {
+	return s.size
+}
+
+// Compares the priority of two elements of the stack (higher is first).
+// Required by sort.Interface.
+func (s *sstackByte) Less(i, j int) bool {
+	r := bytes.Compare(s.blocks[i/blockSize][i%blockSize].priority, s.blocks[j/blockSize][j%blockSize].priority) > 0
+	if s.reverse {
+		return !r
+	}
+	return r
+}
+
+// Swaps two elements in the stack. Required by sort.Interface.
+func (s *sstackByte) Swap(i, j int) {
+	ib, io, jb, jo := i/blockSize, i%blockSize, j/blockSize, j%blockSize
+	s.blocks[ib][io], s.blocks[jb][jo] = s.blocks[jb][jo], s.blocks[ib][io]
+}
+
+// Resets the stack, effectively clearing its contents.
+func (s *sstackByte) Reset() {
+	*s = *newsstackByte(s.reverse)
+}

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -204,7 +204,7 @@ func (db *shardedDB) newIterator(newIterator func(Database) Iterator) Iterator {
 // runCombineWorker fetches any key/value from resultChs and put the data in resultCh
 // in binary-alphabetical order.
 func (it shardedDBIterator) runCombineWorker() {
-	type entryWithNum struct {
+	type entryWithShardNum struct {
 		entry
 		shardNum int
 	}
@@ -213,7 +213,7 @@ func (it shardedDBIterator) runCombineWorker() {
 	entries := prque.NewByteSlice(true)
 	for i, ch := range it.resultChs {
 		if e, ok := <-ch; ok {
-			entries.Push(entryWithNum{e, i}, e.key)
+			entries.Push(entryWithShardNum{e, i}, e.key)
 		}
 	}
 
@@ -228,7 +228,7 @@ chanIter:
 		}
 
 		// look for smallest key
-		minEntry := entries.PopItem().(entryWithNum)
+		minEntry := entries.PopItem().(entryWithShardNum)
 
 		// fill resultCh with smallest key
 		it.resultCh <- minEntry.entry

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -208,11 +208,10 @@ func (it shardedDBIterator) runCombineWorker() {
 		entry
 		shardNum int
 	}
-	entries := prque.NewByteSlice(true) // contains smallest values from each iterators
 
-	// fill initial values for entries
-	for i := len(it.resultChs) - 1; i >= 0; i-- {
-		ch := it.resultChs[i]
+	// creates min-priority queue smallest values from each iterators
+	entries := prque.NewByteSlice(true)
+	for i, ch := range it.resultChs {
 		if e, ok := <-ch; ok {
 			entries.Push(entryWithNum{e, i}, e.key)
 		}

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -74,14 +74,14 @@ func testIterator(t *testing.T, entriesFromIterator func(db shardedDB, entryNum 
 	}
 }
 
-// TODO implement TestShardedDBChIteratorWithStart and TestShardedDBChIteratorWithPrefix
-func TestShardedDBChIterator(t *testing.T) {
+// TODO implement TestShardedDBChanIteratorWithStart and TestShardedDBChanIteratorWithStartWitPrefix
+func TestShardedDBChanIterator(t *testing.T) {
 	testIterator(t, func(db shardedDB, entryNum int) []entry {
 		entries := make([]entry, 0, entryNum) // store all items
 		var l sync.RWMutex                    // mutex for entries
 
 		// create chan Iterator and get channels
-		it := db.NewshardedDBChIterator(context.Background(), func(db Database) Iterator { return db.NewIterator() })
+		it := db.NewChanIterator(context.Background(), func(db Database) Iterator { return db.NewIterator() })
 		chans := it.Channels()
 
 		// listen all channels and get key/value

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -23,7 +23,6 @@ var ShardedDBConfig = []*DBConfig{
 func createEntries(entryNum int) []entry {
 	entries := make([]entry, entryNum)
 	for i := 0; i < entryNum; i++ {
-		//entries[i] = entry{common.MakeRandomBytes(10), common.MakeRandomBytes(10)}
 		entries[i] = entry{common.MakeRandomBytes(256), common.MakeRandomBytes(600)}
 	}
 	return entries
@@ -117,7 +116,7 @@ func TestShardedDBChanIterator(t *testing.T) {
 		var l sync.RWMutex                    // mutex for entries
 
 		// create chan Iterator and get channels
-		it := db.NewChanIterator(context.Background(), func(db Database) Iterator { return db.NewIterator() })
+		it := db.NewChanIterator(context.Background(), nil, func(db Database) Iterator { return db.NewIterator() })
 		chans := it.Channels()
 
 		// listen all channels and get key/value
@@ -237,7 +236,7 @@ func TestShardedDBChanIterator_Release(t *testing.T) {
 		func(db shardedDB) {
 			// Next() returns True if Release() is not called
 			{
-				it := db.NewChanIterator(context.Background(), func(db Database) Iterator { return db.NewIterator() })
+				it := db.NewChanIterator(context.Background(), nil, func(db Database) Iterator { return db.NewIterator() })
 				defer it.Release()
 
 				for _, ch := range it.Channels() {
@@ -253,7 +252,7 @@ func TestShardedDBChanIterator_Release(t *testing.T) {
 
 			//  Next() returns False if Release() is called
 			{
-				it := db.NewChanIterator(context.Background(), func(db Database) Iterator { return db.NewIterator() })
+				it := db.NewChanIterator(context.Background(), nil, func(db Database) Iterator { return db.NewIterator() })
 				it.Release()
 				for _, ch := range it.Channels() {
 

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -74,6 +74,7 @@ func testIterator(t *testing.T, entriesFromIterator func(db shardedDB, entryNum 
 	}
 }
 
+// TODO implement TestShardedDBChIteratorWithStart and TestShardedDBChIteratorWithPrefix
 func TestShardedDBChIterator(t *testing.T) {
 	testIterator(t, func(db shardedDB, entryNum int) []entry {
 		entries := make([]entry, 0, entryNum) // store all items
@@ -105,6 +106,7 @@ func TestShardedDBChIterator(t *testing.T) {
 	})
 }
 
+// TODO implement TestShardedDBIteratorWithStart and TestShardedDBIteratorWithPrefix
 func TestShardedDBIterator(t *testing.T) {
 	testIterator(t, func(db shardedDB, entryNum int) []entry {
 		entries := make([]entry, 0, entryNum)

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -1,0 +1,120 @@
+package database
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/klaytn/klaytn/common"
+)
+
+var ShardedDBConfig = []*DBConfig{
+	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 1, ParallelDBWrite: true},
+	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 4, ParallelDBWrite: true},
+	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 8, ParallelDBWrite: true},
+	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 16, ParallelDBWrite: true},
+}
+
+func createEntries(entryNum int) []entry {
+	entries := make([]entry, entryNum)
+	for i := 0; i < entryNum; i++ {
+		entries[i] = entry{common.MakeRandomBytes(256), common.MakeRandomBytes(600)}
+	}
+	return entries
+}
+
+func testIterator(t *testing.T, entriesFromIterator func(db shardedDB, entryNum int) []entry) {
+	entryNum := 500
+	entries := createEntries(entryNum)
+	dbs := make([]shardedDB, len(ShardedDBConfig))
+
+	// create DB and write data for testing
+	for i, config := range ShardedDBConfig {
+		config.Dir, _ = ioutil.TempDir(os.TempDir(), "test-shardedDB-iterator")
+		defer func(dir string) {
+			if err := os.RemoveAll(dir); err != nil {
+				t.Fatalf("fail to delete file %v", err)
+			}
+		}(config.Dir)
+
+		// create sharded DB
+		db, err := newShardedDB(config, 0, config.NumStateTrieShards)
+		dbs[i] = *db
+		if err != nil {
+			t.Log("Error occured while creating DB")
+			t.FailNow()
+		}
+
+		// write entries data in DB
+		batch := db.NewBatch()
+		for _, entry := range entries {
+			batch.Put(entry.key, entry.val)
+		}
+		assert.NoError(t, batch.Write())
+	}
+
+	// sort entries for each compare
+	sort.Slice(entries, func(i, j int) bool { return bytes.Compare(entries[i].key, entries[j].key) < 0 })
+
+	// get data from iterator and compare
+	for _, db := range dbs {
+		// create iterator
+		entriesFromIt := entriesFromIterator(db, entryNum)
+
+		// compare if entries generated and entries from iterator is same
+		assert.Equal(t, len(entries), len(entriesFromIt))
+		reflect.DeepEqual(entries, entriesFromIt)
+	}
+}
+
+func TestShardedDBChIterator(t *testing.T) {
+	testIterator(t, func(db shardedDB, entryNum int) []entry {
+		entries := make([]entry, 0, entryNum) // store all items
+		var l sync.RWMutex                    // mutex for entries
+
+		// create chan Iterator and get channels
+		it := db.NewshardedDBChIterator(context.Background(), func(db Database) Iterator { return db.NewIterator() })
+		chans := it.Channels()
+
+		// listen all channels and get key/value
+		done := make(chan struct{})
+		for _, ch := range chans {
+			go func(ch chan entry) {
+				for e := range ch {
+					l.Lock()
+					entries = append(entries, e)
+					l.Unlock()
+				}
+				done <- struct{}{} // tell
+			}(ch)
+		}
+		// wait for all iterators to finish
+		for range chans {
+			<-done
+		}
+		close(done)
+		it.Release()
+		return entries
+	})
+}
+
+func TestShardedDBIterator(t *testing.T) {
+	testIterator(t, func(db shardedDB, entryNum int) []entry {
+		entries := make([]entry, 0, entryNum)
+		it := db.NewIterator()
+
+		for it.Next() {
+			entries = append(entries, entry{it.Key(), it.Value()})
+		}
+		it.Release()
+		assert.NoError(t, it.Error())
+		return entries
+	})
+}

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -150,7 +150,7 @@ func testShardedIterator_Release(t *testing.T, entryNum int, checkFunc func(db s
 		}(config.Dir)
 
 		// create sharded DB
-		db, err := newShardedDB(config, 0, config.NumStateTrieShards)
+		db, err := newShardedDB(config, MiscDB, config.NumStateTrieShards)
 		if err != nil {
 			t.Log("Error occured while creating DB")
 			t.FailNow()

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 var ShardedDBConfig = []*DBConfig{
-	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 1, ParallelDBWrite: true},
 	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 4, ParallelDBWrite: true},
 	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 8, ParallelDBWrite: true},
 	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 16, ParallelDBWrite: true},
@@ -30,6 +29,7 @@ func createEntries(entryNum int) []entry {
 	return entries
 }
 
+// testIterator tests if given iterator iterates all entries
 func testIterator(t *testing.T, entriesFromIterator func(db shardedDB, entryNum int) []entry) {
 	entryNum := 500
 	entries := createEntries(entryNum)
@@ -67,10 +67,11 @@ func testIterator(t *testing.T, entriesFromIterator func(db shardedDB, entryNum 
 	for _, db := range dbs {
 		// create iterator
 		entriesFromIt := entriesFromIterator(db, entryNum)
+		sort.Slice(entriesFromIt, func(i, j int) bool { return bytes.Compare(entriesFromIt[i].key, entriesFromIt[j].key) < 0 })
 
 		// compare if entries generated and entries from iterator is same
 		assert.Equal(t, len(entries), len(entriesFromIt))
-		reflect.DeepEqual(entries, entriesFromIt)
+		assert.True(t, reflect.DeepEqual(entries, entriesFromIt))
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

There are 3 kinds of shardedDB
1. shardedDBChanIterator
   - This is created by calling `NewChanIterator` (this is a new function)
   - There are iterators and workers for each shardDB (If there are 4 shards in DB, 4  iterators and workers will be created)
   - If `resultCh` is given, all items are written to `resultCh`, unsorted.
   - If `resultCh` is not given, new channels are created for each DB. Items are written to corresponding channels in binary-alphabetical order. The channels can be gained by calling `Channels()`.
   - Each channels iterates item in sorted order.
2. shardedDBIterator
   - This is created by calling `NewIterator`, `NewIteratorWithStart`, `NewIteratorWithPrefix` (this is the original implementation of `Iteratee` interface)
   - contains `shardedDBChIterator`
   - There are 1 main channel and 1 worker that combines all shards.
   - The first `Next()` call could take some time. (Time for workers to fill channels)
3. shardedDBIteratorUnsorted
   - This is created by calling `NewIteratorUnsorted` (this is a new function)
   - The interface is same as `shardedDBIterator` except that it returns items unsorted and is much faster.
    
<img width="1920" alt="Screen Shot 2020-12-24 at 12 21 06 PM" src="https://user-images.githubusercontent.com/13597401/103057376-a51d0500-45e2-11eb-8837-523f6ac041c6.png">
<img width="961" alt="Screen Shot 2020-12-24 at 12 21 13 PM" src="https://user-images.githubusercontent.com/13597401/103057377-a64e3200-45e2-11eb-8f88-753da35b7cdd.png">

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

