### PR TITLE
Prque for []byte type in priority

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -145,7 +145,7 @@ func MakeRandomBytes(n int) []byte {
 	return s
 }
 
-// IntToByteLittleEndian encodes a number as little endian uint64
+// Uint64ToByteLittleEndian encodes a number as little endian uint64
 func Uint64ToByteLittleEndian(num uint64) []byte {
 	enc := make([]byte, 8)
 	binary.LittleEndian.PutUint64(enc, num)

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -160,3 +160,8 @@ func Int64ToByteBigEndian(number uint64) []byte {
 
 	return enc
 }
+
+// Int64ToByteBigEndian encodes a number as big endian uint64
+func ByteBigEndianToInt64(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -146,22 +146,22 @@ func MakeRandomBytes(n int) []byte {
 }
 
 // IntToByteLittleEndian encodes a number as little endian uint64
-func Int64ToByteLittleEndian(num uint64) []byte {
+func Uint64ToByteLittleEndian(num uint64) []byte {
 	enc := make([]byte, 8)
 	binary.LittleEndian.PutUint64(enc, num)
 
 	return enc
 }
 
-// Int64ToByteBigEndian encodes a number as big endian uint64
-func Int64ToByteBigEndian(number uint64) []byte {
+// Uint64ToByteBigEndian encodes a number as big endian uint64
+func Uint64ToByteBigEndian(number uint64) []byte {
 	enc := make([]byte, 8)
 	binary.BigEndian.PutUint64(enc, number)
 
 	return enc
 }
 
-// Int64ToByteBigEndian encodes a number as big endian uint64
-func ByteBigEndianToInt64(b []byte) uint64 {
+// ByteBigEndianToUint64 decodes big endian uint64 to a number
+func ByteBigEndianToUint64(b []byte) uint64 {
 	return binary.BigEndian.Uint64(b)
 }

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -104,8 +104,8 @@ func TestNoPrefixShortHexOddLength(t *testing.T) {
 	}
 }
 
-func TestInt64ToByteBigEndian(t *testing.T) {
-	expected := []byte{1, 3, 4, 2}
+func TestUint64ToByteBigEndian(t *testing.T) {
+	expected := []byte{9, 1, 5, 3, 4, 2, 8, 6}
 	input := uint64(
 		9*256*256*256*256*256*256*256 +
 			1*256*256*256*256*256*256 +
@@ -121,7 +121,7 @@ func TestInt64ToByteBigEndian(t *testing.T) {
 	}
 }
 
-func TestByteBigEndianToInt64(t *testing.T) {
+func TestByteBigEndianToUint64(t *testing.T) {
 	expected := uint64(
 		9*256*256*256*256*256*256*256 +
 			1*256*256*256*256*256*256 +
@@ -138,7 +138,7 @@ func TestByteBigEndianToInt64(t *testing.T) {
 	}
 }
 
-func TestInt64ToByteBigEndian_Convert(t *testing.T) {
+func TestUint64ToByteBigEndian_Convert(t *testing.T) {
 	input := uint64(789456123)
 	b := Uint64ToByteBigEndian(input)
 	n := ByteBigEndianToUint64(b)
@@ -147,7 +147,7 @@ func TestInt64ToByteBigEndian_Convert(t *testing.T) {
 	}
 }
 
-func TestByteBigEndianToInt64_Convert(t *testing.T) {
+func TestByteBigEndianToUint64_Convert(t *testing.T) {
 	input := MakeRandomBytes(8)
 	n := ByteBigEndianToUint64(input)
 	b := Uint64ToByteBigEndian(n)

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -105,6 +105,40 @@ func TestNoPrefixShortHexOddLength(t *testing.T) {
 }
 
 func TestInt64ToByteBigEndian(t *testing.T) {
+	expected := []byte{1, 3, 4, 2}
+	input := uint64(
+		9*256*256*256*256*256*256*256 +
+			1*256*256*256*256*256*256 +
+			5*256*256*256*256*256 +
+			3*256*256*256*256 +
+			4*256*256*256 +
+			2*256*256 +
+			8*256 +
+			6)
+	result := Uint64ToByteBigEndian(input)[4:]
+	if !bytes.Equal(expected, result) {
+		t.Errorf("Expected %x got %x", expected, result)
+	}
+}
+
+func TestByteBigEndianToInt64(t *testing.T) {
+	expected := uint64(
+		9*256*256*256*256*256*256*256 +
+			1*256*256*256*256*256*256 +
+			5*256*256*256*256*256 +
+			3*256*256*256*256 +
+			4*256*256*256 +
+			2*256*256 +
+			8*256 +
+			6)
+	input := []byte{9, 1, 5, 3, 4, 2, 8, 6}
+	n := ByteBigEndianToUint64(input)
+	if n != expected {
+		t.Errorf("Expected %x got %x", input, expected)
+	}
+}
+
+func TestInt64ToByteBigEndian_Convert(t *testing.T) {
 	input := uint64(789456123)
 	b := Uint64ToByteBigEndian(input)
 	n := ByteBigEndianToUint64(b)
@@ -113,7 +147,7 @@ func TestInt64ToByteBigEndian(t *testing.T) {
 	}
 }
 
-func TestByteBigEndianToInt64(t *testing.T) {
+func TestByteBigEndianToInt64_Convert(t *testing.T) {
 	input := MakeRandomBytes(8)
 	n := ByteBigEndianToUint64(input)
 	b := Uint64ToByteBigEndian(n)

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -103,3 +103,21 @@ func TestNoPrefixShortHexOddLength(t *testing.T) {
 		t.Errorf("Expected %x got %x", expected, result)
 	}
 }
+
+func TestInt64ToByteBigEndian(t *testing.T) {
+	input := uint64(789456123)
+	b := Int64ToByteBigEndian(input)
+	n := ByteBigEndianToInt64(b)
+	if input != n {
+		t.Errorf("Expected %x got %x", input, n)
+	}
+}
+
+func TestByteBigEndianToInt64(t *testing.T) {
+	input := MakeRandomBytes(8)
+	n := ByteBigEndianToInt64(input)
+	b := Int64ToByteBigEndian(n)
+	if !bytes.Equal(input, b) {
+		t.Errorf("Expected %x got %x", input, b)
+	}
+}

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -106,8 +106,8 @@ func TestNoPrefixShortHexOddLength(t *testing.T) {
 
 func TestInt64ToByteBigEndian(t *testing.T) {
 	input := uint64(789456123)
-	b := Int64ToByteBigEndian(input)
-	n := ByteBigEndianToInt64(b)
+	b := Uint64ToByteBigEndian(input)
+	n := ByteBigEndianToUint64(b)
 	if input != n {
 		t.Errorf("Expected %x got %x", input, n)
 	}
@@ -115,8 +115,8 @@ func TestInt64ToByteBigEndian(t *testing.T) {
 
 func TestByteBigEndianToInt64(t *testing.T) {
 	input := MakeRandomBytes(8)
-	n := ByteBigEndianToInt64(input)
-	b := Int64ToByteBigEndian(n)
+	n := ByteBigEndianToUint64(input)
+	b := Uint64ToByteBigEndian(n)
 	if !bytes.Equal(input, b) {
 		t.Errorf("Expected %x got %x", input, b)
 	}

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -115,7 +115,7 @@ func TestUint64ToByteBigEndian(t *testing.T) {
 			2*256*256 +
 			8*256 +
 			6)
-	result := Uint64ToByteBigEndian(input)[4:]
+	result := Uint64ToByteBigEndian(input)
 	if !bytes.Equal(expected, result) {
 		t.Errorf("Expected %x got %x", expected, result)
 	}

--- a/common/prque/prque_byteSlice.go
+++ b/common/prque/prque_byteSlice.go
@@ -1,0 +1,72 @@
+// CookieJar - A contestant's algorithm toolbox
+// Copyright (c) 2013 Peter Szilagyi. All rights reserved.
+//
+// CookieJar is dual licensed: use of this source code is governed by a BSD
+// license that can be found in the LICENSE file. Alternatively, the CookieJar
+// toolbox may be used in accordance with the terms and conditions contained
+// in a signed written agreement between you and the author(s).
+
+// This is a duplicated and slightly modified version of "gopkg.in/karalabe/cookiejar.v2/collections/prque".
+
+// Package prque implements a priority queue data structure supporting arbitrary
+// value types and int64 priorities.
+//
+// If you would like to use a max-priority queue, use NewByteSlice.
+// If you would like to use a min-priority queue, use NewByteSliceInverted.
+//
+// Internally the queue is based on the standard heap package working on a
+// sortable version of the block based stack.
+
+package prque
+
+import "container/heap"
+
+type PrqueByteSlice struct {
+	cont *sstackByte
+}
+
+// NewByteSlice creates a new max-priority queue.
+func NewByteSlice() *PrqueByteSlice {
+	return &PrqueByteSlice{newsstackByte(false)}
+}
+
+// NewByteSliceInverted creates a new min-priority queue.
+func NewByteSliceInverted() *PrqueByteSlice {
+	return &PrqueByteSlice{newsstackByte(true)}
+}
+
+// Pushes a value with a given priority into the queue, expanding if necessary.
+func (p *PrqueByteSlice) Push(data interface{}, priority []byte) {
+	heap.Push(p.cont, &itemByteSlice{data, priority})
+}
+
+// Pops the value with the greates priority off the stack and returns it.
+// Currently no shrinking is done.
+func (p *PrqueByteSlice) Pop() (interface{}, []byte) {
+	item := heap.Pop(p.cont).(*itemByteSlice)
+	return item.value, item.priority
+}
+
+// Pops only the item from the queue, dropping the associated priority value.
+func (p *PrqueByteSlice) PopItem() interface{} {
+	return heap.Pop(p.cont).(*itemByteSlice).value
+}
+
+// Checks whether the priority queue is empty.
+func (p *PrqueByteSlice) Empty() bool {
+	return p.cont.Len() == 0
+}
+
+// Returns the number of element in the priority queue.
+func (p *PrqueByteSlice) Size() int {
+	return p.cont.Len()
+}
+
+// Clears the contents of the priority queue.
+func (p *PrqueByteSlice) Reset() {
+	if p.cont.reverse {
+		*p = *NewByteSlice()
+	} else {
+		*p = *NewByteSliceInverted()
+	}
+}

--- a/common/prque/prque_byteSlice_test.go
+++ b/common/prque/prque_byteSlice_test.go
@@ -12,9 +12,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/klaytn/klaytn/common/math"
-
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/math"
 )
 
 func TestPrqueByteSlice(t *testing.T) {
@@ -52,6 +51,51 @@ func TestPrqueByteSlice(t *testing.T) {
 				t.Errorf("push/pop mismatch: have %v, want %v.", val, dict[prevPrio])
 			}
 			delete(dict, prevPrio)
+		}
+		if len(dict) != 0 {
+			t.Errorf("items left in dict: dict %v.", dict)
+		}
+	}
+}
+
+func TestPrqueByteSliceInverted(t *testing.T) {
+	// Generate a batch of random data and a specific priority order
+	size := 16 * blockSize
+	data := make([]int, size)
+	prio := make([][]byte, size)
+	for i := 0; i < size; i++ {
+		data[i] = rand.Int()
+		prio[i] = common.MakeRandomBytes(256)
+	}
+	queue := NewByteSliceInverted()
+	for rep := 0; rep < 2; rep++ {
+		// Fill a priority queue with the above data
+		for i := 0; i < size; i++ {
+			queue.Push(data[i], prio[i])
+			if queue.Size() != i+1 {
+				t.Errorf("queue size mismatch: have %v, want %v.", queue.Size(), i+1)
+			}
+		}
+		// Create a map the values to the priorities for easier verification
+		dict := make(map[uint64]int)
+		for i := 0; i < size; i++ {
+			dict[common.ByteBigEndianToUint64(prio[i])] = data[i]
+		}
+		// Pop out the elements in priority order and verify them
+		prevPrio := uint64(0)
+		for !queue.Empty() {
+			val, prio := queue.Pop()
+			if common.ByteBigEndianToUint64(prio) < prevPrio {
+				t.Errorf("invalid priority order: %v after %v.", prio, prevPrio)
+			}
+			prevPrio = common.ByteBigEndianToUint64(prio)
+			if val != dict[prevPrio] {
+				t.Errorf("push/pop mismatch: have %v, want %v.", val, dict[prevPrio])
+			}
+			delete(dict, prevPrio)
+		}
+		if len(dict) != 0 {
+			t.Errorf("items left in dict: dict %v.", dict)
 		}
 	}
 }

--- a/common/prque/prque_byteSlice_test.go
+++ b/common/prque/prque_byteSlice_test.go
@@ -1,0 +1,92 @@
+// CookieJar - A contestant's algorithm toolbox
+// Copyright (c) 2013 Peter Szilagyi. All rights reserved.
+//
+// CookieJar is dual licensed: use of this source code is governed by a BSD
+// license that can be found in the LICENSE file. Alternatively, the CookieJar
+// toolbox may be used in accordance with the terms and conditions contained
+// in a signed written agreement between you and the author(s).
+
+package prque
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/klaytn/klaytn/common/math"
+
+	"github.com/klaytn/klaytn/common"
+)
+
+func TestPrqueByteSlice(t *testing.T) {
+	// Generate a batch of random data and a specific priority order
+	size := 16 * blockSize
+	data := make([]int, size)
+	prio := make([][]byte, size)
+	for i := 0; i < size; i++ {
+		data[i] = rand.Int()
+		prio[i] = common.MakeRandomBytes(256)
+	}
+	queue := NewByteSlice()
+	for rep := 0; rep < 2; rep++ {
+		// Fill a priority queue with the above data
+		for i := 0; i < size; i++ {
+			queue.Push(data[i], prio[i])
+			if queue.Size() != i+1 {
+				t.Errorf("queue size mismatch: have %v, want %v.", queue.Size(), i+1)
+			}
+		}
+		// Create a map the values to the priorities for easier verification
+		dict := make(map[uint64]int)
+		for i := 0; i < size; i++ {
+			dict[common.ByteBigEndianToInt64(prio[i])] = data[i]
+		}
+		// Pop out the elements in priority order and verify them
+		prevPrio := uint64(math.MaxUint64)
+		for !queue.Empty() {
+			val, prio := queue.Pop()
+			if common.ByteBigEndianToInt64(prio) > prevPrio {
+				t.Errorf("invalid priority order: %v after %v.", prio, prevPrio)
+			}
+			prevPrio = common.ByteBigEndianToInt64(prio)
+			if val != dict[prevPrio] {
+				t.Errorf("push/pop mismatch: have %v, want %v.", val, dict[prevPrio])
+			}
+			delete(dict, prevPrio)
+		}
+	}
+}
+
+func BenchmarkPrqueByteSlicePush(b *testing.B) {
+	// Create some initial data
+	data := make([]int, b.N)
+	prio := make([][]byte, b.N)
+	for i := 0; i < len(data); i++ {
+		data[i] = rand.Int()
+		prio[i] = common.MakeRandomBytes(256)
+	}
+	// Execute the benchmark
+	b.ResetTimer()
+	queue := NewByteSlice()
+	for i := 0; i < len(data); i++ {
+		queue.Push(data[i], prio[i])
+	}
+}
+
+func BenchmarkPrqueByteSlicePop(b *testing.B) {
+	// Create some initial data
+	data := make([]int, b.N)
+	prio := make([][]byte, b.N)
+	for i := 0; i < len(data); i++ {
+		data[i] = rand.Int()
+		prio[i] = common.MakeRandomBytes(256)
+	}
+	queue := NewByteSlice()
+	for i := 0; i < len(data); i++ {
+		queue.Push(data[i], prio[i])
+	}
+	// Execute the benchmark
+	b.ResetTimer()
+	for !queue.Empty() {
+		queue.Pop()
+	}
+}

--- a/common/prque/prque_byteSlice_test.go
+++ b/common/prque/prque_byteSlice_test.go
@@ -38,16 +38,16 @@ func TestPrqueByteSlice(t *testing.T) {
 		// Create a map the values to the priorities for easier verification
 		dict := make(map[uint64]int)
 		for i := 0; i < size; i++ {
-			dict[common.ByteBigEndianToInt64(prio[i])] = data[i]
+			dict[common.ByteBigEndianToUint64(prio[i])] = data[i]
 		}
 		// Pop out the elements in priority order and verify them
 		prevPrio := uint64(math.MaxUint64)
 		for !queue.Empty() {
 			val, prio := queue.Pop()
-			if common.ByteBigEndianToInt64(prio) > prevPrio {
+			if common.ByteBigEndianToUint64(prio) > prevPrio {
 				t.Errorf("invalid priority order: %v after %v.", prio, prevPrio)
 			}
-			prevPrio = common.ByteBigEndianToInt64(prio)
+			prevPrio = common.ByteBigEndianToUint64(prio)
 			if val != dict[prevPrio] {
 				t.Errorf("push/pop mismatch: have %v, want %v.", val, dict[prevPrio])
 			}

--- a/common/prque/sstack_byteSlice.go
+++ b/common/prque/sstack_byteSlice.go
@@ -1,0 +1,101 @@
+// CookieJar - A contestant's algorithm toolbox
+// Copyright (c) 2013 Peter Szilagyi. All rights reserved.
+//
+// CookieJar is dual licensed: use of this source code is governed by a BSD
+// license that can be found in the LICENSE file. Alternatively, the CookieJar
+// toolbox may be used in accordance with the terms and conditions contained
+// in a signed written agreement between you and the author(s).
+
+// This is a duplicated and slightly modified version of "gopkg.in/karalabe/cookiejar.v2/collections/prque".
+
+package prque
+
+import "bytes"
+
+// A prioritized item in the sorted stack.
+//
+// Note: priorities can "wrap around" the int64 range, a comes before b if bytes.Compare(a.priority - b.priority) > 0.
+// The difference between the lowest and highest priorities in the queue at any point should be less than 2^63.
+type itemByteSlice struct {
+	value    interface{}
+	priority []byte
+}
+
+// Internal sortable stack data structure. Implements the Push and Pop ops for
+// the stack (heap) functionality and the Len, Less and Swap methods for the
+// sortability requirements of the heaps.
+type sstackByte struct {
+	size     int
+	capacity int
+	offset   int
+	reverse  bool // reverse the result of Less()
+
+	blocks [][]*itemByteSlice
+	active []*itemByteSlice
+}
+
+// Creates a new, empty stack.
+func newsstackByte(reverse bool) *sstackByte {
+	result := new(sstackByte)
+	result.active = make([]*itemByteSlice, blockSize)
+	result.blocks = [][]*itemByteSlice{result.active}
+	result.capacity = blockSize
+	result.reverse = reverse
+	return result
+}
+
+// Pushes a value onto the stack, expanding it if necessary. Required by
+// heap.Interface.
+func (s *sstackByte) Push(data interface{}) {
+	if s.size == s.capacity {
+		s.active = make([]*itemByteSlice, blockSize)
+		s.blocks = append(s.blocks, s.active)
+		s.capacity += blockSize
+		s.offset = 0
+	} else if s.offset == blockSize {
+		s.active = s.blocks[s.size/blockSize]
+		s.offset = 0
+	}
+	s.active[s.offset] = data.(*itemByteSlice)
+	s.offset++
+	s.size++
+}
+
+// Pops a value off the stack and returns it. Currently no shrinking is done.
+// Required by heap.Interface.
+func (s *sstackByte) Pop() (res interface{}) {
+	s.size--
+	s.offset--
+	if s.offset < 0 {
+		s.offset = blockSize - 1
+		s.active = s.blocks[s.size/blockSize]
+	}
+	res, s.active[s.offset] = s.active[s.offset], nil
+	return
+}
+
+// Returns the length of the stack. Required by sort.Interface.
+func (s *sstackByte) Len() int {
+	return s.size
+}
+
+// Compares the priority of two elements of the stack (higher is first).
+// Required by sort.Interface.
+func (s *sstackByte) Less(i, j int) bool {
+	r := bytes.Compare(s.blocks[i/blockSize][i%blockSize].priority, s.blocks[j/blockSize][j%blockSize].priority) > 0
+	if s.reverse {
+		return !r
+	}
+	return r
+}
+
+// Swaps two elements in the stack. Required by sort.Interface.
+func (s *sstackByte) Swap(i, j int) {
+	ib, io, jb, jo := i/blockSize, i%blockSize, j/blockSize, j%blockSize
+	s.blocks[ib][io], s.blocks[jb][jo] = s.blocks[jb][jo], s.blocks[ib][io]
+}
+
+// Resets the stack, effectively clearing its contents.
+func (s *sstackByte) Reset() {
+	*s = *newsstackByte(s.reverse)
+}

--- a/datasync/chaindatafetcher/kafka/consumer_test.go
+++ b/datasync/chaindatafetcher/kafka/consumer_test.go
@@ -36,8 +36,8 @@ func Test_newSegment_Success(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	total := uint64(10)
 	idx := rand.Uint64() % total
-	totalBytes := common.Int64ToByteBigEndian(total)
-	idxBytes := common.Int64ToByteBigEndian(idx)
+	totalBytes := common.Uint64ToByteBigEndian(total)
+	idxBytes := common.Uint64ToByteBigEndian(idx)
 	key := "test-key"
 	msg := &sarama.ConsumerMessage{
 		Headers: []*sarama.RecordHeader{

--- a/datasync/chaindatafetcher/kafka/kafka.go
+++ b/datasync/chaindatafetcher/kafka/kafka.go
@@ -142,11 +142,11 @@ func (k *Kafka) makeProducerMessage(topic, key string, segment []byte, segmentId
 		Headers: []sarama.RecordHeader{
 			{
 				Key:   []byte(KeyTotalSegments),
-				Value: common.Int64ToByteBigEndian(totalSegments),
+				Value: common.Uint64ToByteBigEndian(totalSegments),
 			},
 			{
 				Key:   []byte(KeySegmentIdx),
-				Value: common.Int64ToByteBigEndian(segmentIdx),
+				Value: common.Uint64ToByteBigEndian(segmentIdx),
 			},
 		},
 		Value: sarama.ByteEncoder(segment),

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -614,7 +614,7 @@ func (dbm *databaseManager) getStateTrieMigrationInfo() uint64 {
 
 func (dbm *databaseManager) setStateTrieMigrationStatus(blockNum uint64) {
 	miscDB := dbm.getDatabase(MiscDB)
-	if err := miscDB.Put(migrationStatusKey, common.Int64ToByteBigEndian(blockNum)); err != nil {
+	if err := miscDB.Put(migrationStatusKey, common.Uint64ToByteBigEndian(blockNum)); err != nil {
 		logger.Crit("Failed to set state trie migration status", "err", err)
 	}
 
@@ -937,7 +937,7 @@ func (dbm *databaseManager) WriteHeader(header *types.Header) {
 	var (
 		hash    = header.Hash()
 		number  = header.Number.Uint64()
-		encoded = common.Int64ToByteBigEndian(number)
+		encoded = common.Uint64ToByteBigEndian(number)
 	)
 	key := headerNumberKey(hash)
 	if err := db.Put(key, encoded); err != nil {
@@ -1810,7 +1810,7 @@ func (dbm *databaseManager) ConvertChildChainBlockHashToParentChainTxHash(scBloc
 func (dbm *databaseManager) WriteLastIndexedBlockNumber(blockNum uint64) {
 	key := lastIndexedBlockKey
 	db := dbm.getDatabase(bridgeServiceDB)
-	if err := db.Put(key, common.Int64ToByteBigEndian(blockNum)); err != nil {
+	if err := db.Put(key, common.Uint64ToByteBigEndian(blockNum)); err != nil {
 		logger.Crit("Failed to store LastIndexedBlockNumber", "blockNumber", blockNum, "err", err)
 	}
 }
@@ -1830,7 +1830,7 @@ func (dbm *databaseManager) GetLastIndexedBlockNumber() uint64 {
 func (dbm *databaseManager) WriteAnchoredBlockNumber(blockNum uint64) {
 	key := lastServiceChainTxReceiptKey
 	db := dbm.getDatabase(bridgeServiceDB)
-	if err := db.Put(key, common.Int64ToByteBigEndian(blockNum)); err != nil {
+	if err := db.Put(key, common.Uint64ToByteBigEndian(blockNum)); err != nil {
 		logger.Crit("Failed to store LatestServiceChainBlockNum", "blockNumber", blockNum, "err", err)
 	}
 }
@@ -2072,7 +2072,7 @@ func (dbm *databaseManager) ReadGovernanceState() ([]byte, error) {
 
 func (dbm *databaseManager) WriteChainDataFetcherCheckpoint(checkpoint uint64) error {
 	db := dbm.getDatabase(MiscDB)
-	return db.Put(chaindatafetcherCheckpointKey, common.Int64ToByteBigEndian(checkpoint))
+	return db.Put(chaindatafetcherCheckpointKey, common.Uint64ToByteBigEndian(checkpoint))
 }
 
 func (dbm *databaseManager) ReadChainDataFetcherCheckpoint() (uint64, error) {

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -728,7 +728,7 @@ func TestDatabaseManager_CreateMigrationDBAndSetStatus(t *testing.T) {
 			assert.True(t, dbm.InMigration())
 
 			// check migration DB path in MiscDB
-			migrationDBPathKey := append(databaseDirPrefix, common.Int64ToByteBigEndian(uint64(StateTrieMigrationDB))...)
+			migrationDBPathKey := append(databaseDirPrefix, common.Uint64ToByteBigEndian(uint64(StateTrieMigrationDB))...)
 			fetchedMigrationPath, err := dbm.getDatabase(MiscDB).Get(migrationDBPathKey)
 			assert.NoError(t, err)
 			expectedMigrationPath := "statetrie_migrated_" + strconv.FormatUint(migrationBlockNum, 10)
@@ -737,7 +737,7 @@ func TestDatabaseManager_CreateMigrationDBAndSetStatus(t *testing.T) {
 			// check block number in MiscDB
 			fetchedBlockNum, err := dbm.getDatabase(MiscDB).Get(migrationStatusKey)
 			assert.NoError(t, err)
-			assert.Equal(t, common.Int64ToByteBigEndian(migrationBlockNum), fetchedBlockNum)
+			assert.Equal(t, common.Uint64ToByteBigEndian(migrationBlockNum), fetchedBlockNum)
 
 			// reset migration status for next test
 			dbm.FinishStateMigration(false)
@@ -771,13 +771,13 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			assert.False(t, dbm.InMigration())
 
 			// check if state DB Path is set to old DB in MiscDB
-			statDBPathKey := append(databaseDirPrefix, common.Int64ToByteBigEndian(uint64(StateTrieDB))...)
+			statDBPathKey := append(databaseDirPrefix, common.Uint64ToByteBigEndian(uint64(StateTrieDB))...)
 			fetchedStateDBPath, err := dbm.getDatabase(MiscDB).Get(statDBPathKey)
 			assert.NoError(t, err)
 			assert.Equal(t, initialDirNames[0], string(fetchedStateDBPath), "old DB should remain")
 
 			// check if migration DB Path is not set in MiscDB
-			migrationDBPathKey := append(databaseDirPrefix, common.Int64ToByteBigEndian(uint64(StateTrieMigrationDB))...)
+			migrationDBPathKey := append(databaseDirPrefix, common.Uint64ToByteBigEndian(uint64(StateTrieMigrationDB))...)
 			fetchedMigrationPath, err := dbm.getDatabase(MiscDB).Get(migrationDBPathKey)
 			assert.NoError(t, err)
 			assert.Equal(t, "", string(fetchedMigrationPath))
@@ -785,7 +785,7 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			// check if block number is not set in MiscDB
 			fetchedBlockNum, err := dbm.getDatabase(MiscDB).Get(migrationStatusKey)
 			assert.NoError(t, err)
-			assert.Equal(t, common.Int64ToByteBigEndian(0), fetchedBlockNum)
+			assert.Equal(t, common.Uint64ToByteBigEndian(0), fetchedBlockNum)
 		}
 
 		// check status in miscDB on successful state migration
@@ -802,14 +802,14 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			assert.False(t, dbm.InMigration())
 
 			// check if state DB Path is set to new DB in MiscDB
-			statDBPathKey := append(databaseDirPrefix, common.Int64ToByteBigEndian(uint64(StateTrieDB))...)
+			statDBPathKey := append(databaseDirPrefix, common.Uint64ToByteBigEndian(uint64(StateTrieDB))...)
 			fetchedStateDBPath, err := dbm.getDatabase(MiscDB).Get(statDBPathKey)
 			assert.NoError(t, err)
 			expectedStateDBPath := "statetrie_migrated_" + strconv.FormatUint(migrationBlockNum2, 10) // new DB format
 			assert.Equal(t, expectedStateDBPath, string(fetchedStateDBPath), "new DB should remain")
 
 			// check if migration DB Path is not set in MiscDB
-			migrationDBPathKey := append(databaseDirPrefix, common.Int64ToByteBigEndian(uint64(StateTrieMigrationDB))...)
+			migrationDBPathKey := append(databaseDirPrefix, common.Uint64ToByteBigEndian(uint64(StateTrieMigrationDB))...)
 			fetchedMigrationPath, err := dbm.getDatabase(MiscDB).Get(migrationDBPathKey)
 			assert.NoError(t, err)
 			assert.Equal(t, "", string(fetchedMigrationPath))
@@ -817,7 +817,7 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			// check if block number is not set in MiscDB
 			fetchedBlockNum, err := dbm.getDatabase(MiscDB).Get(migrationStatusKey)
 			assert.NoError(t, err)
-			assert.Equal(t, common.Int64ToByteBigEndian(0), fetchedBlockNum)
+			assert.Equal(t, common.Uint64ToByteBigEndian(0), fetchedBlockNum)
 		}
 	}
 }

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -107,7 +107,7 @@ type TxLookupEntry struct {
 
 // headerKey = headerPrefix + num (uint64 big endian) + hash
 func headerKey(number uint64, hash common.Hash) []byte {
-	return append(append(headerPrefix, common.Int64ToByteBigEndian(number)...), hash.Bytes()...)
+	return append(append(headerPrefix, common.Uint64ToByteBigEndian(number)...), hash.Bytes()...)
 }
 
 // headerTDKey = headerPrefix + num (uint64 big endian) + hash + headerTDSuffix
@@ -117,7 +117,7 @@ func headerTDKey(number uint64, hash common.Hash) []byte {
 
 // headerHashKey = headerPrefix + num (uint64 big endian) + headerHashSuffix
 func headerHashKey(number uint64) []byte {
-	return append(append(headerPrefix, common.Int64ToByteBigEndian(number)...), headerHashSuffix...)
+	return append(append(headerPrefix, common.Uint64ToByteBigEndian(number)...), headerHashSuffix...)
 }
 
 // headerNumberKey = headerNumberPrefix + hash
@@ -127,12 +127,12 @@ func headerNumberKey(hash common.Hash) []byte {
 
 // blockBodyKey = blockBodyPrefix + num (uint64 big endian) + hash
 func blockBodyKey(number uint64, hash common.Hash) []byte {
-	return append(append(blockBodyPrefix, common.Int64ToByteBigEndian(number)...), hash.Bytes()...)
+	return append(append(blockBodyPrefix, common.Uint64ToByteBigEndian(number)...), hash.Bytes()...)
 }
 
 // blockReceiptsKey = blockReceiptsPrefix + num (uint64 big endian) + hash
 func blockReceiptsKey(number uint64, hash common.Hash) []byte {
-	return append(append(blockReceiptsPrefix, common.Int64ToByteBigEndian(number)...), hash.Bytes()...)
+	return append(append(blockReceiptsPrefix, common.Uint64ToByteBigEndian(number)...), hash.Bytes()...)
 }
 
 // TxLookupKey = txLookupPrefix + hash
@@ -185,10 +185,10 @@ func BloomBitsKey(bit uint, section uint64, hash common.Hash) []byte {
 }
 
 func makeKey(prefix []byte, num uint64) []byte {
-	byteKey := common.Int64ToByteLittleEndian(num)
+	byteKey := common.Uint64ToByteLittleEndian(num)
 	return append(prefix, byteKey...)
 }
 
 func databaseDirKey(dbEntryType uint64) []byte {
-	return append(databaseDirPrefix, common.Int64ToByteBigEndian(dbEntryType)...)
+	return append(databaseDirPrefix, common.Uint64ToByteBigEndian(dbEntryType)...)
 }

--- a/tests/state_migration_test.go
+++ b/tests/state_migration_test.go
@@ -17,18 +17,19 @@
 package tests
 
 import (
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/node"
-	"github.com/klaytn/klaytn/node/cn"
-	"github.com/klaytn/klaytn/storage/database"
-	"github.com/stretchr/testify/assert"
-	"github.com/syndtr/goleveldb/leveldb"
 	"math/big"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/node"
+	"github.com/klaytn/klaytn/node/cn"
+	"github.com/klaytn/klaytn/storage/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // continuous occurrence of state trie migration and node restart must success
@@ -54,7 +55,7 @@ func TestMigration_ContinuousRestartAndMigration(t *testing.T) {
 		waitMigrationEnds(t, node)
 
 		// check if migration succeeds (StateTrieDB changes when migration finishes)
-		newPathKey := append([]byte("databaseDirectory"), common.Int64ToByteBigEndian(uint64(database.StateTrieDB))...)
+		newPathKey := append([]byte("databaseDirectory"), common.Uint64ToByteBigEndian(uint64(database.StateTrieDB))...)
 		newStateTriePath, err := node.ChainDB().GetMiscDB().Get(newPathKey)
 		assert.NoError(t, err)
 		assert.NotEqual(t, stateTriePath, newStateTriePath, "migration failed")
@@ -69,7 +70,7 @@ func TestMigration_StartMigrationByMiscDB(t *testing.T) {
 	fullNode, cn, validator, _, workspace, _, _, _ := newSimpleBlockchain(t, 10)
 	defer os.RemoveAll(workspace)
 
-	stateTriePathKey := append([]byte("databaseDirectory"), common.Int64ToByteBigEndian(uint64(database.StateTrieDB))...)
+	stateTriePathKey := append([]byte("databaseDirectory"), common.Uint64ToByteBigEndian(uint64(database.StateTrieDB))...)
 
 	// use the default StateTrie DB if it is not set on miscDB
 	{
@@ -142,11 +143,11 @@ func TestMigration_StartMigrationByMiscDBOnRestart(t *testing.T) {
 
 	// set migration status in miscDB
 	migrationBlockNum := node.BlockChain().CurrentBlock().Header().Number.Uint64()
-	err := miscDB.Put([]byte("migrationStatus"), common.Int64ToByteBigEndian(migrationBlockNum))
+	err := miscDB.Put([]byte("migrationStatus"), common.Uint64ToByteBigEndian(migrationBlockNum))
 	assert.NoError(t, err)
 
 	// set migration db path in miscDB
-	migrationPathKey := append([]byte("databaseDirectory"), common.Int64ToByteBigEndian(uint64(database.StateTrieMigrationDB))...)
+	migrationPathKey := append([]byte("databaseDirectory"), common.Uint64ToByteBigEndian(uint64(database.StateTrieMigrationDB))...)
 	migrationPath := []byte("statetrie_migrated_" + strconv.FormatUint(migrationBlockNum, 10))
 	err = miscDB.Put(migrationPathKey, migrationPath)
 	assert.NoError(t, err)
@@ -167,7 +168,7 @@ func TestMigration_StartMigrationByMiscDBOnRestart(t *testing.T) {
 	waitMigrationEnds(t, node)
 
 	// state trie path should not be "statetrie" in miscDB
-	newPathKey := append([]byte("databaseDirectory"), common.Int64ToByteBigEndian(uint64(database.StateTrieDB))...)
+	newPathKey := append([]byte("databaseDirectory"), common.Uint64ToByteBigEndian(uint64(database.StateTrieDB))...)
 	dir, err := miscDB.Get(newPathKey)
 	assert.NoError(t, err)
 	assert.NotEqual(t, "statetrie", string(dir), "migration failed")


### PR DESCRIPTION
## Proposed changes

- Introduce prque for `[]byte` type.
- `prqueByteSlice` has same structure with `Prque`.
  (Generic version is very slow due to type inference. https://github.com/klaytn/klaytn/pull/840)
- This code is a part of https://github.com/klaytn/klaytn/pull/822. 
- `prqueByteSlice` will be used in `shardedDBIterator`.
- Created `ByteBigEndianToUint64` for test code.
- Renamed `Int64ToByteLittleEndian` -> `Uint64ToByteLittleEndian`
- Renamed `Int64ToByteBigEndian` -> `Uint64ToByteBigEndian`

Commits
https://github.com/klaytn/klaytn/pull/855/commits/4e8a7d81d63f4e1c40f3fdeb568195f259bbda8a : `ByteBigEndianToUint64`
https://github.com/klaytn/klaytn/pull/855/commits/cd07b1569c21f7572e297579a341395e69d63b75 : prque for []byte

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

I ran a benchmark to compare with `[][]byte` type. `prqueByteSlice` is much faster and `[][]byte` can create an OOM.
`prqueByteSlice` : 
```
goos: linux
goarch: amd64
BenchmarkPrqueByteSlicePop-2   	 1000000	      2976 ns/op
PASS
ok  	_/home/ubuntu/prque/byteheap	13.892s
```
`[]byte` : 
```
goos: linux
goarch: amd64
BenchmarkHeapByteSlicePop-2   	fatal error: runtime: out of memory
...
FAIL	_/home/ubuntu/prque/byteheap	181.235s
```