### PR TITLE
rpc: fix subscription corner case and speed up tests

### DIFF
--- a/networks/rpc/subscription.go
+++ b/networks/rpc/subscription.go
@@ -52,9 +52,10 @@ type notifierKey struct{}
 // Server callbacks use the notifier to send notifications.
 type Notifier struct {
 	codec    ServerCodec
-	subMu    sync.RWMutex // guards active and inactive maps
+	subMu    sync.Mutex
 	active   map[ID]*Subscription
 	inactive map[ID]*Subscription
+	buffer   map[ID][]interface{} // unsent notifications of inactive subscriptions
 }
 
 // newNotifier creates a new notifier that can be used to send subscription
@@ -64,6 +65,7 @@ func newNotifier(codec ServerCodec) *Notifier {
 		codec:    codec,
 		active:   make(map[ID]*Subscription),
 		inactive: make(map[ID]*Subscription),
+		buffer:   make(map[ID][]interface{}),
 	}
 }
 
@@ -88,18 +90,24 @@ func (n *Notifier) CreateSubscription() *Subscription {
 // Notify sends a notification to the client with the given data as payload.
 // If an error occurs the RPC connection is closed and the error is returned.
 func (n *Notifier) Notify(id ID, data interface{}) error {
-	n.subMu.RLock()
-	defer n.subMu.RUnlock()
+	n.subMu.Lock()
+	defer n.subMu.Unlock()
 
-	sub, active := n.active[id]
-	if active {
-		notification := n.codec.CreateNotification(string(id), sub.namespace, data)
-		if err := n.codec.Write(notification); err != nil {
-			n.codec.Close()
-			return err
-		}
+	if sub, active := n.active[id]; active {
+		n.send(sub, data)
+	} else {
+		n.buffer[id] = append(n.buffer[id], data)
 	}
 	return nil
+}
+
+func (n *Notifier) send(sub *Subscription, data interface{}) error {
+	notification := n.codec.CreateNotification(string(sub.ID), sub.namespace, data)
+	err := n.codec.Write(notification)
+	if err != nil {
+		n.codec.Close()
+	}
+	return err
 }
 
 // Closed returns a channel that is closed when the RPC connection is closed.
@@ -127,10 +135,16 @@ func (n *Notifier) unsubscribe(id ID) error {
 func (n *Notifier) activate(id ID, namespace string) {
 	n.subMu.Lock()
 	defer n.subMu.Unlock()
+
 	if sub, found := n.inactive[id]; found {
 		sub.namespace = namespace
 		n.active[id] = sub
 		delete(n.inactive, id)
+		// Send buffered notifications.
+		for _, data := range n.buffer[id] {
+			n.send(sub, data)
+		}
+		delete(n.buffer, id)
 	}
 }
 

--- a/networks/rpc/subscription_test.go
+++ b/networks/rpc/subscription_test.go
@@ -31,9 +31,8 @@ import (
 )
 
 type NotificationTestService struct {
-	mu           sync.Mutex
-	unsubscribed bool
-
+	mu                      sync.Mutex
+	unsubscribed            chan string
 	gotHangSubscriptionReq  chan struct{}
 	unblockHangSubscription chan struct{}
 }
@@ -42,16 +41,10 @@ func (s *NotificationTestService) Echo(i int) int {
 	return i
 }
 
-func (s *NotificationTestService) wasUnsubCallbackCalled() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.unsubscribed
-}
-
 func (s *NotificationTestService) Unsubscribe(subid string) {
-	s.mu.Lock()
-	s.unsubscribed = true
-	s.mu.Unlock()
+	if s.unsubscribed != nil {
+		s.unsubscribed <- subid
+	}
 }
 
 func (s *NotificationTestService) SomeSubscription(ctx context.Context, n, val int) (*Subscription, error) {
@@ -69,7 +62,6 @@ func (s *NotificationTestService) SomeSubscription(ctx context.Context, n, val i
 		// test expects n events, if we begin sending event immediately some events
 		// will probably be dropped since the subscription ID might not be send to
 		// the client.
-		time.Sleep(5 * time.Second)
 		for i := 0; i < n; i++ {
 			if err := notifier.Notify(subscription.ID, val+i); err != nil {
 				return
@@ -78,13 +70,10 @@ func (s *NotificationTestService) SomeSubscription(ctx context.Context, n, val i
 
 		select {
 		case <-notifier.Closed():
-			s.mu.Lock()
-			s.unsubscribed = true
-			s.mu.Unlock()
 		case <-subscription.Err():
-			s.mu.Lock()
-			s.unsubscribed = true
-			s.mu.Unlock()
+		}
+		if s.unsubscribed != nil {
+			s.unsubscribed <- string(subscription.ID)
 		}
 	}()
 
@@ -111,7 +100,7 @@ func (s *NotificationTestService) HangSubscription(ctx context.Context, val int)
 
 func TestNotifications(t *testing.T) {
 	server := NewServer()
-	service := &NotificationTestService{}
+	service := &NotificationTestService{unsubscribed: make(chan string)}
 
 	if err := server.RegisterName("klay", service); err != nil {
 		t.Fatalf("unable to register test service %v", err)
@@ -161,10 +150,10 @@ func TestNotifications(t *testing.T) {
 	}
 
 	clientConn.Close() // causes notification unsubscribe callback to be called
-	time.Sleep(1 * time.Second)
-
-	if !service.wasUnsubCallbackCalled() {
-		t.Error("unsubscribe callback not called after closing connection")
+	select {
+	case <-service.unsubscribed:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Unsubscribe not called after one second")
 	}
 }
 
@@ -237,18 +226,19 @@ func TestSubscriptionMultipleNamespaces(t *testing.T) {
 	}()
 
 	var (
-		namespaces             = []string{"klay", "shh", "bzz"}
+		namespaces        = []string{"klay", "shh", "bzz"}
+		service           = NotificationTestService{}
+		subCount          = len(namespaces) * 2
+		notificationCount = 3
+
 		server                 = NewServer()
-		service                = NotificationTestService{}
 		clientConn, serverConn = net.Pipe()
-
-		out           = json.NewEncoder(clientConn)
-		in            = json.NewDecoder(clientConn)
-		successes     = make(chan jsonSuccessResponse)
-		failures      = make(chan jsonErrResponse)
-		notifications = make(chan jsonNotification)
-
-		errors = make(chan error, 10)
+		out                    = json.NewEncoder(clientConn)
+		in                     = json.NewDecoder(clientConn)
+		successes              = make(chan jsonSuccessResponse)
+		failures               = make(chan jsonErrResponse)
+		notifications          = make(chan jsonNotification)
+		errors                 = make(chan error, 10)
 	)
 
 	// setup and start server
@@ -265,13 +255,12 @@ func TestSubscriptionMultipleNamespaces(t *testing.T) {
 	go waitForMessages(t, in, successes, failures, notifications, errors)
 
 	// create subscriptions one by one
-	n := 3
 	for i, namespace := range namespaces {
 		request := map[string]interface{}{
 			"id":      i,
 			"method":  fmt.Sprintf("%s_subscribe", namespace),
 			"version": "2.0",
-			"params":  []interface{}{"someSubscription", n, i},
+			"params":  []interface{}{"someSubscription", notificationCount, i},
 		}
 
 		if err := out.Encode(&request); err != nil {
@@ -286,7 +275,7 @@ func TestSubscriptionMultipleNamespaces(t *testing.T) {
 			"id":      i,
 			"method":  fmt.Sprintf("%s_subscribe", namespace),
 			"version": "2.0",
-			"params":  []interface{}{"someSubscription", n, i},
+			"params":  []interface{}{"someSubscription", notificationCount, i},
 		})
 	}
 
@@ -295,46 +284,39 @@ func TestSubscriptionMultipleNamespaces(t *testing.T) {
 	}
 
 	timeout := time.After(30 * time.Second)
-	subids := make(map[string]string, 2*len(namespaces))
-	count := make(map[string]int, 2*len(namespaces))
-
-	for {
-		done := true
-		for id := range count {
-			if count, found := count[id]; !found || count < (2*n) {
+	subids := make(map[string]string, subCount)
+	count := make(map[string]int, subCount)
+	allReceived := func() bool {
+		done := len(count) == subCount
+		for _, c := range count {
+			if c < notificationCount {
 				done = false
 			}
 		}
-
-		if done && len(count) == len(namespaces) {
-			break
-		}
-
+		return done
+	}
+	for !allReceived() {
 		select {
-		case err := <-errors:
-			t.Fatal(err)
 		case suc := <-successes: // subscription created
 			subids[namespaces[int(suc.Id.(float64))]] = suc.Result.(string)
+		case notification := <-notifications:
+			count[notification.Params.Subscription]++
+		case err := <-errors:
+			t.Fatal(err)
 		case failure := <-failures:
 			t.Errorf("received error: %v", failure.Error)
-		case notification := <-notifications:
-			if cnt, found := count[notification.Params.Subscription]; found {
-				count[notification.Params.Subscription] = cnt + 1
-			} else {
-				count[notification.Params.Subscription] = 1
-			}
 		case <-timeout:
 			for _, namespace := range namespaces {
 				subid, found := subids[namespace]
 				if !found {
-					t.Errorf("Subscription for '%s' not created", namespace)
+					t.Errorf("subscription for %q not created", namespace)
 					continue
 				}
-				if count, found := count[subid]; !found || count < n {
-					t.Errorf("Didn't receive all notifications (%d<%d) in time for namespace '%s'", count, n, namespace)
+				if count, found := count[subid]; !found || count < notificationCount {
+					t.Errorf("didn't receive all notifications (%d<%d) in time for namespace %q", count, notificationCount, namespace)
 				}
 			}
-			return
+			t.Fatal("timed out")
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

- This PR is derived from [geth PR 17874](https://github.com/ethereum/go-ethereum/pull/17874).
- The problem was that the notification msg is dropped when the msg is arrived before the subscriptionId arrived.
- So, this PR fix it by buffering notifications until the subscriptionId arrives.
- On the other hand, the subscription_test.go become faster because there is no longer a need to forcibly wait for the notificationId to arrive. For example, the tests in `rpc` folder takes 6 seconds now. dev branch, it takes 61 seconds.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
