### PR TITLE
Remove darwin/386 in cross compile scripts

### DIFF
--- a/build/cross-compile.sh
+++ b/build/cross-compile.sh
@@ -59,10 +59,6 @@ case "$SUBCOMMAND" in
         ADDITIONAL_OPTIONS="--ldflags '-extldflags \"-static\"'"
         shift
         ;;
-    darwin-386)
-        TARGET="darwin/386"
-        shift
-        ;;
     darwin-amd64)
         TARGET="darwin-10.10/amd64"
         shift
@@ -76,11 +72,11 @@ case "$SUBCOMMAND" in
         shift
         ;;
     *)
-        echo "Undefined architecture for cross-compile. Supported architectures: linux-386, linux-amd64, linux-arm-5, linux-arm-6, linux-arm-7, linux-arm64, linux-mips, linux-mipsle, linux-mips64, linux-mips64le, darwin-386, darwin-amd64, windows-386, windows-amd64"
+        echo "Undefined architecture for cross-compile. Supported architectures: linux-386, linux-amd64, linux-arm-5, linux-arm-6, linux-arm-7, linux-arm64, linux-mips, linux-mipsle, linux-mips64, linux-mips64le, darwin-amd64, windows-386, windows-amd64"
         echo "Usage: ${0} {arch} [kcn|kpn...]"
-        echo "    ${0} linux-386"
-        echo "    ${0} darwin-386 kcn"
-        echo "    ${0} windows-386 kcn kpn"
+        echo "    ${0} linux-amd64"
+        echo "    ${0} darwin-amd64 kcn"
+        echo "    ${0} windows-amd64 kcn kpn"
         exit 1
         ;;
 esac

--- a/build/package-tar.sh
+++ b/build/package-tar.sh
@@ -9,7 +9,7 @@ set -e
 function printUsage {
     echo "Usage: ${0} [-b] <arch> <target>"
     echo "         -b: use baobab configuration"
-    echo "     <arch>:  linux-386 | linux-amd64 | darwin-386 | darwin-amd64 | windows-386 | windows-amd64"
+    echo "     <arch>:  linux-386 | linux-amd64 | darwin-amd64 | windows-386 | windows-amd64"
     echo "   <target>:  kcn | kpn | ken | kbn | kscn | kspn | ksen | kgen | homi"
     echo ""
     echo "    ${0} linux-amd64 kcn"
@@ -39,10 +39,6 @@ case "$SUBCOMMAND" in
 		PLATFORM_SUFFIX="linux-amd64"
 		shift
 		;;
-	darwin-386)
-		PLATFORM_SUFFIX="darwin-386"
-		shift
-		;;
 	darwin-amd64)
 		PLATFORM_SUFFIX="darwin-10.10-amd64"
 		shift
@@ -56,7 +52,7 @@ case "$SUBCOMMAND" in
 		shift
 		;;
 	*)
-		echo "Undefined architecture for packaging. Supported architectures: linux-386, linux-amd64, darwin-386, darwin-amd64, windows-386, windows-amd64"
+		echo "Undefined architecture for packaging. Supported architectures: linux-386, linux-amd64, darwin-amd64, windows-386, windows-amd64"
 		printUsage
 		;;
 esac


### PR DESCRIPTION
## Proposed changes

Remove darwin/386 in cross compile scripts since golang doesn't support it from version 1.15

```
As announced in the Go 1.14 release notes, Go 1.15 drops support for 32-bit binaries on macOS, iOS, iPadOS, watchOS, and tvOS (the darwin/386 and darwin/arm ports). Go continues to support the 64-bit darwin/amd64 and darwin/arm64 ports.
```
from https://golang.org/doc/go1.15

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
