### PR TITLE
API: Introduce init flags for klay_getLogs and klay_getFilterLogs APIs

### DIFF
--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -255,6 +255,8 @@ var FlagGroups = []FlagGroup{
 			ExecFlag,
 			PreloadJSFlag,
 			MaxRequestContentLengthFlag,
+			APIFilterGetLogsDeadlineFlag,
+			APIFilterGetLogsMaxItemsFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -51,6 +51,7 @@ import (
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/node"
 	"github.com/klaytn/klaytn/node/cn"
+	"github.com/klaytn/klaytn/node/cn/filters"
 	"github.com/klaytn/klaytn/node/sc"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
@@ -523,6 +524,16 @@ var (
 	PreloadJSFlag = cli.StringFlag{
 		Name:  "preload",
 		Usage: "Comma separated list of JavaScript files to preload into the console",
+	}
+	APIFilterGetLogsDeadlineFlag = cli.DurationFlag{
+		Name:  "api.filter.getLogs.deadline",
+		Usage: "Execution deadline for log collecting filter APIs (Default: 10s)",
+		Value: filters.GetLogsDeadline,
+	}
+	APIFilterGetLogsMaxItemsFlag = cli.IntFlag{
+		Name:  "api.filter.getLogs.maxitems",
+		Usage: "Maximum allowed number of return items for log collecting filter API (Default: 10000)",
+		Value: filters.GetLogsMaxItems,
 	}
 
 	// Network Settings
@@ -1180,6 +1191,12 @@ func setgRPC(ctx *cli.Context, cfg *node.Config) {
 	}
 }
 
+// setAPIConfig sets configurations for specific APIs.
+func setAPIConfig(ctx *cli.Context) {
+	filters.GetLogsDeadline = ctx.GlobalDuration(APIFilterGetLogsDeadlineFlag.Name)
+	filters.GetLogsMaxItems = ctx.GlobalInt(APIFilterGetLogsMaxItemsFlag.Name)
+}
+
 // MakeAddress converts an account specified directly as a hex encoded string or
 // a key index in the key store to an internal account representation.
 func MakeAddress(ks *keystore.KeyStore, account string) (accounts.Account, error) {
@@ -1318,6 +1335,7 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	setHTTP(ctx, cfg)
 	setWS(ctx, cfg)
 	setgRPC(ctx, cfg)
+	setAPIConfig(ctx)
 	setNodeUserIdent(ctx, cfg)
 
 	if dbtype := database.DBType(ctx.GlobalString(DbTypeFlag.Name)).ToValid(); len(dbtype) != 0 {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -527,12 +527,12 @@ var (
 	}
 	APIFilterGetLogsDeadlineFlag = cli.DurationFlag{
 		Name:  "api.filter.getLogs.deadline",
-		Usage: "Execution deadline for log collecting filter APIs (Default: 10s)",
+		Usage: "Execution deadline for log collecting filter APIs",
 		Value: filters.GetLogsDeadline,
 	}
 	APIFilterGetLogsMaxItemsFlag = cli.IntFlag{
 		Name:  "api.filter.getLogs.maxitems",
-		Usage: "Maximum allowed number of return items for log collecting filter API (Default: 10000)",
+		Usage: "Maximum allowed number of return items for log collecting filter API",
 		Value: filters.GetLogsMaxItems,
 	}
 

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -111,6 +111,8 @@ var CommonNodeFlags = []cli.Flag{
 	utils.RestartTimeOutFlag,
 	utils.DaemonPathFlag,
 	utils.ConfigFileFlag,
+	utils.APIFilterGetLogsMaxItemsFlag,
+	utils.APIFilterGetLogsDeadlineFlag,
 }
 
 // Common RPC flags

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -21,9 +21,10 @@
 package core
 
 import (
+	"reflect"
+
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/istanbul"
-	"reflect"
 )
 
 func (c *core) sendCommit() {

--- a/consensus/istanbul/core/message_set.go
+++ b/consensus/istanbul/core/message_set.go
@@ -22,11 +22,12 @@ package core
 
 import (
 	"fmt"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/consensus/istanbul"
 	"math/big"
 	"strings"
 	"sync"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
 )
 
 // Construct a new message set to accumulate messages for given sequence/view number.

--- a/node/cn/filters/api.go
+++ b/node/cn/filters/api.go
@@ -365,7 +365,7 @@ func (api *PublicFilterAPI) UninstallFilter(id rpc.ID) bool {
 // GetFilterLogs returns the logs for the filter with the given id.
 // If the filter could not be found an empty array of logs is returned.
 func (api *PublicFilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.Log, error) {
-	ctx = context.WithValue(ctx, "maxItem", GetLogsMaxItems)
+	ctx = context.WithValue(ctx, getLogsCxtKeyMaxItems, GetLogsMaxItems)
 	ctx, cancelFnc := context.WithTimeout(ctx, GetLogsDeadline)
 	defer cancelFnc()
 

--- a/node/cn/filters/api.go
+++ b/node/cn/filters/api.go
@@ -42,9 +42,9 @@ import (
 var (
 	deadline = 5 * time.Minute // consider a filter inactive if it has not been polled for within deadline
 
-	getLogsCxtKeyMaxItems = "maxItems"
-	GetLogsDeadline       = 10 * time.Second
-	GetLogsMaxItems       = int(10000)
+	getLogsCxtKeyMaxItems = "maxItems"       // the value of the context key should have the type of GetLogsMaxItems
+	GetLogsDeadline       = 10 * time.Second // execution deadlines for getLogs and getFilterLogs APIs
+	GetLogsMaxItems       = int(10000)       // maximum allowed number of return items for getLogs and getFilterLogs APIs
 )
 
 // filter is a helper struct that holds meta information over the filter type

--- a/node/cn/filters/filter.go
+++ b/node/cn/filters/filter.go
@@ -163,13 +163,7 @@ func (f *Filter) indexedLogs(ctx context.Context, end uint64) ([]*types.Log, err
 	// Iterate over the matches until exhausted or context closed
 	var logs []*types.Log
 
-	maxItems := math.MaxInt32 - 1
-	if val := ctx.Value(getLogsCxtKeyMaxItems); val != nil {
-		val, ok := val.(int)
-		if ok {
-			maxItems = val
-		}
-	}
+	maxItems := getMaxItems(ctx)
 
 	for {
 		select {
@@ -211,13 +205,7 @@ func (f *Filter) indexedLogs(ctx context.Context, end uint64) ([]*types.Log, err
 func (f *Filter) unindexedLogs(ctx context.Context, end uint64) ([]*types.Log, error) {
 	var logs []*types.Log
 
-	maxItems := math.MaxInt32 - 1
-	if val := ctx.Value(getLogsCxtKeyMaxItems); val != nil {
-		val, ok := val.(int)
-		if ok {
-			maxItems = val
-		}
-	}
+	maxItems := getMaxItems(ctx)
 
 	for ; f.begin <= int64(end); f.begin++ {
 		header, err := f.backend.HeaderByNumber(ctx, rpc.BlockNumber(f.begin))
@@ -346,4 +334,17 @@ func bloomFilter(bloom types.Bloom, addresses []common.Address, topics [][]commo
 		}
 	}
 	return true
+}
+
+// getMaxItems returns the value of getLogsCxtKeyMaxItems set in the given context.
+// If the value is not set in the context, it will returns MaxInt32-1.
+func getMaxItems(ctx context.Context) int {
+	maxItems := math.MaxInt32 - 1
+	if val := ctx.Value(getLogsCxtKeyMaxItems); val != nil {
+		val, ok := val.(int)
+		if ok {
+			maxItems = val
+		}
+	}
+	return maxItems
 }

--- a/node/cn/filters/filter.go
+++ b/node/cn/filters/filter.go
@@ -228,6 +228,7 @@ func (f *Filter) unindexedLogs(ctx context.Context, end uint64) ([]*types.Log, e
 				return logs, errors.New("query timeout exceeded")
 			}
 			return logs, errors.New("query is canceled. " + ctx.Err().Error())
+		default:
 		}
 	}
 	return logs, nil


### PR DESCRIPTION
## Proposed changes

Introduce init flags for `klay_getLogs` and `klay_getFilterLogs` APIs

- `api.filter.getLogs.deadline`: Execution deadline for log collecting filter APIs (Default: 10s)
- `api.filter.getLogs.maxitems`: Maximum allowed number of return items for log collecting filter API (Default: 10000)

**Test result**
```
# curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay_getLogs","params":[{"fromBlock":"0x3210300","toBlock":"0x3210400"}],"id":1}' http://localhost:8551
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"query returned more than 10000 results"}}
```

```
# curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay_getLogs","params":[{"fromBlock":"0x3210300","toBlock":"0x3210400"}],"id":1}' http://localhost:8551
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"query timeout exceeded"}}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

