### PR TITLE
Synchronously write block logs to cache for KES

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1309,7 +1309,13 @@ func (bc *BlockChain) writeBlockLogsToRemoteCache(blockLogsKey []byte, receipts 
 		return
 	}
 	// TODO-Klaytn-KES: refine this not to use trieNodeCache
-	bc.stateCache.TrieDB().TrieNodeCache().Set(blockLogsKey, encodedBlockLogs)
+	cache, ok := bc.stateCache.TrieDB().TrieNodeCache().(*statedb.HybridCache)
+	if !ok {
+		logger.Error("only HybridCache supports block logs writing",
+			"TrieNodeCacheType", reflect.TypeOf(bc.stateCache.TrieDB().TrieNodeCache()))
+	} else {
+		cache.Remote().Set(blockLogsKey, encodedBlockLogs)
+	}
 }
 
 // writeBlockWithStateSerial writes the block and all associated state to the database in serial manner.

--- a/storage/statedb/cache_hybrid.go
+++ b/storage/statedb/cache_hybrid.go
@@ -38,6 +38,14 @@ type HybridCache struct {
 	remote *RedisCache
 }
 
+func (cache *HybridCache) Local() TrieNodeCache {
+	return cache.local
+}
+
+func (cache *HybridCache) Remote() *RedisCache {
+	return cache.remote
+}
+
 // Set writes data to local cache synchronously and to remote cache asynchronously.
 func (cache *HybridCache) Set(k, v []byte) {
 	cache.local.Set(k, v)

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -121,7 +121,7 @@ func (cache *RedisCache) Get(k []byte) []byte {
 // To write data asynchronously, use SetAsync instead.
 func (cache *RedisCache) Set(k, v []byte) {
 	if err := cache.client.Set(hexutil.Encode(k), v, 0).Err(); err != nil {
-		logger.Warn("failed to set an item on redis cache", "err", err, "key", hexutil.Encode(k))
+		logger.Error("failed to set an item on redis cache", "err", err, "key", hexutil.Encode(k))
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

`bc.stateCache.TrieDB().TrieNodeCache().Set()` asynchronously write logs to the remote cache, but async write could miss item if the writing channel of the remote cache is full. Indeed, the local cache doesn't need to store block logs. 

With this PR, block logs will be written synchronously to the remote Redis cache. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
