### PR TITLE
Iterator for shardedDB (New)

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -160,3 +160,16 @@ func Int64ToByteBigEndian(number uint64) []byte {
 
 	return enc
 }
+
+type Entry struct {
+	Key, Val []byte
+}
+
+// CreateEntries creates random key/value pairs.
+func CreateEntries(entryNum int) []Entry {
+	entries := make([]Entry, entryNum)
+	for i := 0; i < entryNum; i++ {
+		entries[i] = Entry{MakeRandomBytes(256), MakeRandomBytes(600)}
+	}
+	return entries
+}

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -169,7 +169,7 @@ type Entry struct {
 func CreateEntries(entryNum int) []Entry {
 	entries := make([]Entry, entryNum)
 	for i := 0; i < entryNum; i++ {
-		entries[i] = Entry{Key: MakeRandomBytes(256), Val: MakeRandomBytes(600)}
+		entries[i] = Entry{Key: MakeRandomBytes(256), Val: MakeRandomBytes(300)}
 	}
 	return entries
 }

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -169,7 +169,7 @@ type Entry struct {
 func CreateEntries(entryNum int) []Entry {
 	entries := make([]Entry, entryNum)
 	for i := 0; i < entryNum; i++ {
-		entries[i] = Entry{MakeRandomBytes(256), MakeRandomBytes(600)}
+		entries[i] = Entry{Key: MakeRandomBytes(256), Val: MakeRandomBytes(600)}
 	}
 	return entries
 }

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -195,7 +195,7 @@ func TestShardDB(t *testing.T) {
 
 	idx := common.BytesToHash(key).Big().Mod(common.BytesToHash(key).Big(), big.NewInt(4))
 
-	fmt.Printf("idx %d   %d   %d", idx, shard, seed)
+	fmt.Printf("idx %d   %d   %d\n", idx, shard, seed)
 
 }
 

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -296,6 +296,9 @@ type shardedDBIteratorUnsorted struct {
 // the key-value database.
 // If you want to get ordered items in serial, checkout shardedDB.NewIterator()
 // If you want to get items in parallel from channels, checkout shardedDB.NewChanIterator()
+// IteratorUnsorted is a implementation of Iterator and data are accessed with
+// Next(), Key() and Value() methods. With ChanIterator, data can be accessed with
+// channels. The channels are gained with Channels() method.
 func (db *shardedDB) NewIteratorUnsorted(prefix []byte, start []byte) Iterator {
 	resultCh := make(chan common.Entry, shardedDBCombineChanSize)
 	it := &shardedDBIteratorUnsorted{

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -228,35 +228,6 @@ chanIter:
 	close(it.resultCh)
 }
 
-type entryWithShardNum struct {
-	common.Entry
-	shardNum int
-}
-
-type entryHeap []entryWithShardNum
-
-func (e entryHeap) Len() int {
-	return len(e)
-}
-
-func (e entryHeap) Less(i, j int) bool {
-	return bytes.Compare(e[i].Key, e[j].Key) < 0
-}
-func (e entryHeap) Swap(i, j int) {
-	e[i], e[j] = e[j], e[i]
-}
-func (e *entryHeap) Push(x interface{}) {
-	*e = append(*e, x.(entryWithShardNum))
-}
-
-func (e *entryHeap) Pop() interface{} {
-	old := *e
-	n := len(old)
-	element := old[n-1]
-	*e = old[0 : n-1]
-	return element
-}
-
 // Next gets the next item from iterators.
 func (it *shardedDBIterator) Next() bool {
 	e, ok := <-it.resultCh
@@ -285,6 +256,35 @@ func (it *shardedDBIterator) Key() []byte {
 
 func (it *shardedDBIterator) Value() []byte {
 	return it.value
+}
+
+type entryWithShardNum struct {
+	common.Entry
+	shardNum int
+}
+
+type entryHeap []entryWithShardNum
+
+func (e entryHeap) Len() int {
+	return len(e)
+}
+
+func (e entryHeap) Less(i, j int) bool {
+	return bytes.Compare(e[i].Key, e[j].Key) < 0
+}
+func (e entryHeap) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+func (e *entryHeap) Push(x interface{}) {
+	*e = append(*e, x.(entryWithShardNum))
+}
+
+func (e *entryHeap) Pop() interface{} {
+	old := *e
+	n := len(old)
+	element := old[n-1]
+	*e = old[0 : n-1]
+	return element
 }
 
 // shardedDBIteratorUnsorted iterates all items of each shardDB.

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -17,9 +17,14 @@
 package database
 
 import (
+	"bytes"
+	"container/heap"
+	"context"
 	"fmt"
 	"path"
 	"strconv"
+
+	"github.com/klaytn/klaytn/common"
 )
 
 var errKeyLengthZero = fmt.Errorf("database key for sharded database should be greater than 0")
@@ -155,75 +160,244 @@ func (db *shardedDB) Close() {
 	}
 }
 
-type shardedDBIterator struct {
-	// TODO-Klaytn implement this later.
-	iterators []Iterator
-	key       []byte
-	value     []byte
+// Not enough size of channel slows down the iterator
+const shardedDBCombineChanSize = 1024 // Size of resultCh
+const shardedDBSubChannelSize = 128   // Size of each sub-channel of resultChs
 
-	//numBatches uint
-	//
-	//taskCh   chan pdbBatchTask
-	//resultCh chan pdbBatchResult
+// shardedDBIterator iterates all items of each shardDB.
+// This is useful when you want to get items in serial in binary-alphabetigcal order.
+type shardedDBIterator struct {
+	shardedDBChanIterator
+
+	resultCh chan common.Entry
+	key      []byte // current key
+	value    []byte // current value
 }
 
 // NewIterator creates a binary-alphabetical iterator over a subset
 // of database content with a particular key prefix, starting at a particular
 // initial key (or after, if it does not exist).
-func (pdb *shardedDB) NewIterator(prefix []byte, start []byte) Iterator {
-	// TODO-Klaytn implement this later.
-	return nil
+func (db *shardedDB) NewIterator(prefix []byte, start []byte) Iterator {
+	it := &shardedDBIterator{
+		shardedDBChanIterator: db.NewChanIterator(context.TODO(), prefix, start, nil),
+		resultCh:              make(chan common.Entry, shardedDBCombineChanSize),
+	}
+
+	go it.runCombineWorker()
+
+	return it
 }
 
-func (pdi *shardedDBIterator) Next() bool {
-	// TODO-Klaytn implement this later.
-	//var minIter Iterator
-	//minIdx := -1
-	//minKey := []byte{0}
-	//minKeyValue := []byte{0}
-	//
-	//for idx, iter := range pdi.iterators {
-	//	if iter != nil {
-	//		if bytes.Compare(minKey, iter.Key()) >= 0 {
-	//			minIdx = idx
-	//			minIter = iter
-	//			minKey = iter.Key()
-	//			minKeyValue = iter.Value()
-	//		}
-	//	}
-	//}
-	//
-	//if minIter == nil {
-	//	return false
-	//}
-	//
-	//pdi.key = minKey
-	//pdi.value = minKeyValue
-	//
-	//if !minIter.Next() {
-	//	pdi.iterators[minIdx] = nil
-	//}
-	//
+// runCombineWorker fetches any key/value from resultChs and put the data in resultCh
+// in binary-alphabetical order.
+func (it *shardedDBIterator) runCombineWorker() {
+
+	// creates min-priority queue smallest values from each iterators
+	entries := &entryHeap{}
+	heap.Init(entries)
+	for i, ch := range it.resultChs {
+		if e, ok := <-ch; ok {
+			heap.Push(entries, entryWithShardNum{e, i})
+		}
+	}
+
+chanIter:
+	for len(*entries) != 0 {
+		// check if done
+		select {
+		case <-it.ctx.Done():
+			logger.Trace("[shardedDBIterator] combine worker ends due to ctx")
+			break chanIter
+		default:
+		}
+
+		// look for smallest key
+		minEntry := heap.Pop(entries).(entryWithShardNum)
+
+		// fill resultCh with smallest key
+		it.resultCh <- minEntry.Entry
+
+		// fill used entry with new entry
+		// skip this if channel is closed
+		if e, ok := <-it.resultChs[minEntry.shardNum]; ok {
+			heap.Push(entries, entryWithShardNum{e, minEntry.shardNum})
+		}
+	}
+	logger.Trace("[shardedDBIterator] combine worker finished")
+	close(it.resultCh)
+}
+
+type entryWithShardNum struct {
+	common.Entry
+	shardNum int
+}
+
+type entryHeap []entryWithShardNum
+
+func (e entryHeap) Len() int {
+	return len(e)
+}
+
+func (e entryHeap) Less(i, j int) bool {
+	return bytes.Compare(e[i].Key, e[j].Key) < 0
+}
+func (e entryHeap) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+func (e *entryHeap) Push(x interface{}) {
+	*e = append(*e, x.(entryWithShardNum))
+}
+
+func (e *entryHeap) Pop() interface{} {
+	old := *e
+	n := len(old)
+	element := old[n-1]
+	*e = old[0 : n-1]
+	return element
+}
+
+// Next gets the next item from iterators.
+func (it *shardedDBIterator) Next() bool {
+	e, ok := <-it.resultCh
+	if !ok {
+		logger.Debug("[shardedDBIterator] Next is called on closed channel")
+		return false
+	}
+	it.key, it.value = e.Key, e.Val
 	return true
 }
 
-func (pdi *shardedDBIterator) Error() error {
-	// TODO-Klaytn implement this later.
+func (it *shardedDBIterator) Error() error {
+	for i, iter := range it.iterators {
+		if iter.Error() != nil {
+			logger.Error("[shardedDBIterator] error from iterator",
+				"err", iter.Error(), "shardNum", i, "key", it.key, "val", it.value)
+			return iter.Error()
+		}
+	}
 	return nil
 }
 
-func (pdi *shardedDBIterator) Key() []byte {
-	// TODO-Klaytn implement this later.
-	return nil
+func (it *shardedDBIterator) Key() []byte {
+	return it.key
 }
 
-func (pdi *shardedDBIterator) Value() []byte {
-	// TODO-Klaytn implement this later.
-	return nil
+func (it *shardedDBIterator) Value() []byte {
+	return it.value
 }
 
-func (pdi *shardedDBIterator) Release() {
-	// TODO-Klaytn implement this later.
+// shardedDBIteratorUnsorted iterates all items of each shardDB.
+// This is useful when you want to get items fast in serial.
+type shardedDBIteratorUnsorted struct {
+	shardedDBIterator
+}
+
+// NewIteratorUnsorted creates a iterator over the entire keyspace contained within
+// the key-value database.
+// If you want to get ordered items in serial, checkout shardedDB.NewIterator()
+// If you want to get items in parallel from channels, checkout shardedDB.NewChanIterator()
+func (db *shardedDB) NewIteratorUnsorted(prefix []byte, start []byte) Iterator {
+	resultCh := make(chan common.Entry, shardedDBCombineChanSize)
+	it := &shardedDBIteratorUnsorted{
+		shardedDBIterator{
+			shardedDBChanIterator: db.NewChanIterator(context.TODO(), prefix, start, resultCh),
+			resultCh:              resultCh,
+		}}
+	return it
+}
+
+// shardedDBChanIterator creates iterators for each shard DB.
+// Channels subscribing each iterators can be gained.
+// Each iterators fetch values in binary-alphabetical order.
+// This is useful when you want to operate on each items in parallel.
+type shardedDBChanIterator struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	iterators []Iterator
+
+	combinedChan bool // all workers put items to one resultChan
+	shardNum     int  // num of shards left to iterate
+	resultChs    []chan common.Entry
+}
+
+// NewChanIterator creates iterators for each shard DB. This is useful when you
+// want to operate on each items in parallel.
+// If `resultCh` is given, all items are written to `resultCh`, unsorted with a
+// particular key prefix, starting at a particular initial key. If `resultCh`
+// is not given, new channels are created for each DB. Items are written to
+// corresponding channels in binary-alphabetical order. The channels can be
+// gained by calling `Channels()`.
+//
+// If you want to get ordered items in serial, checkout shardedDB.NewIterator()
+// If you want to get unordered items in serial with Iterator Interface,
+// checkout shardedDB.NewIteratorUnsorted().
+func (db *shardedDB) NewChanIterator(ctx context.Context, prefix []byte, start []byte, resultCh chan common.Entry) shardedDBChanIterator {
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+
+	it := shardedDBChanIterator{
+		ctx:          ctx,
+		cancel:       nil,
+		iterators:    make([]Iterator, len(db.shards)),
+		combinedChan: resultCh != nil,
+		shardNum:     len(db.shards),
+		resultChs:    make([]chan common.Entry, len(db.shards)),
+	}
+	it.ctx, it.cancel = context.WithCancel(ctx)
+
+	for i, shard := range db.shards {
+		it.iterators[i] = shard.NewIterator(prefix, start)
+		if resultCh == nil {
+			it.resultChs[i] = make(chan common.Entry, shardedDBSubChannelSize)
+		} else {
+			it.resultChs[i] = resultCh
+		}
+		go it.runChanWorker(it.ctx, it.iterators[i], it.resultChs[i])
+	}
+
+	return it
+}
+
+// runChanWorker runs a worker. The worker gets key/value pair from
+// `it` and push the value to `resultCh`.
+// `iterator.Release()` is called after all iterating is finished.
+// `resultCh` is closed after the iterating is finished.
+func (sit *shardedDBChanIterator) runChanWorker(ctx context.Context, it Iterator, resultCh chan common.Entry) {
+iter:
+	for it.Next() {
+		select {
+		case <-ctx.Done():
+			break iter
+		default:
+		}
+		key := make([]byte, len(it.Key()))
+		val := make([]byte, len(it.Value()))
+		copy(key, it.Key())
+		copy(val, it.Value())
+		resultCh <- common.Entry{Key: key, Val: val}
+	}
+	// Release the iterator. There is nothing to iterate anymore.
+	it.Release()
+	// Close `resultCh`. If it is `combinedChan`, the close only happens
+	// when this is the last living worker.
+	if sit.shardNum--; sit.combinedChan && sit.shardNum > 0 {
+		return
+	}
+	close(resultCh)
+}
+
+// Channels returns channels that can subscribe on.
+func (it *shardedDBChanIterator) Channels() []chan common.Entry {
+	return it.resultChs
+}
+
+// Release stops all iterators, channels and workers
+// Even Release() is called, there could be some items left in the channel.
+// Each iterator.Release() is called in `runChanWorker`.
+func (it *shardedDBChanIterator) Release() {
+	it.cancel()
 }
 
 func (db *shardedDB) NewBatch() Batch {
@@ -255,7 +429,7 @@ type shardedDBBatch struct {
 }
 
 func (sdbBatch *shardedDBBatch) Put(key []byte, value []byte) error {
-	if ShardIndex, err := shardIndexByKey(key, uint(sdbBatch.numBatches)); err != nil {
+	if ShardIndex, err := shardIndexByKey(key, sdbBatch.numBatches); err != nil {
 		return err
 	} else {
 		return sdbBatch.batches[ShardIndex].Put(key, value)
@@ -263,7 +437,7 @@ func (sdbBatch *shardedDBBatch) Put(key []byte, value []byte) error {
 }
 
 func (sdbBatch *shardedDBBatch) Delete(key []byte) error {
-	if ShardIndex, err := shardIndexByKey(key, uint(sdbBatch.numBatches)); err != nil {
+	if ShardIndex, err := shardIndexByKey(key, sdbBatch.numBatches); err != nil {
 		return err
 	} else {
 		return sdbBatch.batches[ShardIndex].Delete(key)

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -322,7 +322,7 @@ type shardedDBChanIterator struct {
 
 	combinedChan bool // all workers put items to one resultChan
 	shardNum     int  // num of shards left to iterate
-	shardNumMu   sync.Mutex
+	shardNumMu   *sync.Mutex
 	resultChs    []chan common.Entry
 }
 
@@ -348,6 +348,7 @@ func (db *shardedDB) NewChanIterator(ctx context.Context, prefix []byte, start [
 		iterators:    make([]Iterator, len(db.shards)),
 		combinedChan: resultCh != nil,
 		shardNum:     len(db.shards),
+		shardNumMu:   &sync.Mutex{},
 		resultChs:    make([]chan common.Entry, len(db.shards)),
 	}
 	it.ctx, it.cancel = context.WithCancel(ctx)

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"sync"
 
 	"github.com/klaytn/klaytn/common"
 )
@@ -321,6 +322,7 @@ type shardedDBChanIterator struct {
 
 	combinedChan bool // all workers put items to one resultChan
 	shardNum     int  // num of shards left to iterate
+	shardNumMu   sync.Mutex
 	resultChs    []chan common.Entry
 }
 
@@ -385,6 +387,8 @@ iter:
 	it.Release()
 	// Close `resultCh`. If it is `combinedChan`, the close only happens
 	// when this is the last living worker.
+	sit.shardNumMu.Lock()
+	defer sit.shardNumMu.Unlock()
 	if sit.shardNum--; sit.combinedChan && sit.shardNum > 0 {
 		return
 	}

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -94,9 +94,9 @@ func TestShardedDBIteratorUnsorted(t *testing.T) {
 	testIterator(t, false, []uint{100}, ShardedDBConfig, newShardedDBIteratorUnsorted)
 }
 
-// TestShardedDBChanIterator tests if shardedDBChanIterator iterates all entries with diverse shard size
-func TestShardedDBChanIterator(t *testing.T) {
-	testIterator(t, false, []uint{100}, ShardedDBConfig, newShardedDBChanIterator)
+// TestShardedDBParallelIterator tests if shardedDBParallelIterator iterates all entries with diverse shard size
+func TestShardedDBParallelIterator(t *testing.T) {
+	testIterator(t, false, []uint{100}, ShardedDBConfig, newShardedDBParallelIterator)
 }
 
 // TestShardedDBIteratorSize tests if shardedDBIterator iterates all entries for different
@@ -114,11 +114,11 @@ func TestShardedDBIteratorUnsortedSize(t *testing.T) {
 	testIterator(t, false, []uint{size - 1, size, size + 1}, []*DBConfig{config}, newShardedDBIteratorUnsorted)
 }
 
-// TestShardedDBChanIteratorSize tests if shardedDBChanIterator iterates all entries
-func TestShardedDBChanIteratorSize(t *testing.T) {
+// TestShardedDBParallelIteratorSize tests if shardedDBParallelIterator iterates all entries
+func TestShardedDBParallelIteratorSize(t *testing.T) {
 	config := ShardedDBConfig[0]
 	size := config.NumStateTrieShards
-	testIterator(t, false, []uint{size - 1, size, size + 1}, []*DBConfig{config}, newShardedDBChanIterator)
+	testIterator(t, false, []uint{size - 1, size, size + 1}, []*DBConfig{config}, newShardedDBParallelIterator)
 }
 
 func newShardedDBIterator(t *testing.T, db shardedDB, entryNum uint) []common.Entry {
@@ -145,12 +145,12 @@ func newShardedDBIteratorUnsorted(t *testing.T, db shardedDB, entryNum uint) []c
 	return entries
 }
 
-func newShardedDBChanIterator(t *testing.T, db shardedDB, entryNum uint) []common.Entry {
+func newShardedDBParallelIterator(t *testing.T, db shardedDB, entryNum uint) []common.Entry {
 	entries := make([]common.Entry, 0, entryNum) // store all items
 	var l sync.RWMutex                           // mutex for entries
 
 	// create chan Iterator and get channels
-	it := db.NewChanIterator(context.Background(), nil, nil, nil)
+	it := db.NewParallelIterator(context.Background(), nil, nil, nil)
 	chans := it.Channels()
 
 	// listen all channels and get key/value
@@ -263,13 +263,13 @@ func TestShardedDBIteratorUnsorted_Release(t *testing.T) {
 	})
 }
 
-func TestShardedDBChanIterator_Release(t *testing.T) {
+func TestShardedDBParallelIterator_Release(t *testing.T) {
 	testShardedIterator_Release(t,
 		int(ShardedDBConfig[len(ShardedDBConfig)-1].NumStateTrieShards*shardedDBSubChannelSize*2),
 		func(db shardedDB) {
 			// Next() returns True if Release() is not called
 			{
-				it := db.NewChanIterator(context.Background(), nil, nil, nil)
+				it := db.NewParallelIterator(context.Background(), nil, nil, nil)
 				defer it.Release()
 
 				for _, ch := range it.Channels() {
@@ -285,7 +285,7 @@ func TestShardedDBChanIterator_Release(t *testing.T) {
 
 			//  Next() returns False if Release() is called
 			{
-				it := db.NewChanIterator(context.Background(), nil, nil, nil)
+				it := db.NewParallelIterator(context.Background(), nil, nil, nil)
 				it.Release()
 				for _, ch := range it.Channels() {
 

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -31,9 +31,9 @@ import (
 )
 
 var ShardedDBConfig = []*DBConfig{
+	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 1, ParallelDBWrite: true},
+	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 2, ParallelDBWrite: true},
 	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 4, ParallelDBWrite: true},
-	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 8, ParallelDBWrite: true},
-	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 16, ParallelDBWrite: true},
 }
 
 // testIterator tests if given iterator iterates all entries

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -225,7 +225,7 @@ func TestShardedDBIterator_Release(t *testing.T) {
 			it.Release()
 
 			// flush data in channel
-			for i := 0; i < shardedDBCombineChanSize; i++ {
+			for i := 0; i < shardedDBCombineChanSize+1; i++ {
 				it.Next()
 			}
 
@@ -254,7 +254,7 @@ func TestShardedDBIteratorUnsorted_Release(t *testing.T) {
 			it.Release()
 
 			// flush data in channel
-			for i := 0; i < shardedDBCombineChanSize; i++ {
+			for i := 0; i < shardedDBCombineChanSize+1; i++ {
 				it.Next()
 			}
 
@@ -291,7 +291,7 @@ func TestShardedDBChanIterator_Release(t *testing.T) {
 				for _, ch := range it.Channels() {
 
 					// flush data in channel
-					for i := 0; i < shardedDBSubChannelSize; i++ {
+					for i := 0; i < shardedDBSubChannelSize+1; i++ {
 						<-ch
 					}
 

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 var ShardedDBConfig = []*DBConfig{
-	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 1, ParallelDBWrite: true},
 	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 2, ParallelDBWrite: true},
 	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 4, ParallelDBWrite: true},
 }

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -127,7 +127,7 @@ func newShardedDBIterator(t *testing.T, db shardedDB, entryNum uint) []common.En
 	it := db.NewIterator(nil, nil)
 
 	for it.Next() {
-		entries = append(entries, common.Entry{it.Key(), it.Value()})
+		entries = append(entries, common.Entry{Key: it.Key(), Val: it.Value()})
 	}
 	it.Release()
 	assert.NoError(t, it.Error())
@@ -139,7 +139,7 @@ func newShardedDBIteratorUnsorted(t *testing.T, db shardedDB, entryNum uint) []c
 	it := db.NewIteratorUnsorted(nil, nil)
 
 	for it.Next() {
-		entries = append(entries, common.Entry{it.Key(), it.Value()})
+		entries = append(entries, common.Entry{Key: it.Key(), Val: it.Value()})
 	}
 	it.Release()
 	assert.NoError(t, it.Error())

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -1,0 +1,304 @@
+// Copyright 2021 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+package database
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/klaytn/klaytn/common"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var ShardedDBConfig = []*DBConfig{
+	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 4, ParallelDBWrite: true},
+	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 8, ParallelDBWrite: true},
+	{DBType: LevelDB, SingleDB: false, NumStateTrieShards: 16, ParallelDBWrite: true},
+}
+
+// testIterator tests if given iterator iterates all entries
+func testIterator(t *testing.T, checkOrder bool, entryNums []uint, dbConfig []*DBConfig, entriesFromIterator func(t *testing.T, db shardedDB, entryNum uint) []common.Entry) {
+	for _, entryNum := range entryNums {
+		entries := common.CreateEntries(int(entryNum))
+		dbs := make([]shardedDB, len(dbConfig))
+
+		// create DB and write data for testing
+		for i, config := range dbConfig {
+			config.Dir, _ = ioutil.TempDir(os.TempDir(), "test-shardedDB-iterator")
+			defer func(dir string) {
+				if err := os.RemoveAll(dir); err != nil {
+					t.Fatalf("fail to delete file %v", err)
+				}
+			}(config.Dir)
+
+			// create sharded DB
+			db, err := newShardedDB(config, 0, config.NumStateTrieShards)
+			dbs[i] = *db
+			if err != nil {
+				t.Log("Error occured while creating DB")
+				t.FailNow()
+			}
+
+			// write entries data in DB
+			batch := db.NewBatch()
+			for _, entry := range entries {
+				assert.NoError(t, batch.Put(entry.Key, entry.Val))
+			}
+			assert.NoError(t, batch.Write())
+		}
+
+		// sort entries for each compare
+		sort.Slice(entries, func(i, j int) bool { return bytes.Compare(entries[i].Key, entries[j].Key) < 0 })
+
+		// get data from iterator and compare
+		for _, db := range dbs {
+			// create iterator
+			entriesFromIt := entriesFromIterator(t, db, entryNum)
+			if !checkOrder {
+				sort.Slice(entriesFromIt, func(i, j int) bool { return bytes.Compare(entriesFromIt[i].Key, entriesFromIt[j].Key) < 0 })
+			}
+
+			// compare if entries generated and entries from iterator is same
+			assert.Equal(t, len(entries), len(entriesFromIt))
+			assert.True(t, reflect.DeepEqual(entries, entriesFromIt))
+		}
+	}
+}
+
+// TestShardedDBIterator tests if shardedDBIterator iterates all entries with diverse shard size
+func TestShardedDBIterator(t *testing.T) {
+	testIterator(t, true, []uint{500}, ShardedDBConfig, newShardedDBIterator)
+}
+
+// TestShardedDBIteratorUnsorted tests if shardedDBIteratorUnsorted iterates all entries with diverse shard size
+func TestShardedDBIteratorUnsorted(t *testing.T) {
+	testIterator(t, false, []uint{500}, ShardedDBConfig, newShardedDBIteratorUnsorted)
+}
+
+// TestShardedDBChanIterator tests if shardedDBChanIterator iterates all entries with diverse shard size
+func TestShardedDBChanIterator(t *testing.T) {
+	testIterator(t, false, []uint{500}, ShardedDBConfig, newShardedDBChanIterator)
+}
+
+// TestShardedDBIteratorSize tests if shardedDBIterator iterates all entries for different
+// entry sizes
+func TestShardedDBIteratorSize(t *testing.T) {
+	config := ShardedDBConfig[len(ShardedDBConfig)-1]
+	size := config.NumStateTrieShards
+	testIterator(t, true, []uint{size - 1, size, size + 1}, []*DBConfig{config}, newShardedDBIterator)
+}
+
+// TestShardedDBIteratorUnsortedSize tests if shardedDBIteratorUnsorted iterates all entries
+func TestShardedDBIteratorUnsortedSize(t *testing.T) {
+	config := ShardedDBConfig[len(ShardedDBConfig)-1]
+	size := config.NumStateTrieShards
+	testIterator(t, false, []uint{size - 1, size, size + 1}, []*DBConfig{config}, newShardedDBIteratorUnsorted)
+}
+
+// TestShardedDBChanIteratorSize tests if shardedDBChanIterator iterates all entries
+func TestShardedDBChanIteratorSize(t *testing.T) {
+	config := ShardedDBConfig[len(ShardedDBConfig)-1]
+	size := config.NumStateTrieShards
+	testIterator(t, false, []uint{size - 1, size, size + 1}, []*DBConfig{config}, newShardedDBChanIterator)
+}
+
+func newShardedDBIterator(t *testing.T, db shardedDB, entryNum uint) []common.Entry {
+	entries := make([]common.Entry, 0, entryNum)
+	it := db.NewIterator(nil, nil)
+
+	for it.Next() {
+		entries = append(entries, common.Entry{it.Key(), it.Value()})
+	}
+	it.Release()
+	assert.NoError(t, it.Error())
+	return entries
+}
+
+func newShardedDBIteratorUnsorted(t *testing.T, db shardedDB, entryNum uint) []common.Entry {
+	entries := make([]common.Entry, 0, entryNum)
+	it := db.NewIteratorUnsorted(nil, nil)
+
+	for it.Next() {
+		entries = append(entries, common.Entry{it.Key(), it.Value()})
+	}
+	it.Release()
+	assert.NoError(t, it.Error())
+	return entries
+}
+
+func newShardedDBChanIterator(t *testing.T, db shardedDB, entryNum uint) []common.Entry {
+	entries := make([]common.Entry, 0, entryNum) // store all items
+	var l sync.RWMutex                           // mutex for entries
+
+	// create chan Iterator and get channels
+	it := db.NewChanIterator(context.Background(), nil, nil, nil)
+	chans := it.Channels()
+
+	// listen all channels and get key/value
+	done := make(chan struct{})
+	for _, ch := range chans {
+		go func(ch chan common.Entry) {
+			for e := range ch {
+				l.Lock()
+				entries = append(entries, e)
+				l.Unlock()
+			}
+			done <- struct{}{} // tell
+		}(ch)
+	}
+	// wait for all iterators to finish
+	for range chans {
+		<-done
+	}
+	close(done)
+	it.Release()
+	return entries
+}
+
+func testShardedIterator_Release(t *testing.T, entryNum int, checkFunc func(db shardedDB)) {
+	entries := common.CreateEntries(entryNum)
+
+	// create DB and write data for testing
+	for _, config := range ShardedDBConfig {
+		config.Dir, _ = ioutil.TempDir(os.TempDir(), "test-shardedDB-iterator")
+		defer func(dir string) {
+			if err := os.RemoveAll(dir); err != nil {
+				t.Fatalf("fail to delete file %v", err)
+			}
+		}(config.Dir)
+
+		// create sharded DB
+		db, err := newShardedDB(config, MiscDB, config.NumStateTrieShards)
+		if err != nil {
+			t.Log("Error occured while creating DB")
+			t.FailNow()
+		}
+
+		// write entries data in DB
+		batch := db.NewBatch()
+		for _, entry := range entries {
+			assert.NoError(t, batch.Put(entry.Key, entry.Val))
+		}
+		assert.NoError(t, batch.Write())
+
+		// check if Release quits iterator
+		checkFunc(*db)
+	}
+}
+
+func TestShardedDBIterator_Release(t *testing.T) {
+	testShardedIterator_Release(t, shardedDBCombineChanSize+10, func(db shardedDB) {
+		// Next() returns True if Release() is not called
+		{
+			it := db.NewIterator(nil, nil)
+			defer it.Release()
+
+			// check if data exists
+			for i := 0; i < shardedDBCombineChanSize+1; i++ {
+				assert.True(t, it.Next())
+			}
+		}
+
+		//  Next() returns False if Release() is called
+		{
+			it := db.NewIterator(nil, nil)
+			it.Release()
+
+			// flush data in channel
+			for i := 0; i < shardedDBCombineChanSize; i++ {
+				it.Next()
+			}
+
+			// check if Next returns false
+			assert.False(t, it.Next())
+		}
+	})
+}
+
+func TestShardedDBIteratorUnsorted_Release(t *testing.T) {
+	testShardedIterator_Release(t, shardedDBCombineChanSize+10, func(db shardedDB) {
+		// Next() returns True if Release() is not called
+		{
+			it := db.NewIteratorUnsorted(nil, nil)
+			defer it.Release()
+
+			// check if data exists
+			for i := 0; i < shardedDBCombineChanSize+1; i++ {
+				assert.True(t, it.Next())
+			}
+		}
+
+		//  Next() returns False if Release() is called
+		{
+			it := db.NewIteratorUnsorted(nil, nil)
+			it.Release()
+
+			// flush data in channel
+			for i := 0; i < shardedDBCombineChanSize; i++ {
+				it.Next()
+			}
+
+			// check if Next returns false
+			assert.False(t, it.Next())
+		}
+	})
+}
+
+func TestShardedDBChanIterator_Release(t *testing.T) {
+	testShardedIterator_Release(t,
+		int(ShardedDBConfig[len(ShardedDBConfig)-1].NumStateTrieShards*shardedDBSubChannelSize*2),
+		func(db shardedDB) {
+			// Next() returns True if Release() is not called
+			{
+				it := db.NewChanIterator(context.Background(), nil, nil, nil)
+				defer it.Release()
+
+				for _, ch := range it.Channels() {
+
+					// check if channel is not closed
+					for i := 0; i < shardedDBSubChannelSize+1; i++ {
+						e, ok := <-ch
+						assert.NotNil(t, e)
+						assert.True(t, ok)
+					}
+				}
+			}
+
+			//  Next() returns False if Release() is called
+			{
+				it := db.NewChanIterator(context.Background(), nil, nil, nil)
+				it.Release()
+				for _, ch := range it.Channels() {
+
+					// flush data in channel
+					for i := 0; i < shardedDBSubChannelSize; i++ {
+						<-ch
+					}
+
+					// check if channel is closed
+					_, ok := <-ch
+					assert.False(t, ok)
+				}
+			}
+		})
+}

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -53,11 +53,11 @@ func testIterator(t *testing.T, checkOrder bool, entryNums []uint, dbConfig []*D
 
 			// create sharded DB
 			db, err := newShardedDB(config, 0, config.NumStateTrieShards)
-			dbs[i] = *db
 			if err != nil {
-				t.Log("Error occured while creating DB")
+				t.Log("Error occured while creating DB :", err)
 				t.FailNow()
 			}
+			dbs[i] = *db
 
 			// write entries data in DB
 			batch := db.NewBatch()
@@ -87,37 +87,37 @@ func testIterator(t *testing.T, checkOrder bool, entryNums []uint, dbConfig []*D
 
 // TestShardedDBIterator tests if shardedDBIterator iterates all entries with diverse shard size
 func TestShardedDBIterator(t *testing.T) {
-	testIterator(t, true, []uint{500}, ShardedDBConfig, newShardedDBIterator)
+	testIterator(t, true, []uint{100}, ShardedDBConfig, newShardedDBIterator)
 }
 
 // TestShardedDBIteratorUnsorted tests if shardedDBIteratorUnsorted iterates all entries with diverse shard size
 func TestShardedDBIteratorUnsorted(t *testing.T) {
-	testIterator(t, false, []uint{500}, ShardedDBConfig, newShardedDBIteratorUnsorted)
+	testIterator(t, false, []uint{100}, ShardedDBConfig, newShardedDBIteratorUnsorted)
 }
 
 // TestShardedDBChanIterator tests if shardedDBChanIterator iterates all entries with diverse shard size
 func TestShardedDBChanIterator(t *testing.T) {
-	testIterator(t, false, []uint{500}, ShardedDBConfig, newShardedDBChanIterator)
+	testIterator(t, false, []uint{100}, ShardedDBConfig, newShardedDBChanIterator)
 }
 
 // TestShardedDBIteratorSize tests if shardedDBIterator iterates all entries for different
 // entry sizes
 func TestShardedDBIteratorSize(t *testing.T) {
-	config := ShardedDBConfig[len(ShardedDBConfig)-1]
+	config := ShardedDBConfig[0]
 	size := config.NumStateTrieShards
 	testIterator(t, true, []uint{size - 1, size, size + 1}, []*DBConfig{config}, newShardedDBIterator)
 }
 
 // TestShardedDBIteratorUnsortedSize tests if shardedDBIteratorUnsorted iterates all entries
 func TestShardedDBIteratorUnsortedSize(t *testing.T) {
-	config := ShardedDBConfig[len(ShardedDBConfig)-1]
+	config := ShardedDBConfig[0]
 	size := config.NumStateTrieShards
 	testIterator(t, false, []uint{size - 1, size, size + 1}, []*DBConfig{config}, newShardedDBIteratorUnsorted)
 }
 
 // TestShardedDBChanIteratorSize tests if shardedDBChanIterator iterates all entries
 func TestShardedDBChanIteratorSize(t *testing.T) {
-	config := ShardedDBConfig[len(ShardedDBConfig)-1]
+	config := ShardedDBConfig[0]
 	size := config.NumStateTrieShards
 	testIterator(t, false, []uint{size - 1, size, size + 1}, []*DBConfig{config}, newShardedDBChanIterator)
 }
@@ -190,7 +190,7 @@ func testShardedIterator_Release(t *testing.T, entryNum int, checkFunc func(db s
 		// create sharded DB
 		db, err := newShardedDB(config, MiscDB, config.NumStateTrieShards)
 		if err != nil {
-			t.Log("Error occured while creating DB")
+			t.Log("Error occured while creating DB :", err)
 			t.FailNow()
 		}
 


### PR DESCRIPTION
## Proposed changes

This is a newer version of https://github.com/klaytn/klaytn/pull/822. This also contains commit from https://github.com/klaytn/klaytn/pull/855.
Please review https://github.com/klaytn/klaytn/commit/80fd645ba7a330136e124cfb371daaf873642bec for the shardedDBIterators.

Difference from the last PR:
- Created a new heap instead of `prqueByteSlice` because of the speed. (Related PR : https://github.com/klaytn/klaytn/pull/855)
- NewIterator interface is applied. (New interface PR: https://github.com/klaytn/klaytn/pull/836)
- Create 3 more testcases for `entryNum`.
- Moved `Entry` and `CreateEntries` to `common` package


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

