### PR TITLE
database: collect LevelDB stats by level

### DIFF
--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -112,11 +112,11 @@ type levelDB struct {
 	nonlevel0CompGauge     metrics.Gauge // Gauge for tracking the number of table compaction in non0 level
 	seekCompGauge          metrics.Gauge // Gauge for tracking the number of table compaction caused by read opt
 
-	levelSizeMeters      []metrics.Meter
-	levelTableCounts     []metrics.Meter
-	levelReadMeters      []metrics.Meter
-	levelWriteMeters     []metrics.Meter
-	levelDurationsMeters []metrics.Timer
+	levelSizesGauge     []metrics.Gauge
+	levelTablesGauge    []metrics.Gauge
+	levelReadGauge      []metrics.Gauge
+	levelWriteGauge     []metrics.Gauge
+	levelDurationsGauge []metrics.Gauge
 
 	perfCheck       bool
 	getTimer        metrics.Timer
@@ -487,20 +487,20 @@ hasError:
 // updateLevelStats collects level-wise stats.
 func (db *levelDB) updateLevelStats(s *leveldb.DBStats, lv int) {
 	// dynamically creates a new metrics for a new level
-	if len(db.levelSizeMeters) <= lv {
+	if len(db.levelSizesGauge) <= lv {
 		prefix := db.prefix + fmt.Sprintf("level%v/", lv)
-		db.levelSizeMeters = append(db.levelSizeMeters, metrics.NewRegisteredMeter(prefix+"size", nil))
-		db.levelTableCounts = append(db.levelTableCounts, metrics.NewRegisteredMeter(prefix+"tables", nil))
-		db.levelReadMeters = append(db.levelReadMeters, metrics.NewRegisteredMeter(prefix+"read", nil))
-		db.levelWriteMeters = append(db.levelWriteMeters, metrics.NewRegisteredMeter(prefix+"write", nil))
-		db.levelDurationsMeters = append(db.levelDurationsMeters, metrics.NewRegisteredTimer(prefix+"duration", nil))
+		db.levelSizesGauge = append(db.levelSizesGauge, metrics.NewRegisteredGauge(prefix+"size", nil))
+		db.levelTablesGauge = append(db.levelTablesGauge, metrics.NewRegisteredGauge(prefix+"tables", nil))
+		db.levelReadGauge = append(db.levelReadGauge, metrics.NewRegisteredGauge(prefix+"read", nil))
+		db.levelWriteGauge = append(db.levelWriteGauge, metrics.NewRegisteredGauge(prefix+"write", nil))
+		db.levelDurationsGauge = append(db.levelDurationsGauge, metrics.NewRegisteredGauge(prefix+"duration", nil))
 	}
 
-	db.levelSizeMeters[lv].Mark(s.LevelSizes[lv])
-	db.levelTableCounts[lv].Mark(int64(s.LevelTablesCounts[lv]))
-	db.levelReadMeters[lv].Mark(s.LevelRead[lv])
-	db.levelWriteMeters[lv].Mark(s.LevelWrite[lv])
-	db.levelDurationsMeters[lv].Update(s.LevelDurations[lv])
+	db.levelSizesGauge[lv].Update(s.LevelSizes[lv])
+	db.levelTablesGauge[lv].Update(int64(s.LevelTablesCounts[lv]))
+	db.levelReadGauge[lv].Update(s.LevelRead[lv])
+	db.levelWriteGauge[lv].Update(s.LevelWrite[lv])
+	db.levelDurationsGauge[lv].Update(int64(s.LevelDurations[lv]))
 }
 
 func (db *levelDB) NewBatch() Batch {


### PR DESCRIPTION
## Proposed changes

- There are stats collected by level, provided by leveldb package
- As they provide as-is statistics, use gauge instead of meter to get the current value
- Also, as levels can be added dynamically, metrics are also added dynamically if there's new level

### LevelDB Partition Size By Level (=Body Partition)
<img width="2672" alt="Screen Shot 2021-02-25 at 9 21 19 AM" src="https://user-images.githubusercontent.com/2115430/109084704-9fab7a80-774b-11eb-9cad-ea09cb6167e4.png">

### LevelDB Compaction Time By Level (=Body Partition)
<img width="2672" alt="Screen Shot 2021-02-25 at 9 22 14 AM" src="https://user-images.githubusercontent.com/2115430/109084714-a33f0180-774b-11eb-905a-674a818ccbed.png">

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
