### PR TITLE
Added timeout for http/fasthttp server

### DIFF
--- a/cmd/kbn/config.go
+++ b/cmd/kbn/config.go
@@ -19,17 +19,19 @@ package main
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
 	"github.com/klaytn/klaytn/cmd/utils"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/networks/p2p/discover"
 	"github.com/klaytn/klaytn/networks/p2p/nat"
 	"github.com/klaytn/klaytn/networks/p2p/netutil"
+	"github.com/klaytn/klaytn/networks/rpc"
 	"gopkg.in/urfave/cli.v1"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 )
 
 const (
@@ -105,6 +107,10 @@ type bootnodeConfig struct {
 	// If the module list is empty, all RPC API endpoints designated public will be
 	// exposed.
 	HTTPModules []string `toml:",omitempty"`
+
+	// HTTPTimeouts allows for customization of the timeout values used by the HTTP RPC
+	// interface.
+	HTTPTimeouts rpc.HTTPTimeouts
 
 	// WSHost is the host interface on which to start the websocket RPC server. If
 	// this field is empty, no websocket API endpoint will be started.

--- a/cmd/kbn/main.go
+++ b/cmd/kbn/main.go
@@ -23,6 +23,11 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/klaytn/klaytn/api/debug"
 	"github.com/klaytn/klaytn/cmd/utils"
 	"github.com/klaytn/klaytn/cmd/utils/nodecmd"
@@ -31,11 +36,8 @@ import (
 	"github.com/klaytn/klaytn/networks/p2p"
 	"github.com/klaytn/klaytn/networks/p2p/discover"
 	"github.com/klaytn/klaytn/networks/p2p/nat"
+	"github.com/klaytn/klaytn/networks/rpc"
 	"gopkg.in/urfave/cli.v1"
-	"net"
-	"os"
-	"os/signal"
-	"syscall"
 )
 
 var (
@@ -70,6 +72,7 @@ func bootnode(ctx *cli.Context) error {
 			HTTPPort:         DefaultHTTPPort,
 			HTTPModules:      []string{"net"},
 			HTTPVirtualHosts: []string{"localhost"},
+			HTTPTimeouts:     rpc.DefaultHTTPTimeouts,
 			WSPort:           DefaultWSPort,
 			WSModules:        []string{"net"},
 			GRPCPort:         DefaultGRPCPort,

--- a/cmd/kbn/node.go
+++ b/cmd/kbn/node.go
@@ -22,13 +22,14 @@ package main
 
 import (
 	"fmt"
+	"net"
+	"strings"
+	"sync"
+
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/networks/grpc"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/node"
-	"net"
-	"strings"
-	"sync"
 )
 
 // Node is a container on which services can be registered.
@@ -229,7 +230,7 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartHTTPEndpoint(endpoint, apis, modules, cors, vhosts)
+	listener, handler, err := rpc.StartHTTPEndpoint(endpoint, apis, modules, cors, vhosts, n.config.HTTPTimeouts)
 	if err != nil {
 		return err
 	}
@@ -248,7 +249,7 @@ func (n *Node) startFastHTTP(endpoint string, apis []rpc.API, modules []string, 
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartFastHTTPEndpoint(endpoint, apis, modules, cors, vhosts)
+	listener, handler, err := rpc.StartFastHTTPEndpoint(endpoint, apis, modules, cors, vhosts, n.config.HTTPTimeouts)
 	if err != nil {
 		return err
 	}
@@ -281,7 +282,7 @@ func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrig
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll)
+	listener, handler, err := rpc.StartWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll, n.config.HTTPTimeouts)
 	if err != nil {
 		return err
 	}
@@ -300,7 +301,7 @@ func (n *Node) startFastWS(endpoint string, apis []rpc.API, modules []string, ws
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartFastWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll)
+	listener, handler, err := rpc.StartFastWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll, n.config.HTTPTimeouts)
 	if err != nil {
 		return err
 	}

--- a/cmd/kbn/node.go
+++ b/cmd/kbn/node.go
@@ -282,7 +282,7 @@ func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrig
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll, n.config.HTTPTimeouts)
+	listener, handler, err := rpc.StartWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll)
 	if err != nil {
 		return err
 	}
@@ -301,7 +301,7 @@ func (n *Node) startFastWS(endpoint string, apis []rpc.API, modules []string, ws
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartFastWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll, n.config.HTTPTimeouts)
+	listener, handler, err := rpc.StartFastWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/jackpal/go-nat-pmp v1.0.1
 	github.com/jinzhu/gorm v1.9.15
 	github.com/julienschmidt/httprouter v1.2.0
-	github.com/klauspost/compress v1.4.1 // indirect
 	github.com/mattn/go-colorable v0.1.2
 	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/naoina/go-stringutil v0.1.0 // indirect
@@ -53,13 +52,14 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
 	github.com/urfave/cli v1.20.0
-	github.com/valyala/fasthttp v1.2.0
+	github.com/valyala/fasthttp v1.16.0
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.2.0 // indirect
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc
 	golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed
+	golang.org/x/tools v0.0.0-20191126055441-b0650ceb63d9
 	google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c // indirect
 	google.golang.org/grpc v1.23.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZq
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
+github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
+github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/aristanetworks/fsnotify v1.4.2/go.mod h1:D/rtu7LpjYM8tRJphJ0hUBYpjai8SfX+aSNsWDTq/Ks=
 github.com/aristanetworks/glog v0.0.0-20180419172825-c15b03b3054f/go.mod h1:KASm+qXFKs/xjSoWn30NrWBBvdTTQq+UjkhjEJHfSFA=
@@ -161,6 +163,8 @@ github.com/klauspost/compress v1.4.0 h1:8nsMz3tWa9SWWPL60G1V6CUsf4lLjWLTNEtibhe8
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.4.1 h1:8VMb5+0wMgdBykOV96DwNwKFQ+WTI4pzYURP99CcB9E=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.10.7 h1:7rix8v8GpI3ZBb0nSozFRgbtXKv+hOe+qfEpZqybrAg=
+github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
@@ -316,6 +320,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.2.0 h1:dzZJf2IuMiclVjdw0kkT+f9u4YdrapbNyGAN47E/qnk=
 github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
+github.com/valyala/fasthttp v1.16.0 h1:9zAqOYLl8Tuy3E5R6ckzGDJ1g8+pw15oQp2iL9Jl6gQ=
+github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
@@ -359,6 +365,7 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc h1:zK/HqS5bZxDptfPJNq8v7vJfXtkU7r9TLIoSr1bXaP4=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -388,6 +395,7 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed h1:J22ig1FUekjjkmZUM7pTKixYm8DvrYsvrBZdunYeIuQ=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/networks/rpc/endpoints.go
+++ b/networks/rpc/endpoints.go
@@ -25,7 +25,7 @@ import (
 )
 
 // StartHTTPEndpoint starts the HTTP RPC endpoint, configured with cors/vhosts/modules
-func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []string, vhosts []string) (net.Listener, *Server, error) {
+func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []string, vhosts []string, timeouts HTTPTimeouts) (net.Listener, *Server, error) {
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
 	for _, module := range modules {
@@ -49,12 +49,12 @@ func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []str
 	if listener, err = net.Listen("tcp", endpoint); err != nil {
 		return nil, nil, err
 	}
-	go NewHTTPServer(cors, vhosts, handler).Serve(listener)
+	go NewHTTPServer(cors, vhosts, timeouts, handler).Serve(listener)
 	return listener, handler, err
 }
 
 // StartHTTPEndpoint starts the HTTP RPC endpoint, configured with cors/vhosts/modules
-func StartFastHTTPEndpoint(endpoint string, apis []API, modules []string, cors []string, vhosts []string) (net.Listener, *Server, error) {
+func StartFastHTTPEndpoint(endpoint string, apis []API, modules []string, cors []string, vhosts []string, timeouts HTTPTimeouts) (net.Listener, *Server, error) {
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
 	for _, module := range modules {
@@ -78,12 +78,12 @@ func StartFastHTTPEndpoint(endpoint string, apis []API, modules []string, cors [
 	if listener, err = net.Listen("tcp4", endpoint); err != nil {
 		return nil, nil, err
 	}
-	go NewFastHTTPServer(cors, vhosts, handler).Serve(listener)
+	go NewFastHTTPServer(cors, vhosts, timeouts, handler).Serve(listener)
 	return listener, handler, err
 }
 
 // StartWSEndpoint starts a websocket endpoint
-func StartWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []string, exposeAll bool) (net.Listener, *Server, error) {
+func StartWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []string, exposeAll bool, timeouts HTTPTimeouts) (net.Listener, *Server, error) {
 
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
@@ -108,12 +108,12 @@ func StartWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []
 	if listener, err = net.Listen("tcp", endpoint); err != nil {
 		return nil, nil, err
 	}
-	go NewWSServer(wsOrigins, handler).Serve(listener)
+	go NewWSServer(wsOrigins, timeouts, handler).Serve(listener)
 	return listener, handler, err
 
 }
 
-func StartFastWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []string, exposeAll bool) (net.Listener, *Server, error) {
+func StartFastWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []string, exposeAll bool, timeouts HTTPTimeouts) (net.Listener, *Server, error) {
 
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
@@ -138,7 +138,7 @@ func StartFastWSEndpoint(endpoint string, apis []API, modules []string, wsOrigin
 	if listener, err = net.Listen("tcp4", endpoint); err != nil {
 		return nil, nil, err
 	}
-	go NewFastWSServer(wsOrigins, handler).Serve(listener)
+	go NewFastWSServer(wsOrigins, timeouts, handler).Serve(listener)
 	return listener, handler, err
 
 }

--- a/networks/rpc/endpoints.go
+++ b/networks/rpc/endpoints.go
@@ -83,7 +83,7 @@ func StartFastHTTPEndpoint(endpoint string, apis []API, modules []string, cors [
 }
 
 // StartWSEndpoint starts a websocket endpoint
-func StartWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []string, exposeAll bool, timeouts HTTPTimeouts) (net.Listener, *Server, error) {
+func StartWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []string, exposeAll bool) (net.Listener, *Server, error) {
 
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
@@ -108,12 +108,12 @@ func StartWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []
 	if listener, err = net.Listen("tcp", endpoint); err != nil {
 		return nil, nil, err
 	}
-	go NewWSServer(wsOrigins, timeouts, handler).Serve(listener)
+	go NewWSServer(wsOrigins, handler).Serve(listener)
 	return listener, handler, err
 
 }
 
-func StartFastWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []string, exposeAll bool, timeouts HTTPTimeouts) (net.Listener, *Server, error) {
+func StartFastWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []string, exposeAll bool) (net.Listener, *Server, error) {
 
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
@@ -138,7 +138,7 @@ func StartFastWSEndpoint(endpoint string, apis []API, modules []string, wsOrigin
 	if listener, err = net.Listen("tcp4", endpoint); err != nil {
 		return nil, nil, err
 	}
-	go NewFastWSServer(wsOrigins, timeouts, handler).Serve(listener)
+	go NewFastWSServer(wsOrigins, handler).Serve(listener)
 	return listener, handler, err
 
 }

--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -73,6 +73,38 @@ func (hc *httpConn) Close() error {
 	return nil
 }
 
+// HTTPTimeouts represents the configuration params for the HTTP RPC server.
+type HTTPTimeouts struct {
+	// ReadTimeout is the maximum duration for reading the entire
+	// request, including the body.
+	//
+	// Because ReadTimeout does not let Handlers make per-request
+	// decisions on each request body's acceptable deadline or
+	// upload rate, most users will prefer to use
+	// ReadHeaderTimeout. It is valid to use them both.
+	ReadTimeout time.Duration
+
+	// WriteTimeout is the maximum duration before timing out
+	// writes of the response. It is reset whenever a new
+	// request's header is read. Like ReadTimeout, it does not
+	// let Handlers make decisions on a per-request basis.
+	WriteTimeout time.Duration
+
+	// IdleTimeout is the maximum amount of time to wait for the
+	// next request when keep-alives are enabled. If IdleTimeout
+	// is zero, the value of ReadTimeout is used. If both are
+	// zero, ReadHeaderTimeout is used.
+	IdleTimeout time.Duration
+}
+
+// DefaultHTTPTimeouts represents the default timeout values used if further
+// configuration is not provided.
+var DefaultHTTPTimeouts = HTTPTimeouts{
+	ReadTimeout:  30 * time.Second,
+	WriteTimeout: 30 * time.Second,
+	IdleTimeout:  120 * time.Second,
+}
+
 // DialHTTPWithClient creates a new RPC client that connects to an RPC server over HTTP
 // using the provided HTTP Client.
 func DialHTTPWithClient(endpoint string, client *http.Client) (*Client, error) {
@@ -168,18 +200,29 @@ func (t *httpReadWriteNopCloser) Close() error {
 // NewHTTPServer creates a new HTTP RPC server around an API provider.
 //
 // Deprecated: Server implements http.Handler
-func NewHTTPServer(cors []string, vhosts []string, srv *Server) *http.Server {
+func NewHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, srv *Server) *http.Server {
 	// Wrap the CORS-handler within a host-handler
 	handler := newCorsHandler(srv, cors)
 	handler = newVHostHandler(vhosts, handler)
-	return &http.Server{Handler: handler}
+	return &http.Server{
+		Handler:      handler,
+		ReadTimeout:  timeouts.ReadTimeout,
+		WriteTimeout: timeouts.WriteTimeout,
+		IdleTimeout:  timeouts.IdleTimeout,
+	}
 }
 
-func NewFastHTTPServer(cors []string, vhosts []string, srv *Server) *fasthttp.Server {
+func NewFastHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, srv *Server) *fasthttp.Server {
 	if len(cors) == 0 {
 		for _, vhost := range vhosts {
 			if vhost == "*" {
-				return &fasthttp.Server{Concurrency: concurrencyLimit, Handler: srv.HandleFastHTTP}
+				return &fasthttp.Server{
+					Concurrency:  concurrencyLimit,
+					Handler:      srv.HandleFastHTTP,
+					ReadTimeout:  timeouts.ReadTimeout,
+					WriteTimeout: timeouts.WriteTimeout,
+					IdleTimeout:  timeouts.IdleTimeout,
+				}
 			}
 		}
 	}
@@ -190,7 +233,13 @@ func NewFastHTTPServer(cors []string, vhosts []string, srv *Server) *fasthttp.Se
 	fhandler := fasthttpadaptor.NewFastHTTPHandler(handler)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
-	return &fasthttp.Server{Concurrency: concurrencyLimit, Handler: fhandler}
+	return &fasthttp.Server{
+		Concurrency:  concurrencyLimit,
+		Handler:      fhandler,
+		ReadTimeout:  timeouts.ReadTimeout,
+		WriteTimeout: timeouts.WriteTimeout,
+		IdleTimeout:  timeouts.IdleTimeout,
+	}
 }
 
 // ServeHTTP serves JSON-RPC requests over HTTP.

--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -201,6 +201,7 @@ func (t *httpReadWriteNopCloser) Close() error {
 //
 // Deprecated: Server implements http.Handler
 func NewHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, srv *Server) *http.Server {
+	timeouts = sanitizeTimeouts(timeouts)
 	// Wrap the CORS-handler within a host-handler
 	handler := newCorsHandler(srv, cors)
 	handler = newVHostHandler(vhosts, handler)
@@ -213,6 +214,7 @@ func NewHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, srv *S
 }
 
 func NewFastHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, srv *Server) *fasthttp.Server {
+	timeouts = sanitizeTimeouts(timeouts)
 	if len(cors) == 0 {
 		for _, vhost := range vhosts {
 			if vhost == "*" {

--- a/networks/rpc/utils.go
+++ b/networks/rpc/utils.go
@@ -224,3 +224,22 @@ func NewID() ID {
 
 	return ID("0x" + rpcId)
 }
+
+// sanitizeTimeouts sets timeouts to default one if timeout is too short.
+func sanitizeTimeouts(timeouts HTTPTimeouts) HTTPTimeouts {
+	// Make sure timeout values are meaningful
+	if timeouts.ReadTimeout < time.Second {
+		logger.Warn("Sanitizing invalid HTTP read timeout", "provided", timeouts.ReadTimeout, "updated", DefaultHTTPTimeouts.ReadTimeout)
+		timeouts.ReadTimeout = DefaultHTTPTimeouts.ReadTimeout
+	}
+	if timeouts.WriteTimeout < time.Second {
+		logger.Warn("Sanitizing invalid HTTP write timeout", "provided", timeouts.WriteTimeout, "updated", DefaultHTTPTimeouts.WriteTimeout)
+		timeouts.WriteTimeout = DefaultHTTPTimeouts.WriteTimeout
+	}
+	if timeouts.IdleTimeout < time.Second {
+		logger.Warn("Sanitizing invalid HTTP idle timeout", "provided", timeouts.IdleTimeout, "updated", DefaultHTTPTimeouts.IdleTimeout)
+		timeouts.IdleTimeout = DefaultHTTPTimeouts.IdleTimeout
+	}
+
+	return timeouts
+}

--- a/networks/rpc/websocket.go
+++ b/networks/rpc/websocket.go
@@ -164,6 +164,7 @@ func (srv *Server) FastWebsocketHandler(ctx *fasthttp.RequestCtx) {
 //
 // Deprecated: use Server.WebsocketHandler
 func NewWSServer(allowedOrigins []string, timeouts HTTPTimeouts, srv *Server) *http.Server {
+	timeouts = sanitizeTimeouts(timeouts)
 	return &http.Server{
 		Handler:      srv.WebsocketHandler(allowedOrigins),
 		ReadTimeout:  timeouts.ReadTimeout,
@@ -173,6 +174,7 @@ func NewWSServer(allowedOrigins []string, timeouts HTTPTimeouts, srv *Server) *h
 }
 
 func NewFastWSServer(allowedOrigins []string, timeouts HTTPTimeouts, srv *Server) *fasthttp.Server {
+	timeouts = sanitizeTimeouts(timeouts)
 	upgrader.CheckOrigin = wsFastHandshakeValidator(allowedOrigins)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)

--- a/networks/rpc/websocket.go
+++ b/networks/rpc/websocket.go
@@ -163,15 +163,27 @@ func (srv *Server) FastWebsocketHandler(ctx *fasthttp.RequestCtx) {
 // NewWSServer creates a new websocket RPC server around an API provider.
 //
 // Deprecated: use Server.WebsocketHandler
-func NewWSServer(allowedOrigins []string, srv *Server) *http.Server {
-	return &http.Server{Handler: srv.WebsocketHandler(allowedOrigins)}
+func NewWSServer(allowedOrigins []string, timeouts HTTPTimeouts, srv *Server) *http.Server {
+	return &http.Server{
+		Handler:      srv.WebsocketHandler(allowedOrigins),
+		ReadTimeout:  timeouts.ReadTimeout,
+		WriteTimeout: timeouts.WriteTimeout,
+		IdleTimeout:  timeouts.IdleTimeout,
+	}
 }
 
-func NewFastWSServer(allowedOrigins []string, srv *Server) *fasthttp.Server {
+func NewFastWSServer(allowedOrigins []string, timeouts HTTPTimeouts, srv *Server) *fasthttp.Server {
 	upgrader.CheckOrigin = wsFastHandshakeValidator(allowedOrigins)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
-	return &fasthttp.Server{Concurrency: concurrencyLimit, MaxRequestBodySize: common.MaxRequestContentLength, Handler: srv.FastWebsocketHandler}
+	return &fasthttp.Server{
+		Concurrency:        concurrencyLimit,
+		MaxRequestBodySize: common.MaxRequestContentLength,
+		Handler:            srv.FastWebsocketHandler,
+		ReadTimeout:        timeouts.ReadTimeout,
+		WriteTimeout:       timeouts.WriteTimeout,
+		IdleTimeout:        timeouts.IdleTimeout,
+	}
 }
 
 func wsFastHandshakeValidator(allowedOrigins []string) func(ctx *fasthttp.RequestCtx) bool {

--- a/networks/rpc/websocket.go
+++ b/networks/rpc/websocket.go
@@ -163,18 +163,13 @@ func (srv *Server) FastWebsocketHandler(ctx *fasthttp.RequestCtx) {
 // NewWSServer creates a new websocket RPC server around an API provider.
 //
 // Deprecated: use Server.WebsocketHandler
-func NewWSServer(allowedOrigins []string, timeouts HTTPTimeouts, srv *Server) *http.Server {
-	timeouts = sanitizeTimeouts(timeouts)
+func NewWSServer(allowedOrigins []string, srv *Server) *http.Server {
 	return &http.Server{
-		Handler:      srv.WebsocketHandler(allowedOrigins),
-		ReadTimeout:  timeouts.ReadTimeout,
-		WriteTimeout: timeouts.WriteTimeout,
-		IdleTimeout:  timeouts.IdleTimeout,
+		Handler: srv.WebsocketHandler(allowedOrigins),
 	}
 }
 
-func NewFastWSServer(allowedOrigins []string, timeouts HTTPTimeouts, srv *Server) *fasthttp.Server {
-	timeouts = sanitizeTimeouts(timeouts)
+func NewFastWSServer(allowedOrigins []string, srv *Server) *fasthttp.Server {
 	upgrader.CheckOrigin = wsFastHandshakeValidator(allowedOrigins)
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
@@ -182,9 +177,6 @@ func NewFastWSServer(allowedOrigins []string, timeouts HTTPTimeouts, srv *Server
 		Concurrency:        concurrencyLimit,
 		MaxRequestBodySize: common.MaxRequestContentLength,
 		Handler:            srv.FastWebsocketHandler,
-		ReadTimeout:        timeouts.ReadTimeout,
-		WriteTimeout:       timeouts.WriteTimeout,
-		IdleTimeout:        timeouts.IdleTimeout,
 	}
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -29,8 +29,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/klaytn/klaytn/storage/database"
-
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/accounts/keystore"
 	"github.com/klaytn/klaytn/common"
@@ -38,6 +36,8 @@ import (
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/networks/p2p"
 	"github.com/klaytn/klaytn/networks/p2p/discover"
+	"github.com/klaytn/klaytn/networks/rpc"
+	"github.com/klaytn/klaytn/storage/database"
 )
 
 const (
@@ -126,6 +126,10 @@ type Config struct {
 	// If the module list is empty, all RPC API endpoints designated public will be
 	// exposed.
 	HTTPModules []string `toml:",omitempty"`
+
+	// HTTPTimeouts allows for customization of the timeout values used by the HTTP RPC
+	// interface.
+	HTTPTimeouts rpc.HTTPTimeouts
 
 	// WSHost is the host interface on which to start the websocket RPC server. If
 	// this field is empty, no websocket API endpoint will be started.

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -28,6 +28,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/klaytn/klaytn/networks/rpc"
+
 	"github.com/klaytn/klaytn/storage/database"
 
 	"github.com/klaytn/klaytn/networks/p2p"
@@ -53,6 +55,7 @@ var DefaultConfig = Config{
 	HTTPPort:         DefaultHTTPPort,
 	HTTPModules:      []string{"net", "web3"},
 	HTTPVirtualHosts: []string{"localhost"},
+	HTTPTimeouts:     rpc.DefaultHTTPTimeouts,
 	WSPort:           DefaultWSPort,
 	WSModules:        []string{"net", "web3"},
 	GRPCPort:         DefaultGRPCPort,

--- a/node/node.go
+++ b/node/node.go
@@ -326,24 +326,24 @@ func (n *Node) startRPC(services map[reflect.Type]Service) error {
 		return err
 	}
 	if n.config.IsFastHTTP() {
-		if err := n.startFastHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPVirtualHosts); err != nil {
+		if err := n.startFastHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPVirtualHosts, n.config.HTTPTimeouts); err != nil {
 			n.stopIPC()
 			n.stopInProc()
 			return err
 		}
-		if err := n.startFastWS(n.wsEndpoint, apis, n.config.WSModules, n.config.WSOrigins, n.config.WSExposeAll); err != nil {
+		if err := n.startFastWS(n.wsEndpoint, apis, n.config.WSModules, n.config.WSOrigins, n.config.WSExposeAll, n.config.HTTPTimeouts); err != nil {
 			n.stopHTTP()
 			n.stopIPC()
 			n.stopInProc()
 			return err
 		}
 	} else {
-		if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPVirtualHosts); err != nil {
+		if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPVirtualHosts, n.config.HTTPTimeouts); err != nil {
 			n.stopIPC()
 			n.stopInProc()
 			return err
 		}
-		if err := n.startWS(n.wsEndpoint, apis, n.config.WSModules, n.config.WSOrigins, n.config.WSExposeAll); err != nil {
+		if err := n.startWS(n.wsEndpoint, apis, n.config.WSModules, n.config.WSOrigins, n.config.WSExposeAll, n.config.HTTPTimeouts); err != nil {
 			n.stopHTTP()
 			n.stopIPC()
 			n.stopInProc()
@@ -441,12 +441,12 @@ func (n *Node) startgRPC(apis []rpc.API) error {
 }
 
 // startHTTP initializes and starts the HTTP RPC endpoint.
-func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, vhosts []string) error {
+func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, vhosts []string, timeouts rpc.HTTPTimeouts) error {
 	// Short circuit if the HTTP endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartHTTPEndpoint(endpoint, apis, modules, cors, vhosts)
+	listener, handler, err := rpc.StartHTTPEndpoint(endpoint, apis, modules, cors, vhosts, timeouts)
 	if err != nil {
 		return err
 	}
@@ -460,12 +460,12 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 }
 
 // startFastHTTP initializes and starts the HTTP RPC endpoint.
-func (n *Node) startFastHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, vhosts []string) error {
+func (n *Node) startFastHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, vhosts []string, timeouts rpc.HTTPTimeouts) error {
 	// Short circuit if the HTTP endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartFastHTTPEndpoint(endpoint, apis, modules, cors, vhosts)
+	listener, handler, err := rpc.StartFastHTTPEndpoint(endpoint, apis, modules, cors, vhosts, timeouts)
 	if err != nil {
 		return err
 	}
@@ -493,12 +493,12 @@ func (n *Node) stopHTTP() {
 }
 
 // startWS initializes and starts the websocket RPC endpoint.
-func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrigins []string, exposeAll bool) error {
+func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrigins []string, exposeAll bool, timeouts rpc.HTTPTimeouts) error {
 	// Short circuit if the WS endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll)
+	listener, handler, err := rpc.StartWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll, timeouts)
 	if err != nil {
 		return err
 	}
@@ -512,12 +512,12 @@ func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrig
 }
 
 // startFastWS initializes and starts the websocket RPC endpoint.
-func (n *Node) startFastWS(endpoint string, apis []rpc.API, modules []string, wsOrigins []string, exposeAll bool) error {
+func (n *Node) startFastWS(endpoint string, apis []rpc.API, modules []string, wsOrigins []string, exposeAll bool, timeouts rpc.HTTPTimeouts) error {
 	// Short circuit if the WS endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartFastWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll)
+	listener, handler, err := rpc.StartFastWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll, timeouts)
 	if err != nil {
 		return err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -331,7 +331,7 @@ func (n *Node) startRPC(services map[reflect.Type]Service) error {
 			n.stopInProc()
 			return err
 		}
-		if err := n.startFastWS(n.wsEndpoint, apis, n.config.WSModules, n.config.WSOrigins, n.config.WSExposeAll, n.config.HTTPTimeouts); err != nil {
+		if err := n.startFastWS(n.wsEndpoint, apis, n.config.WSModules, n.config.WSOrigins, n.config.WSExposeAll); err != nil {
 			n.stopHTTP()
 			n.stopIPC()
 			n.stopInProc()
@@ -343,7 +343,7 @@ func (n *Node) startRPC(services map[reflect.Type]Service) error {
 			n.stopInProc()
 			return err
 		}
-		if err := n.startWS(n.wsEndpoint, apis, n.config.WSModules, n.config.WSOrigins, n.config.WSExposeAll, n.config.HTTPTimeouts); err != nil {
+		if err := n.startWS(n.wsEndpoint, apis, n.config.WSModules, n.config.WSOrigins, n.config.WSExposeAll); err != nil {
 			n.stopHTTP()
 			n.stopIPC()
 			n.stopInProc()
@@ -493,12 +493,12 @@ func (n *Node) stopHTTP() {
 }
 
 // startWS initializes and starts the websocket RPC endpoint.
-func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrigins []string, exposeAll bool, timeouts rpc.HTTPTimeouts) error {
+func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrigins []string, exposeAll bool) error {
 	// Short circuit if the WS endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll, timeouts)
+	listener, handler, err := rpc.StartWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll)
 	if err != nil {
 		return err
 	}
@@ -512,12 +512,12 @@ func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrig
 }
 
 // startFastWS initializes and starts the websocket RPC endpoint.
-func (n *Node) startFastWS(endpoint string, apis []rpc.API, modules []string, wsOrigins []string, exposeAll bool, timeouts rpc.HTTPTimeouts) error {
+func (n *Node) startFastWS(endpoint string, apis []rpc.API, modules []string, wsOrigins []string, exposeAll bool) error {
 	// Short circuit if the WS endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartFastWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll, timeouts)
+	listener, handler, err := rpc.StartFastWSEndpoint(endpoint, apis, modules, wsOrigins, exposeAll)
 	if err != nil {
 		return err
 	}

--- a/node/utils.go
+++ b/node/utils.go
@@ -238,13 +238,13 @@ func (api *PrivateAdminAPI) StartWS(host *string, port *int, allowedOrigins *str
 	if api.node.config.IsFastHTTP() {
 		if err := api.node.startFastWS(
 			fmt.Sprintf("%s:%d", *host, *port),
-			api.node.rpcAPIs, modules, origins, api.node.config.WSExposeAll, api.node.config.HTTPTimeouts); err != nil {
+			api.node.rpcAPIs, modules, origins, api.node.config.WSExposeAll); err != nil {
 			return false, err
 		}
 	} else {
 		if err := api.node.startWS(
 			fmt.Sprintf("%s:%d", *host, *port),
-			api.node.rpcAPIs, modules, origins, api.node.config.WSExposeAll, api.node.config.HTTPTimeouts); err != nil {
+			api.node.rpcAPIs, modules, origins, api.node.config.WSExposeAll); err != nil {
 			return false, err
 		}
 	}

--- a/node/utils.go
+++ b/node/utils.go
@@ -172,11 +172,15 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 	}
 
 	if api.node.config.IsFastHTTP() {
-		if err := api.node.startFastHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, allowedOrigins, allowedVHosts); err != nil {
+		if err := api.node.startFastHTTP(
+			fmt.Sprintf("%s:%d", *host, *port),
+			api.node.rpcAPIs, modules, allowedOrigins, allowedVHosts, api.node.config.HTTPTimeouts); err != nil {
 			return false, err
 		}
 	} else {
-		if err := api.node.startHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, allowedOrigins, allowedVHosts); err != nil {
+		if err := api.node.startHTTP(
+			fmt.Sprintf("%s:%d", *host, *port),
+			api.node.rpcAPIs, modules, allowedOrigins, allowedVHosts, api.node.config.HTTPTimeouts); err != nil {
 			return false, err
 		}
 	}
@@ -232,11 +236,15 @@ func (api *PrivateAdminAPI) StartWS(host *string, port *int, allowedOrigins *str
 	}
 
 	if api.node.config.IsFastHTTP() {
-		if err := api.node.startFastWS(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, origins, api.node.config.WSExposeAll); err != nil {
+		if err := api.node.startFastWS(
+			fmt.Sprintf("%s:%d", *host, *port),
+			api.node.rpcAPIs, modules, origins, api.node.config.WSExposeAll, api.node.config.HTTPTimeouts); err != nil {
 			return false, err
 		}
 	} else {
-		if err := api.node.startWS(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, origins, api.node.config.WSExposeAll); err != nil {
+		if err := api.node.startWS(
+			fmt.Sprintf("%s:%d", *host, *port),
+			api.node.rpcAPIs, modules, origins, api.node.config.WSExposeAll, api.node.config.HTTPTimeouts); err != nil {
 			return false, err
 		}
 	}


### PR DESCRIPTION
## Proposed changes

This PR is the same as #721 and remained only timeout-related codes.
I have tested this manually. Hard to create unittests, but please let me know if you have any suggenstion.
Below is the original description.

This PR sets several timeouts for RPC/WS server based on https://github.com/ethereum/go-ethereum/pull/17240 like below.

```
var DefaultHTTPTimeouts = HTTPTimeouts{
	ReadTimeout:  30 * time.Second,
	WriteTimeout: 30 * time.Second,
	IdleTimeout:  120 * time.Second,
}
```

Before this PR, there is no time out, so server has unlimited timeouts.
And this applied the latest fast http pkg and minor change.

some genconfig files are updated.

If we want to change the timeout config, we need create  any config file (eg. `http_timeout.toml`) like below.
```
[Node.HTTPTimeouts]
ReadTimeout = 50000000000
WriteTimeout = 50000000000
IdleTimeout = 200000000000
```
Then we can run a EN like below.
`ken --config http_timeout.toml ... `

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

