### PR TITLE
Increase MaxRetry number for DynamoDB

### DIFF
--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -58,7 +58,7 @@ var noTableNameErr = errors.New("dynamoDB table name not provided")
 // batch write size
 const dynamoWriteSizeLimit = 399 * 1024 // The maximum write size is 400KB including attribute names and values
 const dynamoBatchSize = 25
-const dynamoMaxRetry = 5
+const dynamoMaxRetry = 10
 const dynamoTimeout = 10 * time.Second
 
 // batch write


### PR DESCRIPTION
## Proposed changes

This PR increase the max retry number of dynamoDB client from 5 to 10.
The client uses DefaultRetryer of AWS SDK and it implements an exponential backoff algorithm. 
AWS recommends the max retry number taking 1-minute total backoff time. 

In the Klaytn code, the backoff time is about 2 seconds if the max retry number is 5.
If the max retry number is 10, the backoff time is about 1 minute. 
(Assume the server returned errors immediately) 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
