### PR TITLE
In klay_getCommittee API, handle genesis block specially

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -209,6 +209,15 @@ func (api *APIExtension) GetCommittee(number *rpc.BlockNumber) ([]common.Address
 	}
 
 	blockNumber := header.Number.Uint64()
+	if blockNumber == 0 {
+		// The committee of genesis block can not be calculated because it requires a previous block.
+		istanbulExtra, err := types.ExtractIstanbulExtra(header)
+		if err != nil {
+			return nil, errExtractIstanbulExtra
+		}
+		return istanbulExtra.Validators, nil
+	}
+
 	round := header.Round()
 	view := &istanbul.View{
 		Sequence: new(big.Int).SetUint64(blockNumber),


### PR DESCRIPTION
## Proposed changes

Merging https://github.com/klaytn/klaytn/pull/891, `klay_getCommittee` dynamically calculates a committe calling `api.istanbul.snapshot(api.chain, blockNumber-1, parentHash, nil)`. However, the function always return error when `blockNumber` is `0`.

With this PR, `klay_getCommittee` derives a committee from the extra data for a block header when `blockNumber` is `0`. The deriving logic is the same as the previous code before https://github.com/klaytn/klaytn/pull/891 merged. 

Before

```
curl --location --request POST 'http://localhost:8551' --header 'Content-Type: application/json' --data-raw '{"jsonrpc": "2.0", "method": "klay_getCommittee", "params": ["0x0"],"id": 1}'
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32000,
        "message": "recovery failed"
    }
}
```
After
```
curl --location --request POST 'http://localhost:8551' --header 'Content-Type: application/json' --data-raw '{"jsonrpc": "2.0", "method": "klay_getCommittee", "params": ["0x0"],"id": 1}'
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": [
        "0x99fb17d324fa0e07f23b49d09028ac0919414db6",
        "0xb74ff9dea397fe9e231df545eb53fe2adf776cb2",
        "0x571e53df607be97431a5bbefca1dffe5aef56f4d",
        "0x5cb1a7dccbd0dc446e3640898ede8820368554c8"
    ]
}
```


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
