### PR TITLE
all: periodically save fastcache to filesystem

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2279,7 +2279,11 @@ func (bc *BlockChain) IsSenderTxHashIndexingEnabled() bool {
 }
 
 func (bc *BlockChain) SaveTrieNodeCacheToDisk() error {
-	return bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(bc.cacheConfig.TrieNodeCacheConfig.FastCacheFileDir)
+	if err := bc.stateCache.TrieDB().CanSaveTrieNodeCacheToFile(); err != nil {
+		return err
+	}
+	go bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(bc.cacheConfig.TrieNodeCacheConfig.FastCacheFileDir)
+	return nil
 }
 
 // ApplyTransaction attempts to apply a transaction to the given state database

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -27,6 +27,7 @@ import (
 	"math/big"
 	mrand "math/rand"
 	"reflect"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -2282,7 +2283,7 @@ func (bc *BlockChain) SaveTrieNodeCacheToDisk() error {
 	if err := bc.stateCache.TrieDB().CanSaveTrieNodeCacheToFile(); err != nil {
 		return err
 	}
-	go bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(bc.cacheConfig.TrieNodeCacheConfig.FastCacheFileDir)
+	go bc.stateCache.TrieDB().SaveTrieNodeCacheToFile(bc.cacheConfig.TrieNodeCacheConfig.FastCacheFileDir, runtime.NumCPU()/2)
 	return nil
 }
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -205,6 +205,10 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 		}
 	}
 
+	if cacheConfig.TrieNodeCacheConfig == nil {
+		cacheConfig.TrieNodeCacheConfig = statedb.GetEmptyTrieNodeCacheConfig()
+	}
+
 	state.EnabledExpensive = db.GetDBConfig().EnableDBPerfMetrics
 
 	// Initialize DeriveSha implementation

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -128,7 +128,7 @@ func getCodeSizeCache() common.Cache {
 // NewDatabaseWithNewCache creates a backing store for state. The returned database
 // is safe for concurrent use and retains a lot of collapsed RLP trie nodes in a
 // large memory cache.
-func NewDatabaseWithNewCache(db database.DBManager, cacheConfig statedb.TrieNodeCacheConfig) Database {
+func NewDatabaseWithNewCache(db database.DBManager, cacheConfig *statedb.TrieNodeCacheConfig) Database {
 	return &cachingDB{
 		db:            statedb.NewDatabaseWithNewCache(db, cacheConfig),
 		codeSizeCache: getCodeSizeCache(),

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -178,6 +178,7 @@ var FlagGroups = []FlagGroup{
 			MemorySizeFlag,
 			TrieNodeCacheTypeFlag,
 			TrieNodeCacheLimitFlag,
+			TrieNodeCacheSavePeriodFlag,
 			TrieNodeCacheRedisEndpointsFlag,
 			TrieNodeCacheRedisClusterFlag,
 			TrieNodeCacheRedisPublishBlockFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -322,6 +322,11 @@ var (
 		Usage: "Memory allowance (MB) to use for caching trie nodes in memory. -1 is for auto-scaling",
 		Value: -1,
 	}
+	TrieNodeCacheSavePeriodFlag = cli.DurationFlag{
+		Name:  "state.trie-cache-save-period",
+		Usage: "Period of saving in memory trie cache to file if fastcache is used",
+		Value: 24 * time.Hour,
+	}
 	SenderTxHashIndexingFlag = cli.BoolFlag{
 		Name:  "sendertxhashindexing",
 		Usage: "Enables storing mapping information of senderTxHash to txHash",
@@ -1491,6 +1496,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 			Name)).ToValid(),
 		LocalCacheSizeMB:          ctx.GlobalInt(TrieNodeCacheLimitFlag.Name),
 		FastCacheFileDir:          ctx.GlobalString(DataDirFlag.Name) + "/fastcache",
+		FastCacheSavePeriod:       ctx.GlobalDuration(TrieNodeCacheSavePeriodFlag.Name),
 		RedisEndpoints:            ctx.GlobalStringSlice(TrieNodeCacheRedisEndpointsFlag.Name),
 		RedisClusterEnable:        ctx.GlobalBool(TrieNodeCacheRedisClusterFlag.Name),
 		RedisPublishBlockEnable:   ctx.GlobalBool(TrieNodeCacheRedisPublishBlockFlag.Name),

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -324,8 +324,8 @@ var (
 	}
 	TrieNodeCacheSavePeriodFlag = cli.DurationFlag{
 		Name:  "state.trie-cache-save-period",
-		Usage: "Period of saving in memory trie cache to file if fastcache is used",
-		Value: 24 * time.Hour,
+		Usage: "Period of saving in memory trie cache to file if fastcache is used, 0 means disabled",
+		Value: 0,
 	}
 	SenderTxHashIndexingFlag = cli.BoolFlag{
 		Name:  "sendertxhashindexing",

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -76,6 +76,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.MemorySizeFlag,
 	utils.TrieNodeCacheTypeFlag,
 	utils.TrieNodeCacheLimitFlag,
+	utils.TrieNodeCacheSavePeriodFlag,
 	utils.TrieNodeCacheRedisEndpointsFlag,
 	utils.TrieNodeCacheRedisClusterFlag,
 	utils.TrieNodeCacheRedisPublishBlockFlag,

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -251,7 +251,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		vmConfig    = config.getVMConfig()
 		cacheConfig = &blockchain.CacheConfig{ArchiveMode: config.NoPruning, CacheSize: config.TrieCacheSize,
 			BlockInterval: config.TrieBlockInterval, TriesInMemory: config.TriesInMemory,
-			TrieNodeCacheConfig: config.TrieNodeCacheConfig, SenderTxHashIndexing: config.SenderTxHashIndexing}
+			TrieNodeCacheConfig: &config.TrieNodeCacheConfig, SenderTxHashIndexing: config.SenderTxHashIndexing}
 	)
 
 	bc, err := blockchain.NewBlockChain(chainDB, cacheConfig, cn.chainConfig, cn.engine, vmConfig)

--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -43,7 +43,7 @@ type FastCache struct {
 // NewFastCache creates a FastCache with given cache size.
 // If you want auto-scaled cache size, set config.LocalCacheSizeMB to AutoScaling.
 // It returns nil if the cache size is zero.
-func NewFastCache(config TrieNodeCacheConfig) TrieNodeCache {
+func NewFastCache(config *TrieNodeCacheConfig) TrieNodeCache {
 	if config.LocalCacheSizeMB == AutoScaling {
 		config.LocalCacheSizeMB = getTrieNodeCacheSizeMB()
 	}

--- a/storage/statedb/cache_hybrid.go
+++ b/storage/statedb/cache_hybrid.go
@@ -18,7 +18,7 @@ package statedb
 
 import "github.com/go-redis/redis/v7"
 
-func NewHybridCache(config TrieNodeCacheConfig) (TrieNodeCache, error) {
+func NewHybridCache(config *TrieNodeCacheConfig) (TrieNodeCache, error) {
 	redis, err := NewRedisCache(config)
 	if err != nil {
 		return nil, err

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestHybridConfig() TrieNodeCacheConfig {
-	return TrieNodeCacheConfig{
+func getTestHybridConfig() *TrieNodeCacheConfig {
+	return &TrieNodeCacheConfig{
 		CacheType:          CacheTypeHybrid,
 		LocalCacheSizeMB:   1024 * 1024,
 		FastCacheFileDir:   "",

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -68,7 +68,7 @@ func newRedisClient(endpoints []string, isCluster bool) (redis.UniversalClient, 
 	}), nil
 }
 
-func NewRedisCache(config TrieNodeCacheConfig) (*RedisCache, error) {
+func NewRedisCache(config *TrieNodeCacheConfig) (*RedisCache, error) {
 	cli, err := newRedisClient(config.RedisEndpoints, config.RedisClusterEnable)
 	if err != nil {
 		logger.Error("failed to create a redis client", "err", err, "endpoint", config.RedisEndpoints,

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestRedisConfig() TrieNodeCacheConfig {
-	return TrieNodeCacheConfig{
+func getTestRedisConfig() *TrieNodeCacheConfig {
+	return &TrieNodeCacheConfig{
 		CacheType:          CacheTypeRedis,
 		LocalCacheSizeMB:   1024 * 1024,
 		RedisEndpoints:     []string{"localhost:6379"},

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -29,7 +29,7 @@ var parentHash = common.HexToHash("1343A3F") // 20199999 in hexadecimal
 
 func TestDatabase_Reference(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMB: 128})
+	db := NewDatabaseWithNewCache(memDB, &TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMB: 128})
 
 	assert.Equal(t, memDB, db.DiskDB())
 	assert.Equal(t, 1, len(db.nodes)) // {} : {}
@@ -57,7 +57,7 @@ func TestDatabase_Reference(t *testing.T) {
 
 func TestDatabase_DeReference(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMB: 128})
+	db := NewDatabaseWithNewCache(memDB, &TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMB: 128})
 	assert.Equal(t, 1, len(db.nodes)) // {} : {}
 
 	db.Dereference(parentHash)
@@ -87,7 +87,7 @@ func TestDatabase_DeReference(t *testing.T) {
 
 func TestDatabase_Size(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMB: 128})
+	db := NewDatabaseWithNewCache(memDB, &TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMB: 128})
 
 	totalMemorySize, preimagesSize := db.Size()
 	assert.Equal(t, common.StorageSize(0), totalMemorySize)
@@ -123,7 +123,7 @@ func TestDatabase_SecureKey(t *testing.T) {
 
 func TestCache(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	db := NewDatabaseWithNewCache(memDB, TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMB: 10})
+	db := NewDatabaseWithNewCache(memDB, &TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMB: 10})
 
 	for i := 0; i < 100; i++ {
 		key, value := common.MakeRandomBytes(256), common.MakeRandomBytes(63*1024) // fastcache can store entrie under 64KB

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -475,7 +475,7 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 		CacheSize:     512,
 		BlockInterval: blockchain.DefaultBlockInterval,
 		TriesInMemory: blockchain.DefaultTriesInMemory,
-		TrieNodeCacheConfig: statedb.TrieNodeCacheConfig{
+		TrieNodeCacheConfig: &statedb.TrieNodeCacheConfig{
 			CacheType:          statedb.CacheTypeLocal,
 			LocalCacheSizeMB:   4096,
 			FastCacheFileDir:   "",


### PR DESCRIPTION
## Proposed changes

- fastcache, in-memory cache structure used to store trie node entries, can be saved to the filesystem by calling `admin.saveTrieNodeToDisk`
- Now it can be saved automatically with the specified interval, without calling API
- `state.trie-cache-save-period` is used to specify the interval, default value is ~24 hour~ 0, which means it is disabled by default. At first it will be started after randomly chosen duration `x`, 
which ranges from `0.5 * state.trie-cache-save-period <= x < 1.0 * state.trie-cache-save-period`  

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
