### PR TITLE
Limit the number of websocket connections and added metrics

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -488,6 +488,11 @@ var (
 		Usage: "Set the Write deadline on the underlying network connection in seconds. 0 means write will not timeout",
 		Value: rpc.WebsocketWriteDeadline,
 	}
+	WSMaxConnections = cli.IntFlag{
+		Name:  "wsmaxconnections",
+		Usage: "Allowed maximum websocket connection number",
+		Value: 3000,
+	}
 	GRPCEnabledFlag = cli.BoolFlag{
 		Name:  "grpc",
 		Usage: "Enable the gRPC server",
@@ -1144,6 +1149,7 @@ func setWS(ctx *cli.Context, cfg *node.Config) {
 	rpc.MaxSubscriptionPerConn = int32(ctx.GlobalInt(WSMaxSubscriptionPerConn.Name))
 	rpc.WebsocketReadDeadline = ctx.GlobalInt64(WSReadDeadLine.Name)
 	rpc.WebsocketWriteDeadline = ctx.GlobalInt64(WSWriteDeadLine.Name)
+	rpc.MaxWebsocketConnections = int32(ctx.GlobalInt(WSMaxConnections.Name))
 }
 
 // setIPC creates an IPC path configuration from the set command line flags,

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -131,6 +131,7 @@ var CommonRPCFlags = []cli.Flag{
 	utils.WSMaxSubscriptionPerConn,
 	utils.WSReadDeadLine,
 	utils.WSWriteDeadLine,
+	utils.WSMaxConnections,
 	utils.IPCDisabledFlag,
 	utils.IPCPathFlag,
 }

--- a/networks/rpc/metrics.go
+++ b/networks/rpc/metrics.go
@@ -7,4 +7,8 @@ var (
 	rpcSuccessResponsesCounter = metrics.NewRegisteredCounter("rpc/counts/success", nil)
 	rpcErrorResponsesCounter   = metrics.NewRegisteredCounter("rpc/counts/errors", nil)
 	rpcPendingRequestsCount    = metrics.NewRegisteredCounter("rpc/counts/pending", nil)
+
+	wsSubscriptionReqCounter   = metrics.NewRegisteredCounter("ws/counts/subscription/request", nil)
+	wsUnsubscriptionReqCounter = metrics.NewRegisteredCounter("ws/counts/unsubscription/request", nil)
+	wsConnCounter              = metrics.NewRegisteredCounter("ws/counts/connections/total", nil)
 )

--- a/networks/rpc/types.go
+++ b/networks/rpc/types.go
@@ -25,10 +25,11 @@ import (
 	"sync"
 
 	"fmt"
-	"github.com/klaytn/klaytn/common/hexutil"
-	"gopkg.in/fatih/set.v0"
 	"math"
 	"strings"
+
+	"github.com/klaytn/klaytn/common/hexutil"
+	"gopkg.in/fatih/set.v0"
 )
 
 // API describes the set of methods offered over the RPC interface
@@ -78,6 +79,8 @@ type Server struct {
 	run      int32
 	codecsMu sync.Mutex
 	codecs   *set.Set
+
+	wsConnCount int32
 }
 
 // rpcRequest represents a raw incoming RPC request

--- a/networks/rpc/websocket.go
+++ b/networks/rpc/websocket.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/klaytn/klaytn/common"
@@ -68,6 +69,15 @@ func (srv *Server) WebsocketHandler(allowedOrigins []string) http.Handler {
 	return websocket.Server{
 		Handshake: wsHandshakeValidator(allowedOrigins),
 		Handler: func(conn *websocket.Conn) {
+			if atomic.LoadInt32(&srv.wsConnCount) >= MaxWebsocketConnections {
+				return
+			}
+			atomic.AddInt32(&srv.wsConnCount, 1)
+			wsConnCounter.Inc(1)
+			defer func() {
+				atomic.AddInt32(&srv.wsConnCount, -1)
+				wsConnCounter.Dec(1)
+			}()
 			// Create a custom encode/decode pair to enforce payload size and number encoding
 			conn.MaxPayloadBytes = common.MaxRequestContentLength
 			if WebsocketReadDeadline != 0 {
@@ -102,13 +112,21 @@ func (srv *Server) FastWebsocketHandler(ctx *fasthttp.RequestCtx) {
 	}
 
 	err := upgrader.Upgrade(ctx, func(conn *fastws.Conn) {
+		if atomic.LoadInt32(&srv.wsConnCount) >= MaxWebsocketConnections {
+			return
+		}
+		atomic.AddInt32(&srv.wsConnCount, 1)
+		wsConnCounter.Inc(1)
+		defer func() {
+			atomic.AddInt32(&srv.wsConnCount, -1)
+			wsConnCounter.Dec(1)
+		}()
 		if WebsocketReadDeadline != 0 {
 			conn.SetReadDeadline(time.Now().Add(time.Duration(WebsocketReadDeadline) * time.Second))
 		}
 		if WebsocketWriteDeadline != 0 {
 			conn.SetWriteDeadline(time.Now().Add(time.Duration(WebsocketWriteDeadline) * time.Second))
 		}
-
 		//Create a custom encode/decode pair to enforce payload size and number encoding
 		encoder := func(v interface{}) error {
 			msg, err := json.Marshal(v)
@@ -116,7 +134,6 @@ func (srv *Server) FastWebsocketHandler(ctx *fasthttp.RequestCtx) {
 				return err
 			}
 			err = conn.WriteMessage(websocket.TextFrame, msg)
-			conn.Close()
 			if err != nil {
 				return err
 			}

--- a/networks/rpc/websocket_test.go
+++ b/networks/rpc/websocket_test.go
@@ -22,12 +22,14 @@ package rpc
 
 import (
 	"context"
-	"github.com/klaytn/klaytn/common"
-	"github.com/stretchr/testify/assert"
+	"net"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/stretchr/testify/assert"
 )
 
 type echoArgs struct {
@@ -78,4 +80,72 @@ func TestWebsocketLargeCall(t *testing.T) {
 	// This call sends slightly larger than the allowed size and shouldn't work.
 	arg = strings.Repeat("x", requestMaxLen)
 	assert.Error(t, client.Call(&result, method, arg), "no error for too large call")
+}
+
+func newTestListener() net.Listener {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		panic(err)
+	}
+	return ln
+}
+
+func TestWSServer_MaxConnections(t *testing.T) {
+	// create server
+	var (
+		srv = newTestServer("service", new(Service))
+		ln  = newTestListener()
+	)
+	defer srv.Stop()
+	defer ln.Close()
+
+	go NewWSServer([]string{"*"}, srv).Serve(ln)
+
+	// set max websocket connections
+	MaxWebsocketConnections = 3
+	testWebsocketMaxConnections(t, "ws://"+ln.Addr().String(), int(MaxWebsocketConnections))
+}
+
+func TestFastWSServer_MaxConnections(t *testing.T) {
+	// create server
+	var (
+		srv = newTestServer("service", new(Service))
+		ln  = newTestListener()
+	)
+	defer srv.Stop()
+	defer ln.Close()
+
+	go NewFastWSServer([]string{"*"}, srv).Serve(ln)
+
+	// set max websocket connections
+	MaxWebsocketConnections = 3
+	testWebsocketMaxConnections(t, "ws://"+ln.Addr().String(), int(MaxWebsocketConnections))
+}
+
+func testWebsocketMaxConnections(t *testing.T, addr string, maxConnections int) {
+	var closers []*Client
+
+	for i := 0; i <= maxConnections; i++ {
+		client, err := DialWebsocket(context.Background(), addr, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		closers = append(closers, client)
+
+		var result echoResult
+		method := "service_echo"
+		arg := strings.Repeat("x", i)
+		err = client.Call(&result, method, arg, 1)
+		if i < int(MaxWebsocketConnections) {
+			assert.NoError(t, err)
+			assert.Equal(t, arg, result.String, "wrong string echoed")
+		} else {
+			assert.Error(t, err)
+			assert.Equal(t, "EOF", err.Error())
+		}
+	}
+
+	for _, client := range closers {
+		client.Close()
+	}
 }


### PR DESCRIPTION
## Proposed changes

- Limit the max number of websocket connections
- added websocket-related metrics: total websocket connections, subscription requests, unsubscription requests

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
