### PR TITLE
Change the log level of some consensus msg from WARN to INFO

### DIFF
--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -103,7 +103,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 	// the previous round skip sending PREPARE messages.
 	if c.state.Cmp(StatePrepared) < 0 {
 		if c.current.IsHashLocked() && commit.Digest == c.current.GetLockedHash() {
-			logger.Info("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
+			logger.Warn("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
 			c.setState(StatePrepared)
 			c.sendCommit()
 		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() {

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -87,7 +87,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			c.setState(StatePrepared)
 			c.sendCommit()
 		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() {
-			logger.Warn("received more than 2f agreements and change state to prepared", "msgType", msgPrepare)
+			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgPrepare)
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()


### PR DESCRIPTION
## Proposed changes

- Info->Warn: `received prepare/commit of the hash locked proposal` log is printed only when round change happened
- Warn->Info: `received more than 2f agreement` log can be printed in round 0

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
