### PR TITLE
Lowered log level for downloader queue

### DIFF
--- a/datasync/downloader/queue.go
+++ b/datasync/downloader/queue.go
@@ -507,7 +507,7 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 			progress = true
 			delete(taskPool, header.Hash())
 			proc = proc - 1
-			logger.Error("Fetch reservation already delivered", "number", header.Number.Uint64())
+			logger.Debug("Fetch reservation already delivered", "number", header.Number.Uint64())
 			continue
 		}
 		if throttle {


### PR DESCRIPTION
## Proposed changes

- The log message is left because the blocks are already processed, but not yet pop from the task queue.
- So, the log level for this is lowered.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
