### PR TITLE
Set websocket connection deadline

### DIFF
--- a/networks/rpc/websocket.go
+++ b/networks/rpc/websocket.go
@@ -96,6 +96,8 @@ func (srv *Server) FastWebsocketHandler(ctx *fasthttp.RequestCtx) {
 	}
 
 	err := upgrader.Upgrade(ctx, func(conn *fastws.Conn) {
+		conn.SetReadDeadline(time.Now().Add(5 * time.Minute)) // Each connection will be closed after the deadline
+
 		//Create a custom encode/decode pair to enforce payload size and number encoding
 		encoder := func(v interface{}) error {
 			msg, err := json.Marshal(v)


### PR DESCRIPTION
## Proposed changes

With this change, each websocket connection will be closed after 5-minute deadline
Since ws upgrader hijacks the original websocket hadler, the deadline is set in the handler of the upgrader. 

After 5 minute, a user receives the following error through the websocket connection.
```
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32600,
    "message": "read tcp4 127.0.0.1:8552->127.0.0.1:64645: i/o timeout"
  }
}
```

TODO: Consider parameterize ws daedline. 
NOTE: This PR is only for a hotfix. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
