### PR TITLE
Allow writing nil value using DynamoDB batch

### DIFF
--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -72,12 +72,27 @@ func newTestMemDB() (Database, func()) {
 }
 
 func newTestDynamoS3DB() (Database, func()) {
+	// to start test with DynamoDB singletons
+	oldDynamoDBClient := dynamoDBClient
+	dynamoDBClient = nil
+
+	oldDynamoOnceWorker := dynamoOnceWorker
+	dynamoOnceWorker = sync.Once{}
+
+	oldDynamoWriteCh := dynamoWriteCh
+	dynamoWriteCh = nil
+
 	db, err := newDynamoDB(GetTestDynamoConfig())
 	if err != nil {
 		panic("failed to create test DynamoS3 database: " + err.Error())
 	}
 	return db, func() {
 		db.deleteDB()
+
+		// to finish test with DynamoDB singletons
+		dynamoDBClient = oldDynamoDBClient
+		dynamoOnceWorker = oldDynamoOnceWorker
+		dynamoWriteCh = oldDynamoWriteCh
 	}
 }
 

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -77,7 +77,7 @@ func newTestDynamoS3DB() (Database, func()) {
 	dynamoDBClient = nil
 
 	oldDynamoOnceWorker := dynamoOnceWorker
-	dynamoOnceWorker = sync.Once{}
+	dynamoOnceWorker = &sync.Once{}
 
 	oldDynamoWriteCh := dynamoWriteCh
 	dynamoWriteCh = nil

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -164,7 +164,6 @@ func TestDatabase_NilValue(t *testing.T) {
 		// batch
 		{
 			batch := db.NewBatch()
-			fmt.Println(db.Type())
 
 			// write nil value
 			key := common.MakeRandomBytes(32)

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -109,6 +109,61 @@ func TestDatabase_NotFoundErr(t *testing.T) {
 	}
 }
 
+// TestDatabase_NilValue checks if all database write/read nil value in the same way.
+func TestDatabase_NilValue(t *testing.T) {
+	for _, dbCreateFn := range testDatabases {
+		db, remove := dbCreateFn()
+		defer remove()
+
+		{
+			// write nil value
+			key := common.MakeRandomBytes(32)
+			assert.Nil(t, db.Put(key, nil))
+
+			// get nil value
+			ret, err := db.Get(key)
+			assert.Equal(t, []byte{}, ret)
+			assert.Nil(t, err)
+
+			// check existence
+			exist, err := db.Has(key)
+			assert.Equal(t, true, exist)
+			assert.Nil(t, err)
+
+			val, err := db.Get(randStrBytes(100))
+			assert.Nil(t, val)
+			assert.Error(t, err)
+			assert.Equal(t, dataNotFoundErr, err)
+		}
+
+		// batch
+		{
+			batch := db.NewBatch()
+			fmt.Println(db.Type())
+
+			// write nil value
+			key := common.MakeRandomBytes(32)
+			assert.Nil(t, batch.Put(key, nil))
+			assert.NoError(t, batch.Write())
+
+			// get nil value
+			ret, err := db.Get(key)
+			assert.Equal(t, []byte{}, ret)
+			assert.Nil(t, err)
+
+			// check existence
+			exist, err := db.Has(key)
+			assert.Equal(t, true, exist)
+			assert.Nil(t, err)
+
+			val, err := db.Get(randStrBytes(100))
+			assert.Nil(t, val)
+			assert.Error(t, err)
+			assert.Equal(t, dataNotFoundErr, err)
+		}
+	}
+}
+
 func testPutGet(db Database, t *testing.T) {
 	// put
 	for _, v := range test_values {

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -71,12 +71,22 @@ func newTestMemDB() (Database, func()) {
 	return NewMemDB(), func() {}
 }
 
+func newTestDynamoS3DB() (Database, func()) {
+	db, err := newDynamoDB(GetTestDynamoConfig())
+	if err != nil {
+		panic("failed to create test DynamoS3 database: " + err.Error())
+	}
+	return db, func() {
+		db.deleteDB()
+	}
+}
+
 var test_values = []string{"a", "1251", "\x00123\x00"}
 
 //var test_values = []string{"", "a", "1251", "\x00123\x00"} original test_values; modified since badgerDB can't store empty key
 
 // TODO-Klaytn-Database Need to add DynamoDB to the below list.
-var testDatabases = []func() (Database, func()){newTestLDB, newTestBadgerDB, newTestMemDB}
+var testDatabases = []func() (Database, func()){newTestLDB, newTestBadgerDB, newTestMemDB, newTestDynamoS3DB}
 
 // TestDatabase_PutGet tests the basic put and get operations.
 func TestDatabase_PutGet(t *testing.T) {

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -498,9 +498,6 @@ func (batch *dynamoBatch) Put(key, val []byte) error {
 
 	data := DynamoData{Key: key, Val: val}
 	dataSize := len(val)
-	if dataSize == 0 {
-		return nil
-	}
 
 	// If the size of the item is larger than the limit, it should be handled in different way
 	if dataSize > dynamoWriteSizeLimit {

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -161,7 +161,6 @@ func newDynamoDB(config *DynamoDBConfig) (*dynamoDB, error) {
 			},
 		})))
 	}
-
 	dynamoDB := &dynamoDB{
 		config: *config,
 		fdb:    s3FileDB,

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -67,8 +67,8 @@ const itemChanSize = WorkerNum * 2
 
 var (
 	dynamoDBClient    *dynamodb.DynamoDB          // handles dynamoDB connections
-	dynamoOnceWorker  sync.Once                   // makes sure worker is created once
 	dynamoWriteCh     chan *batchWriteWorkerInput // use global write channel for shared worker
+	dynamoOnceWorker  = &sync.Once{}              // makes sure worker is created once
 	dynamoOpenedDBNum uint
 )
 

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -213,31 +213,6 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write() {
 	}
 }
 
-func (s *SuiteDynamoDB) TestDynamoBatch_Write_EmptyVal() {
-	dynamo, err := newDynamoDB(GetTestDynamoConfig())
-	if err != nil {
-		s.FailNow("failed to create dynamoDB", err)
-	}
-	s.dynamoDBs = append(s.dynamoDBs, dynamo)
-
-	batch := dynamo.NewBatch()
-
-	// write nil value
-	key := common.MakeRandomBytes(32)
-	s.Nil(batch.Put(key, nil))
-	s.NoError(batch.Write())
-
-	// get nil value
-	ret, err := dynamo.Get(key)
-	s.Equal([]byte{}, ret)
-	s.Nil(err)
-
-	// check existence
-	exist, err := dynamo.Has(key)
-	s.Equal(true, exist)
-	s.Nil(err)
-}
-
 func (s *SuiteDynamoDB) TestDynamoBatch_Write_LargeData() {
 	dynamo, err := newDynamoDB(GetTestDynamoConfig())
 	if err != nil {

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -91,28 +91,6 @@ func (s *SuiteDynamoDB) TestDynamoDB_Put() {
 	s.NoError(returnedErr)
 }
 
-func (s *SuiteDynamoDB) TestDynamoDB_Put_EmptyVal() {
-	dynamo, err := newDynamoDB(GetTestDynamoConfig())
-	if err != nil {
-		s.FailNow("failed to create dynamoDB", err)
-	}
-	s.dynamoDBs = append(s.dynamoDBs, dynamo)
-
-	// write nil value
-	key := common.MakeRandomBytes(32)
-	s.Nil(dynamo.Put(key, nil))
-
-	// get nil value
-	ret, err := dynamo.Get(key)
-	s.Equal([]byte{}, ret)
-	s.Nil(err)
-
-	// check existence
-	exist, err := dynamo.Has(key)
-	s.Equal(true, exist)
-	s.Nil(err)
-}
-
 // TestDynamoDB_Timeout tests if a timeout error occurs.
 // When there is no answer from DynamoDB server due to network failure,
 // a timeout error should occur.

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -91,6 +91,28 @@ func (s *SuiteDynamoDB) TestDynamoDB_Put() {
 	s.NoError(returnedErr)
 }
 
+func (s *SuiteDynamoDB) TestDynamoDB_Put_EmptyVal() {
+	dynamo, err := newDynamoDB(GetTestDynamoConfig())
+	if err != nil {
+		s.FailNow("failed to create dynamoDB", err)
+	}
+	s.dynamoDBs = append(s.dynamoDBs, dynamo)
+
+	// write nil value
+	key := common.MakeRandomBytes(32)
+	s.Nil(dynamo.Put(key, nil))
+
+	// get nil value
+	ret, err := dynamo.Get(key)
+	s.Equal([]byte{}, ret)
+	s.Nil(err)
+
+	// check existence
+	exist, err := dynamo.Has(key)
+	s.Equal(true, exist)
+	s.Nil(err)
+}
+
 // TestDynamoDB_Timeout tests if a timeout error occurs.
 // When there is no answer from DynamoDB server due to network failure,
 // a timeout error should occur.
@@ -191,7 +213,32 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write() {
 	}
 }
 
-func (s *SuiteDynamoDB) TestDynamoBatch_WriteLargeData() {
+func (s *SuiteDynamoDB) TestDynamoBatch_Write_EmptyVal() {
+	dynamo, err := newDynamoDB(GetTestDynamoConfig())
+	if err != nil {
+		s.FailNow("failed to create dynamoDB", err)
+	}
+	s.dynamoDBs = append(s.dynamoDBs, dynamo)
+
+	batch := dynamo.NewBatch()
+
+	// write nil value
+	key := common.MakeRandomBytes(32)
+	s.Nil(batch.Put(key, nil))
+	s.NoError(batch.Write())
+
+	// get nil value
+	ret, err := dynamo.Get(key)
+	s.Equal([]byte{}, ret)
+	s.Nil(err)
+
+	// check existence
+	exist, err := dynamo.Has(key)
+	s.Equal(true, exist)
+	s.Nil(err)
+}
+
+func (s *SuiteDynamoDB) TestDynamoBatch_Write_LargeData() {
 	dynamo, err := newDynamoDB(GetTestDynamoConfig())
 	if err != nil {
 		s.FailNow("failed to create dynamoDB", err)
@@ -222,7 +269,7 @@ func (s *SuiteDynamoDB) TestDynamoBatch_WriteLargeData() {
 	}
 }
 
-func (s *SuiteDynamoDB) TestDynamoBatch_DuplicatedKey() {
+func (s *SuiteDynamoDB) TestDynamoBatch_Write_DuplicatedKey() {
 	dynamo, err := newDynamoDB(GetTestDynamoConfig())
 	if err != nil {
 		s.FailNow("failed to create dynamoDB", err)
@@ -257,7 +304,7 @@ func (s *SuiteDynamoDB) TestDynamoBatch_DuplicatedKey() {
 
 // testDynamoBatch_WriteMutliTables checks if there is no error when working with more than one tables.
 // This also checks if shared workers works as expected.
-func (s *SuiteDynamoDB) TestDynamoBatch_WriteMutliTables() {
+func (s *SuiteDynamoDB) TestDynamoBatch_Write_MutliTables() {
 	// this test might end with Crit, enableLog to find out the log
 	//enableLog()
 

--- a/storage/database/memory_database.go
+++ b/storage/database/memory_database.go
@@ -89,6 +89,9 @@ func (db *MemDB) Get(key []byte) ([]byte, error) {
 		return nil, errMemorydbClosed
 	}
 	if entry, ok := db.db[string(key)]; ok {
+		if entry == nil {
+			entry = []byte{}
+		}
 		return common.CopyBytes(entry), nil
 	}
 	return nil, dataNotFoundErr


### PR DESCRIPTION
## Proposed changes

Currently, DynamoDB Batch doesn't allow writing `nil` value, but some logic tries to write `nil` value on the database. 
This PR allows that. 

Note: LevelDB and DynamoDB (non-batch) are able to write `nil` value. 

The logic writing `nil` value with a batch: https://github.com/klaytn/klaytn/blob/da66d4958a4706c4cdaced107c3d1b37eab9d22b/node/cn/bloombits.go#L143-L146


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
