### PR TITLE
Replace errors.Wrap with errors.WithMessage

### DIFF
--- a/blockchain/state/iterator.go
+++ b/blockchain/state/iterator.go
@@ -191,17 +191,17 @@ func CheckStateConsistencyParallel(oldDB Database, newDB Database, root common.H
 	// Check if the tries can be called
 	_, err := oldDB.OpenTrie(root)
 	if err != nil {
-		return errors.Wrap(err, "can not open oldDB trie")
+		return errors.WithMessage(err, "can not open oldDB trie")
 	}
 	_, err = newDB.OpenTrie(root)
 	if err != nil {
-		return errors.Wrap(err, "can not open newDB trie")
+		return errors.WithMessage(err, "can not open newDB trie")
 	}
 	// get children hash
 	children, err := oldDB.TrieDB().NodeChildren(root)
 	if err != nil {
 		logger.Error("cannot start CheckStateConsistencyParallel", "err", err)
-		return errors.Wrap(err, "cannot get children before consistency check")
+		return errors.WithMessage(err, "cannot get children before consistency check")
 	}
 
 	logger.Info("CheckStateConsistencyParallel is started", "root", root.String(), "len(children)", len(children))
@@ -256,12 +256,12 @@ func concurrentIterator(oldDB Database, newDB Database, root common.Hash, quit c
 	// Create and iterate a state trie rooted in a sub-node
 	oldState, err := New(root, oldDB)
 	if err != nil {
-		return errors.Wrap(err, "can not open oldDB trie")
+		return errors.WithMessage(err, "can not open oldDB trie")
 	}
 
 	newState, err := New(root, newDB)
 	if err != nil {
-		return errors.Wrap(err, "can not open newDB trie")
+		return errors.WithMessage(err, "can not open newDB trie")
 	}
 
 	oldIt := NewNodeIterator(oldState)

--- a/networks/rpc/client.go
+++ b/networks/rpc/client.go
@@ -462,12 +462,12 @@ func (c *Client) newMessage(method string, paramsIn ...interface{}) (*jsonrpcMes
 func (c *Client) getMessageSize(method string, args ...interface{}) (int, error) {
 	msg, err := c.newMessage(method, args)
 	if err != nil {
-		return -1, errors.Wrap(err, "failed to make a new message")
+		return -1, errors.WithMessage(err, "failed to make a new message")
 	}
 
 	data, err := json.Marshal(msg)
 	if err != nil {
-		return -1, errors.Wrap(err, "failed to marshal new message")
+		return -1, errors.WithMessage(err, "failed to marshal new message")
 	}
 
 	return len(data), nil

--- a/tests/klay_blockchain_test.go
+++ b/tests/klay_blockchain_test.go
@@ -172,11 +172,11 @@ func newKlaytnNode(t *testing.T, dir string, validator *TestAccountType) (*node.
 	cnConf.NumStateTrieShards = 4
 
 	if err = fullNode.Register(func(ctx *node.ServiceContext) (node.Service, error) { return cn.New(ctx, cnConf) }); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to register Klaytn protocol")
+		return nil, nil, errors.WithMessage(err, "failed to register Klaytn protocol")
 	}
 
 	if err = fullNode.Start(); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to start test fullNode")
+		return nil, nil, errors.WithMessage(err, "failed to start test fullNode")
 	}
 
 	if err := fullNode.Service(&klaytnNode); err != nil {


### PR DESCRIPTION
## Proposed changes

- This code replace `errors.Wrap` with `errors.WithMessage`.
  - `errors.Wrap` stores the call stack while `errors.WithMessage` does not.
  - None of the code uses the call stack.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
