### PR TITLE
Set chain of Istanbul backend when the fake worker is enabled

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -136,4 +136,7 @@ type Istanbul interface {
 
 	// Stop stops the engine
 	Stop() error
+
+	// SetChain sets chain of the Istanbul backend
+	SetChain(chain ChainReader)
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -498,6 +498,11 @@ func (sb *backend) APIs(chain consensus.ChainReader) []rpc.API {
 	}
 }
 
+// SetChain sets chain of the Istanbul backend
+func (sb *backend) SetChain(chain consensus.ChainReader) {
+	sb.chain = chain
+}
+
 // Start implements consensus.Istanbul.Start
 func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types.Block, hasBadBlock func(hash common.Hash) bool) error {
 	sb.coreMu.Lock()
@@ -513,7 +518,7 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	}
 	sb.commitCh = make(chan *types.Result, 1)
 
-	sb.chain = chain
+	sb.SetChain(chain)
 	sb.currentBlock = currentBlock
 	sb.hasBadBlock = hasBadBlock
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -318,6 +318,12 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	// set worker
 	if config.WorkerDisable {
 		cn.miner = work.NewFakeWorker()
+		// Istanbul backend can be accessed by APIs to call its methods even though the core of the
+		// consensus engine doesn't run.
+		istBackend, ok := cn.engine.(consensus.Istanbul)
+		if ok {
+			istBackend.SetChain(cn.blockchain)
+		}
 	} else {
 		// TODO-Klaytn improve to handle drop transaction on network traffic in PN and EN
 		cn.miner = work.New(cn, cn.chainConfig, cn.EventMux(), cn.engine, ctx.NodeType(), crypto.PubkeyToAddress(ctx.NodeKey().PublicKey), cn.config.TxResendUseLegacy)


### PR DESCRIPTION
## Proposed changes

Merging https://github.com/klaytn/klaytn/pull/891, `api.istanbul.GetProposer(blockNumber - 1)` in `getConsensusInfo` method directly access to the chain of the consensus backend instead of using `api.chain`.

The change works well in normal operation but results in failure when `FakeWorker` is enabled because `FakeWorker` doesn't set `chain` of the consensus backend. This PR explicitly sets `chain` when `NewFakeWorker` is called. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
