### PR TITLE
Commit hash is gathered during the build process on detached HEAD

### DIFF
--- a/utils/build/env.go
+++ b/utils/build/env.go
@@ -103,6 +103,10 @@ func LocalEnv() Environment {
 	head := readGitFile("HEAD")
 	if splits := strings.Split(head, " "); len(splits) == 2 {
 		head = splits[1]
+	} else if len(splits) == 1 && len(splits[0]) == 40 {
+		// HEAD file of detached HEAD contains only commit hash
+		env.Commit = splits[0]
+		return env
 	} else {
 		return env
 	}


### PR DESCRIPTION
## Proposed changes

The binary built on a detached HEAD (usually when git is checkouted with a tag instead of a branch) also contains a commit hash.

**Before the PR is merged**
```
$ git checkout v1.6.0 && make ken && build/bin/ken version
Klaytn v1.6.0
```

**After the PR is merged on v1.6.0**
```
$ git checkout v1.6.0 && make ken && build/bin/ken version
Klaytn v1.6.0+517bfc9f65
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
