### PR TITLE
work: Not to initiate vmConfig.JumpTable at ApplyTransactions

### DIFF
--- a/work/worker.go
+++ b/work/worker.go
@@ -655,7 +655,6 @@ func (env *Task) ApplyTransactions(txs *types.TransactionsByPriceAndNonce, bc Bl
 	}()
 
 	vmConfig := &vm.Config{
-		JumpTable:                vm.ConstantinopleInstructionSet,
 		RunningEVM:               chEVM,
 		UseOpcodeComputationCost: true,
 	}


### PR DESCRIPTION
NewEVMInterpreter is not working properly if vmConfig.JumpTable is initiated. If it is initialized, `cfg.JumpTable[STOP]` exists, so `!cfg.JumpTable[STOP].valid` returns false.
```
// NewEVMInterpreter returns a new instance of the Interpreter.
func NewEVMInterpreter(evm *EVM, cfg *Config) *Interpreter {
	// We use the STOP instruction whether to see
	// the jump table was initialised. If it was not
	// we'll set the default jump table.
	if !cfg.JumpTable[STOP].valid {
		var jt JumpTable
		switch {
		case evm.chainRules.IsIstanbul:
			jt = IstanbulInstructionSet
		default:
			jt = ConstantinopleInstructionSet
		}
		cfg.JumpTable = jt
	}

	return &Interpreter{
		evm: evm,
		cfg: cfg,
	}
}
```
## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
