### PR TITLE
Add error handling in NewTrieForPrefetching

### DIFF
--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -84,6 +84,9 @@ func NewTrie(root common.Hash, db *Database) (*Trie, error) {
 
 func NewTrieForPrefetching(root common.Hash, db *Database) (*Trie, error) {
 	trie, err := NewTrie(root, db)
+	if err != nil {
+		return nil, err
+	}
 	trie.prefetching = true
 	return trie, err
 }


### PR DESCRIPTION
## Proposed changes

- This PR adds error handling in `NewTrieForPrefetching`.
- Previously, if `NewTrie` returns error, `trie` is returned with `nil`. 
This eventually made `nil pointer dereference` error in `trie.prefetching = true`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments


