### PR TITLE
Introduce an init option, rpc.concurrencylimit

### DIFF
--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -241,6 +241,7 @@ var FlagGroups = []FlagGroup{
 			RPCVirtualHostsFlag,
 			RPCApiFlag,
 			RPCGlobalGasCap,
+			RPCConcurrencyLimit,
 			IPCDisabledFlag,
 			IPCPathFlag,
 			WSEnabledFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -451,6 +451,11 @@ var (
 		Name:  "rpc.gascap",
 		Usage: "Sets a cap on gas that can be used in klay_call/estimateGas",
 	}
+	RPCConcurrencyLimit = cli.IntFlag{
+		Name:  "rpc.concurrencylimit",
+		Usage: "Sets a limit of concurrent connection number of HTTP-RPC server",
+		Value: rpc.ConcurrencyLimit,
+	}
 	WSEnabledFlag = cli.BoolFlag{
 		Name:  "ws",
 		Usage: "Enable the WS-RPC server",
@@ -1136,6 +1141,10 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.GlobalIsSet(RPCVirtualHostsFlag.Name) {
 		cfg.HTTPVirtualHosts = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
+	}
+	if ctx.GlobalIsSet(RPCConcurrencyLimit.Name) {
+		rpc.ConcurrencyLimit = ctx.GlobalInt(RPCConcurrencyLimit.Name)
+		logger.Info("Set the concurrency limit of RPC-HTTP server", "limit", rpc.ConcurrencyLimit)
 	}
 }
 

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -128,6 +128,7 @@ var CommonRPCFlags = []cli.Flag{
 	utils.GRPCEnabledFlag,
 	utils.GRPCListenAddrFlag,
 	utils.GRPCPortFlag,
+	utils.RPCConcurrencyLimit,
 	utils.WSApiFlag,
 	utils.WSAllowedOriginsFlag,
 	utils.WSMaxSubscriptionPerConn,

--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -219,7 +219,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, sr
 		for _, vhost := range vhosts {
 			if vhost == "*" {
 				return &fasthttp.Server{
-					Concurrency:  concurrencyLimit,
+					Concurrency:  ConcurrencyLimit,
 					Handler:      srv.HandleFastHTTP,
 					ReadTimeout:  timeouts.ReadTimeout,
 					WriteTimeout: timeouts.WriteTimeout,
@@ -236,7 +236,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, sr
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
 	return &fasthttp.Server{
-		Concurrency:  concurrencyLimit,
+		Concurrency:  ConcurrencyLimit,
 		Handler:      fhandler,
 		ReadTimeout:  timeouts.ReadTimeout,
 		WriteTimeout: timeouts.WriteTimeout,

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -46,12 +46,13 @@ const (
 
 	// pendingRequestLimit is a limit for concurrent RPC method calls
 	pendingRequestLimit = 200000
-
-	// concurrencyLimit is a limit for the number of concurrency connection for RPC servers
-	concurrencyLimit = 3000
 )
 
 var (
+	// ConcurrencyLimit is a limit for the number of concurrency connection for RPC servers
+	// It can be overwritten by rpc.concurrencylimit flag.
+	ConcurrencyLimit = 3000
+
 	// pendingRequestCount is a total number of concurrent RPC method calls
 	pendingRequestCount int64 = 0
 

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -49,8 +49,8 @@ const (
 )
 
 var (
-	// ConcurrencyLimit is a limit for the number of concurrency connection for RPC servers
-	// It can be overwritten by rpc.concurrencylimit flag.
+	// ConcurrencyLimit is a limit for the number of concurrency connection for RPC servers.
+	// It can be overwritten by rpc.concurrencylimit flag
 	ConcurrencyLimit = 3000
 
 	// pendingRequestCount is a total number of concurrent RPC method calls

--- a/networks/rpc/websocket.go
+++ b/networks/rpc/websocket.go
@@ -174,7 +174,7 @@ func NewFastWSServer(allowedOrigins []string, srv *Server) *fasthttp.Server {
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
 	return &fasthttp.Server{
-		Concurrency:        concurrencyLimit,
+		Concurrency:        ConcurrencyLimit,
 		MaxRequestBodySize: common.MaxRequestContentLength,
 		Handler:            srv.FastWebsocketHandler,
 	}


### PR DESCRIPTION
## Proposed changes

Introduce an init option, `rpc.concurrencylimit`, which means the maximum number of concurrent connections RPC-HTTP server may serve.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
