### PR TITLE
Increase redis channel size

### DIFF
--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -26,8 +26,10 @@ import (
 )
 
 const (
-	redisSetItemChannelSize       = 1024
-	redisSubscriptionChannelSize  = 100 // default value of redis client
+	// Channel size for aync item set. If average item size is 400Byte, 4MB could be used.
+	redisSetItemChannelSize = 10000
+	// Channel size for block subscription. If average block size is 10KB, 10MB could be used.
+	redisSubscriptionChannelSize  = 1000
 	redisSubscriptionChannelBlock = "latestBlock"
 )
 


### PR DESCRIPTION
## Proposed changes

Redis uses channels to set items asynchronously or publish/subscribe blocks. 
The current channel size is not enough for the node in sync mode which could process hundreds of blocks in a second. 
This PR increases the channel size of the Redis cache. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
