### PR TITLE
Only CNs execute sendNextRoundChange properly

### DIFF
--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -304,7 +304,7 @@ func (c *core) catchUpRound(view *istanbul.View) {
 	c.roundChangeSet.Clear(view.Round)
 
 	c.newRoundChangeTimer()
-	logger.Warn("[RC] Catch up round", "new_round", view.Round, "new_seq", view.Sequence, "new_proposer", c.valSet)
+	logger.Warn("[RC] Catch up round", "new_round", view.Round, "new_seq", view.Sequence, "new_proposer", c.valSet.GetProposer())
 }
 
 // updateRoundState updates round state by checking if locking block is necessary

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -30,11 +30,11 @@ import (
 
 // sendNextRoundChange sends the ROUND CHANGE message with current round + 1
 func (c *core) sendNextRoundChange(loc string) {
-	cv := c.currentView()
-	if c.backend.NodeType() == common.CONSENSUSNODE {
-		logger.Warn("[RC] sendNextRoundChange happened", "where", loc)
+	if c.backend.NodeType() != common.CONSENSUSNODE {
+		return
 	}
-	c.sendRoundChange(new(big.Int).Add(cv.Round, common.Big1))
+	logger.Warn("[RC] sendNextRoundChange happened", "where", loc)
+	c.sendRoundChange(new(big.Int).Add(c.currentView().Round, common.Big1))
 }
 
 // sendRoundChange sends the ROUND CHANGE message with the given round


### PR DESCRIPTION
## Proposed changes

Currently, ENs/PNs send and handle IBFT consensus messages. 
With this PR, only CNs execute sendNextRoundChange properly.

**Future work** 

EN/PN doesn't need to send or handle consensus messages. 
The necessary part for EN/PN will be investigated and other parts will be disabled for EN/PN later. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
