### PR TITLE
Rename RedisCache.Set and RedisCache.set

### DIFF
--- a/storage/statedb/cache_hybrid.go
+++ b/storage/statedb/cache_hybrid.go
@@ -31,15 +31,17 @@ func newHybridCache(config *TrieNodeCacheConfig) (TrieNodeCache, error) {
 }
 
 // HybridCache integrates two kinds of caches: local, remote.
-// local cache uses memory of the local machine and remote cache uses memory of the remote machine.
+// Local cache uses memory of the local machine and remote cache uses memory of the remote machine.
+// When it sets data to both caches, only remote cache is set asynchronously
 type HybridCache struct {
 	local  TrieNodeCache
 	remote *RedisCache
 }
 
+// Set writes data to local cache synchronously and to remote cache asynchronously.
 func (cache *HybridCache) Set(k, v []byte) {
 	cache.local.Set(k, v)
-	cache.remote.Set(k, v)
+	cache.remote.SetAsync(k, v)
 }
 
 func (cache *HybridCache) Get(k []byte) []byte {

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -3,6 +3,7 @@ package statedb
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,6 +28,7 @@ func TestHybridCache_Set(t *testing.T) {
 	// Set an item
 	key, value := randBytes(32), randBytes(500)
 	cache.Set(key, value)
+	time.Sleep(sleepDurationForAsyncBehavior)
 
 	// Type assertion to check both of local cache and remote cache
 	hybrid, ok := cache.(*HybridCache)
@@ -70,7 +72,8 @@ func TestHybridCache_Get(t *testing.T) {
 	{
 		// Store an item into remote cache
 		key, value := randBytes(32), randBytes(500)
-		remoteCache.Set(key, value)
+		remoteCache.SetAsync(key, value)
+		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Make sure the item is not stored in the local cache.
 		assert.Equal(t, len(localCache.Get(key)), 0)
@@ -88,7 +91,8 @@ func TestHybridCache_Get(t *testing.T) {
 		// Store an item into the remote cache
 		key, value := randBytes(32), randBytes(500)
 		localCache.Set(key, value)
-		remoteCache.Set(key, []byte{0x11})
+		remoteCache.SetAsync(key, []byte{0x11})
+		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal := hybrid.Get(key)
@@ -126,7 +130,8 @@ func TestHybridCache_Has(t *testing.T) {
 	{
 		// Store an item into remote cache
 		key, value := randBytes(32), randBytes(500)
-		remoteCache.Set(key, value)
+		remoteCache.SetAsync(key, value)
+		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal, returnedExist := hybrid.Has(key)
@@ -139,7 +144,8 @@ func TestHybridCache_Has(t *testing.T) {
 		// Store an item into the remote cache
 		key, value := randBytes(32), randBytes(500)
 		localCache.Set(key, value)
-		remoteCache.Set(key, []byte{0x11})
+		remoteCache.SetAsync(key, []byte{0x11})
+		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal, returnedExist := hybrid.Has(key)

--- a/storage/statedb/cache_hybrid_test.go
+++ b/storage/statedb/cache_hybrid_test.go
@@ -3,7 +3,6 @@ package statedb
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -28,7 +27,6 @@ func TestHybridCache_Set(t *testing.T) {
 	// Set an item
 	key, value := randBytes(32), randBytes(500)
 	cache.Set(key, value)
-	time.Sleep(sleepDurationForAsyncBehavior)
 
 	// Type assertion to check both of local cache and remote cache
 	hybrid, ok := cache.(*HybridCache)
@@ -73,7 +71,6 @@ func TestHybridCache_Get(t *testing.T) {
 		// Store an item into remote cache
 		key, value := randBytes(32), randBytes(500)
 		remoteCache.Set(key, value)
-		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Make sure the item is not stored in the local cache.
 		assert.Equal(t, len(localCache.Get(key)), 0)
@@ -92,7 +89,6 @@ func TestHybridCache_Get(t *testing.T) {
 		key, value := randBytes(32), randBytes(500)
 		localCache.Set(key, value)
 		remoteCache.Set(key, []byte{0x11})
-		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal := hybrid.Get(key)
@@ -131,7 +127,6 @@ func TestHybridCache_Has(t *testing.T) {
 		// Store an item into remote cache
 		key, value := randBytes(32), randBytes(500)
 		remoteCache.Set(key, value)
-		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal, returnedExist := hybrid.Has(key)
@@ -145,7 +140,6 @@ func TestHybridCache_Has(t *testing.T) {
 		key, value := randBytes(32), randBytes(500)
 		localCache.Set(key, value)
 		remoteCache.Set(key, []byte{0x11})
-		time.Sleep(sleepDurationForAsyncBehavior)
 
 		// Get the item from the hybrid cache and check the validity
 		returnedVal, returnedExist := hybrid.Has(key)

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -96,7 +96,7 @@ func newRedisCache(config *TrieNodeCacheConfig) (*RedisCache, error) {
 	for i := 0; i < workerNum; i++ {
 		go func() {
 			for item := range cache.setItemCh {
-				cache.set(item.key, item.value)
+				cache.Set(item.key, item.value)
 			}
 		}()
 	}
@@ -115,22 +115,22 @@ func (cache *RedisCache) Get(k []byte) []byte {
 	return val
 }
 
-// Set writes data asynchronously. Not all data is written if a setItemCh is full.
-// To write data synchronously, use set instead.
+// Set writes data synchronously.
+// To write data asynchronously, use SetAsync instead.
 func (cache *RedisCache) Set(k, v []byte) {
+	if err := cache.client.Set(hexutil.Encode(k), v, 0).Err(); err != nil {
+		logger.Warn("failed to set an item on redis cache", "err", err, "key", hexutil.Encode(k))
+	}
+}
+
+// SetAsync writes data asynchronously. Not all data is written if a setItemCh is full.
+// To write data synchronously, use Set instead.
+func (cache *RedisCache) SetAsync(k, v []byte) {
 	item := setItem{key: k, value: v}
 	select {
 	case cache.setItemCh <- item:
 	default:
 		logger.Warn("redis setItem channel is full")
-	}
-}
-
-// set writes data synchronously.
-// To write data asynchronously, use Set instead.
-func (cache *RedisCache) set(k, v []byte) {
-	if err := cache.client.Set(hexutil.Encode(k), v, 0).Err(); err != nil {
-		logger.Warn("failed to set an item on redis cache", "err", err, "key", hexutil.Encode(k))
 	}
 }
 

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -91,7 +91,6 @@ func TestRedisCache(t *testing.T) {
 
 	key, value := randBytes(32), randBytes(500)
 	cache.Set(key, value)
-	time.Sleep(sleepDurationForAsyncBehavior)
 
 	getValue := cache.Get(key)
 	assert.Equal(t, bytes.Compare(value, getValue), 0)
@@ -110,13 +109,12 @@ func TestRedisCache_Set_LargeData(t *testing.T) {
 
 	key, value := randBytes(32), randBytes(5*1024*1024) // 5MB value
 	cache.Set(key, value)
-	time.Sleep(sleepDurationForAsyncBehavior)
 
 	retValue := cache.Get(key)
 	assert.Equal(t, bytes.Compare(value, retValue), 0)
 }
 
-func TestRedisCache_Set_LargeNumberItems(t *testing.T) {
+func TestRedisCache_SetAsynchronous_LargeNumberItems(t *testing.T) {
 	cache, err := newRedisCache(getTestRedisConfig())
 	if err != nil {
 		t.Fatal(err)
@@ -139,7 +137,7 @@ func TestRedisCache_Set_LargeNumberItems(t *testing.T) {
 				time.Sleep(2 * time.Second)
 			}
 			// set writes items asynchronously
-			cache.Set(items[i].key, items[i].value)
+			cache.SetAsync(items[i].key, items[i].value)
 		}
 	}()
 
@@ -201,7 +199,7 @@ func TestRedisCache_Timeout(t *testing.T) {
 
 	start := time.Now()
 	redisCache := cache.(*RedisCache) // Because RedisCache.Set writes item asynchronously, use RedisCache.set
-	redisCache.set(key, value)
+	redisCache.Set(key, value)
 	assert.Equal(t, redisCacheTimeout, time.Since(start).Round(redisCacheTimeout/2))
 
 	start = time.Now()

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -114,6 +114,39 @@ func TestRedisCache_Set_LargeData(t *testing.T) {
 	assert.Equal(t, bytes.Compare(value, retValue), 0)
 }
 
+// TestRedisCache_SetAsync tests basic operations of redis cache using SetAsync instead of Set.
+func TestRedisCache_SetAsync(t *testing.T) {
+	cache, err := newRedisCache(getTestRedisConfig())
+	assert.Nil(t, err)
+
+	key, value := randBytes(32), randBytes(500)
+	cache.SetAsync(key, value)
+	time.Sleep(sleepDurationForAsyncBehavior)
+
+	getValue := cache.Get(key)
+	assert.Equal(t, bytes.Compare(value, getValue), 0)
+
+	hasValue, ok := cache.Has(key)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, bytes.Compare(value, hasValue), 0)
+}
+
+// TestRedisCache_SetAsync_LargeData check whether redis cache can store an large data asynchronously (5MB).
+func TestRedisCache_SetAsync_LargeData(t *testing.T) {
+	cache, err := newRedisCache(getTestRedisConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, value := randBytes(32), randBytes(5*1024*1024) // 5MB value
+	cache.SetAsync(key, value)
+	time.Sleep(sleepDurationForAsyncBehavior)
+
+	retValue := cache.Get(key)
+	assert.Equal(t, bytes.Compare(value, retValue), 0)
+}
+
+// TestRedisCache_SetAsync_LargeNumberItems asynchronously sets lots of items exceeding channel size.
 func TestRedisCache_SetAsync_LargeNumberItems(t *testing.T) {
 	cache, err := newRedisCache(getTestRedisConfig())
 	if err != nil {

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -114,7 +114,7 @@ func TestRedisCache_Set_LargeData(t *testing.T) {
 	assert.Equal(t, bytes.Compare(value, retValue), 0)
 }
 
-func TestRedisCache_SetAsynchronous_LargeNumberItems(t *testing.T) {
+func TestRedisCache_SetAsync_LargeNumberItems(t *testing.T) {
 	cache, err := newRedisCache(getTestRedisConfig())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Proposed changes

I need to convert `RedisCache.set` to a public method and realize that using `RedisCache.Set` for an asynchronous behavior is a little awkward. So, I switched the meaning of `RedisCache.Set` to indicate a synchronous behavior.

- Rename `RedisCache.Set` to `RedisCache.SetAsync` 
- Rename `RedisCache.set` to `RedisCache.Set` 
  (The method will be used later in other PR)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
