### PR TITLE
Updated istanbul consensus engine to verify headers synchronously

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -245,7 +245,7 @@ func (c *Clique) CanVerifyHeadersConcurrently() bool {
 	return true
 }
 
-// PreprocessHeaderVerification prepare header verification for heavy computation before synchronous header verification such as ecrecover.
+// PreprocessHeaderVerification prepares header verification for heavy computation before synchronous header verification such as ecrecover.
 func (c *Clique) PreprocessHeaderVerification(headers []*types.Header) (chan<- struct{}, <-chan error) {
 	panic("this method is not used for Clique engine")
 }

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -240,6 +240,16 @@ func (c *Clique) Author(header *types.Header) (common.Address, error) {
 	return ecrecover(header, c.signatures)
 }
 
+// CanVerifyHeadersConcurrently returns true if concurrent header verification possible, otherwise returns false.
+func (c *Clique) CanVerifyHeadersConcurrently() bool {
+	return true
+}
+
+// PreprocessHeaderVerification prepare header verification for heavy computation before synchronous header verification such as ecrecover.
+func (c *Clique) PreprocessHeaderVerification(headers []*types.Header) (chan<- struct{}, <-chan error) {
+	panic("this method is not used for Clique engine")
+}
+
 // VerifyHeader checks whether a header conforms to the consensus rules.
 func (c *Clique) VerifyHeader(chain consensus.ChainReader, header *types.Header, seal bool) error {
 	return c.verifyHeader(chain, header, nil)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -63,6 +63,12 @@ type Engine interface {
 	// block.
 	Author(header *types.Header) (common.Address, error)
 
+	// CanVerifyHeadersConcurrently returns true if concurrent header verification possible, otherwise returns false.
+	CanVerifyHeadersConcurrently() bool
+
+	// PreprocessHeaderVerification prepare header verification for heavy computation before synchronous header verification such as ecrecover.
+	PreprocessHeaderVerification(headers []*types.Header) (chan<- struct{}, <-chan error)
+
 	// VerifyHeader checks whether a header conforms to the consensus rules of a
 	// given engine. Verifying the seal may be done optionally here, or explicitly
 	// via the VerifySeal method.

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -66,7 +66,7 @@ type Engine interface {
 	// CanVerifyHeadersConcurrently returns true if concurrent header verification possible, otherwise returns false.
 	CanVerifyHeadersConcurrently() bool
 
-	// PreprocessHeaderVerification prepare header verification for heavy computation before synchronous header verification such as ecrecover.
+	// PreprocessHeaderVerification prepares header verification for heavy computation before synchronous header verification such as ecrecover.
 	PreprocessHeaderVerification(headers []*types.Header) (chan<- struct{}, <-chan error)
 
 	// VerifyHeader checks whether a header conforms to the consensus rules of a

--- a/consensus/gxhash/consensus.go
+++ b/consensus/gxhash/consensus.go
@@ -62,7 +62,7 @@ func (gxhash *Gxhash) CanVerifyHeadersConcurrently() bool {
 	return true
 }
 
-// PreprocessHeaderVerification prepare header verification for heavy computation before synchronous header verification such as ecrecover.
+// PreprocessHeaderVerification prepares header verification for heavy computation before synchronous header verification such as ecrecover.
 func (gxhash *Gxhash) PreprocessHeaderVerification(headers []*types.Header) (chan<- struct{}, <-chan error) {
 	panic("this method is not used for PoW engine")
 }

--- a/consensus/gxhash/consensus.go
+++ b/consensus/gxhash/consensus.go
@@ -57,6 +57,16 @@ func (gxhash *Gxhash) Author(header *types.Header) (common.Address, error) {
 	return params.AuthorAddressForTesting, nil
 }
 
+// CanVerifyHeadersConcurrently returns true if concurrent header verification possible, otherwise returns false.
+func (gxhash *Gxhash) CanVerifyHeadersConcurrently() bool {
+	return true
+}
+
+// PreprocessHeaderVerification prepare header verification for heavy computation before synchronous header verification such as ecrecover.
+func (gxhash *Gxhash) PreprocessHeaderVerification(headers []*types.Header) (chan<- struct{}, <-chan error) {
+	panic("this method is not used for PoW engine")
+}
+
 // VerifyHeader checks whether a header conforms to the consensus rules of the
 // stock Klaytn gxhash engine.
 func (gxhash *Gxhash) VerifyHeader(chain consensus.ChainReader, header *types.Header, seal bool) error {

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -356,7 +356,7 @@ func (sb *backend) Sign(data []byte) ([]byte, error) {
 
 // CheckSignature implements istanbul.Backend.CheckSignature
 func (sb *backend) CheckSignature(data []byte, address common.Address, sig []byte) error {
-	signer, err := istanbul.GetSignatureAddress(data, sig)
+	signer, err := cacheSignatureAddresses(data, sig)
 	if err != nil {
 		logger.Error("Failed to get signer address", "err", err)
 		return err

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -96,8 +96,8 @@ var (
 	nonceAuthVote = hexutil.MustDecode("0xffffffffffffffff") // Magic nonce number to vote on adding a new validator
 	nonceDropVote = hexutil.MustDecode("0x0000000000000000") // Magic nonce number to vote on removing a validator.
 
-	inmemoryBlocks             = 100 // Number of blocks to precompute validators' addresses
-	inmemoryValidatorsPerBlock = 30  // Approximate number of validators' addresses from ecrecover
+	inmemoryBlocks             = 2048 // Number of blocks to precompute validators' addresses
+	inmemoryValidatorsPerBlock = 30   // Approximate number of validators' addresses from ecrecover
 	recentAddresses, _         = lru.NewARC(inmemoryBlocks)
 	signatureAddresses, _      = lru.New(inmemoryBlocks * inmemoryValidatorsPerBlock)
 )

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -112,7 +112,7 @@ func (sb *backend) CanVerifyHeadersConcurrently() bool {
 	return false
 }
 
-// PreprocessHeaderVerification prepare header verification for heavy computation before synchronous header verification such as ecrecover.
+// PreprocessHeaderVerification prepares header verification for heavy computation before synchronous header verification such as ecrecover.
 func (sb *backend) PreprocessHeaderVerification(headers []*types.Header) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
 	results := make(chan error, inmemoryBlocks)
@@ -151,7 +151,7 @@ func (sb *backend) computeSignatureAddrs(header *types.Header) error {
 		}
 		addr, err := istanbul.GetSignatureAddress(proposalSeal, seal)
 		if err != nil {
-			return err
+			return errInvalidSignature
 		}
 		signatureAddresses.Add(sealStr, addr)
 	}

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -262,6 +262,9 @@ func TestVerifySeal(t *testing.T) {
 	}
 	block := makeBlock(chain, engine, genesis)
 
+	// clean cache before testing
+	signatureAddresses.Purge()
+
 	// change block content
 	header := block.Header()
 	header.Number = big.NewInt(4)
@@ -270,6 +273,9 @@ func TestVerifySeal(t *testing.T) {
 	if err != errUnauthorized {
 		t.Errorf("error mismatch: have %v, want %v", err, errUnauthorized)
 	}
+
+	// clean cache before testing
+	signatureAddresses.Purge()
 
 	// unauthorized users but still can get correct signer address
 	engine.privateKey, _ = crypto.GenerateKey()

--- a/consensus/mocks/engine_mock.go
+++ b/consensus/mocks/engine_mock.go
@@ -82,6 +82,20 @@ func (mr *MockEngineMockRecorder) CalcBlockScore(arg0, arg1, arg2 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcBlockScore", reflect.TypeOf((*MockEngine)(nil).CalcBlockScore), arg0, arg1, arg2)
 }
 
+// CanVerifyHeadersConcurrently mocks base method
+func (m *MockEngine) CanVerifyHeadersConcurrently() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CanVerifyHeadersConcurrently")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CanVerifyHeadersConcurrently indicates an expected call of CanVerifyHeadersConcurrently
+func (mr *MockEngineMockRecorder) CanVerifyHeadersConcurrently() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanVerifyHeadersConcurrently", reflect.TypeOf((*MockEngine)(nil).CanVerifyHeadersConcurrently))
+}
+
 // Finalize mocks base method
 func (m *MockEngine) Finalize(arg0 consensus.ChainReader, arg1 *types.Header, arg2 *state.StateDB, arg3 []*types.Transaction, arg4 []*types.Receipt) (*types.Block, error) {
 	m.ctrl.T.Helper()
@@ -109,6 +123,21 @@ func (m *MockEngine) Prepare(arg0 consensus.ChainReader, arg1 *types.Header) err
 func (mr *MockEngineMockRecorder) Prepare(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockEngine)(nil).Prepare), arg0, arg1)
+}
+
+// PreprocessHeaderVerification mocks base method
+func (m *MockEngine) PreprocessHeaderVerification(arg0 []*types.Header) (chan<- struct{}, <-chan error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreprocessHeaderVerification", arg0)
+	ret0, _ := ret[0].(chan<- struct{})
+	ret1, _ := ret[1].(<-chan error)
+	return ret0, ret1
+}
+
+// PreprocessHeaderVerification indicates an expected call of PreprocessHeaderVerification
+func (mr *MockEngineMockRecorder) PreprocessHeaderVerification(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreprocessHeaderVerification", reflect.TypeOf((*MockEngine)(nil).PreprocessHeaderVerification), arg0)
 }
 
 // Protocol mocks base method


### PR DESCRIPTION
## Proposed changes

- **UPDATE**: The addresses cache is updated. Previously, the `ecrecover` method used an ARU cache with block hash as a key, but we need to cache all the addresses recovered from committed seals of a block. So, 65-bytes signatures are used as keys. Furthermore, the size of the cache is increased to 2048 * 30 (max number of downloaded blocks * approximate sub group size of validators).

- After the PR https://github.com/klaytn/klaytn/pull/920, the `Refresh` method must be called all the time to refresh proposer candidates as well as validators.
- The `Refresh` method wasn't always called before because the header verification concurrently occurs while downloading a batch of blocks. (If the header does not exist, it ignores to refresh)
- The `Refresh` method didn't work properly since it was failed to get staking information to verify headers. (It tries to call a contract method on a specific block which is not yet inserted)
- This PR updates the header verification synchronously, while the computation of addresses will be processed concurrently to prevent download performance.

- The simple synchronous verification performs poorly as below panel, so extracting the pub key from seals handled concurrently.
![image](https://user-images.githubusercontent.com/45347815/117402768-f5698380-af41-11eb-99f2-a6574c66de6c.png)

- The comparision sync test is attached.
EN0 : master branch (Klaytn v1.6.1+f695312c38)
EN1 : After this PR (Klaytn v1.6.1+d76876935e)
EN2 : Before this PR (Klaytn v1.6.1+37b05fe791)

![screencapture-54-180-156-230-3000-d-KnJhY-iWz-klaytn-main-overview-2021-05-17-09_20_39](https://user-images.githubusercontent.com/45347815/118417898-2f304c00-b6f1-11eb-8fc8-ba8e63a91c9e.png)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

