### PR TITLE
blockchain/genesis: refactor ChainConfig

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -248,7 +248,7 @@ func SetupGenesisBlock(db database.DBManager, genesis *Genesis, networkId uint64
 	// Special case: don't change the existing config of a non-mainnet chain if no new
 	// config is supplied. These chains would get AllProtocolChanges (and a compat error)
 	// if we just continued here.
-	if genesis == nil && stored != params.MainnetGenesisHash {
+	if genesis == nil && stored != params.CypressGenesisHash {
 		return storedcfg, stored, nil
 	}
 
@@ -364,31 +364,26 @@ func GenesisBlockForTesting(db database.DBManager, addr common.Address, balance 
 	return g.MustCommit(db)
 }
 
-// DefaultGenesisBlock returns the Klaytn main net genesis block.
+// DefaultGenesisBlock returns the Cypress mainnet genesis block.
+// It is also used for default genesis block.
 func DefaultGenesisBlock() *Genesis {
-	return cypressGenesisBlock()
-}
-
-func cypressGenesisBlock() *Genesis {
 	ret := &Genesis{}
 	if err := json.Unmarshal(cypressGenesisJson, &ret); err != nil {
-		logger.Error("Error in Unmarshaling Cypress Genesis Json", "err", err)
+		logger.Error("Error in Unmarshalling Cypress Genesis Json", "err", err)
 	}
+	ret.Config = params.CypressChainConfig
 	return ret
 }
 
-func baobabGenesisBlock() *Genesis {
+// DefaultBaobabGenesisBlock returns the Baobab testnet genesis block.
+func DefaultBaobabGenesisBlock() *Genesis {
 	ret := &Genesis{}
 	if err := json.Unmarshal(baobabGenesisJson, &ret); err != nil {
-		logger.Error("Error in Unmarshaling", "err", err)
+		logger.Error("Error in Unmarshalling Baobab Genesis Json", "err", err)
 		return nil
 	}
+	ret.Config = params.BaobabChainConfig
 	return ret
-}
-
-// DefaultBaobabGenesisBlock returns the Baobab network genesis block.
-func DefaultBaobabGenesisBlock() *Genesis {
-	return baobabGenesisBlock()
 }
 
 func decodePrealloc(data string) GenesisAlloc {

--- a/consensus/istanbul/validator/default_test.go
+++ b/consensus/istanbul/validator/default_test.go
@@ -22,14 +22,15 @@ package validator
 
 import (
 	"fmt"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/consensus/istanbul"
-	"github.com/klaytn/klaytn/crypto"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -183,7 +183,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create call tracer: %v", err)
 	}
-	evm := vm.NewEVM(context, statedb, params.MainnetChainConfig, &vm.Config{Debug: true, Tracer: tracer})
+	evm := vm.NewEVM(context, statedb, params.CypressChainConfig, &vm.Config{Debug: true, Tracer: tracer})
 
 	msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
 	if err != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -30,22 +30,63 @@ import (
 
 // Genesis hashes to enforce below configs on.
 var (
-	MainnetGenesisHash      = common.HexToHash("// todo generate new hash for mainnet") // Mainnet genesis hash to enforce below configs on
-	TestnetGenesisHash      = common.HexToHash("// todo generate new hash for testnet") // Testnet genesis hash to enforce below configs on
+	CypressGenesisHash      = common.HexToHash("// todo generate new hash for cypress") // cypress genesis hash to enforce below configs on
+	BaobabGenesisHash       = common.HexToHash("// todo generate new hash for baobab")  // baobab genesis hash to enforce below configs on
 	AuthorAddressForTesting = common.HexToAddress("0xc0ea08a2d404d3172d2add29a45be56da40e2949")
+	mintingAmount, _        = new(big.Int).SetString("9600000000000000000", 10)
 )
 
 var (
-	// MainnetChainConfig is the chain parameters to run a node on the main network.
-	MainnetChainConfig = &ChainConfig{
-		ChainID: big.NewInt(1),
-		Gxhash:  new(GxhashConfig),
+	// CypressChainConfig is the chain parameters to run a node on the cypress main network.
+	CypressChainConfig = &ChainConfig{
+		ChainID:            big.NewInt(int64(CypressNetworkId)),
+		Incompatible1Block: nil,
+		DeriveShaImpl:      2,
+		Governance: &GovernanceConfig{
+			GoverningNode:  common.HexToAddress("0x52d41ca72af615a1ac3301b0a93efa222ecc7541"),
+			GovernanceMode: "single",
+			Reward: &RewardConfig{
+				MintingAmount:          mintingAmount,
+				Ratio:                  "34/54/12",
+				UseGiniCoeff:           true,
+				DeferredTxFee:          true,
+				StakingUpdateInterval:  86400,
+				ProposerUpdateInterval: 3600,
+				MinimumStake:           big.NewInt(5000000),
+			},
+		},
+		Istanbul: &IstanbulConfig{
+			Epoch:          604800,
+			ProposerPolicy: 2,
+			SubGroupSize:   22,
+		},
+		UnitPrice: 25000000000,
 	}
 
-	// TestnetChainConfig contains the chain parameters to run a node on the Ropsten test network.
-	TestnetChainConfig = &ChainConfig{
-		ChainID: big.NewInt(2),
-		Gxhash:  new(GxhashConfig),
+	// BaobabChainConfig contains the chain parameters to run a node on the Baobab test network.
+	BaobabChainConfig = &ChainConfig{
+		ChainID:            big.NewInt(int64(BaobabNetworkId)),
+		Incompatible1Block: nil,
+		DeriveShaImpl:      2,
+		Governance: &GovernanceConfig{
+			GoverningNode:  common.HexToAddress("0x99fb17d324fa0e07f23b49d09028ac0919414db6"),
+			GovernanceMode: "single",
+			Reward: &RewardConfig{
+				MintingAmount:          mintingAmount,
+				Ratio:                  "34/54/12",
+				UseGiniCoeff:           true,
+				DeferredTxFee:          true,
+				StakingUpdateInterval:  86400,
+				ProposerUpdateInterval: 3600,
+				MinimumStake:           big.NewInt(5000000),
+			},
+		},
+		Istanbul: &IstanbulConfig{
+			Epoch:          604800,
+			ProposerPolicy: 2,
+			SubGroupSize:   22,
+		},
+		UnitPrice: 25000000000,
 	}
 
 	// AllGxhashProtocolChanges contains every protocol change (GxIPs) introduced
@@ -119,6 +160,8 @@ const (
 // set of configuration options.
 type ChainConfig struct {
 	ChainID *big.Int `json:"chainId"` // chainId identifies the current chain and is used for replay protection
+
+	Incompatible1Block *big.Int `json:"incompatible1Block"` // incompatible1 switch block (nil = no fork, 0 = already incompatible1)
 
 	// Various consensus engines
 	Gxhash   *GxhashConfig   `json:"gxhash,omitempty"` // (deprecated) not supported engine
@@ -198,21 +241,28 @@ func (c *ChainConfig) String() string {
 		engine = "unknown"
 	}
 	if c.Istanbul != nil {
-		return fmt.Sprintf("{ChainID: %v Engine: %v SubGroupSize: %d UnitPrice: %d DeriveShaImpl: %d}",
+		return fmt.Sprintf("{ChainID: %v Incompatible1Block: %v SubGroupSize: %d UnitPrice: %d DeriveShaImpl: %d Engine: %v}",
 			c.ChainID,
-			engine,
+			c.Incompatible1Block,
 			c.Istanbul.SubGroupSize,
 			c.UnitPrice,
 			c.DeriveShaImpl,
+			engine,
 		)
 	} else {
-		return fmt.Sprintf("{ChainID: %v Engine: %v UnitPrice: %d DeriveShaImpl: %d}",
+		return fmt.Sprintf("{ChainID: %v Incompatible1Block: %v UnitPrice: %d DeriveShaImpl: %d Engine: %v }",
 			c.ChainID,
-			engine,
+			c.Incompatible1Block,
 			c.UnitPrice,
 			c.DeriveShaImpl,
+			engine,
 		)
 	}
+}
+
+// IsIncompatible1 returns whether num is either equal to the incompatible1 block or greater.
+func (c *ChainConfig) IsIncompatible1(num *big.Int) bool {
+	return isForked(c.Incompatible1Block, num)
 }
 
 // GasTable returns the gas table corresponding to the current phase.
@@ -241,6 +291,9 @@ func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64) *Confi
 }
 
 func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *ConfigCompatError {
+	if isForkIncompatible(c.Incompatible1Block, newcfg.Incompatible1Block, head) {
+		return newCompatError("Incompatible1 Block", c.Incompatible1Block, newcfg.Incompatible1Block)
+	}
 	return nil
 }
 
@@ -352,7 +405,8 @@ func (err *ConfigCompatError) Error() string {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	ChainID *big.Int
+	ChainID         *big.Int
+	IsInCompatible1 bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -361,7 +415,10 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 	if chainID == nil {
 		chainID = new(big.Int)
 	}
-	return Rules{ChainID: new(big.Int).Set(chainID)}
+	return Rules{
+		ChainID:         new(big.Int).Set(chainID),
+		IsInCompatible1: c.IsIncompatible1(num),
+	}
 }
 
 // Copy copies self to a new governance config and return it

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -24,6 +24,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math/big"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/vm"
@@ -33,7 +35,6 @@ import (
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
-	"math/big"
 )
 
 // VMTest checks EVM execution without block or transaction context.
@@ -155,7 +156,7 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 		GasPrice:    t.json.Exec.GasPrice,
 	}
 	vmconfig.NoRecursion = true
-	return vm.NewEVM(context, statedb, params.MainnetChainConfig, &vmconfig)
+	return vm.NewEVM(context, statedb, params.CypressChainConfig, &vmconfig)
 }
 
 func vmTestBlockHash(n uint64) common.Hash {


### PR DESCRIPTION
## Proposed changes
Klaytn is preparing for its next hard fork. What matters in it is the promise of the update deadline. Nodes will update the release containing the incompatible changes that cause the hardfork until the deadline. Geth promises this period by setting the hard fork block number in the code.
Since Geth and Klaytn are both open source, private networks are operated in addition to the mainnet/testnet. In particular, using Klaytn can also operate a service chain, one of the layer2 solutions. The characteristic of these chains is that there is a separate node operating entity, and they need to be familiar with hard forks, find related guides, and set up hard fork block numbers.
However, since code related to Klaytn's block number is a little different from geth, in order to prevent any confusion in advance, we try to match this codebase as much as possible. Therefore this PR is suggested.

* This PR changes mainnet(cypress)/baobab adds chain config location to `params/config.go`
* It also adds incompatible1Block field to the chainConfig struct. The name of the field is temporary.

https://github.com/klaytn/klaytn/pull/882/commits/ca42a114813abbe9d6a893b284caa32c58133ad5: applied due to goimport `consensus/istanbul/validator/default_test.go`

**Test that the compatibility is not broken**

step1. deploy below contract before change binary. It is to check the previously deployed contract is working well.
```
contract Contract {
    function callVmLogPrecompiledContract() public returns (bool) {
        address vmlogaddr = address(0x09);
        vmlogaddr.call("Hello, Klaytn");
    }
}
```
step2. run init. `$ ken init --datadir data genesis.json`

**Chain Configuration Result**
dev
```
INFO ... Initialised chain configuration  config="{ChainID: 940625 Engine: istanbul ...}"
```
PR
```
INFO ... Initialised chain configuration  config="{ChainID: 940625 Incompatible1Block: <nil> ... Engine: istanbul}"
```
**call contract result**(ex. data/ken/logs/vm.log)
dev
```
tx=0x0000000000000000000000000000000000000000000000000000000000000000 caller=0x044E43A75bB2e8A2d5b2328e05370715C377421D msg=Hello, Klaytn
tx=0x0000000000000000000000000000000000000000000000000000000000000000 caller=0x044E43A75bB2e8A2d5b2328e05370715C377421D msg=Hello, Klaytn
tx=0x474a622c39aa5f230e43dcd2ffa19aec26ccdb915a9cadf21a1e3a39d928dc67 caller=0x044E43A75bB2e8A2d5b2328e05370715C377421D msg=Hello, Klaytn
tx=0x474a622c39aa5f230e43dcd2ffa19aec26ccdb915a9cadf21a1e3a39d928dc67 caller=0x044E43A75bB2e8A2d5b2328e05370715C377421D msg=Hello, Klaytn
```
PR
```
tx=0x0000000000000000000000000000000000000000000000000000000000000000 caller=0x044E43A75bB2e8A2d5b2328e05370715C377421D msg=Hello, Klaytn
tx=0x0000000000000000000000000000000000000000000000000000000000000000 caller=0x044E43A75bB2e8A2d5b2328e05370715C377421D msg=Hello, Klaytn
tx=0x6b8892220c581eca54278ce5fb1e98322842a2c02b1e313bca1ed63905f35bc0 caller=0x044E43A75bB2e8A2d5b2328e05370715C377421D msg=Hello, Klaytn
tx=0x6b8892220c581eca54278ce5fb1e98322842a2c02b1e313bca1ed63905f35bc0 caller=0x044E43A75bB2e8A2d5b2328e05370715C377421D msg=Hello, Klaytn
```
## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
