### PR TITLE
Increase default MaxSubscriptionPerWSConn to 3000

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -483,7 +483,7 @@ var (
 	WSMaxSubscriptionPerConn = cli.IntFlag{
 		Name:  "wsmaxsubscriptionperconn",
 		Usage: "Allowed maximum subscription number per a websocket connection",
-		Value: 5,
+		Value: int(rpc.MaxSubscriptionPerWSConn),
 	}
 	WSReadDeadLine = cli.Int64Flag{
 		Name:  "wsreaddeadline",

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -58,7 +58,7 @@ var (
 
 	// TODO-Klaytn: move websocket configurations to Config struct in /network/rpc/server.go
 	// MaxSubscriptionPerWSConn is a maximum number of subscription for a websocket connection
-	MaxSubscriptionPerWSConn int32 = 5
+	MaxSubscriptionPerWSConn int32 = 3000
 
 	// WebsocketReadDeadline is the read deadline on the underlying network connection in seconds. 0 means read will not timeout
 	WebsocketReadDeadline int64 = 0


### PR DESCRIPTION
## Proposed changes

I think the default RPC configuration of Klaytn node is not supposed to have tight limits because RPC is usually open for trusted or controllable users. However, `MaxSubscriptionPerWSConn` is too small as a default value. 

This PR increases the default value of `MaxSubscriptionPerWSConn` from 5 to 3000.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
