### PR TITLE
database: updated dbConfigRatio based on disk usage

### DIFF
--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -262,14 +262,14 @@ var dbBaseDirs = [databaseEntryTypeSize]string{
 // Sum of dbConfigRatio should be 100.
 // Otherwise, logger.Crit will be called at checkDBEntryConfigRatio.
 var dbConfigRatio = [databaseEntryTypeSize]int{
-	3,  // MiscDB
-	6,  // headerDB
-	16, // BodyDB
-	16, // ReceiptsDB
-	19, // StateTrieDB
-	19, // StateTrieMigrationDB
-	17, // TXLookUpEntryDB
-	4,  // bridgeServiceDB
+	2,  // MiscDB
+	5,  // headerDB
+	5,  // BodyDB
+	5,  // ReceiptsDB
+	40, // StateTrieDB
+	40, // StateTrieMigrationDB
+	2,  // TXLookUpEntryDB
+	1,  // bridgeServiceDB
 }
 
 // checkDBEntryConfigRatio checks if sum of dbConfigRatio is 100.


### PR DESCRIPTION
## Proposed changes

- Previous dbConfigRatio does not reflect the current disk usage of each database
- Updated dbConfigRatio based on the current disk usage of databases
- Disk usage of each database 

```
Full node : 1.2 TB
942G    ./statetrie
92G     ./header
72G     ./body
63G     ./receipts
9.3G    ./txlookup
4.1G    ./misc
288K    ./bridgeservice
1.2T    .


Archive node : 2.3 TB
2.0T	./statetrie
92G	./header
72G	./body
63G	./receipts
9.3G	./txlookup
4.1G	./misc
48K	./bridgeservice
2.3T	.
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
