### PR TITLE
Wait until DB remove is finshed in FinishStateMigration

### DIFF
--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -111,7 +111,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 		if returnErr != ErrQuitBySignal {
 			// lock to prevent from a conflict of state DB close and state DB write
 			bc.mu.Lock()
-			bc.db.FinishStateMigration(returnErr == nil)
+			bc.db.FinishStateMigration(returnErr == nil, nil)
 			bc.mu.Unlock()
 		}
 	}()

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -111,7 +111,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 		if returnErr != ErrQuitBySignal {
 			// lock to prevent from a conflict of state DB close and state DB write
 			bc.mu.Lock()
-			bc.db.FinishStateMigration(returnErr == nil, nil)
+			bc.db.FinishStateMigration(returnErr == nil)
 			bc.mu.Unlock()
 		}
 	}()

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -55,7 +55,7 @@ type DBManager interface {
 	GetDBConfig() *DBConfig
 	getDatabase(DBEntryType) Database
 	CreateMigrationDBAndSetStatus(blockNum uint64) error
-	FinishStateMigration(succeed bool, endCheck chan struct{})
+	FinishStateMigration(succeed bool) chan struct{}
 	GetStateTrieDB() Database
 	GetStateTrieMigrationDB() Database
 	GetMiscDB() Database
@@ -680,7 +680,8 @@ func (dbm *databaseManager) CreateMigrationDBAndSetStatus(blockNum uint64) error
 
 // FinishStateMigration updates stateTrieDB and removes the old one.
 // The function should be called only after when state trie migration is finished.
-func (dbm *databaseManager) FinishStateMigration(succeed bool, endCheck chan struct{}) {
+// It returns a channel that closes when removeDB is finished.
+func (dbm *databaseManager) FinishStateMigration(succeed bool) chan struct{} {
 	// lock to prevent from a conflict of reading state DB and changing state DB
 	dbm.lockInMigration.Lock()
 	defer dbm.lockInMigration.Unlock()
@@ -709,7 +710,9 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool, endCheck chan str
 	dbPathToBeRemoved := filepath.Join(dbm.config.Dir, dbDirToBeRemoved)
 	dbToBeRemoved.Close()
 
+	endCheck := make(chan struct{})
 	go removeDB(dbPathToBeRemoved, endCheck)
+	return endCheck
 }
 
 func removeDB(dbPath string, endCheck chan struct{}) {

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -435,7 +435,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		assert.True(t, hasStateTrieNode)
 		assert.True(t, hasOldStateTrieNode)
 
-		dbm.FinishStateMigration(true)
+		dbm.FinishStateMigration(true, nil)
 	}
 }
 
@@ -740,7 +740,7 @@ func TestDatabaseManager_CreateMigrationDBAndSetStatus(t *testing.T) {
 			assert.Equal(t, common.Int64ToByteBigEndian(migrationBlockNum), fetchedBlockNum)
 
 			// reset migration status for next test
-			dbm.FinishStateMigration(false)
+			dbm.FinishStateMigration(false, nil) // migration fail
 		}
 	}
 }
@@ -765,7 +765,14 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			// finish migration with failure
 			err := dbm.CreateMigrationDBAndSetStatus(migrationBlockNum)
 			assert.NoError(t, err)
-			dbm.FinishStateMigration(false)
+			endCheck := make(chan struct{})
+			dbm.FinishStateMigration(false, endCheck) // migration fail
+			select {
+			case <-endCheck: // wait for removing DB
+			case <-time.After(1 * time.Second):
+				t.Log("Take too long for a DB to be removed")
+				t.FailNow()
+			}
 
 			// check if in migration state
 			assert.False(t, dbm.InMigration())
@@ -774,6 +781,8 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			statDBPathKey := append(databaseDirPrefix, common.Int64ToByteBigEndian(uint64(StateTrieDB))...)
 			fetchedStateDBPath, err := dbm.getDatabase(MiscDB).Get(statDBPathKey)
 			assert.NoError(t, err)
+			dirNames := getFilesInDir(t, dbm.GetDBConfig().Dir, "statetrie")
+			assert.Equal(t, 1, len(dirNames)) // check if DB is removed
 			assert.Equal(t, initialDirNames[0], string(fetchedStateDBPath), "old DB should remain")
 
 			// check if migration DB Path is not set in MiscDB
@@ -796,7 +805,14 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			// finish migration successfully
 			err := dbm.CreateMigrationDBAndSetStatus(migrationBlockNum2)
 			assert.NoError(t, err)
-			dbm.FinishStateMigration(true)
+			endCheck := make(chan struct{})
+			dbm.FinishStateMigration(true, endCheck) // migration succeed
+			select {
+			case <-endCheck: // wait for removing DB
+			case <-time.After(1 * time.Second):
+				t.Log("Take too long for a DB to be removed")
+				t.FailNow()
+			}
 
 			// check if in migration state
 			assert.False(t, dbm.InMigration())
@@ -805,6 +821,8 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			statDBPathKey := append(databaseDirPrefix, common.Int64ToByteBigEndian(uint64(StateTrieDB))...)
 			fetchedStateDBPath, err := dbm.getDatabase(MiscDB).Get(statDBPathKey)
 			assert.NoError(t, err)
+			dirNames := getFilesInDir(t, dbm.GetDBConfig().Dir, "statetrie")
+			assert.Equal(t, 1, len(dirNames))                                                         // check if DB is removed
 			expectedStateDBPath := "statetrie_migrated_" + strconv.FormatUint(migrationBlockNum2, 10) // new DB format
 			assert.Equal(t, expectedStateDBPath, string(fetchedStateDBPath), "new DB should remain")
 
@@ -846,11 +864,17 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 			assert.True(t, dirNames[0] == NewMigrationPath || dirNames[1] == NewMigrationPath)
 
 			// check if old db is deleted on migration success
-			dbm.FinishStateMigration(true)     // migration success
-			time.Sleep(200 * time.Millisecond) // wait for removing DB
+			endCheck := make(chan struct{})
+			dbm.FinishStateMigration(true, endCheck) // migration succeed
+			select {
+			case <-endCheck: // wait for removing DB
+			case <-time.After(1 * time.Second):
+				t.Log("Take too long for a DB to be removed")
+				t.FailNow()
+			}
 
 			newDirNames := getFilesInDir(t, dbm.GetDBConfig().Dir, "statetrie")
-			assert.Equal(t, 1, len(newDirNames))
+			assert.Equal(t, 1, len(newDirNames)) // check if DB is removed
 			assert.Equal(t, NewMigrationPath, newDirNames[0], "new DB should remain")
 		}
 
@@ -872,11 +896,17 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 			assert.True(t, dirNames[0] == NewMigrationPath || dirNames[1] == NewMigrationPath)
 
 			// check if new db is deleted on migration fail
-			dbm.FinishStateMigration(false)    // migration fail
-			time.Sleep(200 * time.Millisecond) // wait for removing DB
+			endCheck := make(chan struct{})
+			dbm.FinishStateMigration(false, endCheck) // migration fail
+			select {
+			case <-endCheck: // wait for removing DB
+			case <-time.After(1 * time.Second):
+				t.Log("Take too long for a DB to be removed")
+				t.FailNow()
+			}
 
 			newDirNames := getFilesInDir(t, dbm.GetDBConfig().Dir, dbm.getDBDir(StateTrieDB))
-			assert.Equal(t, 1, len(newDirNames))
+			assert.Equal(t, 1, len(newDirNames)) // check if DB is removed
 			assert.Equal(t, initialDirNames[0], newDirNames[0], "old DB should remain")
 		}
 	}

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -435,7 +435,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		assert.True(t, hasStateTrieNode)
 		assert.True(t, hasOldStateTrieNode)
 
-		dbm.FinishStateMigration(true, nil)
+		dbm.FinishStateMigration(true)
 	}
 }
 
@@ -740,7 +740,7 @@ func TestDatabaseManager_CreateMigrationDBAndSetStatus(t *testing.T) {
 			assert.Equal(t, common.Int64ToByteBigEndian(migrationBlockNum), fetchedBlockNum)
 
 			// reset migration status for next test
-			dbm.FinishStateMigration(false, nil) // migration fail
+			dbm.FinishStateMigration(false) // migration fail
 		}
 	}
 }
@@ -765,8 +765,7 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			// finish migration with failure
 			err := dbm.CreateMigrationDBAndSetStatus(migrationBlockNum)
 			assert.NoError(t, err)
-			endCheck := make(chan struct{})
-			dbm.FinishStateMigration(false, endCheck) // migration fail
+			endCheck := dbm.FinishStateMigration(false) // migration fail
 			select {
 			case <-endCheck: // wait for removing DB
 			case <-time.After(1 * time.Second):
@@ -805,8 +804,7 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 			// finish migration successfully
 			err := dbm.CreateMigrationDBAndSetStatus(migrationBlockNum2)
 			assert.NoError(t, err)
-			endCheck := make(chan struct{})
-			dbm.FinishStateMigration(true, endCheck) // migration succeed
+			endCheck := dbm.FinishStateMigration(true) // migration succeed
 			select {
 			case <-endCheck: // wait for removing DB
 			case <-time.After(1 * time.Second):
@@ -864,8 +862,7 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 			assert.True(t, dirNames[0] == NewMigrationPath || dirNames[1] == NewMigrationPath)
 
 			// check if old db is deleted on migration success
-			endCheck := make(chan struct{})
-			dbm.FinishStateMigration(true, endCheck) // migration succeed
+			endCheck := dbm.FinishStateMigration(true) // migration succeed
 			select {
 			case <-endCheck: // wait for removing DB
 			case <-time.After(1 * time.Second):
@@ -896,8 +893,7 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 			assert.True(t, dirNames[0] == NewMigrationPath || dirNames[1] == NewMigrationPath)
 
 			// check if new db is deleted on migration fail
-			endCheck := make(chan struct{})
-			dbm.FinishStateMigration(false, endCheck) // migration fail
+			endCheck := dbm.FinishStateMigration(false) // migration fail
 			select {
 			case <-endCheck: // wait for removing DB
 			case <-time.After(1 * time.Second):


### PR DESCRIPTION
## Proposed changes

- Before this PR : `removeDB` is called in a new routine in `FinishStateMigration`. It was unable to know if the DB is removed from caller. However, there are test codes that checks if a DB is removed. The test fails due to this.
- After this PR : You can return a channel to check if `removeDB` is finished. The test fails if the DB remove is not finished in 1 second.
- Error message when the test fails :
```
--- FAIL: TestDBManager_StateMigrationDBPath (9.84s)
    db_manager_test.go:853: 
        	Error Trace:	db_manager_test.go:853
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	TestDBManager_StateMigrationDBPath
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

