### PR TITLE
dynamoDB.Has() doesn't return dataNotFoundErr

### DIFF
--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -321,6 +321,9 @@ func (dynamo *dynamoDB) put(key []byte, val []byte) error {
 // Has returns true if the corresponding value to the given key exists.
 func (dynamo *dynamoDB) Has(key []byte) (bool, error) {
 	if _, err := dynamo.Get(key); err != nil {
+		if err == dataNotFoundErr {
+			return false, nil
+		}
 		return false, err
 	}
 	return true, nil


### PR DESCRIPTION
## Proposed changes

LevelDB returns `false, nil` when `Has()` method is called with a not-existing key. 
But, DynamoDB returns `false, err` when `Has()` method is called with a not-existing key. 
This PR unifies the behavior of the `Has()` method of LevelDB and DynamoDB.

Currently, It doesn't affect any other logic because all caller of `Database().Has()` handles return values like the following. 
```
if has, err := db.Has(headerKey(number, hash)); !has || err != nil {
    return false
}
return true
```

Refer to this part of LevelDB Code:
https://github.com/syndtr/goleveldb/blob/64b5b1c739545ed311fb9d9924d19d188fabdc83/leveldb/db.go#L794-L835

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
