### PR TITLE
state: properly reset static variable stateObjEncoder

### DIFF
--- a/blockchain/state/state_object_encoder.go
+++ b/blockchain/state/state_object_encoder.go
@@ -63,7 +63,8 @@ func getStateObjectEncoder(requiredChSize int) *stateObjectEncoder {
 // resetStateObjectEncoder closes existing tasksCh and assigns a new stateObjectEncoder.
 func resetStateObjectEncoder(numGoRoutines, tasksChSize int) *stateObjectEncoder {
 	close(stateObjEncoder.tasksCh)
-	return newStateObjectEncoder(numGoRoutines, tasksChSize)
+	stateObjEncoder = newStateObjectEncoder(numGoRoutines, tasksChSize)
+	return stateObjEncoder
 }
 
 // stateObjectEncoder handles tasksCh and resultsCh

--- a/blockchain/state/state_object_encoder_test.go
+++ b/blockchain/state/state_object_encoder_test.go
@@ -30,7 +30,7 @@ func TestResetStateObjectEncoder(t *testing.T) {
 
 	firstChSize := 1
 	secondChSize := 2
-	testAcc, err := account.NewAccountWithType(account.LegacyAccountType)
+	testAcc, err := account.NewAccountWithType(account.ExternallyOwnedAccountType)
 	if err != nil {
 		t.Fatal("failed to create a test account", "err", err)
 	}

--- a/blockchain/state/state_object_encoder_test.go
+++ b/blockchain/state/state_object_encoder_test.go
@@ -19,12 +19,21 @@ package state
 import (
 	"testing"
 
+	"github.com/klaytn/klaytn/blockchain/types/account"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestResetStateObjectEncoder(t *testing.T) {
+	defer func() {
+		resetStateObjectEncoder(stateObjEncoderDefaultWorkers, stateObjEncoderDefaultCap)
+	}()
+
 	firstChSize := 1
 	secondChSize := 2
+	testAcc, err := account.NewAccountWithType(account.LegacyAccountType)
+	if err != nil {
+		t.Fatal("failed to create a test account", "err", err)
+	}
 
 	// reset stateObjectEncoder for test
 	resetStateObjectEncoder(1, firstChSize)
@@ -34,13 +43,13 @@ func TestResetStateObjectEncoder(t *testing.T) {
 	// getStateObjectEncoder(firstChSize) should not assign a new channel
 	soe := getStateObjectEncoder(firstChSize)
 	assert.Equal(t, firstChSize, cap(stateObjEncoder.tasksCh))
-	soe.encode(&stateObject{})
+	soe.encode(&stateObject{account: testAcc})
 
 	// getStateObjectEncoder(secondChSize) should assign a new channel
 	soe = getStateObjectEncoder(secondChSize)
 	assert.Equal(t, secondChSize, cap(stateObjEncoder.tasksCh))
 	assert.Equal(t, 0, len(stateObjEncoder.tasksCh))
 
-	soe.encode(&stateObject{})
-	soe.encode(&stateObject{})
+	soe.encode(&stateObject{account: testAcc})
+	soe.encode(&stateObject{account: testAcc})
 }

--- a/blockchain/state/state_object_encoder_test.go
+++ b/blockchain/state/state_object_encoder_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResetStateObjectEncoder(t *testing.T) {
+	firstChSize := 1
+	secondChSize := 2
+
+	// reset stateObjectEncoder for test
+	resetStateObjectEncoder(1, firstChSize)
+	assert.Equal(t, firstChSize, cap(stateObjEncoder.tasksCh))
+	assert.Equal(t, 0, len(stateObjEncoder.tasksCh))
+
+	// getStateObjectEncoder(firstChSize) should not assign a new channel
+	soe := getStateObjectEncoder(firstChSize)
+	assert.Equal(t, firstChSize, cap(stateObjEncoder.tasksCh))
+	soe.encode(&stateObject{})
+
+	// getStateObjectEncoder(secondChSize) should assign a new channel
+	soe = getStateObjectEncoder(secondChSize)
+	assert.Equal(t, secondChSize, cap(stateObjEncoder.tasksCh))
+	assert.Equal(t, 0, len(stateObjEncoder.tasksCh))
+
+	soe.encode(&stateObject{})
+	soe.encode(&stateObject{})
+}


### PR DESCRIPTION
## Proposed changes

- `resetStateObjectEncoder` should update the static variable `stateObjEncoder`, but it hasn't
- Now it properly updates the static variable when needed

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
