### PR TITLE
Modified to use senderCache when prefetching with Lock unlike #962

### DIFF
--- a/blockchain/state_prefetcher.go
+++ b/blockchain/state_prefetcher.go
@@ -96,10 +96,8 @@ func (p *statePrefetcher) PrefetchTx(block *types.Block, ti int, stateDB *state.
 // and uses the input parameters for its environment. The goal is not to execute
 // the transaction successfully, rather to warm up touched data slots.
 func precacheTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, statedb *state.StateDB, header *types.Header, tx *types.Transaction, cfg vm.Config) error {
-	copiedTx := *tx
-
 	// Convert the transaction into an executable message and pre-cache its sender
-	msg, err := copiedTx.AsMessageWithAccountKeyPicker(types.MakeSigner(config, header.Number), statedb, header.Number.Uint64())
+	msg, err := tx.AsMessageWithAccountKeyPicker(types.MakeSigner(config, header.Number), statedb, header.Number.Uint64())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed changes
Like #962, this PR can resolve the issue. But the added `lock` can protects a race condition of the uint64 variable.

### Test Result
EN0 : v1.6.1
EN1 : v1.6.2.rc3
![image](https://user-images.githubusercontent.com/29390878/118574392-476e9c80-b7bf-11eb-946d-760d005557ba.png)


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
