### PR TITLE
Raise fd limit when it is less than min value

### DIFF
--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -79,8 +79,12 @@ func GetOpenFilesLimit() int {
 		logger.Crit("Failed to retrieve file descriptor allowance", "err", err)
 	}
 	if limit < minFileDescriptorsForDBManager {
-		logger.Crit("Raised number of file descriptor  is below the minimum value",
-			"currFileDescriptorsLimit", limit, "minFileDescriptorsForDBManager", minFileDescriptorsForDBManager)
+		raised, err := fdlimit.Raise(minFileDescriptorsForDBManager)
+		if err != nil || raised != minFileDescriptorsForDBManager {
+			logger.Crit("Raised number of file descriptor  is below the minimum value",
+				"currFileDescriptorsLimit", limit, "minFileDescriptorsForDBManager", minFileDescriptorsForDBManager)
+		}
+		limit = int(raised)
 	}
 	return limit / 2 // Leave half for networking and other stuff
 }

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -81,7 +81,7 @@ func GetOpenFilesLimit() int {
 	if limit < minFileDescriptorsForDBManager {
 		raised, err := fdlimit.Raise(minFileDescriptorsForDBManager)
 		if err != nil || raised != minFileDescriptorsForDBManager {
-			logger.Crit("Raised number of file descriptor  is below the minimum value",
+			logger.Crit("Raised number of file descriptor is below the minimum value",
 				"currFileDescriptorsLimit", limit, "minFileDescriptorsForDBManager", minFileDescriptorsForDBManager)
 		}
 		limit = int(raised)

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -80,7 +80,7 @@ func GetOpenFilesLimit() int {
 	}
 	if limit < minFileDescriptorsForDBManager {
 		raised, err := fdlimit.Raise(minFileDescriptorsForDBManager)
-		if err != nil || raised != minFileDescriptorsForDBManager {
+		if err != nil || raised < minFileDescriptorsForDBManager {
 			logger.Crit("Raised number of file descriptor is below the minimum value",
 				"currFileDescriptorsLimit", limit, "minFileDescriptorsForDBManager", minFileDescriptorsForDBManager)
 		}


### PR DESCRIPTION
## Proposed changes

Raise fd limit when it is less than min value. 
In some test cases, `GetOpenFilesLimit` is called without raising fd limit. 
Since it causes panic when it is less than min value, fd increasing logic in added in `GetOpenFilesLimit` as it was.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
