### PR TITLE
utils, fdlimit, database: increase fd limit to process's maximum value

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -31,14 +31,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/klaytn/klaytn/common/fdlimit"
-	"github.com/klaytn/klaytn/networks/rpc"
-
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/accounts/keystore"
 	"github.com/klaytn/klaytn/api/debug"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/fdlimit"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/datasync/chaindatafetcher"
 	"github.com/klaytn/klaytn/datasync/chaindatafetcher/kafka"
@@ -58,9 +56,6 @@ import (
 	"github.com/klaytn/klaytn/storage/statedb"
 	"gopkg.in/urfave/cli.v1"
 )
-
-// minFDLimit is the minimum file descriptor limit for RPC servers (heuristic value. concurrency limit of RPC and WS servers)
-var minFDLimit = rpc.ConcurrencyLimit * 2
 
 func InitHelper() {
 	cli.AppHelpTemplate = AppHelpTemplate
@@ -1382,46 +1377,26 @@ func checkExclusive(ctx *cli.Context, args ...interface{}) {
 	}
 }
 
-// checkAndRaiseFDLimit checks the file descriptor limit and
-// increases the file descriptor limit if the process has a small limit
-func checkAndRaiseFDLimit() {
-	limit, err := fdlimit.Current()
+// raiseFDLimit increases the file descriptor limit to process's maximum value
+func raiseFDLimit() {
+	limit, err := fdlimit.Maximum()
 	if err != nil {
-		logger.Error("fail to read fd limit. you may suffer fd exhaustion", "err", err)
+		logger.Error("Failed to read maximum fd. you may suffer fd exhaustion", "err", err)
 		return
 	}
-	// if it has enough file descriptor limit, do nothing
-	if limit >= minFDLimit {
-		return
-	}
-	// try increasing file descriptor limit
-	targetLimit := limit + minFDLimit
-	if err := fdlimit.Raise(uint64(targetLimit)); err != nil {
-		logger.Warn("fail to increase fd limit. you may suffer fd exhaustion", "err", err)
-		return
-	}
-	// check if new fd limit is applied
-	newLimit, err := fdlimit.Current()
+	raised, err := fdlimit.Raise(uint64(limit))
 	if err != nil {
-		logger.Error("fail to read fd limit after increasing fd limit, current limit may not be accurate",
-			"err", err, "oldLimit", limit, "newLimit", limit+minFDLimit)
+		logger.Warn("Failed to increase fd limit. you may suffer fd exhaustion", "err", err)
 		return
 	}
-	// if the retrieved limit does not match the expected one, leave an error log
-	if newLimit != targetLimit {
-		logger.Warn("Tried increasing the file descriptor limit of the process for RPC servers, but it didn't work",
-			"oldLimit", limit, "targetLimit", targetLimit, "actualLimit", newLimit)
-	} else {
-		logger.Warn("Increase the file descriptor limit of the process for RPC servers",
-			"oldLimit", limit, "newLimit", newLimit)
-	}
+	logger.Info("Raised fd limit to process's maximum value", "fd", raised)
 }
 
 // SetKlayConfig applies klay-related command line flags to the config.
 func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 	// TODO-Klaytn-Bootnode: better have to check conflicts about network flags when we add Klaytn's `mainnet` parameter
 	// checkExclusive(ctx, DeveloperFlag, TestnetFlag, RinkebyFlag)
-	checkAndRaiseFDLimit()
+	raiseFDLimit()
 
 	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
 	setServiceChainSigner(ctx, ks, cfg)

--- a/common/fdlimit/fdlimit_darwin.go
+++ b/common/fdlimit/fdlimit_darwin.go
@@ -14,18 +14,16 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build freebsd dragonfly
-
 package fdlimit
 
 import "syscall"
 
-// This file is largely identical to fdlimit_unix.go,
-// but Rlimit fields have type int64 on *BSD so it needs
-// an extra conversion.
+// hardlimit is the number of file descriptors allowed at max by the kernel.
+const hardlimit = 10240
 
 // Raise tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
+// Returns the size it was set to (may differ from the desired 'max')
 func Raise(max uint64) (uint64, error) {
 	// Get the current limit
 	var limit syscall.Rlimit
@@ -34,16 +32,17 @@ func Raise(max uint64) (uint64, error) {
 	}
 	// Try to update the limit to the max allowance
 	limit.Cur = limit.Max
-	if limit.Cur > int64(max) {
-		limit.Cur = int64(max)
+	if limit.Cur > max {
+		limit.Cur = max
 	}
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
 	}
+	// MacOS can silently apply further caps, so retrieve the actually set limit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
 	}
-	return uint64(limit.Cur), nil
+	return limit.Cur, nil
 }
 
 // Current retrieves the number of file descriptors allowed to be opened by this
@@ -59,9 +58,14 @@ func Current() (int, error) {
 // Maximum retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
 func Maximum() (int, error) {
+	// Retrieve the maximum allowed by dynamic OS limits
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
+	}
+	// Cap it to OPEN_MAX (10240) because macos is a special snowflake
+	if limit.Max > hardlimit {
+		limit.Max = hardlimit
 	}
 	return int(limit.Max), nil
 }

--- a/common/fdlimit/fdlimit_freebsd.go
+++ b/common/fdlimit/fdlimit_freebsd.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build freebsd dragonfly
+// +build freebsd
 
 package fdlimit
 

--- a/common/fdlimit/fdlimit_test.go
+++ b/common/fdlimit/fdlimit_test.go
@@ -24,7 +24,7 @@ import (
 // TestFileDescriptorLimits simply tests whether the file descriptor allowance
 // per this process can be retrieved.
 func TestFileDescriptorLimits(t *testing.T) {
-	target := 20000
+	target := 4096
 	hardlimit, err := Maximum()
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +36,7 @@ func TestFileDescriptorLimits(t *testing.T) {
 	if limit, err := Current(); err != nil || limit <= 0 {
 		t.Fatalf("failed to retrieve file descriptor limit (%d): %v", limit, err)
 	}
-	if err := Raise(uint64(target)); err != nil {
+	if _, err := Raise(uint64(target)); err != nil {
 		t.Fatalf("failed to raise file allowance")
 	}
 	if limit, err := Current(); err != nil || limit < target {

--- a/common/fdlimit/fdlimit_unix.go
+++ b/common/fdlimit/fdlimit_unix.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build linux darwin netbsd openbsd solaris
+// +build linux netbsd openbsd solaris
 
 package fdlimit
 
@@ -22,11 +22,12 @@ import "syscall"
 
 // Raise tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
-func Raise(max uint64) error {
+// Returns the size it was set to (may differ from the desired 'max')
+func Raise(max uint64) (uint64, error) {
 	// Get the current limit
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
-		return err
+		return 0, err
 	}
 	// Try to update the limit to the max allowance
 	limit.Cur = limit.Max
@@ -34,9 +35,13 @@ func Raise(max uint64) error {
 		limit.Cur = max
 	}
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
-		return err
+		return 0, err
 	}
-	return nil
+	// MacOS can silently apply further caps, so retrieve the actually set limit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	return limit.Cur, nil
 }
 
 // Current retrieves the number of file descriptors allowed to be opened by this

--- a/common/fdlimit/fdlimit_windows.go
+++ b/common/fdlimit/fdlimit_windows.go
@@ -16,28 +16,31 @@
 
 package fdlimit
 
-import "errors"
+import "fmt"
+
+// hardlimit is the number of file descriptors allowed at max by the kernel.
+const hardlimit = 16384
 
 // Raise tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
-func Raise(max uint64) error {
+func Raise(max uint64) (uint64, error) {
 	// This method is NOP by design:
 	//  * Linux/Darwin counterparts need to manually increase per process limits
 	//  * On Windows Go uses the CreateFile API, which is limited to 16K files, non
 	//    changeable from within a running process
 	// This way we can always "request" raising the limits, which will either have
 	// or not have effect based on the platform we're running on.
-	if max > 16384 {
-		return errors.New("file descriptor limit (16384) reached")
+	if max > hardlimit {
+		return hardlimit, fmt.Errorf("file descriptor limit (%d) reached", hardlimit)
 	}
-	return nil
+	return max, nil
 }
 
 // Current retrieves the number of file descriptors allowed to be opened by this
 // process.
 func Current() (int, error) {
 	// Please see Raise for the reason why we use hard coded 16K as the limit
-	return 16384, nil
+	return hardlimit, nil
 }
 
 // Maximum retrieves the maximum number of file descriptors this process is

--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/klaytn/klaytn/common"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -35,8 +34,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/klaytn/klaytn/common"
+
 	"bufio"
 	"errors"
+
 	"github.com/rs/cors"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpadaptor"
@@ -177,7 +179,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, srv *Server) *fasthttp.Se
 	if len(cors) == 0 {
 		for _, vhost := range vhosts {
 			if vhost == "*" {
-				return &fasthttp.Server{Concurrency: concurrencyLimit, Handler: srv.HandleFastHTTP}
+				return &fasthttp.Server{Concurrency: ConcurrencyLimit, Handler: srv.HandleFastHTTP}
 			}
 		}
 	}
@@ -188,7 +190,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, srv *Server) *fasthttp.Se
 	fhandler := fasthttpadaptor.NewFastHTTPHandler(handler)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
-	return &fasthttp.Server{Concurrency: concurrencyLimit, Handler: fhandler}
+	return &fasthttp.Server{Concurrency: ConcurrencyLimit, Handler: fhandler}
 }
 
 // ServeHTTP serves JSON-RPC requests over HTTP.

--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -179,7 +179,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, srv *Server) *fasthttp.Se
 	if len(cors) == 0 {
 		for _, vhost := range vhosts {
 			if vhost == "*" {
-				return &fasthttp.Server{Concurrency: ConcurrencyLimit, Handler: srv.HandleFastHTTP}
+				return &fasthttp.Server{Concurrency: concurrencyLimit, Handler: srv.HandleFastHTTP}
 			}
 		}
 	}
@@ -190,7 +190,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, srv *Server) *fasthttp.Se
 	fhandler := fasthttpadaptor.NewFastHTTPHandler(handler)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
-	return &fasthttp.Server{Concurrency: ConcurrencyLimit, Handler: fhandler}
+	return &fasthttp.Server{Concurrency: concurrencyLimit, Handler: fhandler}
 }
 
 // ServeHTTP serves JSON-RPC requests over HTTP.

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -47,8 +47,8 @@ const (
 	// pendingRequestLimit is a limit for concurrent RPC method calls
 	pendingRequestLimit = 200000
 
-	// ConcurrencyLimit is a limit for the number of concurrency connection for RPC servers
-	ConcurrencyLimit = 3000
+	// concurrencyLimit is a limit for the number of concurrency connection for RPC servers
+	concurrencyLimit = 3000
 )
 
 // pendingRequestCount is a total number of concurrent RPC method calls

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/klaytn/klaytn/common/fdlimit"
 	"gopkg.in/fatih/set.v0"
 )
 
@@ -48,55 +47,15 @@ const (
 	// pendingRequestLimit is a limit for concurrent RPC method calls
 	pendingRequestLimit = 200000
 
-	// concurrencyLimit is a limit for the number of concurrency connection for RPC servers
-	concurrencyLimit = 3000
-
-	// minFDLimit is the minimum file descriptor limit for RPC servers (heuristic value. concurrency limit of RPC and WS servers)
-	minFDLimit = concurrencyLimit * 2
+	// ConcurrencyLimit is a limit for the number of concurrency connection for RPC servers
+	ConcurrencyLimit = 3000
 )
 
 // pendingRequestCount is a total number of concurrent RPC method calls
 var pendingRequestCount int64 = 0
 
-// checkAndRaiseFDLimit checks the file descriptor limit and
-// increases the file descriptor limit if the process has a small limit
-func checkAndRaiseFDLimit() {
-	limit, err := fdlimit.Current()
-	if err != nil {
-		logger.Error("fail to read fd limit. you may suffer fd exhaustion", "err", err)
-		return
-	}
-	// if it has enough file descriptor limit, do nothing
-	if limit >= minFDLimit {
-		return
-	}
-	// try increasing file descriptor limit
-	targetLimit := limit + minFDLimit
-	if err := fdlimit.Raise(uint64(targetLimit)); err != nil {
-		logger.Warn("fail to increase fd limit. you may suffer fd exhaustion", "err", err)
-		return
-	}
-	// check if new fd limit is applied
-	newLimit, err := fdlimit.Current()
-	if err != nil {
-		logger.Error("fail to read fd limit after increasing fd limit, current limit may not be accurate",
-			"err", err, "oldLimit", limit, "newLimit", limit+minFDLimit)
-		return
-	}
-	// if the retrieved limit does not match the expected one, leave an error log
-	if newLimit != targetLimit {
-		logger.Warn("Tried increasing the file descriptor limit of the process for RPC servers, but it didn't work",
-			"oldLimit", limit, "targetLimit", targetLimit, "actualLimit", newLimit)
-	} else {
-		logger.Warn("Increase the file descriptor limit of the process for RPC servers",
-			"oldLimit", limit, "newLimit", newLimit)
-	}
-}
-
 // NewServer will create a new server instance with no registered handlers.
 func NewServer() *Server {
-	checkAndRaiseFDLimit()
-
 	server := &Server{
 		services: make(serviceRegistry),
 		codecs:   set.New(),

--- a/networks/rpc/websocket.go
+++ b/networks/rpc/websocket.go
@@ -26,9 +26,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/klaytn/klaytn/common"
-	"golang.org/x/net/websocket"
-	"gopkg.in/fatih/set.v0"
 	"net"
 	"net/http"
 	"net/url"
@@ -36,7 +33,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/klaytn/klaytn/common"
+	"golang.org/x/net/websocket"
+	"gopkg.in/fatih/set.v0"
+
 	"bufio"
+
 	fastws "github.com/clevergo/websocket"
 	"github.com/valyala/fasthttp"
 )
@@ -139,7 +141,7 @@ func NewFastWSServer(allowedOrigins []string, srv *Server) *fasthttp.Server {
 	upgrader.CheckOrigin = wsFastHandshakeValidator(allowedOrigins)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
-	return &fasthttp.Server{Concurrency: concurrencyLimit, MaxRequestBodySize: common.MaxRequestContentLength, Handler: srv.FastWebsocketHandler}
+	return &fasthttp.Server{Concurrency: ConcurrencyLimit, MaxRequestBodySize: common.MaxRequestContentLength, Handler: srv.FastWebsocketHandler}
 }
 
 func wsFastHandshakeValidator(allowedOrigins []string) func(ctx *fasthttp.RequestCtx) bool {

--- a/networks/rpc/websocket.go
+++ b/networks/rpc/websocket.go
@@ -141,7 +141,7 @@ func NewFastWSServer(allowedOrigins []string, srv *Server) *fasthttp.Server {
 	upgrader.CheckOrigin = wsFastHandshakeValidator(allowedOrigins)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
-	return &fasthttp.Server{Concurrency: ConcurrencyLimit, MaxRequestBodySize: common.MaxRequestContentLength, Handler: srv.FastWebsocketHandler}
+	return &fasthttp.Server{Concurrency: concurrencyLimit, MaxRequestBodySize: common.MaxRequestContentLength, Handler: srv.FastWebsocketHandler}
 }
 
 func wsFastHandshakeValidator(allowedOrigins []string) func(ctx *fasthttp.RequestCtx) bool {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -241,6 +241,10 @@ const (
 	databaseEntryTypeSize
 )
 
+func (et DBEntryType) String() string {
+	return dbBaseDirs[et]
+}
+
 const notInMigrationFlag = 0
 const inMigrationFlag = 1
 

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -53,6 +53,7 @@ const (
 	minBlockCacheCapacity     = 2 * minWriteBufferSize
 	MinOpenFilesCacheCapacity = 16
 	minBitsPerKeyForFilter    = 10
+	minFileDescriptors        = 2048
 )
 
 var defaultLevelDBOption = &opt.Options{
@@ -78,13 +79,11 @@ func GetOpenFilesLimit() int {
 	if err != nil {
 		logger.Crit("Failed to retrieve file descriptor allowance", "err", err)
 	}
-	if limit < 2048 {
-		if err := fdlimit.Raise(2048); err != nil {
-			logger.Crit("Failed to raise file descriptor allowance", "err", err)
+	if limit < minFileDescriptors {
+		if err := fdlimit.Raise(minFileDescriptors); err != nil {
+			logger.Crit("Failed to raise file descriptor allowance to the minimum value",
+				"err", err, "minFileDescriptors", minFileDescriptors)
 		}
-	}
-	if limit > 2048 { // cap database file descriptors even if more is available
-		limit = 2048
 	}
 	return limit / 2 // Leave half for networking and other stuff
 }

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -81,7 +81,7 @@ func GetOpenFilesLimit() int {
 		logger.Crit("Failed to retrieve file descriptor allowance", "err", err)
 	}
 	if limit < minFileDescriptorsForDBManager {
-		logger.Crit("Failed to raise file descriptor allowance to the minimum value",
+		logger.Crit("Raised number of file descriptor  is below the minimum value",
 			"currFileDescriptorsLimit", limit, "minFileDescriptorsForDBManager", minFileDescriptorsForDBManager)
 	}
 	return limit / 2 // Leave half for networking and other stuff


### PR DESCRIPTION
## Proposed changes

- Before this change, `rpc.checkAndRaiseFDLimit` **raises the number of fds to some target value if it is below our minimum value, which is called when RPC server starts, which means not always called.**
- After this change, `utils.raiseFDLimit` is called inside `SetKlayConfig` and **raises the number of fds to process's maximum value, which means it is always called.**
- Also fixed missing logic to divide assigned fds to sharded database by number of shards.
- Applied https://github.com/ethereum/go-ethereum/pull/19035 to be aliged to go-ethereum.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
