### PR TITLE
Add chainId API for compatibility with Ethereum (Metamask)

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -63,7 +63,17 @@ func (s *PublicBlockChainAPI) BlockNumber() *big.Int {
 }
 
 // ChainID returns the chain ID of the chain from genesis file.
+// This will be deprecated.
 func (s *PublicBlockChainAPI) ChainID() *big.Int {
+	if s.b.ChainConfig() != nil {
+		return s.b.ChainConfig().ChainID
+	}
+	return nil
+}
+
+// ChainId returns the chain ID of the chain from genesis file.
+// This is for compatibility with ethereum client
+func (s *PublicBlockChainAPI) ChainId() *big.Int {
 	if s.b.ChainConfig() != nil {
 		return s.b.ChainConfig().ChainID
 	}

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -63,12 +63,8 @@ func (s *PublicBlockChainAPI) BlockNumber() *big.Int {
 }
 
 // ChainID returns the chain ID of the chain from genesis file.
-// This will be deprecated.
 func (s *PublicBlockChainAPI) ChainID() *big.Int {
-	if s.b.ChainConfig() != nil {
-		return s.b.ChainConfig().ChainID
-	}
-	return nil
+	return s.ChainId()
 }
 
 // ChainId returns the chain ID of the chain from genesis file.

--- a/console/jsre/deps/web3.js
+++ b/console/jsre/deps/web3.js
@@ -5580,9 +5580,9 @@ var properties = function () {
           outputFormatter: formatters.outputBigNumberFormatter
         }),
         new Property({
-        name: 'chainId',
-        getter: 'klay_chainId',
-        outputFormatter: formatters.outputBigNumberFormatter
+          name: 'chainId',
+          getter: 'klay_chainId',
+          outputFormatter: formatters.outputBigNumberFormatter
         }),
         new Property({
             name: 'protocolVersion',

--- a/console/jsre/deps/web3.js
+++ b/console/jsre/deps/web3.js
@@ -5580,6 +5580,11 @@ var properties = function () {
           outputFormatter: formatters.outputBigNumberFormatter
         }),
         new Property({
+        name: 'chainId',
+        getter: 'klay_chainId',
+        outputFormatter: formatters.outputBigNumberFormatter
+        }),
+        new Property({
             name: 'protocolVersion',
             getter: 'klay_protocolVersion'
         })


### PR DESCRIPTION
## Proposed changes

This PR added `chainId` API. We already have `chainID`. 
But In ethereum, the API name is `chainId` for getting chain ID. 
So I added it and `chainID` will be deprecated in the future.

With this PR, we can use metamask with our client.

![image](https://user-images.githubusercontent.com/29390878/104874946-7acb2700-5997-11eb-82d0-3e6ba62b764c.png)


Related with https://github.com/ethereum/go-ethereum/pull/17617

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
