### PR TITLE
Add an option to unlock the genesis account by default

### DIFF
--- a/cmd/homi/docker/service/validator.go
+++ b/cmd/homi/docker/service/validator.go
@@ -159,7 +159,7 @@ var validatorTemplate = `{{ .Name }}:
 {{- end }}
         echo 'ADDITIONAL="$$ADDITIONAL --debug --metrics --prometheus"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
         /klaytn-docker-pkg/bin/k{{ .NodeType }}d start
-{{- if eq .NodeType "cn" }}
+{{- if eq .NodeType "cn" "scn"}}
         sleep 1
         ken attach --exec "personal.importRawKey('{{ .NodeKey }}', '')" http://localhost:{{ .RPCPort }}
         ken attach --exec "personal.unlockAccount('{{ .Address }}', '', 999999999)" http://localhost:{{ .RPCPort }}

--- a/cmd/homi/docker/service/validator.go
+++ b/cmd/homi/docker/service/validator.go
@@ -159,7 +159,7 @@ var validatorTemplate = `{{ .Name }}:
 {{- end }}
         echo 'ADDITIONAL="$$ADDITIONAL --debug --metrics --prometheus"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
         /klaytn-docker-pkg/bin/k{{ .NodeType }}d start
-{{- if eq .NodeType "cn" "scn"}}
+{{- if eq .NodeType "cn"}}
         sleep 1
         ken attach --exec "personal.importRawKey('{{ .NodeKey }}', '')" http://localhost:{{ .RPCPort }}
         ken attach --exec "personal.unlockAccount('{{ .Address }}', '', 999999999)" http://localhost:{{ .RPCPort }}

--- a/cmd/homi/docker/service/validator.go
+++ b/cmd/homi/docker/service/validator.go
@@ -159,6 +159,11 @@ var validatorTemplate = `{{ .Name }}:
 {{- end }}
         echo 'ADDITIONAL="$$ADDITIONAL --debug --metrics --prometheus"' >> /klaytn-docker-pkg/conf/k{{ .NodeType }}d.conf
         /klaytn-docker-pkg/bin/k{{ .NodeType }}d start
+{{- if eq .NodeType "cn" }}
+        sleep 1
+        ken attach --exec "personal.importRawKey('{{ .NodeKey }}', '')" http://localhost:{{ .RPCPort }}
+        ken attach --exec "personal.unlockAccount('{{ .Address }}', '', 999999999)" http://localhost:{{ .RPCPort }}
+{{- end }}
         tail -F klaytn/log/k{{ .NodeType }}d.out
     networks:
       app_net:


### PR DESCRIPTION
## Proposed changes

When using docker-compose, it is useful if the genesis account
is unlocked by default.

For example, you can connect it with your local node on Klaytn IDE.
In this case, you need to unlock an account to deploy a contract.
With this option --unlock-genesis-account, it is automatically done.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

N/A

## Further comments