### PR TITLE
Limit the number of subscriptions for a websocket connection

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -48,6 +48,7 @@ import (
 	"github.com/klaytn/klaytn/networks/p2p/discover"
 	"github.com/klaytn/klaytn/networks/p2p/nat"
 	"github.com/klaytn/klaytn/networks/p2p/netutil"
+	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/node"
 	"github.com/klaytn/klaytn/node/cn"
 	"github.com/klaytn/klaytn/node/sc"
@@ -444,14 +445,6 @@ var (
 		Name:  "rpc.gascap",
 		Usage: "Sets a cap on gas that can be used in klay_call/estimateGas",
 	}
-	IPCDisabledFlag = cli.BoolFlag{
-		Name:  "ipcdisable",
-		Usage: "Disable the IPC-RPC server",
-	}
-	IPCPathFlag = DirectoryFlag{
-		Name:  "ipcpath",
-		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
-	}
 	WSEnabledFlag = cli.BoolFlag{
 		Name:  "ws",
 		Usage: "Enable the WS-RPC server",
@@ -465,6 +458,21 @@ var (
 		Name:  "wsport",
 		Usage: "WS-RPC server listening port",
 		Value: node.DefaultWSPort,
+	}
+	WSApiFlag = cli.StringFlag{
+		Name:  "wsapi",
+		Usage: "API's offered over the WS-RPC interface",
+		Value: "",
+	}
+	WSAllowedOriginsFlag = cli.StringFlag{
+		Name:  "wsorigins",
+		Usage: "Origins from which to accept websockets requests",
+		Value: "",
+	}
+	WSMaxSubscriptionPerConn = cli.IntFlag{
+		Name:  "wsmaxsubscriptionperconn",
+		Usage: "Allowed maximum subscription number per a websocket connection",
+		Value: 5,
 	}
 	GRPCEnabledFlag = cli.BoolFlag{
 		Name:  "grpc",
@@ -480,15 +488,13 @@ var (
 		Usage: "gRPC server listening port",
 		Value: node.DefaultGRPCPort,
 	}
-	WSApiFlag = cli.StringFlag{
-		Name:  "wsapi",
-		Usage: "API's offered over the WS-RPC interface",
-		Value: "",
+	IPCDisabledFlag = cli.BoolFlag{
+		Name:  "ipcdisable",
+		Usage: "Disable the IPC-RPC server",
 	}
-	WSAllowedOriginsFlag = cli.StringFlag{
-		Name:  "wsorigins",
-		Usage: "Origins from which to accept websockets requests",
-		Value: "",
+	IPCPathFlag = DirectoryFlag{
+		Name:  "ipcpath",
+		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
 	}
 	ExecFlag = cli.StringFlag{
 		Name:  "exec",
@@ -1121,6 +1127,7 @@ func setWS(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(WSApiFlag.Name) {
 		cfg.WSModules = splitAndTrim(ctx.GlobalString(WSApiFlag.Name))
 	}
+	rpc.MaxSubscriptionPerConn = int32(ctx.GlobalInt(WSMaxSubscriptionPerConn.Name))
 }
 
 // setIPC creates an IPC path configuration from the set command line flags,

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -127,6 +127,7 @@ var CommonRPCFlags = []cli.Flag{
 	utils.GRPCPortFlag,
 	utils.WSApiFlag,
 	utils.WSAllowedOriginsFlag,
+	utils.WSMaxSubscriptionPerConn,
 	utils.IPCDisabledFlag,
 	utils.IPCPathFlag,
 }

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -295,6 +295,11 @@ web3._extend({
 			name: 'saveTrieNodeCacheToDisk',
 			call: 'admin_saveTrieNodeCacheToDisk',
 		}),
+		new web3._extend.Method({
+			name: 'setMaxSubscriptionPerConn',
+			call: 'admin_setMaxSubscriptionPerConn',
+			params: 1
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -49,13 +49,15 @@ const (
 
 	// concurrencyLimit is a limit for the number of concurrency connection for RPC servers
 	concurrencyLimit = 3000
-
-	// maxSubscriptionPerConn is a maximum number of subscription for a server connection
-	maxSubscriptionPerConn = 5
 )
 
-// pendingRequestCount is a total number of concurrent RPC method calls
-var pendingRequestCount int64 = 0
+var (
+	// pendingRequestCount is a total number of concurrent RPC method calls
+	pendingRequestCount int64 = 0
+
+	// MaxSubscriptionPerConn is a maximum number of subscription for a server connection
+	MaxSubscriptionPerConn int32 = 5
+)
 
 // NewServer will create a new server instance with no registered handlers.
 func NewServer() *Server {
@@ -346,9 +348,9 @@ func (s *Server) handle(ctx context.Context, codec ServerCodec, req *serverReque
 	}
 
 	if req.callb.isSubscribe {
-		if atomic.LoadInt32(subCnt) >= maxSubscriptionPerConn {
+		if atomic.LoadInt32(subCnt) >= MaxSubscriptionPerConn {
 			return codec.CreateErrorResponse(&req.id, &callbackError{
-				fmt.Sprintf("Maximum %d subscriptions are allowed for a websocket connection", maxSubscriptionPerConn),
+				fmt.Sprintf("Maximum %d subscriptions are allowed for a websocket connection", MaxSubscriptionPerConn),
 			}), nil
 		}
 

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -51,7 +51,7 @@ const (
 	concurrencyLimit = 3000
 
 	// maxSubscriptionPerConn is a maximum number of subscription for a server connection
-	maxSubscriptionPerConn = 10
+	maxSubscriptionPerConn = 5
 )
 
 // pendingRequestCount is a total number of concurrent RPC method calls

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -350,7 +350,8 @@ func (s *Server) handle(ctx context.Context, codec ServerCodec, req *serverReque
 	if req.callb.isSubscribe {
 		if atomic.LoadInt32(subCnt) >= MaxSubscriptionPerConn {
 			return codec.CreateErrorResponse(&req.id, &callbackError{
-				fmt.Sprintf("Maximum %d subscriptions are allowed for a websocket connection", MaxSubscriptionPerConn),
+				fmt.Sprintf("Maximum %d subscriptions are allowed for a websocket connection. "+
+					"The limit can be updated with 'admin_setMaxSubscriptionPerConn' API", MaxSubscriptionPerConn),
 			}), nil
 		}
 

--- a/networks/rpc/subscription_test.go
+++ b/networks/rpc/subscription_test.go
@@ -230,6 +230,12 @@ func waitForMessages(t *testing.T, in *json.Decoder, successes chan<- jsonSucces
 // TestSubscriptionMultipleNamespaces ensures that subscriptions can exists
 // for multiple different namespaces.
 func TestSubscriptionMultipleNamespaces(t *testing.T) {
+	oldMaxSubscription := MaxSubscriptionPerConn
+	MaxSubscriptionPerConn = 100
+	defer func() {
+		MaxSubscriptionPerConn = oldMaxSubscription
+	}()
+
 	var (
 		namespaces             = []string{"klay", "shh", "bzz"}
 		server                 = NewServer()

--- a/node/utils.go
+++ b/node/utils.go
@@ -23,14 +23,15 @@ package node
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/networks/p2p"
 	"github.com/klaytn/klaytn/networks/p2p/discover"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/rcrowley/go-metrics"
-	"strings"
-	"time"
 )
 
 // PrivateAdminAPI is the collection of administrative API methods exposed only
@@ -252,6 +253,12 @@ func (api *PrivateAdminAPI) StopWS() (bool, error) {
 	}
 	api.node.stopWS()
 	return true, nil
+}
+
+func (api *PrivateAdminAPI) SetMaxSubscriptionPerConn(num int32) {
+	logger.Info("Change the max subscription number for a websocket connection",
+		"old", rpc.MaxSubscriptionPerConn, "new", num)
+	rpc.MaxSubscriptionPerConn = num
 }
 
 // PublicAdminAPI is the collection of administrative API methods exposed over


### PR DESCRIPTION
## Proposed changes

Too many subscriptions `klay_subscription` can delay block synchronization or cause Out-of-Memory of Klaytn nodes. 
For ENs used in enterprise services, Klaytn nodes need to manage the subscription number on the server-side. 
This PR limits the maximum subscription number for a server connection to 10.

If a user requests more than 10 active subscriptions, he/she will get the following error.
```
{
  "jsonrpc": "2.0",
  "id": 0,
  "error": {
    "code": -32000,
    "message": "Maximum 10 subscriptions are allowed for a websocket connection"
  }
```

~TODO: consider obtaining `maxSubscriptionPerConn` from a flag value.~ 
=> New API `admin_setMaxSubscriptionPerConn` is introduced and tested on my local environment. 
\+ New flag `wsmaxsubscriptionperconn` is added. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
