### PR TITLE
Add age log message and metric

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -67,11 +67,13 @@ var (
 	storageUpdateTimer = metrics.NewRegisteredTimer("state/storage/updates", nil)
 	storageCommitTimer = metrics.NewRegisteredTimer("state/storage/commits", nil)
 
-	blockInsertTimer        = metrics.NewRegisteredTimer("chain/inserts", nil)
-	blockProcessTimer       = metrics.NewRegisteredTimer("chain/process", nil)
-	blockExecutionTimer     = metrics.NewRegisteredTimer("chain/execution", nil)
-	blockFinalizeTimer      = metrics.NewRegisteredTimer("chain/finalize", nil)
-	blockValidateTimer      = metrics.NewRegisteredTimer("chain/validate", nil)
+	blockInsertTimer    = metrics.NewRegisteredTimer("chain/inserts", nil)
+	blockProcessTimer   = metrics.NewRegisteredTimer("chain/process", nil)
+	blockExecutionTimer = metrics.NewRegisteredTimer("chain/execution", nil)
+	blockFinalizeTimer  = metrics.NewRegisteredTimer("chain/finalize", nil)
+	blockValidateTimer  = metrics.NewRegisteredTimer("chain/validate", nil)
+	BlockAgeTimer       = metrics.NewRegisteredTimer("chain/age", nil)
+
 	ErrNoGenesis            = errors.New("genesis not found in chain")
 	ErrNotExistNode         = errors.New("the node does not exist in cached node")
 	ErrQuitBySignal         = errors.New("quit by signal")
@@ -375,9 +377,9 @@ func (bc *BlockChain) loadLastState() error {
 	blockTd := bc.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
 	fastTd := bc.GetTd(currentFastBlock.Hash(), currentFastBlock.NumberU64())
 
-	logger.Info("Loaded most recent local header", "number", currentHeader.Number, "hash", currentHeader.Hash(), "td", headerTd)
-	logger.Info("Loaded most recent local full block", "number", currentBlock.Number(), "hash", currentBlock.Hash(), "td", blockTd)
-	logger.Info("Loaded most recent local fast block", "number", currentFastBlock.Number(), "hash", currentFastBlock.Hash(), "td", fastTd)
+	logger.Info("Loaded most recent local header", "number", currentHeader.Number, "hash", currentHeader.Hash(), "td", headerTd, "age", common.PrettyAge(time.Unix(int64(currentHeader.Time.Uint64()), 0)))
+	logger.Info("Loaded most recent local full block", "number", currentBlock.Number(), "hash", currentBlock.Hash(), "td", blockTd, "age", common.PrettyAge(time.Unix(int64(currentHeader.Time.Uint64()), 0)))
+	logger.Info("Loaded most recent local fast block", "number", currentFastBlock.Number(), "hash", currentFastBlock.Hash(), "td", fastTd, "age", common.PrettyAge(time.Unix(int64(currentHeader.Time.Uint64()), 0)))
 
 	return nil
 }
@@ -1671,6 +1673,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 
 		trieAccess := stateDB.AccountReads + stateDB.AccountHashes + stateDB.AccountUpdates + stateDB.AccountCommits
 		trieAccess += stateDB.StorageReads + stateDB.StorageHashes + stateDB.StorageUpdates + stateDB.StorageCommits
+		block.TimeFoS()
+		timestamp := time.Unix(int64(block.Time().Uint64()), 0)
+		BlockAgeTimer.Update(time.Since(timestamp))
 
 		switch writeResult.Status {
 		case CanonStatTy:
@@ -1891,6 +1896,10 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 			"number", end.Number(), "hash", end.Hash(), "blocks", st.processed, "txs", txs, "elapsed", common.PrettyDuration(elapsed),
 			"trieDBSize", cache, "mgas", float64(st.usedGas) / 1000000, "mgasps", float64(st.usedGas) * 1000 / float64(elapsed),
 		}
+
+		timestamp := time.Unix(int64(end.Time().Uint64()), 0)
+		context = append(context, []interface{}{"age", common.PrettyAge(timestamp)}...)
+
 		if st.queued > 0 {
 			context = append(context, []interface{}{"queued", st.queued}...)
 		}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1673,9 +1673,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 
 		trieAccess := stateDB.AccountReads + stateDB.AccountHashes + stateDB.AccountUpdates + stateDB.AccountCommits
 		trieAccess += stateDB.StorageReads + stateDB.StorageHashes + stateDB.StorageUpdates + stateDB.StorageCommits
-		block.TimeFoS()
-		timestamp := time.Unix(int64(block.Time().Uint64()), 0)
-		BlockAgeTimer.Update(time.Since(timestamp))
+
+		BlockAgeTimer.Update(time.Since(time.Unix(int64(block.Time().Uint64()), 0)))
 
 		switch writeResult.Status {
 		case CanonStatTy:

--- a/common/format.go
+++ b/common/format.go
@@ -42,3 +42,46 @@ func (d PrettyDuration) String() string {
 	}
 	return label
 }
+
+// PrettyAge is a pretty printed version of a time.Duration value that rounds
+// the values up to a single most significant unit, days/weeks/years included.
+type PrettyAge time.Time
+
+// ageUnits is a list of units the age pretty printing uses.
+var ageUnits = []struct {
+	Size   time.Duration
+	Symbol string
+}{
+	{12 * 30 * 24 * time.Hour, "y"},
+	{30 * 24 * time.Hour, "mo"},
+	{7 * 24 * time.Hour, "w"},
+	{24 * time.Hour, "d"},
+	{time.Hour, "h"},
+	{time.Minute, "m"},
+	{time.Second, "s"},
+	{time.Millisecond, "ms"},
+}
+
+// String implements the Stringer interface, allowing pretty printing of duration
+// values rounded to the most significant time unit.
+func (t PrettyAge) String() string {
+	// Calculate the time difference and handle the 0 cornercase
+	diff := time.Since(time.Time(t))
+	if diff < time.Second {
+		return "0"
+	}
+	// Accumulate a precision of 3 components before returning
+	result, prec := "", 0
+
+	for _, unit := range ageUnits {
+		if diff > unit.Size {
+			result = fmt.Sprintf("%s%d%s", result, diff/unit.Size, unit.Symbol)
+			diff %= unit.Size
+
+			if prec += 1; prec >= 3 {
+				break
+			}
+		}
+	}
+	return result
+}


### PR DESCRIPTION
## Proposed changes

This PR is from https://github.com/ethereum/go-ethereum/pull/17718.
And I added a metric in addition.
This age shows how old is the recent block.
This effectively shows how far behind this node is.

```
INFO[01/08,01:49:43 +09] [5] Loaded most recent local header           number=48381635 hash=43c4d7…4f2d98 td=48381636 age=26s753ms
INFO[01/08,01:49:43 +09] [5] Loaded most recent local full block       number=48381635 hash=43c4d7…4f2d98 td=48381636 age=26s753ms
INFO[01/08,01:49:43 +09] [5] Loaded most recent local fast block       number=48381635 hash=43c4d7…4f2d98 td=48381636 age=26s753ms
...
INFO[01/08,01:50:09 +09] [5] Imported new chain segment                number=48381644 hash=27d601…526e86 blocks=9 txs=41 elapsed=10.045s   trieDBSize=1.19mB mgas=3.759 mgasps=0.374 age=43s208ms
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
