### PR TITLE
Removed MYSQL from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ executors:
     docker:
       - image: klaytn/build_base:1.1-go1.15.7-solc0.4.24
       - image: localstack/localstack:0.11.5
-      - image: circleci/mysql:5.7
       - image: circleci/redis:6.0.8-alpine
       - name: zookeeper
         image: wurstmeister/zookeeper
@@ -232,16 +231,6 @@ commands:
               fi
   wait-other-containers-ready:
     steps:
-      - run:
-          name: "Waiting for MySQL to be ready"
-          command: |
-            for i in `seq 1 10`;
-            do
-              nc -z 127.0.0.1 3306 && echo Success && exit 0
-              echo -n .
-              sleep 1
-            done
-            echo Failed waiting for MySQL && exit 1
       - run:
           name: "Waiting for Redis to be ready"
           command: |


### PR DESCRIPTION
## Proposed changes

- Mysql is used for deprecated chaindatafetcher, so the container is removed from CI.
- The related-tests are skipped when the container is not launched.
- reverted: https://github.com/klaytn/klaytn/pull/594

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
