### PR TITLE
Change access modifier of TrieNoceCache constructors to private

### DIFF
--- a/storage/statedb/cache.go
+++ b/storage/statedb/cache.go
@@ -71,7 +71,8 @@ const (
 )
 
 var (
-	errNotSupportedCacheType = errors.New("not supported stateDB TrieNodeCache type")
+	errNotSupportedCacheType  = errors.New("not supported stateDB TrieNodeCache type")
+	errNilTrieNodeCacheConfig = errors.New("TrieNodeCacheConfig is nil")
 )
 
 func (cacheType TrieNodeCacheType) ToValid() TrieNodeCacheType {
@@ -88,14 +89,17 @@ func (cacheType TrieNodeCacheType) ToValid() TrieNodeCacheType {
 // NewTrieNodeCache creates one type of any supported trie node caches.
 // NOTE: It returns (nil, nil) when the cache type is CacheTypeLocal and its size is set to zero.
 func NewTrieNodeCache(config *TrieNodeCacheConfig) (TrieNodeCache, error) {
+	if config == nil {
+		return nil, errNilTrieNodeCacheConfig
+	}
 	switch config.CacheType {
 	case CacheTypeLocal:
-		return NewFastCache(config), nil
+		return newFastCache(config), nil
 	case CacheTypeRedis:
-		return NewRedisCache(config)
+		return newRedisCache(config)
 	case CacheTypeHybrid:
 		logger.Info("Set hybrid trie node cache using both of localCache (fastCache) and redisCache")
-		return NewHybridCache(config)
+		return newHybridCache(config)
 	default:
 	}
 	logger.Error("Invalid trie node cache type", "cacheType", config.CacheType)

--- a/storage/statedb/cache_fastcache.go
+++ b/storage/statedb/cache_fastcache.go
@@ -40,10 +40,10 @@ type FastCache struct {
 	fast *fastcache.Cache
 }
 
-// NewFastCache creates a FastCache with given cache size.
+// newFastCache creates a FastCache with given cache size.
 // If you want auto-scaled cache size, set config.LocalCacheSizeMB to AutoScaling.
 // It returns nil if the cache size is zero.
-func NewFastCache(config *TrieNodeCacheConfig) TrieNodeCache {
+func newFastCache(config *TrieNodeCacheConfig) TrieNodeCache {
 	if config.LocalCacheSizeMB == AutoScaling {
 		config.LocalCacheSizeMB = getTrieNodeCacheSizeMB()
 	}

--- a/storage/statedb/cache_fastcache_test.go
+++ b/storage/statedb/cache_fastcache_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package statedb
+
+func getTestFastCacheConfig() *TrieNodeCacheConfig {
+	return &TrieNodeCacheConfig{
+		CacheType:           CacheTypeLocal,
+		LocalCacheSizeMB:    100,
+		FastCacheFileDir:    "./test/fastcache",
+		FastCacheSavePeriod: 0,
+	}
+}

--- a/storage/statedb/cache_hybrid.go
+++ b/storage/statedb/cache_hybrid.go
@@ -18,14 +18,14 @@ package statedb
 
 import "github.com/go-redis/redis/v7"
 
-func NewHybridCache(config *TrieNodeCacheConfig) (TrieNodeCache, error) {
-	redis, err := NewRedisCache(config)
+func newHybridCache(config *TrieNodeCacheConfig) (TrieNodeCache, error) {
+	redis, err := newRedisCache(config)
 	if err != nil {
 		return nil, err
 	}
 
 	return &HybridCache{
-		local:  NewFastCache(config),
+		local:  newFastCache(config),
 		remote: redis,
 	}, nil
 }

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -20,7 +20,7 @@ func getTestHybridConfig() *TrieNodeCacheConfig {
 
 // TestHybridCache_Set tests whether a hybrid cache can set an item into both of local and remote caches.
 func TestHybridCache_Set(t *testing.T) {
-	cache, err := NewHybridCache(getTestHybridConfig())
+	cache, err := newHybridCache(getTestHybridConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,8 +46,8 @@ func TestHybridCache_Set(t *testing.T) {
 // TestHybridCache_Get tests whether a hybrid cache can get an item from both of local and remote caches.
 func TestHybridCache_Get(t *testing.T) {
 	// Prepare caches to be integrated with a hybrid cache
-	localCache := NewFastCache(getTestHybridConfig())
-	remoteCache, err := NewRedisCache(getTestHybridConfig())
+	localCache := newFastCache(getTestHybridConfig())
+	remoteCache, err := newRedisCache(getTestHybridConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,8 +103,8 @@ func TestHybridCache_Get(t *testing.T) {
 // TestHybridCache_Has tests whether a hybrid cache can check an item from both of local and remote caches.
 func TestHybridCache_Has(t *testing.T) {
 	// Prepare caches to be integrated with a hybrid cache
-	localCache := NewFastCache(getTestHybridConfig())
-	remoteCache, err := NewRedisCache(getTestHybridConfig())
+	localCache := newFastCache(getTestHybridConfig())
+	remoteCache, err := newRedisCache(getTestHybridConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -76,9 +76,9 @@ func newRedisClient(endpoints []string, isCluster bool) (redis.UniversalClient, 
 	}), nil
 }
 
-// NewRedisCache creates a redis cache containing redis client, setItemCh and pubSub.
+// newRedisCache creates a redis cache containing redis client, setItemCh and pubSub.
 // It generates worker goroutines to process Set commands asynchronously.
-func NewRedisCache(config *TrieNodeCacheConfig) (*RedisCache, error) {
+func newRedisCache(config *TrieNodeCacheConfig) (*RedisCache, error) {
 	cli, err := newRedisClient(config.RedisEndpoints, config.RedisClusterEnable)
 	if err != nil {
 		logger.Error("failed to create a redis client", "err", err, "endpoint", config.RedisEndpoints,

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -47,7 +47,7 @@ func TestSubscription(t *testing.T) {
 	wg.Add(1)
 
 	go func() {
-		cache, err := NewRedisCache(getTestRedisConfig())
+		cache, err := newRedisCache(getTestRedisConfig())
 		assert.Nil(t, err)
 
 		ch := cache.SubscribeBlockCh()
@@ -70,7 +70,7 @@ func TestSubscription(t *testing.T) {
 	}()
 	time.Sleep(sleepDurationForAsyncBehavior)
 
-	cache, err := NewRedisCache(getTestRedisConfig())
+	cache, err := newRedisCache(getTestRedisConfig())
 	assert.Nil(t, err)
 
 	if err := cache.PublishBlock(msg1); err != nil {
@@ -86,7 +86,7 @@ func TestSubscription(t *testing.T) {
 
 // TestRedisCache tests basic operations of redis cache
 func TestRedisCache(t *testing.T) {
-	cache, err := NewRedisCache(getTestRedisConfig())
+	cache, err := newRedisCache(getTestRedisConfig())
 	assert.Nil(t, err)
 
 	key, value := randBytes(32), randBytes(500)
@@ -103,7 +103,7 @@ func TestRedisCache(t *testing.T) {
 
 // TestRedisCache_Set_LargeData check whether redis cache can store an large data (5MB).
 func TestRedisCache_Set_LargeData(t *testing.T) {
-	cache, err := NewRedisCache(getTestRedisConfig())
+	cache, err := newRedisCache(getTestRedisConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestRedisCache_Set_LargeData(t *testing.T) {
 }
 
 func TestRedisCache_Set_LargeNumberItems(t *testing.T) {
-	cache, err := NewRedisCache(getTestRedisConfig())
+	cache, err := newRedisCache(getTestRedisConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/statedb/cache_test.go
+++ b/storage/statedb/cache_test.go
@@ -71,7 +71,7 @@ func TestFastCache_SaveAndLoad(t *testing.T) {
 	config.FastCacheFileDir = dirName
 
 	// Create a fastcache from the file and save the data to the cache
-	fastCache := NewFastCache(config)
+	fastCache := newFastCache(config)
 	for idx, key := range keys {
 		assert.DeepEqual(t, fastCache.Get(key), []byte(nil))
 		fastCache.Set(key, vals[idx])
@@ -81,7 +81,7 @@ func TestFastCache_SaveAndLoad(t *testing.T) {
 	assert.NilError(t, fastCache.SaveToFile(dirName, runtime.NumCPU()))
 
 	// Create a fastcache from the file and check if the data exists
-	fastCacheFromFile := NewFastCache(config)
+	fastCacheFromFile := newFastCache(config)
 	for idx, key := range keys {
 		assert.DeepEqual(t, fastCacheFromFile.Get(key), vals[idx])
 	}

--- a/storage/statedb/cache_test.go
+++ b/storage/statedb/cache_test.go
@@ -28,25 +28,22 @@ import (
 	"github.com/docker/docker/pkg/testutil/assert"
 )
 
-// TODO-Klaytn: Enable tests when redis is prepared on CI
-
 // TestNewTrieNodeCache tests creating all kinds of supported trie node caches.
-func _TestNewTrieNodeCache(t *testing.T) {
+func TestNewTrieNodeCache(t *testing.T) {
 	testCases := []struct {
-		cacheType    TrieNodeCacheType
+		cacheConfig  *TrieNodeCacheConfig
 		expectedType reflect.Type
+		err          error
 	}{
-		{CacheTypeLocal, reflect.TypeOf(&FastCache{})},
-		{CacheTypeRedis, reflect.TypeOf(&RedisCache{})},
-		{CacheTypeHybrid, reflect.TypeOf(&HybridCache{})},
+		{getTestFastCacheConfig(), reflect.TypeOf(&FastCache{}), nil},
+		{getTestRedisConfig(), reflect.TypeOf(&RedisCache{}), nil},
+		{getTestHybridConfig(), reflect.TypeOf(&HybridCache{}), nil},
+		{nil, nil, errNilTrieNodeCacheConfig},
 	}
 
 	for _, tc := range testCases {
-		config := getTestHybridConfig()
-		config.CacheType = tc.cacheType
-
-		cache, err := NewTrieNodeCache(config)
-		assert.NilError(t, err)
+		cache, err := NewTrieNodeCache(tc.cacheConfig)
+		assert.Equal(t, err, tc.err)
 		assert.Equal(t, reflect.TypeOf(cache), tc.expectedType)
 	}
 }


### PR DESCRIPTION
## Proposed changes

1. Add a `nil` checking logic 
2. Change the access modifier of TrieNoceCache constructors to private

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
