### PR TITLE
Prevent nil receipts and added retry logic for making chain events

### DIFF
--- a/datasync/chaindatafetcher/chaindata_fetcher.go
+++ b/datasync/chaindatafetcher/chaindata_fetcher.go
@@ -273,9 +273,13 @@ func (f *ChainDataFetcher) makeChainEventWithRetry(blockNumber uint64) (blockcha
 		case <-f.stopCh:
 			return ev, err
 		default:
-			logger.Warn("retrying to make a chain event...", "blockNumber", blockNumber, "retryCount", retryCount, "retryMax", retryMax, "err", err)
-			if retryCount >= retryMax {
-				logger.Error("the max retry exceeded")
+			if retryCount < retryMax {
+				logger.Warn("retrying to make a chain event...", "blockNumber", blockNumber, "retryCount", retryCount, "retryMax", retryMax, "err", err)
+			}
+
+			// leaves an error log periodically after max retry
+			if retryCount%retryMax == 0 {
+				logger.Error("max retry exceeded. retrying to make a chain event...", "blockNumber", blockNumber, "retryCount", retryCount, "retryMax", retryMax, "err", err)
 			}
 			time.Sleep(retryInterval)
 			ev, err = f.makeChainEvent(blockNumber)

--- a/datasync/chaindatafetcher/chaindata_fetcher.go
+++ b/datasync/chaindatafetcher/chaindata_fetcher.go
@@ -268,13 +268,13 @@ func (f *ChainDataFetcher) retryMakeChainEvent(blockNumber uint64) (blockchain.C
 		retryInterval = 1 * time.Second
 	)
 	ev, err := f.makeChainEvent(blockNumber)
-	for i := 1; err != nil; i++ {
+	for retryCount := 1; err != nil; retryCount++ {
 		select {
 		case <-f.stopCh:
 			return ev, err
 		default:
-			logger.Warn("retrying to make a chain event...", "blockNumber", blockNumber, "retryCount", i, "retryMax", retryMax, "err", err)
-			if i >= retryMax {
+			logger.Warn("retrying to make a chain event...", "blockNumber", blockNumber, "retryCount", retryCount, "retryMax", retryMax, "err", err)
+			if retryCount >= retryMax {
 				logger.Error("the max retry exceeded")
 			}
 			time.Sleep(retryInterval)

--- a/datasync/chaindatafetcher/chaindata_fetcher.go
+++ b/datasync/chaindatafetcher/chaindata_fetcher.go
@@ -262,7 +262,7 @@ func (f *ChainDataFetcher) stopRangeFetching() error {
 	return nil
 }
 
-func (f *ChainDataFetcher) retryMakeChainEvent(blockNumber uint64) (blockchain.ChainEvent, error) {
+func (f *ChainDataFetcher) makeChainEventWithRetry(blockNumber uint64) (blockchain.ChainEvent, error) {
 	var (
 		retryMax      = 100
 		retryInterval = 1 * time.Second
@@ -457,7 +457,7 @@ func (f *ChainDataFetcher) handleRequest() {
 			}
 		case req := <-f.reqCh:
 			numRequestsGauge.Update(int64(len(f.reqCh)))
-			ev, err := f.retryMakeChainEvent(req.BlockNumber)
+			ev, err := f.makeChainEventWithRetry(req.BlockNumber)
 			if err != nil {
 				// TODO-ChainDataFetcher handle error
 				logger.Error("making chain event is failed", "err", err)

--- a/datasync/chaindatafetcher/chaindata_fetcher_test.go
+++ b/datasync/chaindatafetcher/chaindata_fetcher_test.go
@@ -297,7 +297,7 @@ func TestChainDataFetcher_retryMakeChainEvent(t *testing.T) {
 	bc.EXPECT().GetBlockByNumber(gomock.Eq(testBlock.NumberU64())).Return(testBlock).Times(1)
 	bc.EXPECT().GetReceiptsByBlockHash(gomock.Eq(testBlock.Hash())).Return(emptyReceipts).Times(1)
 
-	actual, err := fetcher.retryMakeChainEvent(testBlock.NumberU64())
+	actual, err := fetcher.makeChainEventWithRetry(testBlock.NumberU64())
 	assert.Equal(t, expected, actual)
 	assert.NoError(t, err)
 
@@ -310,7 +310,7 @@ func TestChainDataFetcher_retryMakeChainEvent(t *testing.T) {
 	bc.EXPECT().GetBlockByNumber(gomock.Eq(testBlock2.NumberU64())).Return(testBlock2).Times(1)
 	bc.EXPECT().GetReceiptsByBlockHash(gomock.Eq(testBlock2.Hash())).Return(emptyReceipts).Times(1) // retry and success
 
-	actual2, err := fetcher.retryMakeChainEvent(testBlock2.NumberU64())
+	actual2, err := fetcher.makeChainEventWithRetry(testBlock2.NumberU64())
 	assert.Equal(t, expected2, actual2)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Proposed changes

Making a chain event is done locally after getting items from database. It was hard to get an error, but the error case is not handled properly. This change checks if receipt list is nil or not, and added retrying logic for making chain events.

Unlike retrying to produce Kafka messages, it should not fail to get data from the database. It retries inifinately, but after 100 retry it leaves error logs.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

