### PR TITLE
Fail should not occur from fakeserver after the test is ended

### DIFF
--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -112,15 +112,16 @@ func (s *SuiteDynamoDB) TestDynamoDB_Timeout() {
 		}
 		defer listen.Close()
 
-		for {
+		for i := 0; i < maxRetries+1; i++ {
 			// Deadline prevents infinite waiting of the fake server
 			// Wait longer than (maxRetries+1) * timeout
 			if err := listen.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
 				s.FailNow(err.Error())
 			}
 			if _, err := listen.AcceptTCP(); err != nil {
+				// timeout is expected
 				if strings.Contains(err.Error(), "timeout") {
-					s.FailNow("timeout. err:" + err.Error())
+					return
 				}
 				s.FailNow(err.Error())
 			}

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -119,7 +119,7 @@ func (s *SuiteDynamoDB) TestDynamoDB_Timeout() {
 				s.FailNow(err.Error())
 			}
 			if _, err := listen.AcceptTCP(); err != nil {
-				// timeout is expected
+				// the fake server ends silently when it meets deadline
 				if strings.Contains(err.Error(), "timeout") {
 					return
 				}


### PR DESCRIPTION
## Proposed changes

Please take a look before other PRs. Some PRs' tests are failing and this PR fixes it.

- Before this PR : When running test codes, there a fail occurs at `s.FailNow("timeout. err:" + err.Error())` after `TestDynamoDB_Timeout` is passed. However the timeout is expected case.
- After this PR : The fake server ends when timeout occurs. FakeServer only tries `maxRetries+1` times at max. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

