### PR TITLE
Rename an API; setMaxSubscriptionPerConn -> setMaxSubscriptionPerWSConn

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1147,7 +1147,7 @@ func setWS(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(WSApiFlag.Name) {
 		cfg.WSModules = splitAndTrim(ctx.GlobalString(WSApiFlag.Name))
 	}
-	rpc.MaxSubscriptionPerConn = int32(ctx.GlobalInt(WSMaxSubscriptionPerConn.Name))
+	rpc.MaxSubscriptionPerWSConn = int32(ctx.GlobalInt(WSMaxSubscriptionPerConn.Name))
 	rpc.WebsocketReadDeadline = ctx.GlobalInt64(WSReadDeadLine.Name)
 	rpc.WebsocketWriteDeadline = ctx.GlobalInt64(WSWriteDeadLine.Name)
 	rpc.MaxWebsocketConnections = int32(ctx.GlobalInt(WSMaxConnections.Name))

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -296,8 +296,8 @@ web3._extend({
 			call: 'admin_saveTrieNodeCacheToDisk',
 		}),
 		new web3._extend.Method({
-			name: 'setMaxSubscriptionPerConn',
-			call: 'admin_setMaxSubscriptionPerConn',
+			name: 'setMaxSubscriptionPerWSConn',
+			call: 'admin_setMaxSubscriptionPerWSConn',
 			params: 1
 		}),
 	],

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -56,8 +56,8 @@ var (
 	pendingRequestCount int64 = 0
 
 	// TODO-Klaytn: move websocket configurations to Config struct in /network/rpc/server.go
-	// MaxSubscriptionPerConn is a maximum number of subscription for a server connection
-	MaxSubscriptionPerConn int32 = 5
+	// MaxSubscriptionPerWSConn is a maximum number of subscription for a server connection
+	MaxSubscriptionPerWSConn int32 = 5
 
 	// WebsocketReadDeadline is the read deadline on the underlying network connection in seconds. 0 means read will not timeout
 	WebsocketReadDeadline int64 = 0
@@ -360,10 +360,10 @@ func (s *Server) handle(ctx context.Context, codec ServerCodec, req *serverReque
 	}
 
 	if req.callb.isSubscribe {
-		if atomic.LoadInt32(subCnt) >= MaxSubscriptionPerConn {
+		if atomic.LoadInt32(subCnt) >= MaxSubscriptionPerWSConn {
 			return codec.CreateErrorResponse(&req.id, &callbackError{
 				fmt.Sprintf("Maximum %d subscriptions are allowed for a websocket connection. "+
-					"The limit can be updated with 'admin_setMaxSubscriptionPerConn' API", MaxSubscriptionPerConn),
+					"The limit can be updated with 'admin_setMaxSubscriptionPerWSConn' API", MaxSubscriptionPerWSConn),
 			}), nil
 		}
 

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -56,7 +56,7 @@ var (
 	pendingRequestCount int64 = 0
 
 	// TODO-Klaytn: move websocket configurations to Config struct in /network/rpc/server.go
-	// MaxSubscriptionPerWSConn is a maximum number of subscription for a server connection
+	// MaxSubscriptionPerWSConn is a maximum number of subscription for a websocket connection
 	MaxSubscriptionPerWSConn int32 = 5
 
 	// WebsocketReadDeadline is the read deadline on the underlying network connection in seconds. 0 means read will not timeout

--- a/networks/rpc/subscription_test.go
+++ b/networks/rpc/subscription_test.go
@@ -219,10 +219,10 @@ func waitForMessages(t *testing.T, in *json.Decoder, successes chan<- jsonSucces
 // TestSubscriptionMultipleNamespaces ensures that subscriptions can exists
 // for multiple different namespaces.
 func TestSubscriptionMultipleNamespaces(t *testing.T) {
-	oldMaxSubscription := MaxSubscriptionPerConn
-	MaxSubscriptionPerConn = 100
+	oldMaxSubscription := MaxSubscriptionPerWSConn
+	MaxSubscriptionPerWSConn = 100
 	defer func() {
-		MaxSubscriptionPerConn = oldMaxSubscription
+		MaxSubscriptionPerWSConn = oldMaxSubscription
 	}()
 
 	var (

--- a/node/utils.go
+++ b/node/utils.go
@@ -255,10 +255,10 @@ func (api *PrivateAdminAPI) StopWS() (bool, error) {
 	return true, nil
 }
 
-func (api *PrivateAdminAPI) SetMaxSubscriptionPerConn(num int32) {
+func (api *PrivateAdminAPI) SetMaxSubscriptionPerWSConn(num int32) {
 	logger.Info("Change the max subscription number for a websocket connection",
-		"old", rpc.MaxSubscriptionPerConn, "new", num)
-	rpc.MaxSubscriptionPerConn = num
+		"old", rpc.MaxSubscriptionPerWSConn, "new", num)
+	rpc.MaxSubscriptionPerWSConn = num
 }
 
 // PublicAdminAPI is the collection of administrative API methods exposed over


### PR DESCRIPTION
## Proposed changes

Rename `setMaxSubscriptionPerConn` to `setMaxSubscriptionPerWSConn` for more precise experession. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
