### PR TITLE
Updated governance initialization

### DIFF
--- a/governance/default.go
+++ b/governance/default.go
@@ -443,6 +443,7 @@ func (g *Governance) updateGovernanceParams() {
 	params.SetStakingUpdateInterval(g.StakingUpdateInterval())
 	params.SetProposerUpdateInterval(g.ProposerUpdateInterval())
 
+	// NOTE: HumanReadable related functions are inactivated now
 	if txGasHumanReadable, ok := g.currentSet.GetValue(params.ConstTxGasHumanReadable); ok {
 		params.TxGasHumanReadable = txGasHumanReadable.(uint64)
 	}
@@ -599,6 +600,8 @@ func newGovernanceCache() common.Cache {
 	return cache
 }
 
+// initializeCache reads governance item data from database and updates Governance.itemCache.
+// The latest governance item data of Governance.itemCache is imported to Governance.currentSet.
 func (g *Governance) initializeCache() error {
 	// get last n governance change block number
 	indices, err := g.db.ReadRecentGovernanceIdx(params.GovernanceIdxCacheLimit)
@@ -914,6 +917,8 @@ func (gov *Governance) WriteGovernanceState(num uint64, isCheckpoint bool) error
 	}
 }
 
+// ReadGovernanceState reads field values of the Governance struct from database.
+// It also updates params.stakingUpdateInterval and params.proposerUpdateInterval with the retrieved value.
 func (gov *Governance) ReadGovernanceState() {
 	b, err := gov.db.ReadGovernanceState()
 	if err != nil {

--- a/governance/default.go
+++ b/governance/default.go
@@ -423,6 +423,7 @@ func NewGovernanceInitialize(chainConfig *params.ChainConfig, dbm database.DBMan
 	ret := NewGovernance(chainConfig, dbm)
 	// nil is for testing or simple function usage
 	if dbm != nil {
+		ret.ReadGovernanceState()
 		if err := ret.initializeCache(); err != nil {
 			// If this is the first time to run, store governance information for genesis block on database
 			cfg := GetGovernanceItemsFromChainConfig(chainConfig)
@@ -434,9 +435,17 @@ func NewGovernanceInitialize(chainConfig *params.ChainConfig, dbm database.DBMan
 				logger.Crit("No governance cache index found in a database", "err", err)
 			}
 		}
-		ret.ReadGovernanceState()
 	}
 	return ret
+}
+
+func (g *Governance) updateGovernanceParams() {
+	params.SetStakingUpdateInterval(g.StakingUpdateInterval())
+	params.SetProposerUpdateInterval(g.ProposerUpdateInterval())
+
+	if txGasHumanReadable, ok := g.currentSet.GetValue(params.ConstTxGasHumanReadable); ok {
+		params.TxGasHumanReadable = txGasHumanReadable.(uint64)
+	}
 }
 
 func (g *Governance) SetNodeAddress(addr common.Address) {
@@ -609,9 +618,14 @@ func (g *Governance) initializeCache() error {
 		}
 	}
 
-	// the last one is the one to be used now
-	ret, _ := g.itemCache.Get(getGovernanceCacheKey(g.actualGovernanceBlock.Load().(uint64)))
-	g.currentSet.Import(ret.(map[string]interface{}))
+	governanceBlock := g.actualGovernanceBlock.Load().(uint64)
+	governanceStateBlock := atomic.LoadUint64(&g.lastGovernanceStateBlock)
+	if governanceBlock >= governanceStateBlock {
+		ret, _ := g.itemCache.Get(getGovernanceCacheKey(governanceBlock))
+		g.currentSet.Import(ret.(map[string]interface{}))
+		g.updateGovernanceParams()
+	}
+
 	return nil
 }
 
@@ -907,12 +921,8 @@ func (gov *Governance) ReadGovernanceState() {
 		return
 	}
 	gov.UnmarshalJSON(b)
-	params.SetStakingUpdateInterval(gov.StakingUpdateInterval())
-	params.SetProposerUpdateInterval(gov.ProposerUpdateInterval())
+	gov.updateGovernanceParams()
 
-	if txGasHumanReadable, ok := gov.currentSet.GetValue(params.ConstTxGasHumanReadable); ok {
-		params.TxGasHumanReadable = txGasHumanReadable.(uint64)
-	}
 	logger.Info("Successfully loaded governance state from database", "blockNumber", atomic.LoadUint64(&gov.lastGovernanceStateBlock))
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -127,7 +127,7 @@ const (
 )
 
 var (
-	TxGasHumanReadable     uint64 = 4000000000
+	TxGasHumanReadable     uint64 = 4000000000         // NOTE: HumanReadable related functions are inactivated now
 	BlockScoreBoundDivisor        = big.NewInt(2048)   // The bound divisor of the blockscore, used in the update calculations.
 	GenesisBlockScore             = big.NewInt(131072) // BlockScore of the Genesis block.
 	MinimumBlockScore             = big.NewInt(131072) // The minimum that the blockscore may ever be.


### PR DESCRIPTION
## Proposed changes

Updated initialization of the governance in order to load proper current set. The `currentSet` of the governance is stored in `Governance` and `GovernanceState`. Although the `currentSet` can be loaded from both persistences, but it doesn't consider the order. So, this PR fixes the metioned bug.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

