### PR TITLE
Generic type for prque (New PR)

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1208,11 +1208,11 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 	if pending > pool.config.ExecSlotsAll {
 		pendingBeforeCap := pending
 		// Assemble a spam order to penalize large transactors first
-		spammers := prque.New()
+		spammers := prque.New(false)
 		for addr, list := range pool.pending {
 			// Only evict transactions from high rollers
 			if !pool.locals.contains(addr) && uint64(list.Len()) > pool.config.ExecSlotsAccount {
-				spammers.Push(addr, int64(list.Len()))
+				spammers.Push(addr, list.Len())
 			}
 		}
 		// Gradually drop transactions from offenders

--- a/common/prque/prque.go
+++ b/common/prque/prque.go
@@ -22,7 +22,9 @@ import (
 	"container/heap"
 )
 
-// Priority queue data structure.
+// Priority queue data structure. The item's type can be int, int64, uint64,
+// []byte and etc.
+// An type assertion error could occur if different type of items are pushed.
 type Prque struct {
 	cont *sstack
 }

--- a/common/prque/prque.go
+++ b/common/prque/prque.go
@@ -28,24 +28,28 @@ type Prque struct {
 }
 
 // New creates a new priority queue.
-func New() *Prque {
-	return &Prque{newSstack()}
+// The priority queue can have any type specified  in sstack.Less.
+func New(reverse bool) *Prque {
+	return &Prque{newSstack(reverse)}
 }
 
 // Pushes a value with a given priority into the queue, expanding if necessary.
-func (p *Prque) Push(data interface{}, priority int64) {
+// The priority queue can have any type specified  in sstack.Less.
+// In a queue, same type should be pushed. Otherwise, a type assertion error
+// will occur. Number types (int, int64, uint64) are different types.
+func (p *Prque) Push(data interface{}, priority interface{}) {
 	heap.Push(p.cont, &item{data, priority})
 }
 
 // Peek returns the value with the greatest priority but does not pop it off.
-func (p *Prque) Peek() (interface{}, int64) {
+func (p *Prque) Peek() (interface{}, interface{}) {
 	item := p.cont.blocks[0][0]
 	return item.value, item.priority
 }
 
 // Pops the value with the greates priority off the stack and returns it.
 // Currently no shrinking is done.
-func (p *Prque) Pop() (interface{}, int64) {
+func (p *Prque) Pop() (interface{}, interface{}) {
 	item := heap.Pop(p.cont).(*item)
 	return item.value, item.priority
 }
@@ -67,5 +71,5 @@ func (p *Prque) Size() int {
 
 // Clears the contents of the priority queue.
 func (p *Prque) Reset() {
-	*p = *New()
+	*p = *New(p.cont.reverse)
 }

--- a/common/prque/prque.go
+++ b/common/prque/prque.go
@@ -11,7 +11,7 @@
 // Package prque implements a priority queue data structure supporting arbitrary
 // value and priorities types.
 //
-// If you would like to use a min-priority queue, simply put false as a reverse parameter.
+// If you would like to use a min-priority queue, simply put false as a invert parameter.
 //
 // Internally the queue is based on the standard heap package working on a
 // sortable version of the block based stack.
@@ -31,8 +31,8 @@ type Prque struct {
 
 // New creates a new priority queue.
 // The priority queue can have any type specified in sstack.Less.
-func New(reverse bool) *Prque {
-	return &Prque{newSstack(reverse)}
+func New(invert bool) *Prque {
+	return &Prque{newSstack(invert)}
 }
 
 // Pushes a value with a given priority into the queue, expanding if necessary.
@@ -73,5 +73,5 @@ func (p *Prque) Size() int {
 
 // Clears the contents of the priority queue.
 func (p *Prque) Reset() {
-	*p = *New(p.cont.reverse)
+	*p = *New(p.cont.invert)
 }

--- a/common/prque/prque.go
+++ b/common/prque/prque.go
@@ -9,9 +9,9 @@
 // This is a duplicated and slightly modified version of "gopkg.in/karalabe/cookiejar.v2/collections/prque".
 
 // Package prque implements a priority queue data structure supporting arbitrary
-// value types and int64 priorities.
+// value and priorities types.
 //
-// If you would like to use a min-priority queue, simply negate the priorities.
+// If you would like to use a min-priority queue, simply put false as a reverse parameter.
 //
 // Internally the queue is based on the standard heap package working on a
 // sortable version of the block based stack.

--- a/common/prque/prque.go
+++ b/common/prque/prque.go
@@ -28,13 +28,13 @@ type Prque struct {
 }
 
 // New creates a new priority queue.
-// The priority queue can have any type specified  in sstack.Less.
+// The priority queue can have any type specified in sstack.Less.
 func New(reverse bool) *Prque {
 	return &Prque{newSstack(reverse)}
 }
 
 // Pushes a value with a given priority into the queue, expanding if necessary.
-// The priority queue can have any type specified  in sstack.Less.
+// The priority queue can have any type specified in sstack.Less.
 // In a queue, same type should be pushed. Otherwise, a type assertion error
 // will occur. Number types (int, int64, uint64) are different types.
 func (p *Prque) Push(data interface{}, priority interface{}) {

--- a/common/prque/sstack.go
+++ b/common/prque/sstack.go
@@ -34,20 +34,20 @@ type sstack struct {
 	size     int
 	capacity int
 	offset   int
-	reverse  bool // reverse the result of Less()
+	invert   bool // min-priority queue
 
 	blocks [][]*item
 	active []*item
 }
 
 // Creates a new, empty stack.
-func newSstack(reverse bool) *sstack {
+func newSstack(invert bool) *sstack {
 	active := make([]*item, blockSize)
 	return &sstack{
 		size:     0,
 		capacity: blockSize,
 		offset:   0,
-		reverse:  reverse,
+		invert:   invert,
 		blocks:   [][]*item{active},
 		active:   active,
 	}
@@ -113,7 +113,7 @@ func (s *sstack) Less(i, j int) bool {
 		result = bytes.Compare(iPriority, jPriority) > 0
 	}
 
-	if s.reverse {
+	if s.invert {
 		return !result
 	}
 	return result
@@ -127,5 +127,5 @@ func (s *sstack) Swap(i, j int) {
 
 // Resets the stack, effectively clearing its contents.
 func (s *sstack) Reset() {
-	*s = *newSstack(s.reverse)
+	*s = *newSstack(s.invert)
 }

--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -95,7 +95,7 @@ func (c *core) storeBacklog(msg *message, src istanbul.Validator) {
 
 	backlog := c.backlogs[src.Address()]
 	if backlog == nil {
-		backlog = prque.New()
+		backlog = prque.New(false)
 	}
 	switch msg.Code {
 	case msgPreprepare:

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -50,7 +50,7 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 		backend:            backend,
 		backlogs:           make(map[common.Address]*prque.Prque),
 		backlogsMu:         new(sync.Mutex),
-		pendingRequests:    prque.New(),
+		pendingRequests:    prque.New(true),
 		pendingRequestsMu:  new(sync.Mutex),
 		consensusTimestamp: time.Time{},
 

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -71,7 +71,7 @@ func (c *core) storeRequestMsg(request *istanbul.Request) {
 	c.pendingRequestsMu.Lock()
 	defer c.pendingRequestsMu.Unlock()
 
-	c.pendingRequests.Push(request, -request.Proposal.Number().Int64())
+	c.pendingRequests.Push(request, request.Proposal.Number().Int64())
 }
 
 func (c *core) processPendingRequests() {

--- a/datasync/fetcher/fetcher.go
+++ b/datasync/fetcher/fetcher.go
@@ -318,7 +318,7 @@ func (f *Fetcher) loop() {
 			// If too high up the chain or phase, continue later
 			number := op.block.NumberU64()
 			if number > height+1 {
-				f.queue.Push(op, op.block.NumberU64())
+				f.queue.Push(op, number)
 				if f.queueChangeHook != nil {
 					f.queueChangeHook(op.block.Hash(), true)
 				}

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -101,7 +101,7 @@ func NewTrieSync(root common.Hash, database StateTrieReadDB, callback LeafCallba
 		database:         database,
 		membatch:         newSyncMemBatch(),
 		requests:         make(map[common.Hash]*request),
-		queue:            prque.New(),
+		queue:            prque.New(false),
 		retrievedByDepth: make(map[int]int),
 		committedByDepth: make(map[int]int),
 		bloom:            bloom,
@@ -294,7 +294,7 @@ func (s *TrieSync) schedule(req *request) {
 	s.retrievedByDepth[req.depth]++
 
 	// Schedule the request for future retrieval
-	s.queue.Push(req.hash, int64(req.depth))
+	s.queue.Push(req.hash, req.depth)
 	s.requests[req.hash] = req
 }
 


### PR DESCRIPTION
## Proposed changes

This is another implementation of https://github.com/klaytn/klaytn/pull/835. (previous code : https://github.com/klaytn/klaytn/compare/dev...winnie-byun:prque) (Ethereum PR : https://github.com/ethereum/go-ethereum/pull/22156)
The difference with previous PR:
- I changed the interface of `prque.New()`.(`prque.New(prque.Type, bool)` -> `prque.New(bool)`)
- There is no need to specify type when creating a priority queue.
- If items of different priority types are pushed, it is catched in `Less()` function.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

