### PR TITLE
Added Staking Information API

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -182,6 +182,12 @@ web3._extend({
 			call: 'governance_itemCacheFromDb',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'getStakingInfo',
+			call: 'governance_getStakingInfo',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		})
 	],
 	properties: [

--- a/governance/api.go
+++ b/governance/api.go
@@ -165,16 +165,16 @@ func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interf
 	}
 }
 
-func (api *PublicGovernanceAPI) GetStakingInfo(num *rpc.BlockNumber) *reward.StakingInfo {
+func (api *PublicGovernanceAPI) GetStakingInfo(num *rpc.BlockNumber) (*reward.StakingInfo, error) {
 	blockNumber := uint64(0)
 	if num == nil || *num == rpc.LatestBlockNumber {
 		blockNumber = api.governance.blockChain.CurrentHeader().Number.Uint64()
 	} else if *num == rpc.PendingBlockNumber {
-		return nil
+		return nil, kerrors.ErrPendingBlockNotSupported
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
-	return reward.GetStakingInfo(blockNumber)
+	return reward.GetStakingInfo(blockNumber), nil
 }
 
 func (api *PublicGovernanceAPI) PendingChanges() map[string]interface{} {

--- a/governance/api.go
+++ b/governance/api.go
@@ -23,12 +23,12 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/klaytn/klaytn/common/hexutil"
-
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/reward"
 )
 
 type PublicGovernanceAPI struct {
@@ -163,6 +163,18 @@ func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interf
 	} else {
 		return nil, error
 	}
+}
+
+func (api *PublicGovernanceAPI) GetStakingInfo(num *rpc.BlockNumber) *reward.StakingInfo {
+	blockNumber := uint64(0)
+	if num == nil || *num == rpc.LatestBlockNumber {
+		blockNumber = api.governance.blockChain.CurrentHeader().Number.Uint64()
+	} else if *num == rpc.PendingBlockNumber {
+		return nil
+	} else {
+		blockNumber = uint64(num.Int64())
+	}
+	return reward.GetStakingInfo(blockNumber)
 }
 
 func (api *PublicGovernanceAPI) PendingChanges() map[string]interface{} {


### PR DESCRIPTION
## Proposed changes

- This API returns staking information. `BlockNum` is the block where staking information of Council is fetched.
- The example of the result is as follows.

```
> governance.getStakingInfo(4185265)
{
  BlockNum: 4060800,
  CouncilNodeAddrs: ["0x52d41ca72af615a1ac3301b0a93efa222ecc7541", "0xf6623192aa096e192024ecb381b04c58df9a6075", "0x56e3a565e31f8fb0ba0b12c03355518c64372120", "0x386ca3cb8bb13f48d1a6adc1fb8df09e7bb7f9c8", "0xf8c9c61c5e7f2b6219d1c28b94e5cb3cdc802594", "0xbca8ffa45cc8e30bbc0522cdf1a1e0ebf540dfe2", "0xf113ec8c22765d485309cf1d025d1b975245b9f8", "0x0b59cae1f03534209fdb9ddf5ea65b310cd7060c", "0xec6c1cede510be308f0fdbbc8dbdf238829bdb34", "0x45ed4bf508ca2061a8b4a16e278ea85a8f87a70b", "0xa2ba8f7798649a778a1fd66d3035904949fec555", "0xe3d92072d8b9a59a0427485a1b5f459271df457c", "0x1782834bf8847e235f21f2c1f13fca4d5dff6621", "0xe783fc94fddaeebef7293d6c5864cff280f121e1", "0x2bdd279522b8a0843831fbb94cfbb24a913597c5", "0x56e8c1463c341abf8b168c3079ea41ce8a387e18", "0xe93a890fb7ec5e993b1a7fd77b0d13a0763eff3d", "0x16c192585a0ab24b552783b4bf7d8dc9f6855c35", "0xed6ee8a1877f9582858dbe2509abb0ac33e5f24e"],
  CouncilRewardAddrs: ["0x186de0382923086f73367bab16af09aeda4e54bf", "0x40549671ca98cf893976a1ddf318359b5d653248", "0x2dab13877237aa5d83c45a245b0107904d3165f6", "0x020794caf06273ef3a9b4b0323c72341ec070b15", "0xca742951868353c0d24b92c867e30af8fc36278d", "0x5f1dbd747996d8d31e2ab0317be7ffffd155522a", "0xbc8d2fd8c2ab4b76306d9d8b9f5721b13f239220", "0xbd2bdd78de340ed82f99120d332acf36dc0a34ea", "0xfc2a7ec29143621c7e0e651ee2bca428a95c7af4", "0xc5b67d88c3a26fcee67fc542009d8526f6b4c8a3", "0x942a8d56c6330578b1e856c1c972a1ce621ff1c4", "0x758476368db33864b704f41cc63b8460f8e7d39a", "0x858995d25ec828306e65421a7abf3ffe00b91eec", "0x716e48a4393fc064730da40d860bf962e618e33c", "0x1381d45adbcc8f52df274e3ffd6d4bb9341d3b0d", "0xdedbab7de9551a2bee78792638af67d59b8675c6", "0x54e8bc489cee5ab638920cc80160d8095df846b1", "0x5e17f617b33ee6cde415439bf5d06874baeddbbf", "0x179679457f93094a4e7186abcb2089661e92fc22"],
  CouncilStakingAddrs: ["0xf7136f02bb99f467451ee3369fb9d069d7701d2c", "0xd13fcb553ea18b60390964107ea38a9b0cd879dc", "0xb601ab857ec1ff0abfdb17f7fc354936307be163", "0x4b1ce86cb46d016e4e80d026c70b148cbc55dc8c", "0x1916ce6726e73dca6242b091322f68bbf520497b", "0xdc465a6ec28bd5b4eb33675b3f55420a86bda3d0", "0xa8f51f43d6d19bdf0eb7df5e279c8058a64d20e4", "0x9b5e406e8c7edb54154ec81de8e3f42e74b5fdf3", "0x1ee5cd9875011a11558c92e7406fcf08ffa0b7f4", "0x664950481f0ba5f799ba3ab36fb26b294997158d", "0xb40767d69d511bf8f12bf2d7f253f1b40dfe38fe", "0xdd269c2ae784e37560e5fc1c2f2ca2b59453b4d7", "0xcae9ba7d56248165e34a7a3196003eaae3b8ff49", "0xcad45055c3127a93703f6a8f69da81da6d290d94", "0xc39e93cfe231b1269c57fc8cf577700f7d08c357", "0x7b8cffae623338f47b98c53570900450c3926352", "0xda664b81c13b050f9b0435d0b712218aa8bb1609", "0x0a5e4618d91c9ba77349c4064a04792a35a56b42", "0xd9147a04bba6ed9e77a46635a071c0a2dc67e01f"],
  CouncilStakingAmounts: [40000000, 5000000, 5000000, 5000000, 66666667, 5000000, 5000000, 5000000, 5000000, 5000000, 5000000, 5000000, 5000000, 5000000, 5000000, 34573334, 11009000, 21303218, 133333334],
  Gini: 0.62,
  KIRAddr: "0x3d803a7375a8ee5996f52a8d6725637a89f5bbf8",
  PoCAddr: "0x278e6332d69eed782784d21802e3504a64a16456",
  UseGini: true
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

