### PR TITLE
Updated governance APIs

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -66,37 +66,40 @@ func (api *API) GetSnapshotAtHash(hash common.Hash) (*Snapshot, error) {
 	return api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
 }
 
-// GetValidators retrieves the list of authorized validators at the specified block.
+// GetValidators retrieves the list of authorized validators with the given block number.
 func (api *API) GetValidators(number *rpc.BlockNumber) ([]common.Address, error) {
-	// Retrieve the requested block number (or current if none requested)
-	var header *types.Header
-	if number == nil || *number == rpc.LatestBlockNumber {
-		header = api.chain.CurrentHeader()
-	} else {
-		header = api.chain.GetHeaderByNumber(uint64(number.Int64()))
-	}
-	// Ensure we have an actually valid block and return the validators from its snapshot
-	if header == nil {
-		return nil, errUnknownBlock
-	}
-	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	snap, err := api.GetSnapshot(number)
 	if err != nil {
 		return nil, err
 	}
 	return snap.validators(), nil
 }
 
-// GetValidatorsAtHash retrieves the state snapshot at a given block.
+// GetValidatorsAtHash retrieves the list of authorized validators with the given block hash.
 func (api *API) GetValidatorsAtHash(hash common.Hash) ([]common.Address, error) {
-	header := api.chain.GetHeaderByHash(hash)
-	if header == nil {
-		return nil, errUnknownBlock
-	}
-	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	snap, err := api.GetSnapshotAtHash(hash)
 	if err != nil {
 		return nil, err
 	}
 	return snap.validators(), nil
+}
+
+// GetDemotedValidators retrieves the list of authorized, but demoted validators with the given block number.
+func (api *API) GetDemotedValidators(number *rpc.BlockNumber) ([]common.Address, error) {
+	snap, err := api.GetSnapshot(number)
+	if err != nil {
+		return nil, err
+	}
+	return snap.demotedValidators(), nil
+}
+
+// GetDemotedValidatorsAtHash retrieves the list of authorized, but demoted validators with the given block hash.
+func (api *API) GetDemotedValidatorsAtHash(hash common.Hash) ([]common.Address, error) {
+	snap, err := api.GetSnapshotAtHash(hash)
+	if err != nil {
+		return nil, err
+	}
+	return snap.demotedValidators(), nil
 }
 
 // Candidates returns the current candidates the node tries to uphold and vote on.
@@ -180,7 +183,8 @@ func (api *APIExtension) GetCouncil(number *rpc.BlockNumber) ([]common.Address, 
 		logger.Error("Failed to get snapshot.", "hash", header.Hash(), "err", err)
 		return nil, errInternalError
 	}
-	return snap.validators(), nil
+
+	return append(snap.validators(), snap.demotedValidators()...), nil
 }
 
 func (api *APIExtension) GetCouncilSize(number *rpc.BlockNumber) (int, error) {

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -243,6 +243,15 @@ func (s *Snapshot) validators() []common.Address {
 	return sortValidatorArray(validators)
 }
 
+// demotedValidators retrieves the list of authorized but demoted validators in ascending order.
+func (s *Snapshot) demotedValidators() []common.Address {
+	demotedValidators := make([]common.Address, 0, len(s.ValSet.DemotedList()))
+	for _, demotedValidator := range s.ValSet.DemotedList() {
+		demotedValidators = append(demotedValidators, demotedValidator.Address())
+	}
+	return sortValidatorArray(demotedValidators)
+}
+
 func (s *Snapshot) committee(prevHash common.Hash, view *istanbul.View) []common.Address {
 	committeeList := s.ValSet.SubList(prevHash, view)
 

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -243,7 +243,7 @@ func (s *Snapshot) validators() []common.Address {
 	return sortValidatorArray(validators)
 }
 
-// demotedValidators retrieves the list of authorized but demoted validators in ascending order.
+// demotedValidators retrieves the list of authorized, but demoted validators in ascending order.
 func (s *Snapshot) demotedValidators() []common.Address {
 	demotedValidators := make([]common.Address, 0, len(s.ValSet.DemotedList()))
 	for _, demotedValidator := range s.ValSet.DemotedList() {

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -984,6 +984,17 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'getDemotedValidators',
+			call: 'istanbul_getDemotedValidators',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
+			name: 'getDemotedValidatorsAtHash',
+			call: 'istanbul_getDemotedValidatorsAtHash',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'discard',
 			call: 'istanbul_discard',
 			params: 1


### PR DESCRIPTION
## Proposed changes

The governance-related APIs are updated. The related definitions are as follows.

- Council: the authorized members to be validators and proposers regardless of the staking amount.
  - `getCouncil`: the addresses of council members at the given block.
  - `getCouncilSize`: the number of council members at the given block.
- Validator: the member of council which is a candidate of block proposer and validators. Only the members who have enough KLAYs are qualified.
  - `getValidators`: the validators at the given block number.
  - `getValidatorsAtHash`: the validators at the given block hash.
- DemotedValidator: the permissioned validator, but not participating validation and proposal since the staked KLAYs are not enough.
  - `getDemotedValidators`: the demoted validators at the given block number.
  - `getDemotedValidatorsAtHash`: the demoted validators at the given block hash.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

