### PR TITLE
[Master] release/v1.6.0 QA Sign-off

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,7 +540,6 @@ workflows:
             - test-others
             - tag-verify
             - tagger-verify
-            - test-linter
           filters: *filter-version-not-release
 
       - tag-verify:


### PR DESCRIPTION
We have linter failed case with last release.
So the PR disabled the condition and re-release v1.6.0
