### PR TITLE
New interface for newIterator

### DIFF
--- a/blockchain/state/iterator_test.go
+++ b/blockchain/state/iterator_test.go
@@ -52,7 +52,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 			t.Errorf("state entry not reported %x", hash)
 		}
 	}
-	it := db.TrieDB().DiskDB().GetMemDB().NewIterator()
+	it := db.TrieDB().DiskDB().GetMemDB().NewIterator(nil, nil)
 	for it.Next() {
 		key := it.Key()
 		if bytes.HasPrefix(key, []byte("secure-key-")) {

--- a/storage/database/badger_database.go
+++ b/storage/database/badger_database.go
@@ -167,20 +167,10 @@ func (bg *badgerDB) Delete(key []byte) error {
 	return txn.Commit()
 }
 
-func (bg *badgerDB) NewIterator() Iterator {
+func (bg *badgerDB) NewIterator(prefix []byte, start []byte) Iterator {
 	//txn := bg.db.NewTransaction(false)
 	//return txn.NewIterator(badger.DefaultIteratorOptions)
 	logger.CritWithStack("badgerDB doesn't support NewIterator")
-	return nil
-}
-
-func (bg *badgerDB) NewIteratorWithStart(start []byte) Iterator {
-	logger.CritWithStack("badgerDB doesn't support NewIteratorWithStart")
-	return nil
-}
-
-func (pdb *badgerDB) NewIteratorWithPrefix(prefix []byte) Iterator {
-	logger.CritWithStack("badgerDB doesn't support NewIteratorWithPrefix")
 	return nil
 }
 

--- a/storage/database/db_migration.go
+++ b/storage/database/db_migration.go
@@ -50,7 +50,7 @@ func (dbm *databaseManager) StartDBMigration(dstdbm DBManager) error {
 	dstDB := dstdbm.getDatabase(MiscDB)
 
 	// create src iterator and dst batch
-	srcIter := srcDB.NewIterator()
+	srcIter := srcDB.NewIterator(nil, nil)
 	dstBatch := dstDB.NewBatch()
 
 	// vars for log

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -413,17 +413,7 @@ func (dynamo *dynamoDB) Meter(prefix string) {
 	dynamoBatchWriteTimeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/time", nil)
 }
 
-func (dynamo *dynamoDB) NewIterator() Iterator {
-	// TODO-Klaytn: implement this later.
-	return nil
-}
-
-func (dynamo *dynamoDB) NewIteratorWithStart(start []byte) Iterator {
-	// TODO-Klaytn: implement this later.
-	return nil
-}
-
-func (dynamo *dynamoDB) NewIteratorWithPrefix(prefix []byte) Iterator {
+func (dynamo *dynamoDB) NewIterator(prefix []byte, start []byte) Iterator {
 	// TODO-Klaytn: implement this later.
 	return nil
 }

--- a/storage/database/iterator.go
+++ b/storage/database/iterator.go
@@ -54,16 +54,11 @@ type Iterator interface {
 
 // Iteratee wraps the NewIterator methods of a backing data store.
 type Iteratee interface {
-	// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-	// contained within the key-value database.
-	NewIterator() Iterator
-
-	// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-	// database content starting at a particular initial key (or after, if it does
-	// not exist).
-	NewIteratorWithStart(start []byte) Iterator
-
-	// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-	// of database content with a particular key prefix.
-	NewIteratorWithPrefix(prefix []byte) Iterator
+	// NewIterator creates a binary-alphabetical iterator over a subset
+	// of database content with a particular key prefix, starting at a particular
+	// initial key (or after, if it does not exist).
+	//
+	// Note: This method assumes that the prefix is NOT part of the start, so there's
+	// no need for the caller to prepend the prefix to the start
+	NewIterator(prefix []byte, start []byte) Iterator
 }

--- a/storage/database/memory_database.go
+++ b/storage/database/memory_database.go
@@ -103,55 +103,26 @@ func (db *MemDB) NewBatch() Batch {
 	return &memBatch{db: db}
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the memory database.
-func (db *MemDB) NewIterator() Iterator {
-	return db.NewIteratorWithStart(nil)
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (db *MemDB) NewIteratorWithStart(start []byte) Iterator {
-	db.lock.RLock()
-	defer db.lock.RUnlock()
-
-	var (
-		st     = string(start)
-		keys   = make([]string, 0, len(db.db))
-		values = make([][]byte, 0, len(db.db))
-	)
-	// Collect the keys from the memory database corresponding to the given start
-	for key := range db.db {
-		if key >= st {
-			keys = append(keys, key)
-		}
-	}
-	// Sort the items and retrieve the associated values
-	sort.Strings(keys)
-	for _, key := range keys {
-		values = append(values, db.db[key])
-	}
-	return &iterator{
-		keys:   keys,
-		values: values,
-	}
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (db *MemDB) NewIteratorWithPrefix(prefix []byte) Iterator {
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (db *MemDB) NewIterator(prefix []byte, start []byte) Iterator {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
 	var (
 		pr     = string(prefix)
+		st     = string(append(prefix, start...))
 		keys   = make([]string, 0, len(db.db))
 		values = make([][]byte, 0, len(db.db))
 	)
 	// Collect the keys from the memory database corresponding to the given prefix
+	// and start
 	for key := range db.db {
-		if strings.HasPrefix(key, pr) {
+		if !strings.HasPrefix(key, pr) {
+			continue
+		}
+		if key >= st {
 			keys = append(keys, key)
 		}
 	}

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -167,37 +167,10 @@ type shardedDBIterator struct {
 	//resultCh chan pdbBatchResult
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the key-value database.
-func (pdb *shardedDB) NewIterator() Iterator {
-	// TODO-Klaytn implement this later.
-	return nil
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (pdb *shardedDB) NewIteratorWithStart(start []byte) Iterator {
-	// TODO-Klaytn implement this later.
-	iterators := make([]Iterator, 0, pdb.numShards)
-	for i := 0; i < int(pdb.numShards); i++ {
-		iterators = append(iterators, pdb.shards[i].NewIteratorWithStart(start))
-	}
-
-	for _, iter := range iterators {
-		if iter != nil {
-			if !iter.Next() {
-				iter = nil
-			}
-		}
-	}
-
-	return &shardedDBIterator{iterators, nil, nil}
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (pdb *shardedDB) NewIteratorWithPrefix(prefix []byte) Iterator {
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (pdb *shardedDB) NewIterator(prefix []byte, start []byte) Iterator {
 	// TODO-Klaytn implement this later.
 	return nil
 }

--- a/storage/statedb/sync_bloom.go
+++ b/storage/statedb/sync_bloom.go
@@ -101,7 +101,7 @@ func (b *SyncBloom) init(database database.Iteratee) {
 	// Note, this is fine, because everything inserted into leveldb by fast sync is
 	// also pushed into the bloom directly, so we're not missing anything when the
 	// iterator is swapped out for a new one.
-	it := database.NewIterator()
+	it := database.NewIterator(nil, nil)
 
 	var (
 		start = time.Now()
@@ -118,7 +118,7 @@ func (b *SyncBloom) init(database database.Iteratee) {
 			key := common.CopyBytes(it.Key())
 
 			it.Release()
-			it = database.NewIteratorWithStart(key)
+			it = database.NewIterator(nil, key)
 
 			logger.Info("Initializing fast sync bloom", "items", b.bloom.N(), "errorrate", b.errorRate(), "elapsed", common.PrettyDuration(time.Since(start)))
 			swap = time.Now()


### PR DESCRIPTION
## Proposed changes

Changed interface of `newIterator` (https://github.com/ethereum/go-ethereum/pull/20808)
Previous interface:
```
NewIterator()
NewIteratorWithPrefix(prefix []byte)
NewIteratorWithStart(start []byte)
```
New interface:
```
NewIterator(prefix, start []byte)
```
If both `prefix` and `start` is specified, we assume to get bytes that start with `prefix` and bigger than `prefix ++ start`.
Ex. If you want bytes starting with 'a' and bigger than 'ab', the params would be `NewIterator('a', 'b')`.

## Types of changes

Please put an x in the boxes related to your change.
- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

