### PR TITLE
Introduce CustomRetryer for DynamoS3DB

### DIFF
--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -119,7 +119,7 @@ type CustomRetryer struct {
 // ShouldRetry overrides AWS SDK's built in DefaultRetryer to retry in all error cases.
 func (r CustomRetryer) ShouldRetry(req *request.Request) bool {
 	logger.Debug("dynamoDB client retry", "error", req.Error, "retryCnt", req.RetryCount, "retryDelay",
-		req.RetryDelay, "maxRetry:", r.MaxRetries())
+		req.RetryDelay, "maxRetry", r.MaxRetries())
 	return req.Error != nil && req.RetryCount < r.MaxRetries()
 }
 

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -36,6 +36,8 @@ import (
 	klaytnmetrics "github.com/klaytn/klaytn/metrics"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
@@ -58,7 +60,7 @@ var noTableNameErr = errors.New("dynamoDB table name not provided")
 // batch write size
 const dynamoWriteSizeLimit = 399 * 1024 // The maximum write size is 400KB including attribute names and values
 const dynamoBatchSize = 25
-const dynamoMaxRetry = 10
+const dynamoMaxRetry = 20
 const dynamoTimeout = 10 * time.Second
 
 // batch write
@@ -104,6 +106,21 @@ type dynamoDB struct {
 type DynamoData struct {
 	Key []byte `json:"Key" dynamodbav:"Key"`
 	Val []byte `json:"Val" dynamodbav:"Val"`
+}
+
+// CustomRetryer wraps AWS SDK's built in DefaultRetryer adding additional custom features.
+// DefaultRetryer of AWS SDK has its own standard of retryable situation,
+// but it's not proper when network environment is not stable.
+// CustomRetryer conservatively retry in all error cases because DB failure of Klaytn is critical.
+type CustomRetryer struct {
+	client.DefaultRetryer
+}
+
+// ShouldRetry overrides AWS SDK's built in DefaultRetryer to retry in all error cases.
+func (r CustomRetryer) ShouldRetry(req *request.Request) bool {
+	logger.Debug("dynamoDB client retry", "error", req.Error, "retryCnt", req.RetryCount, "retryDelay",
+		req.RetryDelay, "maxRetry:", r.MaxRetries())
+	return req.Error != nil && req.RetryCount < r.MaxRetries()
 }
 
 // GetTestDynamoConfig gets dynamo config for actual aws DynamoDB test
@@ -153,6 +170,13 @@ func newDynamoDB(config *DynamoDBConfig) (*dynamoDB, error) {
 	if dynamoDBClient == nil {
 		dynamoDBClient = dynamodb.New(session.Must(session.NewSessionWithOptions(session.Options{
 			Config: aws.Config{
+				Retryer: CustomRetryer{
+					DefaultRetryer: client.DefaultRetryer{
+						NumMaxRetries:    dynamoMaxRetry,
+						MaxRetryDelay:    time.Second,
+						MaxThrottleDelay: time.Second,
+					},
+				},
 				Endpoint:         aws.String(config.Endpoint),
 				Region:           aws.String(config.Region),
 				S3ForcePathStyle: aws.Bool(true),
@@ -310,7 +334,7 @@ func (dynamo *dynamoDB) put(key []byte, val []byte) error {
 
 	_, err = dynamoDBClient.PutItem(params)
 	if err != nil {
-		dynamo.logger.Error("failed to put an item", "err", err, "key", hexutil.Encode(data.Key))
+		dynamo.logger.Crit("failed to put an item", "err", err, "key", hexutil.Encode(data.Key))
 		return err
 	}
 
@@ -352,7 +376,7 @@ func (dynamo *dynamoDB) get(key []byte) ([]byte, error) {
 
 	result, err := dynamoDBClient.GetItem(params)
 	if err != nil {
-		dynamo.logger.Error("failed to get an item", "err", err, "key", hexutil.Encode(key))
+		dynamo.logger.Crit("failed to get an item", "err", err, "key", hexutil.Encode(key))
 		return nil, err
 	}
 
@@ -362,6 +386,7 @@ func (dynamo *dynamoDB) get(key []byte) ([]byte, error) {
 
 	var data DynamoData
 	if err := dynamodbattribute.UnmarshalMap(result.Item, &data); err != nil {
+		dynamo.logger.Crit("failed to unmarshal dynamodb data", "err", err)
 		return nil, err
 	}
 
@@ -370,7 +395,11 @@ func (dynamo *dynamoDB) get(key []byte) ([]byte, error) {
 	}
 
 	if bytes.Equal(data.Val, overSizedDataPrefix) {
-		return dynamo.fdb.read(key)
+		ret, err := dynamo.fdb.read(key)
+		if err != nil {
+			dynamo.logger.Crit("failed to read filedb data", "err", err, "key", hexutil.Encode(key))
+		}
+		return ret, err
 	}
 
 	return data.Val, nil
@@ -389,7 +418,7 @@ func (dynamo *dynamoDB) Delete(key []byte) error {
 
 	_, err := dynamoDBClient.DeleteItem(params)
 	if err != nil {
-		dynamo.logger.Error("failed to delete an item", "err", err, "key", hexutil.Encode(key))
+		dynamo.logger.Crit("failed to delete an item", "err", err, "key", hexutil.Encode(key))
 		return err
 	}
 	return nil

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -22,6 +22,7 @@ package database
 import (
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -302,7 +303,10 @@ func TestDynamoDB_Retry(t *testing.T) {
 			}
 			conn, err := listen.AcceptTCP()
 			if err != nil {
-				t.Fatal(err)
+				// the fake server ends silently when it meets deadline
+				if strings.Contains(err.Error(), "timeout") {
+					return
+				}
 			}
 			requestCnt++
 			_ = conn.Close()

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -21,16 +21,13 @@ package database
 
 import (
 	"net"
-	"net/http"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/stretchr/testify/suite"
@@ -89,75 +86,6 @@ func (s *SuiteDynamoDB) TestDynamoDB_Put() {
 	returnedVal, returnedErr := dynamo.Get(testKey)
 	s.Equal(testVal, returnedVal)
 	s.NoError(returnedErr)
-}
-
-// TestDynamoDB_Timeout tests if a timeout error occurs.
-// When there is no answer from DynamoDB server due to network failure,
-// a timeout error should occur.
-// A fake server is setup to simulate a server with a response latency.
-func (s *SuiteDynamoDB) TestDynamoDB_Timeout() {
-	// fakeEndpoint allows TCP handshakes, but doesn't answer anything to client.
-	// The fake server is used to produce a network failure scenario.
-	fakeEndpoint := "127.0.0.1:14566"
-	maxRetries := 2
-	timeout := 1 * time.Second
-	serverReadyWg := sync.WaitGroup{}
-	serverReadyWg.Add(1)
-
-	go func() {
-		tcpAddr, err := net.ResolveTCPAddr("tcp", fakeEndpoint)
-		if err != nil {
-			s.FailNow(err.Error())
-		}
-
-		listen, err := net.ListenTCP("tcp", tcpAddr)
-		if err != nil {
-			s.FailNow(err.Error())
-		}
-		defer listen.Close()
-		serverReadyWg.Done()
-
-		for i := 0; i < maxRetries+1; i++ {
-			// Deadline prevents infinite waiting of the fake server
-			// Wait longer than (maxRetries+1) * timeout
-			if err := listen.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-				s.FailNow(err.Error())
-			}
-			if _, err := listen.AcceptTCP(); err != nil {
-				// the fake server ends silently when it meets deadline
-				if strings.Contains(err.Error(), "timeout") {
-					return
-				}
-				s.FailNow(err.Error())
-			}
-		}
-	}()
-
-	conf := GetTestDynamoConfig() // dummy values to create dynamoDB
-	conf.Endpoint = fakeEndpoint
-	conf.TableName = "test-table"
-
-	dynamoDBClient = dynamodb.New(session.Must(session.NewSessionWithOptions(session.Options{
-		Config: aws.Config{
-			Endpoint:   aws.String(conf.Endpoint),
-			Region:     aws.String(conf.Region),
-			MaxRetries: aws.Int(maxRetries),
-			HTTPClient: &http.Client{Timeout: timeout},
-		},
-	})))
-	expectedElapsed := time.Duration(maxRetries+1) * timeout
-
-	dynamoDB := &dynamoDB{
-		config: *conf,
-		logger: logger.NewWith("logger"),
-	}
-	serverReadyWg.Wait()
-
-	start := time.Now()
-	_, err := dynamoDB.get([]byte{0x1, 0x2})
-	s.NotNil(err)
-	s.True(strings.Contains(err.Error(), "Timeout"))
-	s.Equal(expectedElapsed, time.Since(start).Round(time.Second))
 }
 
 func (s *SuiteDynamoDB) TestDynamoBatch_Write() {
@@ -255,9 +183,9 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write_DuplicatedKey() {
 	}
 }
 
-// testDynamoBatch_WriteMutliTables checks if there is no error when working with more than one tables.
+// TestDynamoBatch_Write_MultiTables checks if there is no error when working with more than one tables.
 // This also checks if shared workers works as expected.
-func (s *SuiteDynamoDB) TestDynamoBatch_Write_MutliTables() {
+func (s *SuiteDynamoDB) TestDynamoBatch_Write_MultiTables() {
 	// this test might end with Crit, enableLog to find out the log
 	//enableLog()
 
@@ -331,4 +259,63 @@ func (dynamo *dynamoDB) deleteDB() {
 	dynamo.Close()
 	dynamo.deleteTable()
 	dynamo.fdb.deleteBucket()
+}
+
+// TestDynamoDB_Retry tests whether dynamoDB client retries successfully.
+// A fake server is setup to simulate a server with a request count.
+func TestDynamoDB_Retry(t *testing.T) {
+	// This test needs a new dynamoDBClient having a fake endpoint.
+	oldClient := dynamoDBClient
+	dynamoDBClient = nil
+	defer func() {
+		dynamoDBClient = oldClient
+	}()
+
+	// fakeEndpoint allows TCP handshakes, but doesn't answer anything to client.
+	// The fake server is used to produce a network failure scenario.
+	fakeEndpoint := "localhost:14566"
+	requestCnt := 0
+
+	serverReadyWg := sync.WaitGroup{}
+	serverReadyWg.Add(1)
+
+	go func() {
+		tcpAddr, err := net.ResolveTCPAddr("tcp", fakeEndpoint)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		listen, err := net.ListenTCP("tcp", tcpAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer listen.Close()
+
+		serverReadyWg.Done()
+
+		// expected request number: dynamoMaxRetry+1. It will wait one more time after all retry done.
+		for i := 0; i < dynamoMaxRetry+1+1; i++ {
+			// Deadline prevents infinite waiting of the fake server
+			// Wait longer than (maxRetries+1) * timeout
+			if err := listen.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+				t.Fatal(err)
+			}
+			conn, err := listen.AcceptTCP()
+			if err != nil {
+				t.Fatal(err)
+			}
+			requestCnt++
+			_ = conn.Close()
+		}
+	}()
+
+	conf := GetTestDynamoConfig() // dummy values to create dynamoDB
+	conf.Endpoint = fakeEndpoint
+
+	serverReadyWg.Wait()
+
+	dynamoDBClient = nil
+	_, err := NewDynamoDB(conf)
+	assert.NotNil(t, err)
+	assert.Equal(t, dynamoMaxRetry+1, requestCnt)
 }

--- a/storage/database/s3filedb.go
+++ b/storage/database/s3filedb.go
@@ -28,10 +28,12 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	"github.com/klaytn/klaytn/common/hexutil"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/klaytn/klaytn/log"
@@ -52,6 +54,13 @@ type s3FileDB struct {
 func newS3FileDB(region, endpoint, bucketName string) (*s3FileDB, error) {
 	localLogger := logger.NewWith("endpoint", endpoint, "bucketName", bucketName)
 	sessionConf, err := session.NewSession(&aws.Config{
+		Retryer: CustomRetryer{
+			DefaultRetryer: client.DefaultRetryer{
+				NumMaxRetries:    dynamoMaxRetry,
+				MaxRetryDelay:    time.Second,
+				MaxThrottleDelay: time.Second,
+			},
+		},
 		Region:           aws.String(region),
 		Endpoint:         aws.String(endpoint),
 		S3ForcePathStyle: aws.Bool(true),


### PR DESCRIPTION
## Proposed changes

- Introduce CustomRetryer for DynamoS3DB to retry requests in all error cases. DefaultRetyer doesn't retry when connection reset occurred, but KES rarely suffers the failures in Docker/EKS environments. 
- Increase `dynamoMaxRetry` from 10 to 20 which takes 10 ~ 20 seconds with CustomRetryer if responses are returned immediately. 
- Print `Critical` log when dynamoS3DB put/get failed. The failure is critical for Klaytn, but DB Manager doesn't handle get failures now. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
