### PR TITLE
blockchain, utils: managing the number of fetcher prefetch workers

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -393,13 +393,15 @@ func (bc *BlockChain) loadLastState() error {
 	currentBlock := bc.GetBlockByHash(head)
 	if currentBlock == nil {
 		// Corrupt or empty database, init from scratch
-		logger.Error("Head block missing, resetting chain", "hash", head)
+		logger.Error("Head block missing, resetting chain",
+			"number", currentBlock.NumberU64(), "hash", head.String())
 		return bc.Reset()
 	}
 	// Make sure the state associated with the block is available
 	if _, err := state.New(currentBlock.Root(), bc.stateCache); err != nil {
 		// Dangling block without a state associated, init from scratch
-		logger.Error("Head state missing, repairing chain", "number", currentBlock.Number(), "hash", currentBlock.Hash())
+		logger.Error("Head state missing, repairing chain",
+			"number", currentBlock.NumberU64(), "hash", currentBlock.Hash().String())
 		if err := bc.repair(&currentBlock); err != nil {
 			return err
 		}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -393,8 +393,7 @@ func (bc *BlockChain) loadLastState() error {
 	currentBlock := bc.GetBlockByHash(head)
 	if currentBlock == nil {
 		// Corrupt or empty database, init from scratch
-		logger.Error("Head block missing, resetting chain",
-			"number", currentBlock.NumberU64(), "hash", head.String())
+		logger.Error("Head block missing, resetting chain", "hash", head.String())
 		return bc.Reset()
 	}
 	// Make sure the state associated with the block is available

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1678,7 +1678,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		// transactions and probabilistically some of the account/storage trie nodes.
 		var followupInterrupt uint32
 
-		if !bc.cacheConfig.TrieNodeCacheConfig.NoPrefetch {
+		if bc.cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker > 0 {
 			// if fetcher works and only a block is given, use prefetchTxWorker
 			if len(chain) == 1 {
 				for ti := range block.Transactions() {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -284,7 +284,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 		}
 	}
 
-	for i := 1; i <= runtime.NumCPU()/2; i++ {
+	for i := 1; i <= bc.cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker; i++ {
 		bc.wg.Add(1)
 		go bc.prefetchTxWorker(i)
 	}

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -177,7 +177,6 @@ var FlagGroups = []FlagGroup{
 			CacheUsageLevelFlag,
 			MemorySizeFlag,
 			TrieNodeCacheTypeFlag,
-			TrieNodeCacheNoPrefetchFlag,
 			NumFetcherPrefetchWorkerFlag,
 			TrieNodeCacheLimitFlag,
 			TrieNodeCacheSavePeriodFlag,

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -178,6 +178,7 @@ var FlagGroups = []FlagGroup{
 			MemorySizeFlag,
 			TrieNodeCacheTypeFlag,
 			TrieNodeCacheNoPrefetchFlag,
+			NumFetcherPrefetchWorkerFlag,
 			TrieNodeCacheLimitFlag,
 			TrieNodeCacheSavePeriodFlag,
 			TrieNodeCacheRedisEndpointsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -306,6 +306,11 @@ var (
 		Name:  "statedb.cache.noprefetch",
 		Usage: "Disable heuristic state prefetch during block import (less CPU and disk IO, more time waiting for data)",
 	}
+	NumFetcherPrefetchWorkerFlag = cli.IntFlag{
+		Name:  "statedb.cache.num-fetcher-prefetch-worker",
+		Usage: "Number of workers used to prefetch block when fetcher fetches block",
+		Value: 1,
+	}
 	TrieNodeCacheRedisEndpointsFlag = cli.StringSliceFlag{
 		Name:  "statedb.cache.redis.endpoints",
 		Usage: "Set endpoints of redis trie node cache. More than one endpoints can be set",
@@ -1524,6 +1529,7 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 		CacheType: statedb.TrieNodeCacheType(ctx.GlobalString(TrieNodeCacheTypeFlag.
 			Name)).ToValid(),
 		NoPrefetch:                ctx.GlobalBool(TrieNodeCacheNoPrefetchFlag.Name),
+		NumFetcherPrefetchWorker:  ctx.GlobalInt(NumFetcherPrefetchWorkerFlag.Name),
 		LocalCacheSizeMB:          ctx.GlobalInt(TrieNodeCacheLimitFlag.Name),
 		FastCacheFileDir:          ctx.GlobalString(DataDirFlag.Name) + "/fastcache",
 		FastCacheSavePeriod:       ctx.GlobalDuration(TrieNodeCacheSavePeriodFlag.Name),

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -305,7 +305,7 @@ var (
 	NumFetcherPrefetchWorkerFlag = cli.IntFlag{
 		Name:  "statedb.cache.num-fetcher-prefetch-worker",
 		Usage: "Number of workers used to prefetch block when fetcher fetches block",
-		Value: 1,
+		Value: 32,
 	}
 	TrieNodeCacheRedisEndpointsFlag = cli.StringSliceFlag{
 		Name:  "statedb.cache.redis.endpoints",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -302,10 +302,6 @@ var (
 			"'HybridCache') (default = 'LocalCache')",
 		Value: string(statedb.CacheTypeLocal),
 	}
-	TrieNodeCacheNoPrefetchFlag = cli.BoolFlag{
-		Name:  "statedb.cache.noprefetch",
-		Usage: "Disable heuristic state prefetch during block import (less CPU and disk IO, more time waiting for data)",
-	}
 	NumFetcherPrefetchWorkerFlag = cli.IntFlag{
 		Name:  "statedb.cache.num-fetcher-prefetch-worker",
 		Usage: "Number of workers used to prefetch block when fetcher fetches block",
@@ -1528,7 +1524,6 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 	cfg.TrieNodeCacheConfig = statedb.TrieNodeCacheConfig{
 		CacheType: statedb.TrieNodeCacheType(ctx.GlobalString(TrieNodeCacheTypeFlag.
 			Name)).ToValid(),
-		NoPrefetch:                ctx.GlobalBool(TrieNodeCacheNoPrefetchFlag.Name),
 		NumFetcherPrefetchWorker:  ctx.GlobalInt(NumFetcherPrefetchWorkerFlag.Name),
 		LocalCacheSizeMB:          ctx.GlobalInt(TrieNodeCacheLimitFlag.Name),
 		FastCacheFileDir:          ctx.GlobalString(DataDirFlag.Name) + "/fastcache",

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -75,7 +75,6 @@ var CommonNodeFlags = []cli.Flag{
 	utils.CacheUsageLevelFlag,
 	utils.MemorySizeFlag,
 	utils.TrieNodeCacheTypeFlag,
-	utils.TrieNodeCacheNoPrefetchFlag,
 	utils.NumFetcherPrefetchWorkerFlag,
 	utils.TrieNodeCacheLimitFlag,
 	utils.TrieNodeCacheSavePeriodFlag,

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -76,6 +76,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.MemorySizeFlag,
 	utils.TrieNodeCacheTypeFlag,
 	utils.TrieNodeCacheNoPrefetchFlag,
+	utils.NumFetcherPrefetchWorkerFlag,
 	utils.TrieNodeCacheLimitFlag,
 	utils.TrieNodeCacheSavePeriodFlag,
 	utils.TrieNodeCacheRedisEndpointsFlag,

--- a/storage/statedb/cache.go
+++ b/storage/statedb/cache.go
@@ -29,8 +29,7 @@ type TrieNodeCacheType string
 // TrieNodeCacheConfig contains configuration values of all TrieNodeCache.
 type TrieNodeCacheConfig struct {
 	CacheType                 TrieNodeCacheType
-	NoPrefetch                bool // Whether to disable heuristic state prefetching for followup blocks
-	NumFetcherPrefetchWorker  int
+	NumFetcherPrefetchWorker  int           // Number of workers used to prefetch a block when fetcher works
 	LocalCacheSizeMB          int           // Memory allowance (MB) to use for caching trie nodes in fast cache
 	FastCacheFileDir          string        // Directory where the persistent fastcache data is stored
 	FastCacheSavePeriod       time.Duration // Period of saving in memory trie cache to file if fastcache is used

--- a/storage/statedb/cache.go
+++ b/storage/statedb/cache.go
@@ -29,7 +29,8 @@ type TrieNodeCacheType string
 // TrieNodeCacheConfig contains configuration values of all TrieNodeCache.
 type TrieNodeCacheConfig struct {
 	CacheType                 TrieNodeCacheType
-	NoPrefetch                bool          // Whether to disable heuristic state prefetching for followup blocks
+	NoPrefetch                bool // Whether to disable heuristic state prefetching for followup blocks
+	NumFetcherPrefetchWorker  int
 	LocalCacheSizeMB          int           // Memory allowance (MB) to use for caching trie nodes in fast cache
 	FastCacheFileDir          string        // Directory where the persistent fastcache data is stored
 	FastCacheSavePeriod       time.Duration // Period of saving in memory trie cache to file if fastcache is used


### PR DESCRIPTION
## Proposed changes

- A new flag `statedb.cache.num-fetcher-prefetch-worker` is added to control the number of workers of prefetcher, specifially working when the fetcher works
- This is review purpose and test result will be uploaded later

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
