### PR TITLE
Enable tx prefetcher for multiple blocks

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1681,7 +1681,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		var followupInterrupt uint32
 
 		if bc.cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker > 0 {
-			// if fetcher works and only a block is given, use prefetchTxWorker
+			// Tx prefetcher is enabled for all cases (both single and multiple block insertion).
 			for ti := range block.Transactions() {
 				select {
 				case bc.prefetchTxCh <- prefetchTx{ti, block, &followupInterrupt}:

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1682,14 +1682,13 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 
 		if bc.cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker > 0 {
 			// if fetcher works and only a block is given, use prefetchTxWorker
-			if len(chain) == 1 {
-				for ti := range block.Transactions() {
-					select {
-					case bc.prefetchTxCh <- prefetchTx{ti, block, &followupInterrupt}:
-					default:
-					}
+			for ti := range block.Transactions() {
+				select {
+				case bc.prefetchTxCh <- prefetchTx{ti, block, &followupInterrupt}:
+				default:
 				}
-			} else if i < len(chain)-1 {
+			}
+			if i < len(chain)-1 {
 				// current block is not the last one, so prefetch the right next block
 				followup := chain[i+1]
 				go func(start time.Time) {


### PR DESCRIPTION
## Proposed changes

- Previously, the tx prefetcher was enabled when only one block is passed into BlockChain.insertChain().
- After sync test, we found that the tx prefetcher is useful when multiple blocks are passed to that function.
- Hence, we enable tx prefetcher if multiple blocks are passed.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/klaytn/klaytn/pull/911
