### PR TITLE
blockchain: improve StatePrefetcher by prefetching txs when fetcher works

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -291,8 +291,8 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 
 	// Take ownership of this particular state
 	go bc.update()
-	go bc.gcCachedNodeLoop()
-	go bc.restartStateMigration()
+	bc.gcCachedNodeLoop()
+	bc.restartStateMigration()
 
 	if cacheConfig.TrieNodeCacheConfig.DumpPeriodically() {
 		logger.Info("LocalCache is used for trie node cache, start saving cache to file periodically",

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -285,6 +285,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 	}
 
 	for i := 1; i <= runtime.NumCPU()/2; i++ {
+		bc.wg.Add(1)
 		go bc.prefetchTxWorker(i)
 	}
 
@@ -311,7 +312,6 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 // prefetchTxWorker receives a block and a transaction index, which it pre-executes
 // to retrieve and cache the data for the actual block processing.
 func (bc *BlockChain) prefetchTxWorker(index int) {
-	bc.wg.Add(1)
 	defer bc.wg.Done()
 
 	logger.Info("prefetchTxWorker is started", "num", index)

--- a/blockchain/state_prefetcher.go
+++ b/blockchain/state_prefetcher.go
@@ -1,3 +1,4 @@
+// Modifications Copyright 2020 The klaytn Authors
 // Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
@@ -13,6 +14,9 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from core/state_prefetcher.go (2019/04/02).
+// Modified and improved for the klaytn development.
 
 package blockchain
 

--- a/blockchain/state_prefetcher.go
+++ b/blockchain/state_prefetcher.go
@@ -77,9 +77,8 @@ func (p *statePrefetcher) Prefetch(block *types.Block, stateDB *state.StateDB, c
 func (p *statePrefetcher) PrefetchTx(block *types.Block, ti int, stateDB *state.StateDB, cfg vm.Config, interrupt *uint32) {
 	var (
 		header = block.Header()
+		tx     = block.Transactions()[ti]
 	)
-	tx := block.Transactions()[ti]
-	// Iterate over and process the individual transactions
 
 	// If block precaching was interrupted, abort
 	if interrupt != nil && atomic.LoadUint32(interrupt) == 1 {

--- a/blockchain/types.go
+++ b/blockchain/types.go
@@ -45,6 +45,7 @@ type Prefetcher interface {
 	// the transaction messages using the statedb, but any changes are discarded. The
 	// only goal is to pre-cache transaction signatures and state trie nodes.
 	Prefetch(block *types.Block, stateDB *state.StateDB, cfg vm.Config, interrupt *uint32)
+	PrefetchTx(block *types.Block, ti int, stateDB *state.StateDB, cfg vm.Config, interrupt *uint32)
 }
 
 // Processor is an interface for processing blocks using a given initial state.


### PR DESCRIPTION
## Proposed changes

- Previous implementation of StatePrefetcher(=https://github.com/klaytn/klaytn/pull/832) won't be helpful when fetcher works, since it will process only a block at a time, since it pre-executes the next block, taken from the list of blocks.
- With this change, if single block is given to `insertChain`, before processing the block, it will be sent to prefetchTxWorker, which executes transactions in the block in a parallel manner. This can pre-cache the data needed for processing the block.

## Test Results
- EN0 is the one with original StatePrefetcher and EN2 is the one with original StatePrefetcher + fetcher optimized StatePrefetcher, EN2 shows about 20-30% of less execution time and LevelDB get time.

<img width="2672" alt="Screen Shot 2021-01-15 at 9 10 51 AM" src="https://user-images.githubusercontent.com/2115430/104673991-2b31f480-5726-11eb-8041-ebbbfaa1d6bd.png">
<img width="2672" alt="Screen Shot 2021-01-15 at 9 11 23 AM" src="https://user-images.githubusercontent.com/2115430/104673994-2cfbb800-5726-11eb-8dd6-41a1a90f081d.png">
<img width="2672" alt="Screen Shot 2021-01-15 at 9 13 47 AM" src="https://user-images.githubusercontent.com/2115430/104674000-2ec57b80-5726-11eb-85a1-1587fdd5e9b6.png">
<img width="2672" alt="Screen Shot 2021-01-15 at 9 14 11 AM" src="https://user-images.githubusercontent.com/2115430/104674003-2ff6a880-5726-11eb-9580-5cd08273a633.png">
<img width="2672" alt="Screen Shot 2021-01-15 at 9 14 28 AM" src="https://user-images.githubusercontent.com/2115430/104674004-31c06c00-5726-11eb-8d36-e8df1e84a4f2.png">

- EN2 does not seem to use more resource than EN0, it only has 10% more goroutines than EN0

<img width="2672" alt="Screen Shot 2021-01-15 at 9 15 45 AM" src="https://user-images.githubusercontent.com/2115430/104674058-4bfa4a00-5726-11eb-8976-728824eb92f1.png">
<img width="2672" alt="Screen Shot 2021-01-15 at 9 16 15 AM" src="https://user-images.githubusercontent.com/2115430/104674063-4dc40d80-5726-11eb-9b1b-d9db3a23386c.png">
<img width="2672" alt="Screen Shot 2021-01-15 at 9 16 22 AM" src="https://user-images.githubusercontent.com/2115430/104674064-4f8dd100-5726-11eb-8f85-4f6f37b3111d.png">


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
