### PR TITLE
Fix the prefech logic for multiple txs of the same sender in a block

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -322,8 +322,7 @@ func (bc *BlockChain) prefetchTxWorker(index int) {
 			logger.Debug("failed to retrieve stateDB for prefetchTxWorker", "err", err)
 			continue
 		}
-		vmCfg := vm.Config{}
-		vmCfg = bc.vmConfig
+		vmCfg := bc.vmConfig
 		vmCfg.Prefetching = true
 		bc.prefetcher.PrefetchTx(followup.block, followup.ti, stateDB, vmCfg, followup.followupInterrupt)
 	}
@@ -1695,8 +1694,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 				followup := chain[i+1]
 				go func(start time.Time) {
 					throwaway, _ := state.NewForPrefetching(parent.Root(), bc.stateCache)
-					vmCfg := vm.Config{}
-					vmCfg = bc.vmConfig
+					vmCfg := bc.vmConfig
 					vmCfg.Prefetching = true
 					bc.prefetcher.Prefetch(followup, throwaway, vmCfg, &followupInterrupt)
 

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -40,9 +40,11 @@ const (
 type Database interface {
 	// OpenTrie opens the main account trie.
 	OpenTrie(root common.Hash) (Trie, error)
+	OpenTrieForPrefetching(root common.Hash) (Trie, error)
 
 	// OpenStorageTrie opens the storage trie of an account.
 	OpenStorageTrie(root common.Hash) (Trie, error)
+	OpenStorageTrieForPrefetching(root common.Hash) (Trie, error)
 
 	// CopyTrie returns an independent copy of the given trie.
 	CopyTrie(Trie) Trie
@@ -155,9 +157,19 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 	return statedb.NewSecureTrie(root, db.db)
 }
 
+// OpenTrieForPrefetching opens the main account trie at a specific root hash.
+func (db *cachingDB) OpenTrieForPrefetching(root common.Hash) (Trie, error) {
+	return statedb.NewSecureTrieForPrefetching(root, db.db)
+}
+
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(root common.Hash) (Trie, error) {
 	return statedb.NewSecureTrie(root, db.db)
+}
+
+// OpenStorageTrieForPrefetching opens the storage trie of an account.
+func (db *cachingDB) OpenStorageTrieForPrefetching(root common.Hash) (Trie, error) {
+	return statedb.NewSecureTrieForPrefetching(root, db.db)
 }
 
 // CopyTrie returns an independent copy of the given trie.

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -90,6 +90,8 @@ type StateDB struct {
 	validRevisions []revision
 	nextRevisionId int
 
+	prefetching bool
+
 	// Measurements gathered during execution for debugging purposes
 	AccountReads   time.Duration
 	AccountHashes  time.Duration
@@ -116,6 +118,25 @@ func New(root common.Hash, db Database) (*StateDB, error) {
 		logs:                     make(map[common.Hash][]*types.Log),
 		preimages:                make(map[common.Hash][]byte),
 		journal:                  newJournal(),
+	}, nil
+}
+
+// Create a new state from a given trie with prefetching
+func NewForPrefetching(root common.Hash, db Database) (*StateDB, error) {
+	tr, err := db.OpenTrieForPrefetching(root)
+	if err != nil {
+		return nil, err
+	}
+	return &StateDB{
+		db:                       db,
+		trie:                     tr,
+		stateObjects:             make(map[common.Address]*stateObject),
+		stateObjectsDirtyStorage: make(map[common.Address]struct{}),
+		stateObjectsDirty:        make(map[common.Address]struct{}),
+		logs:                     make(map[common.Hash][]*types.Log),
+		preimages:                make(map[common.Hash][]byte),
+		journal:                  newJournal(),
+		prefetching:              true,
 	}, nil
 }
 

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -227,9 +227,14 @@ func (st *StateTransition) preCheck() error {
 // returning the result including the used gas. It returns an error if failed.
 // An error indicates a consensus issue.
 func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, kerr kerror) {
-	if kerr.ErrTxInvalid = st.preCheck(); kerr.ErrTxInvalid != nil {
-		return
+	if st.evm.IsPrefetching() {
+		st.gas = st.msg.Gas()
+	} else {
+		if kerr.ErrTxInvalid = st.preCheck(); kerr.ErrTxInvalid != nil {
+			return
+		}
 	}
+
 	msg := st.msg
 
 	// Pay intrinsic gas.

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -189,6 +189,10 @@ func (evm *EVM) Cancel(reason int32) {
 	}
 }
 
+func (evm *EVM) IsPrefetching() bool {
+	return evm.vmConfig.Prefetching
+}
+
 // Cancelled returns true if Cancel has been called
 func (evm *EVM) Cancelled() bool {
 	return atomic.LoadInt32(&evm.abort) == 1

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -47,6 +47,9 @@ type Config struct {
 
 	// Enables collecting internal transaction data during processing a block
 	EnableInternalTxTracing bool
+
+	// Prefetching is true if the EVM is used for prefetching.
+	Prefetching bool
 }
 
 // keccakState wraps sha3.state. In addition to the usual hash methods, it also supports

--- a/storage/statedb/secure_trie.go
+++ b/storage/statedb/secure_trie.go
@@ -63,6 +63,17 @@ func NewSecureTrie(root common.Hash, db *Database) (*SecureTrie, error) {
 	return &SecureTrie{trie: *trie}, nil
 }
 
+func NewSecureTrieForPrefetching(root common.Hash, db *Database) (*SecureTrie, error) {
+	if db == nil {
+		panic("statedb.NewSecureTrie called without a database")
+	}
+	trie, err := NewTrieForPrefetching(root, db)
+	if err != nil {
+		return nil, err
+	}
+	return &SecureTrie{trie: *trie}, nil
+}
+
 // Get returns the value for key stored in the trie.
 // The value bytes must not be modified by the caller.
 func (t *SecureTrie) Get(key []byte) []byte {

--- a/storage/statedb/secure_trie.go
+++ b/storage/statedb/secure_trie.go
@@ -65,7 +65,7 @@ func NewSecureTrie(root common.Hash, db *Database) (*SecureTrie, error) {
 
 func NewSecureTrieForPrefetching(root common.Hash, db *Database) (*SecureTrie, error) {
 	if db == nil {
-		panic("statedb.NewSecureTrie called without a database")
+		panic("statedb.NewSecureTrieForPrefetching called without a database")
 	}
 	trie, err := NewTrieForPrefetching(root, db)
 	if err != nil {


### PR DESCRIPTION
## Proposed changes

**PROBLEM**
- Prefetch worker executes transactions in a block in parallel.
- However, if there are multiple transactions from the same account
  cannot be executed due to nonce check logic.

**SOLUTION**
- For prefetch execution, nonce check logic is disabled.
- Gas was set to the gas value of the transaction. (See
  blockchain/state_transition.go:230)
- To be aware of the prefetch execution, a field `prefetching` is addded
  to vm.Config, state.StateDB
- To check the efficiency of the prefetch,
  memcacheCleanPrefetchMissMeter is added. This value increases when
  a cache miss occurs in the prefetch execution.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

