### PR TITLE
all: added HybridTimer to collect time-related metrics

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -33,6 +33,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	klaytnmetrics "github.com/klaytn/klaytn/metrics"
+
 	"github.com/go-redis/redis/v7"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/klaytn/klaytn/blockchain/state"
@@ -58,24 +60,24 @@ import (
 const insertTimeLimit = common.PrettyDuration(time.Second)
 
 var (
-	accountReadTimer   = metrics.NewRegisteredTimer("state/account/reads", nil)
-	accountHashTimer   = metrics.NewRegisteredTimer("state/account/hashes", nil)
-	accountUpdateTimer = metrics.NewRegisteredTimer("state/account/updates", nil)
-	accountCommitTimer = metrics.NewRegisteredTimer("state/account/commits", nil)
+	accountReadTimer   = klaytnmetrics.NewRegisteredHybridTimer("state/account/reads", nil)
+	accountHashTimer   = klaytnmetrics.NewRegisteredHybridTimer("state/account/hashes", nil)
+	accountUpdateTimer = klaytnmetrics.NewRegisteredHybridTimer("state/account/updates", nil)
+	accountCommitTimer = klaytnmetrics.NewRegisteredHybridTimer("state/account/commits", nil)
 
-	storageReadTimer   = metrics.NewRegisteredTimer("state/storage/reads", nil)
-	storageHashTimer   = metrics.NewRegisteredTimer("state/storage/hashes", nil)
-	storageUpdateTimer = metrics.NewRegisteredTimer("state/storage/updates", nil)
-	storageCommitTimer = metrics.NewRegisteredTimer("state/storage/commits", nil)
+	storageReadTimer   = klaytnmetrics.NewRegisteredHybridTimer("state/storage/reads", nil)
+	storageHashTimer   = klaytnmetrics.NewRegisteredHybridTimer("state/storage/hashes", nil)
+	storageUpdateTimer = klaytnmetrics.NewRegisteredHybridTimer("state/storage/updates", nil)
+	storageCommitTimer = klaytnmetrics.NewRegisteredHybridTimer("state/storage/commits", nil)
 
-	blockInsertTimer    = metrics.NewRegisteredTimer("chain/inserts", nil)
-	blockProcessTimer   = metrics.NewRegisteredTimer("chain/process", nil)
-	blockExecutionTimer = metrics.NewRegisteredTimer("chain/execution", nil)
-	blockFinalizeTimer  = metrics.NewRegisteredTimer("chain/finalize", nil)
-	blockValidateTimer  = metrics.NewRegisteredTimer("chain/validate", nil)
-	blockAgeTimer       = metrics.NewRegisteredTimer("chain/age", nil)
+	blockInsertTimer    = klaytnmetrics.NewRegisteredHybridTimer("chain/inserts", nil)
+	blockProcessTimer   = klaytnmetrics.NewRegisteredHybridTimer("chain/process", nil)
+	blockExecutionTimer = klaytnmetrics.NewRegisteredHybridTimer("chain/execution", nil)
+	blockFinalizeTimer  = klaytnmetrics.NewRegisteredHybridTimer("chain/finalize", nil)
+	blockValidateTimer  = klaytnmetrics.NewRegisteredHybridTimer("chain/validate", nil)
+	blockAgeTimer       = klaytnmetrics.NewRegisteredHybridTimer("chain/age", nil)
 
-	blockPrefetchExecuteTimer   = metrics.NewRegisteredTimer("chain/prefetch/executes", nil)
+	blockPrefetchExecuteTimer   = klaytnmetrics.NewRegisteredHybridTimer("chain/prefetch/executes", nil)
 	blockPrefetchInterruptMeter = metrics.NewRegisteredMeter("chain/prefetch/interrupts", nil)
 
 	ErrNoGenesis            = errors.New("genesis not found in chain")

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -830,7 +830,7 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) 
 				logger.Debug("Received skeleton from incorrect peer", "peer", packet.PeerId())
 				break
 			}
-			headerReqTimer.UpdateSince(request)
+			headerReqTimer.Update(time.Since(request))
 			timeout.Stop()
 
 			// If the skeleton's finished, pull any remaining head headers directly from the origin

--- a/datasync/downloader/metrics.go
+++ b/datasync/downloader/metrics.go
@@ -20,21 +20,24 @@
 
 package downloader
 
-import "github.com/rcrowley/go-metrics"
+import (
+	klaytnmetrics "github.com/klaytn/klaytn/metrics"
+	"github.com/rcrowley/go-metrics"
+)
 
 var (
 	headerInMeter      = metrics.NewRegisteredMeter("klay/downloader/headers/in", nil)
-	headerReqTimer     = metrics.NewRegisteredTimer("klay/downloader/headers/req", nil)
+	headerReqTimer     = klaytnmetrics.NewRegisteredHybridTimer("klay/downloader/headers/req", nil)
 	headerDropMeter    = metrics.NewRegisteredMeter("klay/downloader/headers/drop", nil)
 	headerTimeoutMeter = metrics.NewRegisteredMeter("klay/downloader/headers/timeout", nil)
 
 	bodyInMeter      = metrics.NewRegisteredMeter("klay/downloader/bodies/in", nil)
-	bodyReqTimer     = metrics.NewRegisteredTimer("klay/downloader/bodies/req", nil)
+	bodyReqTimer     = klaytnmetrics.NewRegisteredHybridTimer("klay/downloader/bodies/req", nil)
 	bodyDropMeter    = metrics.NewRegisteredMeter("klay/downloader/bodies/drop", nil)
 	bodyTimeoutMeter = metrics.NewRegisteredMeter("klay/downloader/bodies/timeout", nil)
 
 	receiptInMeter      = metrics.NewRegisteredMeter("klay/downloader/receipts/in", nil)
-	receiptReqTimer     = metrics.NewRegisteredTimer("klay/downloader/receipts/req", nil)
+	receiptReqTimer     = klaytnmetrics.NewRegisteredHybridTimer("klay/downloader/receipts/req", nil)
 	receiptDropMeter    = metrics.NewRegisteredMeter("klay/downloader/receipts/drop", nil)
 	receiptTimeoutMeter = metrics.NewRegisteredMeter("klay/downloader/receipts/timeout", nil)
 

--- a/datasync/downloader/queue.go
+++ b/datasync/downloader/queue.go
@@ -27,6 +27,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	klaytnmetrics "github.com/klaytn/klaytn/metrics"
+
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/prque"
@@ -690,7 +692,7 @@ func (q *queue) DeliverHeaders(id string, headers []*types.Header, headerProcCh 
 	if request == nil {
 		return 0, errNoFetchesPending
 	}
-	headerReqTimer.UpdateSince(request.Time)
+	headerReqTimer.Update(time.Since(request.Time))
 	delete(q.headerPendPool, id)
 
 	// Ensure headers can be mapped onto the skeleton chain
@@ -809,7 +811,7 @@ func (q *queue) DeliverReceipts(id string, receiptList [][]*types.Receipt) (int,
 // reason this lock is not obtained in here is because the parameters already need
 // to access the queue, so they already need a lock anyway.
 func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header, taskQueue *prque.Prque,
-	pendPool map[string]*fetchRequest, reqTimer metrics.Timer,
+	pendPool map[string]*fetchRequest, reqTimer klaytnmetrics.HybridTimer,
 	results int, validate func(index int, header *types.Header) error,
 	reconstruct func(index int, result *fetchResult)) (int, error) {
 
@@ -818,7 +820,7 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header, taskQ
 	if request == nil {
 		return 0, errNoFetchesPending
 	}
-	reqTimer.UpdateSince(request.Time)
+	reqTimer.Update(time.Since(request.Time))
 	delete(pendPool, id)
 
 	// If no data items were retrieved, mark them as unavailable for the origin peer

--- a/datasync/fetcher/fetcher.go
+++ b/datasync/fetcher/fetcher.go
@@ -700,7 +700,7 @@ func (f *Fetcher) insertWork(peer string, block *types.Block) {
 	switch err := f.verifyHeader(block.Header()); err {
 	case nil:
 		// All ok, quickly propagate to our peers
-		propBroadcastOutTimer.UpdateSince(block.ReceivedAt)
+		propBroadcastOutTimer.Update(time.Since(block.ReceivedAt))
 		go f.broadcastBlock(block)
 
 	case consensus.ErrFutureBlock:
@@ -718,7 +718,7 @@ func (f *Fetcher) insertWork(peer string, block *types.Block) {
 		return
 	}
 	// If import succeeded, broadcast the block
-	propAnnounceOutTimer.UpdateSince(block.ReceivedAt)
+	propAnnounceOutTimer.Update(time.Since(block.ReceivedAt))
 	go f.broadcastBlockHash(block)
 
 	// Invoke the testing hook if needed

--- a/datasync/fetcher/metrics.go
+++ b/datasync/fetcher/metrics.go
@@ -20,16 +20,19 @@
 
 package fetcher
 
-import "github.com/rcrowley/go-metrics"
+import (
+	klaytnmetrics "github.com/klaytn/klaytn/metrics"
+	"github.com/rcrowley/go-metrics"
+)
 
 var (
 	propAnnounceInMeter   = metrics.NewRegisteredMeter("cn/fetcher/prop/announces/in", nil)
-	propAnnounceOutTimer  = metrics.NewRegisteredTimer("cn/fetcher/prop/announces/out", nil)
+	propAnnounceOutTimer  = klaytnmetrics.NewRegisteredHybridTimer("cn/fetcher/prop/announces/out", nil)
 	propAnnounceDropMeter = metrics.NewRegisteredMeter("cn/fetcher/prop/announces/drop", nil)
 	propAnnounceDOSMeter  = metrics.NewRegisteredMeter("cn/fetcher/prop/announces/dos", nil)
 
 	propBroadcastInMeter   = metrics.NewRegisteredMeter("cn/fetcher/prop/broadcasts/in", nil)
-	propBroadcastOutTimer  = metrics.NewRegisteredTimer("cn/fetcher/prop/broadcasts/out", nil)
+	propBroadcastOutTimer  = klaytnmetrics.NewRegisteredHybridTimer("cn/fetcher/prop/broadcasts/out", nil)
 	propBroadcastDropMeter = metrics.NewRegisteredMeter("cn/fetcher/prop/broadcasts/drop", nil)
 	propBroadcastDOSMeter  = metrics.NewRegisteredMeter("cn/fetcher/prop/broadcasts/dos", nil)
 

--- a/metrics/hybrid_timer.go
+++ b/metrics/hybrid_timer.go
@@ -1,0 +1,80 @@
+// Copyright 2021 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/rcrowley/go-metrics"
+)
+
+const gaugeSuffix = "/maxgauge"
+
+var mu sync.Mutex
+var gauges = make(map[string]metrics.Gauge)
+
+// ResetMaxGauges sets the value of registered gauges to 0.
+func ResetMaxGauges() {
+	for _, g := range gauges {
+		g.Update(0)
+	}
+}
+
+// registerHybridGauge registers the given metric under the given name.
+// It returns a DuplicateMetric if a metric by the given name is already registered.
+func registerHybridGauge(name string, g metrics.Gauge) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, exist := gauges[name]; exist {
+		return
+	}
+	gauges[name] = g
+}
+
+// HybridTimer holds both metrics.Meter and metrics.Gauge to track
+// meter-wise value and temporal maximum value during the certain period.
+type HybridTimer interface {
+	Update(d time.Duration)
+}
+
+type hybridTimer struct {
+	m metrics.Meter
+	g metrics.Gauge
+}
+
+// NewRegisteredHybridTimer constructs and registers a new HybridTimer.
+// `name` is used by meter and `name`+"/maxgauge" is used by gauge.
+func NewRegisteredHybridTimer(name string, r metrics.Registry) HybridTimer {
+	meter := metrics.NewRegisteredMeter(name, r)
+	gaugeName := name + gaugeSuffix
+
+	g := metrics.NewRegisteredGauge(gaugeName, r)
+	registerHybridGauge(gaugeName, g)
+	return &hybridTimer{m: meter, g: g}
+}
+
+// Update updates the value of meter and gauge.
+// The value of gauge is updated only if the current value
+// is greater than the current value.
+func (mg *hybridTimer) Update(d time.Duration) {
+	if mg.g.Value() < int64(d) {
+		mg.g.Update(int64(d))
+	}
+	mg.m.Mark(int64(d))
+}

--- a/metrics/hybrid_timer.go
+++ b/metrics/hybrid_timer.go
@@ -30,6 +30,8 @@ var gauges = make(map[string]metrics.Gauge)
 
 // ResetMaxGauges sets the value of registered gauges to 0.
 func ResetMaxGauges() {
+	mu.Lock()
+	defer mu.Unlock()
 	for _, g := range gauges {
 		g.Update(0)
 	}

--- a/metrics/prometheus/prometheusmetrics.go
+++ b/metrics/prometheus/prometheusmetrics.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	klaytnmetrics "github.com/klaytn/klaytn/metrics"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rcrowley/go-metrics"
 )
@@ -67,6 +69,7 @@ func (c *PrometheusConfig) gaugeFromNameAndValue(name string, val float64) {
 func (c *PrometheusConfig) UpdatePrometheusMetrics() {
 	for range time.Tick(c.FlushInterval) {
 		c.UpdatePrometheusMetricsOnce()
+		klaytnmetrics.ResetMaxGauges()
 	}
 }
 

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -33,6 +33,8 @@ import (
 	"sync"
 	"time"
 
+	klaytnmetrics "github.com/klaytn/klaytn/metrics"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -95,8 +97,8 @@ type dynamoDB struct {
 	logger log.Logger // Contextual logger tracking the database path
 
 	// metrics
-	getTimer metrics.Timer
-	putTimer metrics.Timer
+	getTimer klaytnmetrics.HybridTimer
+	putTimer klaytnmetrics.HybridTimer
 }
 
 type DynamoData struct {
@@ -401,8 +403,8 @@ func (dynamo *dynamoDB) Close() {
 }
 
 func (dynamo *dynamoDB) Meter(prefix string) {
-	dynamo.getTimer = metrics.NewRegisteredTimer(prefix+"get/time", nil)
-	dynamo.putTimer = metrics.NewRegisteredTimer(prefix+"put/time", nil)
+	dynamo.getTimer = klaytnmetrics.NewRegisteredHybridTimer(prefix+"get/time", nil)
+	dynamo.putTimer = klaytnmetrics.NewRegisteredHybridTimer(prefix+"put/time", nil)
 	dynamoBatchWriteTimeMeter = metrics.NewRegisteredMeter(prefix+"batchwrite/time", nil)
 }
 

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	klaytnmetrics "github.com/klaytn/klaytn/metrics"
+
 	"github.com/klaytn/klaytn/common/fdlimit"
 	"github.com/klaytn/klaytn/log"
 	metricutils "github.com/klaytn/klaytn/metrics/utils"
@@ -100,12 +102,12 @@ type levelDB struct {
 	aliveSnapshotsMeter metrics.Meter // Meter for measuring the number of alive snapshots
 	aliveIteratorsMeter metrics.Meter // Meter for measuring the number of alive iterators
 
-	compTimer              metrics.Timer // Meter for measuring the total time spent in database compaction
-	compReadMeter          metrics.Meter // Meter for measuring the data read during compaction
-	compWriteMeter         metrics.Meter // Meter for measuring the data written during compaction
-	diskReadMeter          metrics.Meter // Meter for measuring the effective amount of data read
-	diskWriteMeter         metrics.Meter // Meter for measuring the effective amount of data written
-	blockCacheGauge        metrics.Gauge // Gauge for measuring the current size of block cache
+	compTimer              klaytnmetrics.HybridTimer // Meter for measuring the total time spent in database compaction
+	compReadMeter          metrics.Meter             // Meter for measuring the data read during compaction
+	compWriteMeter         metrics.Meter             // Meter for measuring the data written during compaction
+	diskReadMeter          metrics.Meter             // Meter for measuring the effective amount of data read
+	diskWriteMeter         metrics.Meter             // Meter for measuring the effective amount of data written
+	blockCacheGauge        metrics.Gauge             // Gauge for measuring the current size of block cache
 	openedTablesCountMeter metrics.Meter
 	memCompGauge           metrics.Gauge // Gauge for tracking the number of memory compaction
 	level0CompGauge        metrics.Gauge // Gauge for tracking the number of table compaction in level0
@@ -119,9 +121,9 @@ type levelDB struct {
 	levelDurationsGauge []metrics.Gauge
 
 	perfCheck       bool
-	getTimer        metrics.Timer
-	putTimer        metrics.Timer
-	batchWriteTimer metrics.Timer
+	getTimer        klaytnmetrics.HybridTimer
+	putTimer        klaytnmetrics.HybridTimer
+	batchWriteTimer klaytnmetrics.HybridTimer
 
 	quitLock sync.Mutex      // Mutex protecting the quit channel access
 	quitChan chan chan error // Quit channel to stop the metrics collection before closing the database
@@ -352,7 +354,7 @@ func (db *levelDB) Meter(prefix string) {
 	db.writeDelayDurationMeter = metrics.NewRegisteredMeter(prefix+"writedelay/duration", nil)
 	db.aliveSnapshotsMeter = metrics.NewRegisteredMeter(prefix+"snapshots", nil)
 	db.aliveIteratorsMeter = metrics.NewRegisteredMeter(prefix+"iterators", nil)
-	db.compTimer = metrics.NewRegisteredTimer(prefix+"compaction/time", nil)
+	db.compTimer = klaytnmetrics.NewRegisteredHybridTimer(prefix+"compaction/time", nil)
 	db.compReadMeter = metrics.NewRegisteredMeter(prefix+"compaction/read", nil)
 	db.compWriteMeter = metrics.NewRegisteredMeter(prefix+"compaction/write", nil)
 	db.diskReadMeter = metrics.NewRegisteredMeter(prefix+"disk/read", nil)
@@ -361,9 +363,9 @@ func (db *levelDB) Meter(prefix string) {
 
 	db.openedTablesCountMeter = metrics.NewRegisteredMeter(prefix+"opendedtables", nil)
 
-	db.getTimer = metrics.NewRegisteredTimer(prefix+"get/time", nil)
-	db.putTimer = metrics.NewRegisteredTimer(prefix+"put/time", nil)
-	db.batchWriteTimer = metrics.NewRegisteredTimer(prefix+"batchwrite/time", nil)
+	db.getTimer = klaytnmetrics.NewRegisteredHybridTimer(prefix+"get/time", nil)
+	db.putTimer = klaytnmetrics.NewRegisteredHybridTimer(prefix+"put/time", nil)
+	db.batchWriteTimer = klaytnmetrics.NewRegisteredHybridTimer(prefix+"batchwrite/time", nil)
 
 	db.memCompGauge = metrics.NewRegisteredGauge(prefix+"compact/memory", nil)
 	db.level0CompGauge = metrics.NewRegisteredGauge(prefix+"compact/level0", nil)

--- a/work/worker.go
+++ b/work/worker.go
@@ -26,6 +26,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	klaytnmetrics "github.com/klaytn/klaytn/metrics"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -67,20 +69,20 @@ var (
 	gasLimitReachedTxsGauge = metrics.NewRegisteredGauge("miner/limitreached/gas/txs", nil)
 	strangeErrorTxsCounter  = metrics.NewRegisteredCounter("miner/strangeerror/txs", nil)
 
-	blockMiningTimer          = metrics.NewRegisteredTimer("miner/block/mining/time", nil)
-	blockMiningExecuteTxTimer = metrics.NewRegisteredTimer("miner/block/execute/time", nil)
-	blockMiningCommitTxTimer  = metrics.NewRegisteredTimer("miner/block/commit/time", nil)
-	blockMiningFinalizeTimer  = metrics.NewRegisteredTimer("miner/block/finalize/time", nil)
+	blockMiningTimer          = klaytnmetrics.NewRegisteredHybridTimer("miner/block/mining/time", nil)
+	blockMiningExecuteTxTimer = klaytnmetrics.NewRegisteredHybridTimer("miner/block/execute/time", nil)
+	blockMiningCommitTxTimer  = klaytnmetrics.NewRegisteredHybridTimer("miner/block/commit/time", nil)
+	blockMiningFinalizeTimer  = klaytnmetrics.NewRegisteredHybridTimer("miner/block/finalize/time", nil)
 
-	accountReadTimer   = metrics.NewRegisteredTimer("miner/block/account/reads", nil)
-	accountHashTimer   = metrics.NewRegisteredTimer("miner/block/account/hashes", nil)
-	accountUpdateTimer = metrics.NewRegisteredTimer("miner/block/account/updates", nil)
-	accountCommitTimer = metrics.NewRegisteredTimer("miner/block/account/commits", nil)
+	accountReadTimer   = klaytnmetrics.NewRegisteredHybridTimer("miner/block/account/reads", nil)
+	accountHashTimer   = klaytnmetrics.NewRegisteredHybridTimer("miner/block/account/hashes", nil)
+	accountUpdateTimer = klaytnmetrics.NewRegisteredHybridTimer("miner/block/account/updates", nil)
+	accountCommitTimer = klaytnmetrics.NewRegisteredHybridTimer("miner/block/account/commits", nil)
 
-	storageReadTimer   = metrics.NewRegisteredTimer("miner/block/storage/reads", nil)
-	storageHashTimer   = metrics.NewRegisteredTimer("miner/block/storage/hashes", nil)
-	storageUpdateTimer = metrics.NewRegisteredTimer("miner/block/storage/updates", nil)
-	storageCommitTimer = metrics.NewRegisteredTimer("miner/block/storage/commits", nil)
+	storageReadTimer   = klaytnmetrics.NewRegisteredHybridTimer("miner/block/storage/reads", nil)
+	storageHashTimer   = klaytnmetrics.NewRegisteredHybridTimer("miner/block/storage/hashes", nil)
+	storageUpdateTimer = klaytnmetrics.NewRegisteredHybridTimer("miner/block/storage/updates", nil)
+	storageCommitTimer = klaytnmetrics.NewRegisteredHybridTimer("miner/block/storage/commits", nil)
 )
 
 // Agent can register themself with the worker


### PR DESCRIPTION
## Proposed changes

- As both `meter` and `gauge` is not perfect metric to collect time-related metrics,
 `HybridTimer` is added to collect both metrics at one time. 
- Compared to the original gauge, gauge in `HybridTimer` is reset in `UpdatePrometheusMetrics`, 
to collect the maximum value in the given period. 
- Therefore, there is a code to compare the new value with the current value in `hybridTimer.Update`
- `HybridTimer` implementation -> https://github.com/klaytn/klaytn/commit/d63caf6c0d9f204536b09f4f264066675fcb6ace
- Replace `Timer` to `HybridTimer` -> https://github.com/klaytn/klaytn/commit/ebf7a7985daea915d3faa0163fe02d9facf1990b

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
