### PR TITLE
Lower the log level of some consensus msg from WARN to INFO

### DIFF
--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -103,11 +103,11 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 	// the previous round skip sending PREPARE messages.
 	if c.state.Cmp(StatePrepared) < 0 {
 		if c.current.IsHashLocked() && commit.Digest == c.current.GetLockedHash() {
-			logger.Warn("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
+			logger.Info("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
 			c.setState(StatePrepared)
 			c.sendCommit()
 		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() {
-			logger.Warn("received more than 2f agreements and change state to prepared", "msgType", msgCommit)
+			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgCommit)
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -43,7 +43,8 @@ func (c *core) sendRoundChange(round *big.Int) {
 
 	cv := c.currentView()
 	if cv.Round.Cmp(round) >= 0 {
-		logger.Warn("Skip sending out the round change message", "current round", cv.Round, "target round", round)
+		logger.Warn("[RC] Skip sending out the round change message", "current round", cv.Round,
+			"target round", round)
 		return
 	}
 


### PR DESCRIPTION
## Proposed changes

Lower the log level of some consensus logs from WARN to INFO.
The logs can be printed when Round Change does not occur.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
