### PR TITLE
Change the log level of Transaction failed log

### DIFF
--- a/work/worker.go
+++ b/work/worker.go
@@ -734,7 +734,7 @@ CommitTransactionLoop:
 		default:
 			// Strange error, discard the transaction and get the next in line (note, the
 			// nonce-too-high clause will prevent us from executing in vain).
-			logger.Error("Transaction failed, account skipped", "sender", from, "hash", tx.Hash().String(), "err", err)
+			logger.Warn("Transaction failed, account skipped", "sender", from, "hash", tx.Hash().String(), "err", err)
 			strangeErrorTxsCounter.Inc(1)
 			txs.Shift()
 		}


### PR DESCRIPTION
## Proposed changes

The log is printed during the block generation.
Since a tx can be skipped in a normal situation (e.g., the sender just send all KLAY in the previous block), "WARN" log level is more proper than "ERROR".

## Types of changes

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
