### PR TITLE
Update default docker image ID

### DIFF
--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -535,8 +535,7 @@ func gen(ctx *cli.Context) error {
 		}
 		scnGenesisJsonBytes, _ := json.MarshalIndent(genIstanbulGenesis(ctx, scnAddress, nil, serviceChainId), "", "\t")
 
-		var dockerImageId string
-		dockerImageId = ctx.String(dockerImageIdFlag.Name)
+		dockerImageId := ctx.String(dockerImageIdFlag.Name)
 
 		compose := compose.New(
 			"172.16.239",

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -534,12 +534,10 @@ func gen(ctx *cli.Context) error {
 			bridgeNodesJsonBytes, _ = json.MarshalIndent(enInfos[:1], "", "\t")
 		}
 		scnGenesisJsonBytes, _ := json.MarshalIndent(genIstanbulGenesis(ctx, scnAddress, nil, serviceChainId), "", "\t")
+
 		var dockerImageId string
-		if scnNum > 0 {
-			dockerImageId = "klaytn-base"
-		} else {
-			dockerImageId = ctx.String(dockerImageIdFlag.Name)
-		}
+		dockerImageId = ctx.String(dockerImageIdFlag.Name)
+
 		compose := compose.New(
 			"172.16.239",
 			cnNum,

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -150,8 +150,8 @@ var (
 
 	dockerImageIdFlag = cli.StringFlag{
 		Name:        "docker-image-id",
-		Value:       "klaytn/klaytn",
-		Usage:       "Base docker image ID (Image[:tag])",
+		Value:       "klaytn/klaytn:latest",	// https://hub.docker.com/r/klaytn/klaytn
+		Usage:       "Base docker image ID (Image[:tag]), e.g., klaytn/klaytn:v1.5.3",
 		Destination: &dockerImageId,
 	}
 

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -150,7 +150,7 @@ var (
 
 	dockerImageIdFlag = cli.StringFlag{
 		Name:        "docker-image-id",
-		Value:       "428948643293.dkr.ecr.ap-northeast-2.amazonaws.com/gxp/client-go:latest",
+		Value:       "klaytn/klaytn",
 		Usage:       "Base docker image ID (Image[:tag])",
 		Destination: &dockerImageId,
 	}

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -150,7 +150,7 @@ var (
 
 	dockerImageIdFlag = cli.StringFlag{
 		Name:        "docker-image-id",
-		Value:       "klaytn/klaytn:latest",	// https://hub.docker.com/r/klaytn/klaytn
+		Value:       "klaytn/klaytn:latest", // https://hub.docker.com/r/klaytn/klaytn
 		Usage:       "Base docker image ID (Image[:tag]), e.g., klaytn/klaytn:v1.5.3",
 		Destination: &dockerImageId,
 	}


### PR DESCRIPTION
## Proposed changes

This PR change default docker image to `klaytn/klaytn` https://hub.docker.com/r/klaytn/klaytn.

From https://forum.klaytn.com/t/docker/558, I notice that we need to change the default docker image ID.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
