### PR TITLE
Updated minimum staking related logic

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -238,11 +238,18 @@ func SetupGenesisBlock(db database.DBManager, genesis *Genesis, networkId uint64
 		if storedcfg.Governance == nil {
 			logger.Crit("Failed to read governance. storedcfg.Governance == nil")
 		}
+		if storedcfg.Governance.Reward == nil {
+			logger.Crit("Failed to read governance. storedcfg.Governance.Reward == nil")
+		}
 		if storedcfg.Governance.Reward.StakingUpdateInterval != 0 {
 			params.SetStakingUpdateInterval(storedcfg.Governance.Reward.StakingUpdateInterval)
 		}
 		if storedcfg.Governance.Reward.ProposerUpdateInterval != 0 {
 			params.SetProposerUpdateInterval(storedcfg.Governance.Reward.ProposerUpdateInterval)
+		}
+		if storedcfg.Governance.Reward.MinimumStake != nil &&
+			storedcfg.Governance.Reward.MinimumStake.Cmp(common.Big0) > 0 {
+			params.SetMinimumStakingAmount(storedcfg.Governance.Reward.MinimumStake)
 		}
 	}
 	// Special case: don't change the existing config of a non-mainnet chain if no new

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -111,6 +111,7 @@ func initGenesis(ctx *cli.Context) error {
 	}
 	params.SetStakingUpdateInterval(genesis.Config.Governance.Reward.StakingUpdateInterval)
 	params.SetProposerUpdateInterval(genesis.Config.Governance.Reward.ProposerUpdateInterval)
+	params.SetMinimumStakingAmount(genesis.Config.Governance.Reward.MinimumStake)
 
 	// Open an initialise both full and light databases
 	stack := MakeFullNode(ctx)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -388,6 +388,7 @@ func (sb *backend) ParentValidators(proposal istanbul.Proposal) istanbul.Validat
 		return sb.getValidators(block.Number().Uint64()-1, block.ParentHash())
 	}
 
+	// TODO-Klaytn-Governance The following return case should not be called. Refactor it to error handling.
 	return validator.NewValidatorSet(nil, nil, istanbul.ProposerPolicy(sb.governance.ProposerPolicy()), sb.governance.CommitteeSize(), sb.chain)
 }
 
@@ -395,6 +396,7 @@ func (sb *backend) getValidators(number uint64, hash common.Hash) istanbul.Valid
 	snap, err := sb.snapshot(sb.chain, number, hash, nil)
 	if err != nil {
 		logger.Error("Snapshot not found.", "err", err)
+		// TODO-Klaytn-Governance The following return case should not be called. Refactor it to error handling.
 		return validator.NewValidatorSet(nil, nil, istanbul.ProposerPolicy(sb.governance.ProposerPolicy()), sb.governance.CommitteeSize(), sb.chain)
 	}
 	return snap.ValSet

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -388,14 +388,14 @@ func (sb *backend) ParentValidators(proposal istanbul.Proposal) istanbul.Validat
 		return sb.getValidators(block.Number().Uint64()-1, block.ParentHash())
 	}
 
-	return validator.NewValidatorSet(nil, istanbul.ProposerPolicy(sb.governance.ProposerPolicy()), sb.governance.CommitteeSize(), sb.chain)
+	return validator.NewValidatorSet(nil, nil, istanbul.ProposerPolicy(sb.governance.ProposerPolicy()), sb.governance.CommitteeSize(), sb.chain)
 }
 
 func (sb *backend) getValidators(number uint64, hash common.Hash) istanbul.ValidatorSet {
 	snap, err := sb.snapshot(sb.chain, number, hash, nil)
 	if err != nil {
 		logger.Error("Snapshot not found.", "err", err)
-		return validator.NewValidatorSet(nil, istanbul.ProposerPolicy(sb.governance.ProposerPolicy()), sb.governance.CommitteeSize(), sb.chain)
+		return validator.NewValidatorSet(nil, nil, istanbul.ProposerPolicy(sb.governance.ProposerPolicy()), sb.governance.CommitteeSize(), sb.chain)
 	}
 	return snap.ValSet
 }

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -702,7 +702,7 @@ func Benchmark_getTargetReceivers(b *testing.B) {
 	// get testing node's address
 	key, _ := crypto.HexToECDSA(PRIVKEY) // This key is to be provided to create backend
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
-	valSet := validator.NewWeightedCouncil(council, rewards, getTestVotingPowers(len(council)), nil, istanbul.WeightedRandom, 21, 0, 0, nil)
+	valSet := validator.NewWeightedCouncil(council, nil, rewards, getTestVotingPowers(len(council)), nil, istanbul.WeightedRandom, 21, 0, 0, nil)
 
 	recents, _ := lru.NewARC(inmemorySnapshots)
 	recentMessages, _ := lru.NewARC(inmemoryPeers)
@@ -748,7 +748,7 @@ func Test_GossipSubPeerTargets(t *testing.T) {
 	// get testing node's address
 	key, _ := crypto.HexToECDSA(PRIVKEY) // This key is to be provided to create backend
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
-	valSet := validator.NewWeightedCouncil(council, rewards, getTestVotingPowers(len(council)), nil, istanbul.WeightedRandom, 21, 0, 0, nil)
+	valSet := validator.NewWeightedCouncil(council, nil, rewards, getTestVotingPowers(len(council)), nil, istanbul.WeightedRandom, 21, 0, 0, nil)
 
 	recents, _ := lru.NewARC(inmemorySnapshots)
 	recentMessages, _ := lru.NewARC(inmemoryPeers)

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -644,7 +644,7 @@ func (sb *backend) snapshot(chain consensus.ChainReader, number uint64, hash com
 		// Let's refresh proposers in Snapshot_N using previous proposersUpdateInterval block for N+1, if not updated yet.
 		pHeader := chain.GetHeaderByNumber(params.CalcProposerBlockNumber(snap.Number + 1))
 		if pHeader != nil {
-			if err := snap.ValSet.Refresh(pHeader.Hash(), pHeader.Number.Uint64()); err != nil {
+			if err := snap.ValSet.Refresh(pHeader.Hash(), pHeader.Number.Uint64(), sb.chain.Config()); err != nil {
 				// There are three error cases and they just don't refresh proposers
 				// (1) no validator at all
 				// (2) invalid formatted hash

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -563,7 +563,7 @@ func (sb *backend) initSnapshot(chain consensus.ChainReader) (*Snapshot, error) 
 	if !ok {
 		committeeSize = params.DefaultSubGroupSize
 	}
-	snap := newSnapshot(sb.governance, 0, genesis.Hash(), validator.NewValidatorSet(istanbulExtra.Validators, istanbul.ProposerPolicy(proposerPolicy), committeeSize, chain), chain.Config())
+	snap := newSnapshot(sb.governance, 0, genesis.Hash(), validator.NewValidatorSet(istanbulExtra.Validators, nil, istanbul.ProposerPolicy(proposerPolicy), committeeSize, chain), chain.Config())
 
 	if err := snap.store(sb.db); err != nil {
 		return nil, err

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -104,7 +104,13 @@ func (sb *backend) ValidatePeerType(addr common.Address) error {
 	for sb.chain == nil {
 		return errNoChainReader
 	}
-	for _, val := range sb.getValidators(sb.chain.CurrentHeader().Number.Uint64(), sb.chain.CurrentHeader().Hash()).List() {
+	validators := sb.getValidators(sb.chain.CurrentHeader().Number.Uint64(), sb.chain.CurrentHeader().Hash())
+	for _, val := range validators.List() {
+		if addr == val.Address() {
+			return nil
+		}
+	}
+	for _, val := range validators.DemotedList() {
 		if addr == val.Address() {
 			return nil
 		}

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -273,10 +273,11 @@ func (s *Snapshot) toJSONStruct() *snapshotJSON {
 	var proposers []common.Address
 	var proposersBlockNum uint64
 	var validators []common.Address
+	var demotedValidators []common.Address
 
 	// TODO-Klaytn-Issue1166 For weightedCouncil
 	if s.ValSet.Policy() == istanbul.WeightedRandom {
-		validators, rewardAddrs, votingPowers, weights, proposers, proposersBlockNum = validator.GetWeightedCouncilData(s.ValSet)
+		validators, demotedValidators, rewardAddrs, votingPowers, weights, proposers, proposersBlockNum = validator.GetWeightedCouncilData(s.ValSet)
 	} else {
 		validators = s.validators()
 	}
@@ -295,6 +296,7 @@ func (s *Snapshot) toJSONStruct() *snapshotJSON {
 		Weights:           weights,
 		Proposers:         proposers,
 		ProposersBlockNum: proposersBlockNum,
+		DemotedValidators: demotedValidators,
 	}
 }
 
@@ -313,7 +315,7 @@ func (s *Snapshot) UnmarshalJSON(b []byte) error {
 
 	// TODO-Klaytn-Issue1166 For weightedCouncil
 	if j.Policy == istanbul.WeightedRandom {
-		s.ValSet = validator.NewWeightedCouncil(j.Validators, j.RewardAddrs, j.VotingPowers, j.Weights, j.Policy, j.SubGroupSize, j.Number, j.ProposersBlockNum, nil)
+		s.ValSet = validator.NewWeightedCouncil(j.Validators, j.DemotedValidators, j.RewardAddrs, j.VotingPowers, j.Weights, j.Policy, j.SubGroupSize, j.Number, j.ProposersBlockNum, nil)
 		validator.RecoverWeightedCouncilProposer(s.ValSet, j.Proposers)
 	} else {
 		s.ValSet = validator.NewSubSet(j.Validators, j.Policy, j.SubGroupSize)

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -263,6 +263,7 @@ type snapshotJSON struct {
 	Weights           []uint64         `json:"weight"`
 	Proposers         []common.Address `json:"proposers"`
 	ProposersBlockNum uint64           `json:"proposersBlockNum"`
+	DemotedValidators []common.Address `json:"demotedValidators"`
 }
 
 func (s *Snapshot) toJSONStruct() *snapshotJSON {

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -45,7 +45,7 @@ func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanb
 	})
 
 	eventMux := new(event.TypeMux)
-	validatorSet := validator.NewWeightedCouncil(validatorAddrs, validatorAddrs, nil, nil,
+	validatorSet := validator.NewWeightedCouncil(validatorAddrs, nil, validatorAddrs, nil, nil,
 		istanbul.WeightedRandom, committeeSize, 0, 0, &blockchain.BlockChain{})
 
 	mockCtrl := gomock.NewController(t)

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -77,6 +77,8 @@ type ValidatorSet interface {
 	SetSubGroupSize(size uint64)
 	// Return the validator array
 	List() []Validator
+	// Return the demoted validator array
+	DemotedList() []Validator
 	// SubList composes a committee after setting a proposer with a default value.
 	SubList(prevHash common.Hash, view *View) []Validator
 	// Return whether the given address is one of sub-list

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -23,6 +23,8 @@ package istanbul
 import (
 	"strings"
 
+	"github.com/klaytn/klaytn/params"
+
 	"github.com/klaytn/klaytn/common"
 )
 
@@ -103,7 +105,7 @@ type ValidatorSet interface {
 	IsSubSet() bool
 
 	// Refreshes a list of candidate proposers with given hash and blockNum
-	Refresh(hash common.Hash, blockNum uint64) error
+	Refresh(hash common.Hash, blockNum uint64, config *params.ChainConfig) error
 
 	SetBlockNum(blockNum uint64)
 

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/klaytn/klaytn/params"
+
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/istanbul"
 )
@@ -360,7 +362,7 @@ func (valSet *defaultSet) F() int {
 
 func (valSet *defaultSet) Policy() istanbul.ProposerPolicy { return valSet.policy }
 
-func (valSet *defaultSet) Refresh(hash common.Hash, blockNum uint64) error {
+func (valSet *defaultSet) Refresh(hash common.Hash, blockNum uint64, config *params.ChainConfig) error {
 	return nil
 }
 func (valSet *defaultSet) SetBlockNum(blockNum uint64)     { /* Do nothing */ }

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -145,6 +145,10 @@ func (valSet *defaultSet) List() []istanbul.Validator {
 	return valSet.validators
 }
 
+func (valSet *defaultSet) DemotedList() []istanbul.Validator {
+	return nil
+}
+
 // SubList composes a committee after setting a proposer with a default value.
 // This functions returns whole validators if it failed to compose a committee.
 func (valSet *defaultSet) SubList(prevHash common.Hash, view *istanbul.View) []istanbul.Validator {

--- a/consensus/istanbul/validator/multi_staking_test.go
+++ b/consensus/istanbul/validator/multi_staking_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 func newTestWeightedCouncil(nodeAddrs []common.Address) *weightedCouncil {
-	return NewWeightedCouncil(nodeAddrs, nil, make([]uint64, len(nodeAddrs)), nil, istanbul.WeightedRandom, 0, 0, 0, nil)
+	return NewWeightedCouncil(nodeAddrs, nil, nil, make([]uint64, len(nodeAddrs)), nil, istanbul.WeightedRandom, 0, 0, 0, nil)
 }
 
 // TestWeightedCouncil_getStakingAmountsOfValidators checks if validators and stakingAmounts from a stakingInfo are matched well.
@@ -99,8 +99,8 @@ func TestWeightedCouncil_getStakingAmountsOfValidators(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		council := newTestWeightedCouncil(testCase.validators)
-
-		weightedValidators, stakingAmounts, err := council.getStakingAmountsOfValidators(testCase.stakingInfo)
+		candidates := append(council.validators, council.demotedValidators...)
+		weightedValidators, stakingAmounts, err := getStakingAmountsOfValidators(candidates, testCase.stakingInfo)
 
 		assert.NoError(t, err)
 		assert.Equal(t, len(testCase.validators), len(weightedValidators))
@@ -307,8 +307,8 @@ func TestWeightedCouncil_validatorWeightWithStakingInfo(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		council := newTestWeightedCouncil(testCase.validators)
-
-		weightedValidators, stakingAmounts, err := council.getStakingAmountsOfValidators(testCase.stakingInfo)
+		candidates := append(council.validators, council.demotedValidators...)
+		weightedValidators, stakingAmounts, err := getStakingAmountsOfValidators(candidates, testCase.stakingInfo)
 		assert.NoError(t, err)
 		totalStaking := calcTotalAmount(weightedValidators, testCase.stakingInfo, stakingAmounts)
 		calcWeight(weightedValidators, stakingAmounts, totalStaking)

--- a/consensus/istanbul/validator/validator.go
+++ b/consensus/istanbul/validator/validator.go
@@ -39,10 +39,10 @@ func New(addr common.Address) istanbul.Validator {
 	}
 }
 
-func NewValidatorSet(addrs []common.Address, proposerPolicy istanbul.ProposerPolicy, subGroupSize uint64, chain consensus.ChainReader) istanbul.ValidatorSet {
+func NewValidatorSet(addrs, demotedAddrs []common.Address, proposerPolicy istanbul.ProposerPolicy, subGroupSize uint64, chain consensus.ChainReader) istanbul.ValidatorSet {
 	var valSet istanbul.ValidatorSet
 	if proposerPolicy == istanbul.WeightedRandom {
-		valSet = NewWeightedCouncil(addrs, nil, nil, nil, proposerPolicy, subGroupSize, 0, 0, chain)
+		valSet = NewWeightedCouncil(addrs, demotedAddrs, nil, nil, nil, proposerPolicy, subGroupSize, 0, 0, chain)
 	} else {
 		valSet = NewSubSet(addrs, proposerPolicy, subGroupSize)
 	}

--- a/consensus/istanbul/validator/validator.go
+++ b/consensus/istanbul/validator/validator.go
@@ -96,7 +96,7 @@ func SelectRandomCommittee(validators []istanbul.Validator, committeeSize uint64
 
 	// ensure committeeSize and proposer indexes are valid
 	validatorSize := len(validators)
-	if validatorSize < int(committeeSize) || validatorSize < proposerIdx || validatorSize < nextProposerIdx {
+	if validatorSize < int(committeeSize) || validatorSize <= proposerIdx || validatorSize <= nextProposerIdx {
 		logger.Error("invalid committee size or validator indexes", "validatorSize", validatorSize,
 			"committeeSize", committeeSize, "proposerIdx", proposerIdx, "nextProposerIdx", nextProposerIdx)
 		return nil

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -223,7 +223,7 @@ func NewWeightedCouncil(addrs []common.Address, demotedAddrs []common.Address, r
 	return valSet
 }
 
-func GetWeightedCouncilData(valSet istanbul.ValidatorSet) (validators []common.Address, rewardAddrs []common.Address, votingPowers []uint64, weights []uint64, proposers []common.Address, proposersBlockNum uint64) {
+func GetWeightedCouncilData(valSet istanbul.ValidatorSet) (validators []common.Address, demotedValidators []common.Address, rewardAddrs []common.Address, votingPowers []uint64, weights []uint64, proposers []common.Address, proposersBlockNum uint64) {
 
 	weightedCouncil, ok := valSet.(*weightedCouncil)
 	if !ok {
@@ -243,6 +243,12 @@ func GetWeightedCouncilData(valSet istanbul.ValidatorSet) (validators []common.A
 			rewardAddrs[i] = weightedVal.RewardAddress()
 			votingPowers[i] = weightedVal.votingPower
 			weights[i] = atomic.LoadUint64(&weightedVal.weight)
+		}
+
+		numDemoted := len(weightedCouncil.demotedValidators)
+		demotedValidators = make([]common.Address, numDemoted)
+		for i, val := range weightedCouncil.demotedValidators {
+			demotedValidators[i] = val.Address()
 		}
 
 		proposers = make([]common.Address, len(weightedCouncil.proposers))

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -313,6 +313,12 @@ func (valSet *weightedCouncil) List() []istanbul.Validator {
 	return valSet.validators
 }
 
+func (valSet *weightedCouncil) DemotedList() []istanbul.Validator {
+	valSet.validatorMu.RLock()
+	defer valSet.validatorMu.RUnlock()
+	return valSet.demotedValidators
+}
+
 // SubList composes a committee after setting a proposer with a default value.
 // This functions returns whole validators if it failed to compose a committee.
 func (valSet *weightedCouncil) SubList(prevHash common.Hash, view *istanbul.View) []istanbul.Validator {

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -101,7 +101,7 @@ type weightedCouncil struct {
 	policy            istanbul.ProposerPolicy
 
 	proposer    atomic.Value // istanbul.Validator
-	validatorMu sync.RWMutex
+	validatorMu sync.RWMutex // this validator mutex protects concurrent usage of validators and demotedValidators
 	selector    istanbul.ProposalSelector
 
 	proposers         []istanbul.Validator

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"math/rand"
 	"reflect"
 	"sort"
@@ -590,7 +591,7 @@ func (valSet *weightedCouncil) Policy() istanbul.ProposerPolicy { return valSet.
 // It returns no error when weightedCouncil:
 //   (1) already has up-do-date proposers
 //   (2) successfully calculated up-do-date proposers
-func (valSet *weightedCouncil) Refresh(hash common.Hash, blockNum uint64) error {
+func (valSet *weightedCouncil) Refresh(hash common.Hash, blockNum uint64, config *params.ChainConfig) error {
 	valSet.validatorMu.Lock()
 	defer valSet.validatorMu.Unlock()
 
@@ -621,16 +622,34 @@ func (valSet *weightedCouncil) Refresh(hash common.Hash, blockNum uint64) error 
 	}
 	valSet.stakingInfo = newStakingInfo
 
-	// get staking amounts of validators and demoted ones
-	candidates := append(valSet.validators, valSet.demotedValidators...)
-	weightedValidators, stakingAmounts, err := getStakingAmountsOfValidators(candidates, newStakingInfo)
-	if err != nil {
-		return err
+	blockNumBig := new(big.Int).SetUint64(blockNum)
+	chainRules := config.Rules(blockNumBig)
+
+	var (
+		weightedValidators []*weightedValidator
+		stakingAmounts     []float64
+	)
+
+	if chainRules.IsIstanbul {
+		// get staking amounts of validators and demoted ones
+		candidates := append(valSet.validators, valSet.demotedValidators...)
+		weightedValidators, stakingAmounts, err = getStakingAmountsOfValidators(candidates, newStakingInfo)
+		if err != nil {
+			return err
+		}
+
+		var demotedValidators []*weightedValidator
+		// divide the obtained validators into two groups which have enough amount of staking
+		weightedValidators, stakingAmounts, demotedValidators, _ = filterPoorValidators(weightedValidators, stakingAmounts)
+		// update new validators and demoted validators of the council
+		valSet.setValidators(weightedValidators, demotedValidators)
+	} else {
+		candidates := valSet.validators
+		weightedValidators, stakingAmounts, err = getStakingAmountsOfValidators(candidates, newStakingInfo)
+		if err != nil {
+			return err
+		}
 	}
-	// divide the obtained validators into two groups which have enough amount of staking
-	weightedValidators, stakingAmounts, demotedValidators, _ := filterPoorValidators(weightedValidators, stakingAmounts)
-	// update new validators and demoted validators of the council
-	valSet.setValidators(weightedValidators, demotedValidators)
 
 	totalStaking := calcTotalAmount(weightedValidators, newStakingInfo, stakingAmounts)
 	calcWeight(weightedValidators, stakingAmounts, totalStaking)

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -488,6 +488,11 @@ func (valSet *weightedCouncil) AddValidator(address common.Address) bool {
 			return false
 		}
 	}
+	for _, v := range valSet.demotedValidators {
+		if v.Address() == address {
+			return false
+		}
+	}
 
 	// TODO-Klaytn-Issue1336 Update for governance implementation. How to determine initial value for rewardAddress and votingPower ?
 	valSet.validators = append(valSet.validators, newWeightedValidator(address, common.Address{}, 1000, 0))
@@ -518,6 +523,12 @@ func (valSet *weightedCouncil) RemoveValidator(address common.Address) bool {
 		if v.Address() == address {
 			valSet.validators = append(valSet.validators[:i], valSet.validators[i+1:]...)
 			valSet.removeValidatorFromProposers(address)
+			return true
+		}
+	}
+	for i, v := range valSet.demotedValidators {
+		if v.Address() == address {
+			valSet.demotedValidators = append(valSet.demotedValidators[:i], valSet.demotedValidators[i+1:]...)
 			return true
 		}
 	}

--- a/consensus/istanbul/validator/weighted_random_test.go
+++ b/consensus/istanbul/validator/weighted_random_test.go
@@ -125,7 +125,7 @@ func makeTestValidators(weights []uint64) (validators istanbul.Validators) {
 
 func makeTestWeightedCouncil(weights []uint64) (valSet *weightedCouncil) {
 	// prepare weighted council
-	valSet = NewWeightedCouncil(testAddrs, testRewardAddrs, testVotingPowers, weights, istanbul.WeightedRandom, 21, 0, 0, nil)
+	valSet = NewWeightedCouncil(testAddrs, nil, testRewardAddrs, testVotingPowers, weights, istanbul.WeightedRandom, 21, 0, 0, nil)
 	return
 }
 

--- a/consensus/istanbul/validator/weighted_test.go
+++ b/consensus/istanbul/validator/weighted_test.go
@@ -51,7 +51,7 @@ func TestNewWeightedCouncil(t *testing.T) {
 	}
 
 	// Create ValidatorSet
-	valSet := NewWeightedCouncil(ExtractValidators(b), rewardAddrs, votingPowers, nil, istanbul.WeightedRandom, 21, 0, 0, nil)
+	valSet := NewWeightedCouncil(ExtractValidators(b), nil, rewardAddrs, votingPowers, nil, istanbul.WeightedRandom, 21, 0, 0, nil)
 	if valSet == nil {
 		t.Errorf("the validator byte array cannot be parsed")
 		t.FailNow()
@@ -88,7 +88,7 @@ func TestNormalWeightedCouncil(t *testing.T) {
 	val1 := newWeightedValidator(addr1, rewardAddr1, votingPower1, weight1)
 	val2 := newWeightedValidator(addr2, rewardAddr2, votingPower2, weight2)
 
-	valSet := NewWeightedCouncil([]common.Address{addr1, addr2}, []common.Address{rewardAddr1, rewardAddr2}, []uint64{votingPower1, votingPower2}, []uint64{weight1, weight2}, istanbul.WeightedRandom, 21, 0, 0, nil)
+	valSet := NewWeightedCouncil([]common.Address{addr1, addr2}, nil, []common.Address{rewardAddr1, rewardAddr2}, []uint64{votingPower1, votingPower2}, []uint64{weight1, weight2}, istanbul.WeightedRandom, 21, 0, 0, nil)
 	if valSet == nil {
 		t.Errorf("the format of validator set is invalid")
 		t.FailNow()
@@ -161,7 +161,7 @@ func TestNormalWeightedCouncil(t *testing.T) {
 }
 
 func TestEmptyWeightedCouncil(t *testing.T) {
-	valSet := NewWeightedCouncil(ExtractValidators([]byte{}), nil, nil, nil, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
+	valSet := NewWeightedCouncil(ExtractValidators([]byte{}), nil, nil, nil, nil, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
 	if valSet == nil {
 		t.Errorf("validator set should not be nil")
 	}
@@ -169,10 +169,10 @@ func TestEmptyWeightedCouncil(t *testing.T) {
 
 func TestNewWeightedCouncil_InvalidPolicy(t *testing.T) {
 	// Invalid proposer policy
-	valSet := NewWeightedCouncil(ExtractValidators([]byte{}), nil, nil, nil, istanbul.Sticky, 0, 0, 0, &blockchain.BlockChain{})
+	valSet := NewWeightedCouncil(ExtractValidators([]byte{}), nil, nil, nil, nil, istanbul.Sticky, 0, 0, 0, &blockchain.BlockChain{})
 	assert.Equal(t, (*weightedCouncil)(nil), valSet)
 
-	valSet = NewWeightedCouncil(ExtractValidators([]byte{}), nil, nil, nil, istanbul.RoundRobin, 0, 0, 0, &blockchain.BlockChain{})
+	valSet = NewWeightedCouncil(ExtractValidators([]byte{}), nil, nil, nil, nil, istanbul.RoundRobin, 0, 0, 0, &blockchain.BlockChain{})
 	assert.Equal(t, (*weightedCouncil)(nil), valSet)
 }
 
@@ -201,21 +201,21 @@ func TestNewWeightedCouncil_IncompleteParams(t *testing.T) {
 	}
 
 	// No validator address
-	valSet := NewWeightedCouncil(ExtractValidators([]byte{}), rewardAddrs, votingPowers, weights, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
+	valSet := NewWeightedCouncil(ExtractValidators([]byte{}), nil, rewardAddrs, votingPowers, weights, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
 	assert.Equal(t, (*weightedCouncil)(nil), valSet)
 
 	// Incomplete rewardAddrs
 	incompleteRewardAddrs := make([]common.Address, 1)
-	valSet = NewWeightedCouncil(ExtractValidators(b), incompleteRewardAddrs, nil, nil, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
+	valSet = NewWeightedCouncil(ExtractValidators(b), nil, incompleteRewardAddrs, nil, nil, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
 	assert.Equal(t, (*weightedCouncil)(nil), valSet)
 
 	// Incomplete rewardAddrs
 	incompleteVotingPowers := make([]uint64, 1)
-	valSet = NewWeightedCouncil(ExtractValidators(b), nil, incompleteVotingPowers, nil, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
+	valSet = NewWeightedCouncil(ExtractValidators(b), nil, nil, incompleteVotingPowers, nil, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
 	assert.Equal(t, (*weightedCouncil)(nil), valSet)
 
 	// Incomplete rewardAddrs
 	incompleteWeights := make([]uint64, 1)
-	valSet = NewWeightedCouncil(ExtractValidators(b), nil, nil, incompleteWeights, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
+	valSet = NewWeightedCouncil(ExtractValidators(b), nil, nil, nil, incompleteWeights, istanbul.WeightedRandom, 0, 0, 0, &blockchain.BlockChain{})
 	assert.Equal(t, (*weightedCouncil)(nil), valSet)
 }

--- a/governance/default.go
+++ b/governance/default.go
@@ -71,6 +71,7 @@ var (
 		"istanbul.policy":               params.Policy,
 		"reward.stakingupdateinterval":  params.StakeUpdateInterval,
 		"reward.proposerupdateinterval": params.ProposerRefreshInterval,
+		"reward.minimumstake":           params.MinimumStake,
 	}
 
 	GovernanceKeyMapReverse = map[int]string{
@@ -442,6 +443,10 @@ func NewGovernanceInitialize(chainConfig *params.ChainConfig, dbm database.DBMan
 func (g *Governance) updateGovernanceParams() {
 	params.SetStakingUpdateInterval(g.StakingUpdateInterval())
 	params.SetProposerUpdateInterval(g.ProposerUpdateInterval())
+
+	if minimumStakingAmount, ok := new(big.Int).SetString(g.MinimumStake(), 10); ok {
+		params.SetMinimumStakingAmount(minimumStakingAmount)
+	}
 
 	// NOTE: HumanReadable related functions are inactivated now
 	if txGasHumanReadable, ok := g.currentSet.GetValue(params.ConstTxGasHumanReadable); ok {

--- a/governance/default.go
+++ b/governance/default.go
@@ -71,7 +71,6 @@ var (
 		"istanbul.policy":               params.Policy,
 		"reward.stakingupdateinterval":  params.StakeUpdateInterval,
 		"reward.proposerupdateinterval": params.ProposerRefreshInterval,
-		"reward.minimumstake":           params.MinimumStake,
 	}
 
 	GovernanceKeyMapReverse = map[int]string{

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -95,6 +95,7 @@ var tstData = []voteValue{
 	{k: "reward.deferredtxfee", v: 0, e: false},
 	{k: "reward.deferredtxfee", v: 1, e: false},
 	{k: "reward.deferredtxfee", v: "true", e: false},
+	{k: "reward.minimumstake", v: "2000000000000000000000000", e: true},
 	{k: "reward.minimumstake", v: 200000000000000, e: false},
 	{k: "reward.stakingupdateinterval", v: uint64(20), e: false},
 	{k: "reward.proposerupdateinterval", v: uint64(20), e: false},

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -606,7 +606,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	rewards := getTestRewards()
 
 	blockCounter := common.Big0
-	valSet := validator.NewWeightedCouncil(council, rewards, getTestVotingPowers(len(council)), nil, istanbul.WeightedRandom, 21, 0, 0, nil)
+	valSet := validator.NewWeightedCouncil(council, nil, rewards, getTestVotingPowers(len(council)), nil, istanbul.WeightedRandom, 21, 0, 0, nil)
 	gov := getGovernance()
 	gov.nodeAddress.Store(council[len(council)-1])
 
@@ -678,7 +678,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	blockCounter := common.Big0
 	var valSet istanbul.ValidatorSet
-	valSet = validator.NewWeightedCouncil(council, rewards, getTestVotingPowers(len(council)), nil, istanbul.WeightedRandom, 21, 0, 0, nil)
+	valSet = validator.NewWeightedCouncil(council, nil, rewards, getTestVotingPowers(len(council)), nil, istanbul.WeightedRandom, 21, 0, 0, nil)
 
 	config := getTestConfig()
 	config.Governance.GovernanceMode = GovernanceModeBallot

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -95,7 +95,6 @@ var tstData = []voteValue{
 	{k: "reward.deferredtxfee", v: 0, e: false},
 	{k: "reward.deferredtxfee", v: 1, e: false},
 	{k: "reward.deferredtxfee", v: "true", e: false},
-	{k: "reward.minimumstake", v: "2000000000000000000000000", e: true},
 	{k: "reward.minimumstake", v: 200000000000000, e: false},
 	{k: "reward.stakingupdateinterval", v: uint64(20), e: false},
 	{k: "reward.proposerupdateinterval", v: uint64(20), e: false},

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -54,7 +54,7 @@ var GovernanceItems = map[int]check{
 	params.Ratio:                   {stringT, checkRatio, nil},
 	params.UseGiniCoeff:            {boolT, checkUint64andBool, updateUseGiniCoeff},
 	params.DeferredTxFee:           {boolT, checkUint64andBool, nil},
-	params.MinimumStake:            {stringT, checkBigInt, nil},
+	params.MinimumStake:            {stringT, checkBigInt, updateMinimumStakingAmount},
 	params.StakeUpdateInterval:     {uint64T, checkUint64andBool, updateStakingUpdateInterval},
 	params.ProposerRefreshInterval: {uint64T, checkUint64andBool, updateProposerUpdateInterval},
 	params.Epoch:                   {uint64T, checkUint64andBool, nil},
@@ -88,6 +88,12 @@ func updateStakingUpdateInterval(g *Governance, k string, v interface{}) {
 
 func updateProposerUpdateInterval(g *Governance, k string, v interface{}) {
 	params.SetProposerUpdateInterval(g.ProposerUpdateInterval())
+}
+
+func updateMinimumStakingAmount(g *Governance, k string, v interface{}) {
+	if val, ok := new(big.Int).SetString(g.MinimumStake(), 10); ok {
+		params.SetMinimumStakingAmount(val)
+	}
 }
 
 func updateProposerPolicy(g *Governance, k string, v interface{}) {

--- a/params/governance_params.go
+++ b/params/governance_params.go
@@ -31,7 +31,8 @@ const (
 	kirContractIncentiveInSton    int64 = 3200000000 // 3.2 KLAY for KIR contract (Unit: ston)
 	pocContractIncentiveInSton    int64 = 3200000000 // 3.2 KLAY for PoC contract (Unit: ston)
 
-	defaultMintedKLAYInSton int64 = 9600000000 // Default amount of minted KLAY. 9.6 KLAY for block reward (Unit: ston)
+	defaultMintedKLAYInSton           int64 = 9600000000 // Default amount of minted KLAY. 9.6 KLAY for block reward (Unit: ston)
+	defaultMinimumStakingAmountInKlay int64 = 5000000    // Default amount of minimum staking (Unit: KLAY)
 
 	DefaultCNRewardRatio  = 34 // Default CN reward ratio 34%
 	DefaultPoCRewardRatio = 54 // Default PoC ratio 54%
@@ -45,6 +46,9 @@ var (
 	PoCContractIncentive    = big.NewInt(0).Mul(big.NewInt(pocContractIncentiveInSton), big.NewInt(Ston))
 
 	DefaultMintedKLAY = big.NewInt(0).Mul(big.NewInt(defaultMintedKLAYInSton), big.NewInt(Ston))
+
+	defaultMinimumStakingAmount = big.NewInt(0).Mul(big.NewInt(defaultMinimumStakingAmountInKlay), big.NewInt(KLAY))
+	minimumStakingAmount        atomic.Value
 
 	stakingUpdateInterval  uint64 = 86400 // About 1 day. 86400 blocks = (24 hrs) * (3600 secs/hr) * (1 block/sec)
 	proposerUpdateInterval uint64 = 3600  // About 1 hour. 3600 blocks = (1 hr) * (3600 secs/hr) * (1 block/sec)
@@ -175,4 +179,15 @@ func SetProposerUpdateInterval(num uint64) {
 func ProposerUpdateInterval() uint64 {
 	ret := atomic.LoadUint64(&proposerUpdateInterval)
 	return ret
+}
+
+func SetMinimumStakingAmount(val *big.Int) {
+	minimumStakingAmount.Store(val)
+}
+
+func MinimumStakingAmount() *big.Int {
+	if m, ok := minimumStakingAmount.Load().(*big.Int); ok {
+		return m
+	}
+	return defaultMinimumStakingAmount
 }

--- a/params/governance_params_test.go
+++ b/params/governance_params_test.go
@@ -17,8 +17,23 @@
 package params
 
 import (
+	"math/big"
 	"testing"
+
+	"github.com/klaytn/klaytn/common"
 )
+
+func TestSetMinimumStakingAmount(t *testing.T) {
+	testData := []*big.Int{common.Big1, common.Big100, common.Big32, common.Big256, common.Big257}
+
+	for i := 0; i < len(testData); i++ {
+		SetMinimumStakingAmount(testData[i])
+
+		if MinimumStakingAmount().Cmp(testData[i]) != 0 {
+			t.Errorf("MinimumStakingAmount is different from the given testData. Result : %v, Expected : %v", MinimumStakingAmount(), testData[i])
+		}
+	}
+}
 
 func TestSetProposerUpdateInterval(t *testing.T) {
 	testData := []uint64{3600, 100, 500, 7200, 10}


### PR DESCRIPTION
## Proposed changes

- Updated the minimum staking update flag available
- Removed the validators who do not have minimum staking amount of KLAY from committees/proposers
  - Case 1. Some members do not have enough KLAYs
    - Members who do not have enough KLAYs cannot be committee as well as proposers
  - Case 2. No validator has enough KLAYs
    - All members become the committee and a proposer is chosen from them
  - Case 3. Governing node in single mode doesn't have enough KLAYs
    - No one can vote until governing node has enough KLAYs
    - This case will be handled in another PR. In single mode, the governing node will always be in proposers/committee.
- Updated for backward-incompatible change

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

