### PR TITLE
Fix invalid validator list in extraData of block header

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -281,10 +281,7 @@ func (api *APIExtension) getConsensusInfo(block *types.Block) (ConsensusInfo, er
 
 	// get origin proposer at 0 round.
 	originProposer := common.Address{}
-	lastProposer := common.Address{}
-	if blockNumber > 0 {
-		lastProposer = api.istanbul.GetProposer(blockNumber - 1)
-	}
+	lastProposer := api.istanbul.GetProposer(blockNumber - 1)
 
 	newValSet := snap.ValSet.Copy()
 	newValSet.CalcProposer(lastProposer, 0)

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -161,9 +161,19 @@ func (api *APIExtension) GetCouncil(number *rpc.BlockNumber) ([]common.Address, 
 	}
 	// Ensure we have an actually valid block and return the council from its snapshot
 	if header == nil {
-		logger.Trace("Failed to find the requested block", "number", number)
 		return nil, errNoBlockExist // return nil if block is not found.
 	}
+
+	// Since v1.6.1, extra.validators represents a list of council
+	// TODO-Klaytn : replace this to the below calculation logic
+	//istanbulExtra, err := types.ExtractIstanbulExtra(header)
+	//if err == nil {
+	//	return istanbulExtra.Validators, nil
+	//} else {
+	//	return nil, errExtractIstanbulExtra
+	//}
+
+	// Calculate council list from snapshot
 	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
 	if err != nil {
 		logger.Error("Failed to get snapshot.", "hash", header.Hash(), "err", err)
@@ -197,12 +207,34 @@ func (api *APIExtension) GetCommittee(number *rpc.BlockNumber) ([]common.Address
 		return nil, errNoBlockExist
 	}
 
-	istanbulExtra, err := types.ExtractIstanbulExtra(header)
-	if err == nil {
-		return istanbulExtra.Validators, nil
-	} else {
-		return nil, errExtractIstanbulExtra
+	blockNumber := header.Number.Uint64()
+	round := header.Round()
+	view := &istanbul.View{
+		Sequence: new(big.Int).SetUint64(blockNumber),
+		Round:    new(big.Int).SetUint64(uint64(round)),
 	}
+
+	// get the proposer of this block.
+	proposer, err := ecrecover(header)
+	if err != nil {
+		return nil, err
+	}
+
+	// get the snapshot of the previous block.
+	parentHash := header.ParentHash
+	snap, err := api.istanbul.snapshot(api.chain, blockNumber-1, parentHash, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// get the committee list of this block at the view (blockNumber, round)
+	committee := snap.ValSet.SubListWithProposer(parentHash, proposer, view)
+	addresses := make([]common.Address, len(committee))
+	for i, v := range committee {
+		addresses[i] = v.Address()
+	}
+
+	return addresses, nil
 }
 
 func (api *APIExtension) GetCommitteeSize(number *rpc.BlockNumber) (int, error) {
@@ -248,17 +280,12 @@ func (api *APIExtension) getConsensusInfo(block *types.Block) (ConsensusInfo, er
 
 	// get origin proposer at 0 round.
 	originProposer := common.Address{}
-	lastProposer := common.Address{}
-	// TODO-Klaytn add the logic to get the last proposer for other policies. Weighted Random doesn't need it.
-	if istanbul.ProposerPolicy(snap.Policy) == istanbul.WeightedRandom {
-		newValSet := snap.ValSet.Copy()
-		newValSet.CalcProposer(lastProposer, 0)
-		originProposer = newValSet.GetProposer().Address()
-	} else {
-		logger.Warn("getConsensusInfo does not support to get origin proposal on", "proposerPolicy", snap.Policy)
-	}
+	_, lastProposer := api.istanbul.LastProposal()
+	newValSet := snap.ValSet.Copy()
+	newValSet.CalcProposer(lastProposer, 0)
+	originProposer = newValSet.GetProposer().Address()
 
-	// get the committee list of this block.
+	// get the committee list of this block at the view (blockNumber, round)
 	committee := snap.ValSet.SubListWithProposer(parentHash, proposer, view)
 	committeeAddrs := make([]common.Address, len(committee))
 	for i, v := range committee {

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -23,6 +23,9 @@ package backend
 import (
 	"errors"
 	"fmt"
+	"math/big"
+	"reflect"
+
 	klaytnApi "github.com/klaytn/klaytn/api"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -30,8 +33,6 @@ import (
 	"github.com/klaytn/klaytn/consensus"
 	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/networks/rpc"
-	"math/big"
-	"reflect"
 )
 
 // API is a user facing RPC API to dump Istanbul state
@@ -280,7 +281,11 @@ func (api *APIExtension) getConsensusInfo(block *types.Block) (ConsensusInfo, er
 
 	// get origin proposer at 0 round.
 	originProposer := common.Address{}
-	_, lastProposer := api.istanbul.LastProposal()
+	lastProposer := common.Address{}
+	if blockNumber > 0 {
+		lastProposer = api.istanbul.GetProposer(blockNumber - 1)
+	}
+
 	newValSet := snap.ValSet.Copy()
 	newValSet.CalcProposer(lastProposer, 0)
 	originProposer = newValSet.GetProposer().Address()

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -324,10 +324,7 @@ func (sb *backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 	header.Vote = sb.governance.GetEncodedVote(sb.address, number)
 
 	// add validators in snapshot to extraData's validators section
-	currentView := sb.currentView.Load().(*istanbul.View)
-	lastProposer := sb.GetProposer(header.Number.Uint64() - 1)
-	snap.ValSet.CalcProposer(lastProposer, currentView.Round.Uint64())
-	extra, err := prepareExtra(header, snap.committee(header.ParentHash, currentView))
+	extra, err := prepareExtra(header, snap.validators())
 	if err != nil {
 		return err
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -323,7 +323,7 @@ func (sb *backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 	// if there is a vote to attach, attach it to the header
 	header.Vote = sb.governance.GetEncodedVote(sb.address, number)
 
-	// add validators in snapshot to extraData's validators section
+	// add validators (council list) in snapshot to extraData's validators section
 	extra, err := prepareExtra(header, snap.validators())
 	if err != nil {
 		return err

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -324,7 +324,10 @@ func (sb *backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 	header.Vote = sb.governance.GetEncodedVote(sb.address, number)
 
 	// add validators in snapshot to extraData's validators section
-	extra, err := prepareExtra(header, snap.committee(header.ParentHash, sb.currentView.Load().(*istanbul.View)))
+	currentView := sb.currentView.Load().(*istanbul.View)
+	lastProposer := sb.GetProposer(header.Number.Uint64() - 1)
+	snap.ValSet.CalcProposer(lastProposer, currentView.Round.Uint64())
+	extra, err := prepareExtra(header, snap.committee(header.ParentHash, currentView))
 	if err != nil {
 		return err
 	}

--- a/tests/klay_test_blockchain_test.go
+++ b/tests/klay_test_blockchain_test.go
@@ -120,6 +120,8 @@ func NewBCData(maxAccounts, numValidators int) (*BCData, error) {
 		return nil, err
 	}
 
+	engine.Start(bc, bc.CurrentBlock, bc.HasBadBlock)
+
 	governance.AddGovernanceCacheForTest(gov, 0, genesis.Config)
 	rewardDistributor := reward.NewRewardDistributor(gov)
 

--- a/work/worker.go
+++ b/work/worker.go
@@ -176,8 +176,6 @@ func newWorker(config *params.ChainConfig, engine consensus.Engine, rewardbase c
 		rewardbase:  rewardbase,
 	}
 
-	// istanbul BFT
-	//	if _, ok := engine.(consensus.Istanbul); ok {
 	// Subscribe NewTxsEvent for tx pool
 	worker.txsSub = backend.TxPool().SubscribeNewTxsEvent(worker.txsCh)
 	// Subscribe events for blockchain
@@ -186,9 +184,6 @@ func newWorker(config *params.ChainConfig, engine consensus.Engine, rewardbase c
 	go worker.update()
 
 	go worker.wait(TxResendUseLegacy)
-	worker.commitNewWork()
-	//	}
-
 	return worker
 }
 


### PR DESCRIPTION
## Proposed changes

This PR fixes the invalid committee list in block header.
Before this PR, the committee is derived with old proposer. So the list was invalid.

This validator list is used for calculating a hash of block.
So it is not easy to save a right committee list of each round.

Therefore, like an original code, I reverted it to save all validator list in the field.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
