### PR TITLE
rpc: Using original context instead of creating own context

### DIFF
--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -206,7 +206,7 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// All checks passed, create a codec that reads direct from the request body
 	// untilEOF and writes the response to w and order the server to process a
 	// single request.
-	ctx := context.Background()
+	ctx := r.Context()
 	ctx = context.WithValue(ctx, "remote", r.RemoteAddr)
 	ctx = context.WithValue(ctx, "scheme", r.Proto)
 	ctx = context.WithValue(ctx, "local", r.Host)
@@ -238,7 +238,8 @@ func (srv *Server) HandleFastHTTP(requestCtx *fasthttp.RequestCtx) {
 	// All checks passed, create a codec that reads direct from the request body
 	// untilEOF and writes the response to w and order the server to process a
 	// single request.
-	ctx := context.Background()
+	var ctx context.Context
+	ctx = requestCtx
 	ctx = context.WithValue(ctx, "remote", requestCtx.RemoteAddr().String())
 	ctx = context.WithValue(ctx, "scheme", string(requestCtx.URI().Scheme()))
 	ctx = context.WithValue(ctx, "local", requestCtx.LocalAddr().String())


### PR DESCRIPTION
## Proposed changes

- This PR is derived from [geth PR #16861](https://github.com/ethereum/go-ethereum/pull/16861).
- Changed to use `http.Request`'s context and `fasthttp.RequestCtx` instead of creating own context.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
