### PR TITLE
database: added Delete and Replay to Batch interface

### DIFF
--- a/node/sc/mainbridge_test.go
+++ b/node/sc/mainbridge_test.go
@@ -64,7 +64,6 @@ func testNewMainBridge(t *testing.T) *MainBridge {
 // testBlockChain returns a test BlockChain with initial values
 func testBlockChain(t *testing.T) *blockchain.BlockChain {
 	db := database.NewMemoryDBManager()
-	defer db.Close()
 
 	gov := governance.NewGovernanceInitialize(&params.ChainConfig{
 		ChainID:       big.NewInt(2018),

--- a/storage/database/badger_database.go
+++ b/storage/database/badger_database.go
@@ -203,21 +203,40 @@ type badgerBatch struct {
 	size int
 }
 
+// Put inserts the given value into the batch for later committing.
 func (b *badgerBatch) Put(key, value []byte) error {
 	err := b.txn.Set(key, value)
 	b.size += len(value)
 	return err
 }
 
+// Delete inserts the a key removal into the batch for later committing.
+func (b *badgerBatch) Delete(key []byte) error {
+	if err := b.txn.Delete(key); err != nil {
+		return err
+	}
+	b.size += 1
+	return nil
+}
+
+// Write flushes any accumulated data to disk.
 func (b *badgerBatch) Write() error {
 	return b.txn.Commit()
 }
 
+// ValueSize retrieves the amount of data queued up for writing.
 func (b *badgerBatch) ValueSize() int {
 	return b.size
 }
 
+// Replay replays the batch contents.
 func (b *badgerBatch) Reset() {
 	b.txn = b.db.NewTransaction(true)
 	b.size = 0
+}
+
+// Replay replays the batch contents.
+func (b *badgerBatch) Replay(w KeyValueWriter) error {
+	logger.CritWithStack("Replay is not implemented in badgerBatch!")
+	return nil
 }

--- a/storage/database/batch.go
+++ b/storage/database/batch.go
@@ -25,7 +25,7 @@ package database
 const IdealBatchSize = 100 * 1024
 
 // Batch is a write-only database that commits changes to its host database
-// when Write is called. A memBatch cannot be used concurrently.
+// when Write is called. A Batch cannot be used concurrently.
 type Batch interface {
 	KeyValueWriter
 
@@ -35,10 +35,10 @@ type Batch interface {
 	// Write flushes any accumulated data to disk.
 	Write() error
 
-	// Reset resets the memBatch for reuse.
+	// Reset resets the Batch for reuse.
 	Reset()
 
-	// Replay replays the memBatch contents.
+	// Replay replays the Batch contents.
 	Replay(w KeyValueWriter) error
 }
 

--- a/storage/database/batch.go
+++ b/storage/database/batch.go
@@ -1,0 +1,50 @@
+// Modifications Copyright 2021 The klaytn Authors
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from ethdb/memBatch.go (2021/01/07).
+// Modified and improved for the klaytn development.
+
+package database
+
+// IdealBatchSize defines the size of the data batches should ideally add in one
+// write.
+const IdealBatchSize = 100 * 1024
+
+// Batch is a write-only database that commits changes to its host database
+// when Write is called. A memBatch cannot be used concurrently.
+type Batch interface {
+	KeyValueWriter
+
+	// ValueSize retrieves the amount of data queued up for writing.
+	ValueSize() int
+
+	// Write flushes any accumulated data to disk.
+	Write() error
+
+	// Reset resets the memBatch for reuse.
+	Reset()
+
+	// Replay replays the memBatch contents.
+	Replay(w KeyValueWriter) error
+}
+
+// Batcher wraps the NewBatch method of a backing data store.
+type Batcher interface {
+	// NewBatch creates a write-only database that buffers changes to its host db
+	// until a final write is called.
+	NewBatch() Batch
+}

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -105,7 +105,7 @@ func TestDatabase_NotFoundErr(t *testing.T) {
 		val, err := db.Get(randStrBytes(100))
 		assert.Nil(t, val)
 		assert.Error(t, err)
-		assert.Equal(t, err, dataNotFoundErr)
+		assert.Equal(t, dataNotFoundErr, err)
 	}
 }
 

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -105,7 +105,7 @@ func TestDatabase_NotFoundErr(t *testing.T) {
 		val, err := db.Get(randStrBytes(100))
 		assert.Nil(t, val)
 		assert.Error(t, err)
-		assert.Equal(t, dataNotFoundErr, err)
+		assert.Equal(t, err, dataNotFoundErr)
 	}
 }
 

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -549,6 +549,12 @@ func (batch *dynamoBatch) Put(key, val []byte) error {
 	return nil
 }
 
+// Delete inserts the a key removal into the batch for later committing.
+func (batch *dynamoBatch) Delete(key []byte) error {
+	logger.CritWithStack("Delete should not be called when using dynamodb batch")
+	return nil
+}
+
 func (batch *dynamoBatch) Write() error {
 	var writeRequest []*dynamodb.WriteRequest
 	numRemainedItems := len(batch.batchItems)
@@ -577,4 +583,9 @@ func (batch *dynamoBatch) Reset() {
 	batch.batchItems = []*dynamodb.WriteRequest{}
 	batch.keyMap = map[string]struct{}{}
 	batch.size = 0
+}
+
+func (batch *dynamoBatch) Replay(w KeyValueWriter) error {
+	logger.CritWithStack("Replay should not be called when using dynamodb batch")
+	return nil
 }

--- a/storage/database/dynamodb_readonly.go
+++ b/storage/database/dynamodb_readonly.go
@@ -67,6 +67,10 @@ func (batch *emptyBatch) Put(key, val []byte) error {
 	return nil
 }
 
+func (batch *emptyBatch) Delete(key []byte) error {
+	return nil
+}
+
 func (batch *emptyBatch) Write() error {
 	return nil
 }
@@ -76,4 +80,8 @@ func (batch *emptyBatch) ValueSize() int {
 }
 
 func (batch *emptyBatch) Reset() {
+}
+
+func (batch *emptyBatch) Replay(w KeyValueWriter) error {
+	return nil
 }

--- a/storage/database/interface.go
+++ b/storage/database/interface.go
@@ -58,34 +58,25 @@ func (db DBType) selfShardable() bool {
 	return false
 }
 
-const IdealBatchSize = 100 * 1024
-
-// Putter wraps the database write operation supported by both batches and regular databases.
-type Putter interface {
+// KeyValueWriter wraps the Put method of a backing data store.
+type KeyValueWriter interface {
+	// Put inserts the given value into the key-value data store.
 	Put(key []byte, value []byte) error
+
+	// Delete removes the key from the key-value data store.
+	Delete(key []byte) error
 }
 
 // Database wraps all database operations. All methods are safe for concurrent use.
 type Database interface {
-	Putter
+	KeyValueWriter
 	Get(key []byte) ([]byte, error)
 	Has(key []byte) (bool, error)
-	Delete(key []byte) error
 	Close()
 	NewBatch() Batch
 	Type() DBType
 	Meter(prefix string)
 	Iteratee
-}
-
-// Batch is a write-only database that commits changes to its host database
-// when Write is called. Batch cannot be used concurrently.
-type Batch interface {
-	Putter
-	ValueSize() int // amount of data in the batch
-	Write() error
-	// Reset resets the batch for reuse
-	Reset()
 }
 
 func WriteBatches(batches ...Batch) (int, error) {

--- a/storage/database/memory_database.go
+++ b/storage/database/memory_database.go
@@ -33,10 +33,6 @@ var (
 	// errMemorydbClosed is returned if a memory database was already closed at the
 	// invocation of a data access operation.
 	errMemorydbClosed = errors.New("database closed")
-
-	// errMemorydbNotFound is returned if a key is requested that is not found in
-	// the provided memory database.
-	errMemorydbNotFound = errors.New("not found")
 )
 
 /*
@@ -95,7 +91,7 @@ func (db *MemDB) Get(key []byte) ([]byte, error) {
 	if entry, ok := db.db[string(key)]; ok {
 		return common.CopyBytes(entry), nil
 	}
-	return nil, errMemorydbNotFound
+	return nil, dataNotFoundErr
 }
 
 // Put inserts the given value into the key-value store.

--- a/storage/database/memory_database.go
+++ b/storage/database/memory_database.go
@@ -21,11 +21,22 @@
 package database
 
 import (
+	"errors"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/klaytn/klaytn/common"
+)
+
+var (
+	// errMemorydbClosed is returned if a memory database was already closed at the
+	// invocation of a data access operation.
+	errMemorydbClosed = errors.New("database closed")
+
+	// errMemorydbNotFound is returned if a key is requested that is not found in
+	// the provided memory database.
+	errMemorydbNotFound = errors.New("not found")
 )
 
 /*
@@ -48,34 +59,67 @@ func NewMemDBWithCap(size int) *MemDB {
 	}
 }
 
+// Close deallocates the internal map and ensures any consecutive data access op
+// fails with an error.
+func (db *MemDB) Close() {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	db.db = nil
+}
+
 func (db *MemDB) Type() DBType {
 	return MemoryDB
 }
 
-func (db *MemDB) Put(key []byte, value []byte) error {
-	db.lock.Lock()
-	defer db.lock.Unlock()
-
-	db.db[string(key)] = common.CopyBytes(value)
-	return nil
-}
-
+// Has retrieves if a key is present in the key-value store.
 func (db *MemDB) Has(key []byte) (bool, error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
+	if db.db == nil {
+		return false, errMemorydbClosed
+	}
 	_, ok := db.db[string(key)]
 	return ok, nil
 }
 
+// Get retrieves the given key if it's present in the key-value store.
 func (db *MemDB) Get(key []byte) ([]byte, error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
+	if db.db == nil {
+		return nil, errMemorydbClosed
+	}
 	if entry, ok := db.db[string(key)]; ok {
 		return common.CopyBytes(entry), nil
 	}
-	return nil, dataNotFoundErr
+	return nil, errMemorydbNotFound
+}
+
+// Put inserts the given value into the key-value store.
+func (db *MemDB) Put(key []byte, value []byte) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.db == nil {
+		return errMemorydbClosed
+	}
+	db.db[string(key)] = common.CopyBytes(value)
+	return nil
+}
+
+// Delete removes the key from the key-value store.
+func (db *MemDB) Delete(key []byte) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.db == nil {
+		return errMemorydbClosed
+	}
+	delete(db.db, string(key))
+	return nil
 }
 
 func (db *MemDB) Keys() [][]byte {
@@ -88,16 +132,6 @@ func (db *MemDB) Keys() [][]byte {
 	}
 	return keys
 }
-
-func (db *MemDB) Delete(key []byte) error {
-	db.lock.Lock()
-	defer db.lock.Unlock()
-
-	delete(db.db, string(key))
-	return nil
-}
-
-func (db *MemDB) Close() {}
 
 func (db *MemDB) NewBatch() Batch {
 	return &memBatch{db: db}
@@ -137,43 +171,102 @@ func (db *MemDB) NewIterator(prefix []byte, start []byte) Iterator {
 	}
 }
 
-func (db *MemDB) Len() int { return len(db.db) }
+// Stat returns a particular internal stat of the database.
+func (db *MemDB) Stat(property string) (string, error) {
+	return "", errors.New("unknown property")
+}
+
+// Compact is not supported on a memory database, but there's no need either as
+// a memory database doesn't waste space anyway.
+func (db *MemDB) Compact(start []byte, limit []byte) error {
+	return nil
+}
+
+// Len returns the number of entries currently present in the memory database.
+//
+// Note, this method is only used for testing (i.e. not public in general) and
+// does not have explicit checks for closed-ness to allow simpler testing code.
+func (db *MemDB) Len() int {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+
+	return len(db.db)
+}
 
 func (db *MemDB) Meter(prefix string) {
 	logger.Warn("MemDB does not support metrics!")
 }
 
-type kv struct{ k, v []byte }
+// keyvalue is a key-value tuple tagged with a deletion field to allow creating
+// memory-database write batches.
+type keyvalue struct {
+	key    []byte
+	value  []byte
+	delete bool
+}
 
+// memBatch is a write-only memory batch that commits changes to its host
+// database when Write is called. A batch cannot be used concurrently.
 type memBatch struct {
 	db     *MemDB
-	writes []kv
+	writes []keyvalue
 	size   int
 }
 
+// Put inserts the given value into the batch for later committing.
 func (b *memBatch) Put(key, value []byte) error {
-	b.writes = append(b.writes, kv{common.CopyBytes(key), common.CopyBytes(value)})
+	b.writes = append(b.writes, keyvalue{common.CopyBytes(key), common.CopyBytes(value), false})
 	b.size += len(value)
 	return nil
 }
 
-func (b *memBatch) Write() error {
-	b.db.lock.Lock()
-	defer b.db.lock.Unlock()
-
-	for _, kv := range b.writes {
-		b.db.db[string(kv.k)] = kv.v
-	}
+// Delete inserts the a key removal into the batch for later committing.
+func (b *memBatch) Delete(key []byte) error {
+	b.writes = append(b.writes, keyvalue{common.CopyBytes(key), nil, true})
+	b.size += 1
 	return nil
 }
 
+// ValueSize retrieves the amount of data queued up for writing.
 func (b *memBatch) ValueSize() int {
 	return b.size
 }
 
+// Write flushes any accumulated data to the memory database.
+func (b *memBatch) Write() error {
+	b.db.lock.Lock()
+	defer b.db.lock.Unlock()
+
+	for _, keyvalue := range b.writes {
+		if keyvalue.delete {
+			delete(b.db.db, string(keyvalue.key))
+			continue
+		}
+		b.db.db[string(keyvalue.key)] = keyvalue.value
+	}
+	return nil
+}
+
+// Reset resets the batch for reuse.
 func (b *memBatch) Reset() {
 	b.writes = b.writes[:0]
 	b.size = 0
+}
+
+// Replay replays the batch contents.
+func (b *memBatch) Replay(w KeyValueWriter) error {
+	for _, keyvalue := range b.writes {
+		if keyvalue.delete {
+			if err := w.Delete(keyvalue.key); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := w.Put(keyvalue.key, keyvalue.value); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // iterator can walk over the (potentially partial) keyspace of a memory key

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -253,7 +253,7 @@ func (s *TrieSync) Process(results []SyncResult) (bool, int, error) {
 
 // Commit flushes the data stored in the internal membatch out to persistent
 // storage, returning the number of items written and any occurred error.
-func (s *TrieSync) Commit(dbw database.Putter) (int, error) {
+func (s *TrieSync) Commit(dbw database.KeyValueWriter) (int, error) {
 	// Dump the membatch into a database dbw
 	for i, key := range s.membatch.order {
 		if err := dbw.Put(key[:], s.membatch.batch[key]); err != nil {


### PR DESCRIPTION
## Proposed changes

- This is to make Klaytn aligned with go-ethereum before taking [Snapshot](https://github.com/ethereum/go-ethereum/pull/20152) structure to Klaytn
- `Delete` and `Replay` functions are added to `Batch` interface
- Related changes are below
- https://github.com/ethereum/go-ethereum/pull/19307
- https://github.com/ethereum/go-ethereum/pull/19244

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
