### PR TITLE
Prevent to write an old governance index again

### DIFF
--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -151,6 +151,7 @@ func initGenesis(ctx *cli.Context) error {
 		}
 
 		// Write governance items to database
+		// If governance data already exist, it'll be skipped with an error log and will not return an error
 		if err := governance.NewGovernance(genesis.Config, chainDB).WriteGovernance(0, govSet,
 			governance.NewGovernanceSet()); err != nil {
 			logger.Crit("Failed to write governance items", "err", err)

--- a/governance/default.go
+++ b/governance/default.go
@@ -182,7 +182,7 @@ type Governance struct {
 
 	db           database.DBManager
 	itemCache    common.Cache
-	idxCache     []uint64
+	idxCache     []uint64 // elements should be in ascending order
 	idxCacheLock *sync.RWMutex
 
 	// The block number when current governance information was changed
@@ -648,6 +648,8 @@ func (g *Governance) addGovernanceCache(num uint64, data GovernanceSet) {
 	defer g.idxCacheLock.Unlock()
 
 	if len(g.idxCache) > 0 && num <= g.idxCache[len(g.idxCache)-1] {
+		logger.Error("The same or more recent governance index exist. Skip updating governance cache",
+			"newIdx", num, "govIdxes", g.idxCache)
 		return
 	}
 	cKey := getGovernanceCacheKey(num)
@@ -673,6 +675,8 @@ func (g *Governance) WriteGovernance(num uint64, data GovernanceSet, delta Gover
 	g.idxCacheLock.RUnlock()
 
 	if len(indices) > 0 && num <= indices[len(indices)-1] {
+		logger.Error("The same or more recent governance index exist. Skip writing governance",
+			"newIdx", num, "govIdxes", indices)
 		return nil
 	}
 

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2052,6 +2053,11 @@ func (dbm *databaseManager) ReadRecentGovernanceIdx(count int) ([]uint64, error)
 		if e := json.Unmarshal(history, &idxHistory); e != nil {
 			return nil, e
 		}
+
+		// Make sure idxHistory should be in ascending order
+		sort.Slice(idxHistory, func(i, j int) bool {
+			return idxHistory[i] < idxHistory[j]
+		})
 
 		max := 0
 		leng := len(idxHistory)

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -924,7 +924,7 @@ func TestDBManager_WriteGovernanceIdx(t *testing.T) {
 			encodedIdxes, err := dbm.GetMiscDB().Get(governanceHistoryKey)
 			assert.Nil(t, err)
 
-			// read and check the idnexes from the database
+			// read and check the indexes from the database
 			actualIdxes := make([]uint64, 0)
 			assert.Nil(t, json.Unmarshal(encodedIdxes, &actualIdxes))
 			assert.Equal(t, testIdxes, actualIdxes)
@@ -972,7 +972,7 @@ func TestDBManager_ReadRecentGovernanceIdx(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Nil(t, dbm.GetMiscDB().Put(governanceHistoryKey, data))
 
-			// read and check the idnexes from the database
+			// read and check the indexes from the database
 			idxes, err = dbm.ReadRecentGovernanceIdx(0)
 			assert.Nil(t, err)
 			assert.Equal(t, expectedIdxes, idxes)

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -956,7 +956,7 @@ func TestDBManager_ReadRecentGovernanceIdx(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Nil(t, dbm.GetMiscDB().Put(governanceHistoryKey, data))
 
-			// read and check the idnexes from the database
+			// read and check the indexes from the database
 			idxes, err = dbm.ReadRecentGovernanceIdx(0)
 			assert.Equal(t, testIdxes, idxes)
 			assert.Nil(t, err)

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -18,6 +18,7 @@ package database
 
 import (
 	"crypto/ecdsa"
+	"encoding/json"
 	"io/ioutil"
 	"math/big"
 	"os"
@@ -905,6 +906,80 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 			assert.Equal(t, 1, len(newDirNames)) // check if DB is removed
 			assert.Equal(t, initialDirNames[0], newDirNames[0], "old DB should remain")
 		}
+	}
+}
+
+func TestDBManager_WriteGovernanceIdx(t *testing.T) {
+	testIdxes := []uint64{100, 200, 300}
+
+	for _, dbm := range dbManagers {
+		// normal case
+		{
+			// write test indexes
+			for _, idx := range testIdxes {
+				assert.Nil(t, dbm.WriteGovernanceIdx(idx))
+			}
+
+			// get the stored indexes
+			encodedIdxes, err := dbm.GetMiscDB().Get(governanceHistoryKey)
+			assert.Nil(t, err)
+
+			// read and check the idnexes from the database
+			actualIdxes := make([]uint64, 0)
+			assert.Nil(t, json.Unmarshal(encodedIdxes, &actualIdxes))
+			assert.Equal(t, testIdxes, actualIdxes)
+		}
+
+		// unexpected case: try to write a governance index not in ascending order
+		{
+			assert.NotNil(t, dbm.WriteGovernanceIdx(testIdxes[0]))
+		}
+
+		// remove test data from database
+		_ = dbm.GetMiscDB().Delete(governanceHistoryKey)
+	}
+}
+
+func TestDBManager_ReadRecentGovernanceIdx(t *testing.T) {
+	testIdxes := []uint64{100, 200, 300}
+
+	for _, dbm := range dbManagers {
+		// check empty
+		idxes, err := dbm.ReadRecentGovernanceIdx(0)
+		assert.Nil(t, idxes)
+		assert.NotNil(t, err)
+
+		// normal case
+		{
+			// write indexes on the database
+			data, err := json.Marshal(testIdxes)
+			assert.Nil(t, err)
+			assert.Nil(t, dbm.GetMiscDB().Put(governanceHistoryKey, data))
+
+			// read and check the idnexes from the database
+			idxes, err = dbm.ReadRecentGovernanceIdx(0)
+			assert.Equal(t, testIdxes, idxes)
+			assert.Nil(t, err)
+		}
+
+		// unexpected case: the governance indexes in the database is not in ascending order
+		{
+			invalidTestIdxes := append(testIdxes, testIdxes[0])
+			expectedIdxes := append([]uint64{testIdxes[0]}, testIdxes...)
+
+			// write invalid indexes on the database
+			data, err := json.Marshal(invalidTestIdxes)
+			assert.Nil(t, err)
+			assert.Nil(t, dbm.GetMiscDB().Put(governanceHistoryKey, data))
+
+			// read and check the idnexes from the database
+			idxes, err = dbm.ReadRecentGovernanceIdx(0)
+			assert.Nil(t, err)
+			assert.Equal(t, expectedIdxes, idxes)
+		}
+
+		// remove test data from database
+		_ = dbm.GetMiscDB().Delete(governanceHistoryKey)
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

If `init` is executed on the existing database, it may corrupt governance index data appending `0` in the governance index slice (The slice should have ascending order). With this PR, appending the same or smaller block number is not allowed on the governance index slice when it is stored on the database. 


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
