### PR TITLE
blockchain/vm: use pointers to oprations vs. copy by value

### DIFF
--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -54,12 +54,11 @@ func enable1884(jt *JumpTable) {
 	jt[SLOAD].computationCost = params.SloadComputationCostEIP1884
 
 	// New opcode
-	jt[SELFBALANCE] = operation{
+	jt[SELFBALANCE] = &operation{
 		execute:         opSelfBalance,
 		constantGas:     GasFastStep,
 		minStack:        minStack(0, 1),
 		maxStack:        maxStack(0, 1),
-		valid:           true,
 		computationCost: params.SelfBalanceComputationCost,
 	}
 }
@@ -74,12 +73,11 @@ func opSelfBalance(pc *uint64, evm *EVM, contract *Contract, memory *Memory, sta
 // - Adds an opcode that returns the current chain’s EIP-155 unique identifier
 func enable1344(jt *JumpTable) {
 	// New opcode
-	jt[CHAINID] = operation{
+	jt[CHAINID] = &operation{
 		execute:         opChainID,
 		constantGas:     GasQuickStep,
 		minStack:        minStack(0, 1),
 		maxStack:        maxStack(0, 1),
-		valid:           true,
 		computationCost: params.ChainIDComputationCost,
 	}
 }

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -38,7 +38,7 @@ type Config struct {
 	NoRecursion             bool   // Disables call, callcode, delegate call and create
 	EnablePreimageRecording bool   // Enables recording of SHA3/keccak preimages
 
-	JumpTable [256]operation // EVM instruction table, automatically populated if unset
+	JumpTable [256]*operation // EVM instruction table, automatically populated if unset
 
 	// RunningEVM is to indicate the running EVM and used to stop the EVM.
 	RunningEVM chan *EVM
@@ -83,7 +83,7 @@ func NewEVMInterpreter(evm *EVM, cfg *Config) *Interpreter {
 	// We use the STOP instruction whether to see
 	// the jump table was initialised. If it was not
 	// we'll set the default jump table.
-	if !cfg.JumpTable[STOP].valid {
+	if cfg.JumpTable[STOP] == nil {
 		var jt JumpTable
 		switch {
 		case evm.chainRules.IsIstanbul:
@@ -219,7 +219,7 @@ func (in *Interpreter) Run(contract *Contract, input []byte) (ret []byte, err er
 		// enough stack items available to perform the operation.
 		op = contract.GetOp(pc)
 		operation := in.cfg.JumpTable[op]
-		if !operation.valid {
+		if operation == nil {
 			return nil, fmt.Errorf("invalid opcode 0x%x", int(op)) // TODO-Klaytn-Issue615
 		}
 		// Validate stack


### PR DESCRIPTION
## Proposed changes

- This PR changes `JumpTable` type to use pointer `operation`.
- It is derived from ethereum/go-ethereum#21336 and related to https://github.com/klaytn/klaytn/pull/956.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
