### PR TITLE
blockchain/vm: TestPrecompiledContractAddressMapping revision

### DIFF
--- a/blockchain/vm/evm_test.go
+++ b/blockchain/vm/evm_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"errors"
 	"math"
 	"math/big"
 	"testing"
@@ -63,7 +64,7 @@ var PrecompiledContractAddressMappingTestData = []struct {
 	{"0x3fe", feePayerInput, false, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},
 	{"0x3ff", validateInput, false, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},
 	// Condition 2. Caller Contract Deploy - after IstanbulCompatible Change, Call - after istanbulCompatible
-	{"0x009", vmLogInput, true, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},
+	{"0x009", vmLogInput, true, Block5, math.MaxUint64, "", errors.New("invalid input length")},
 	{"0x00a", feePayerInput, true, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},
 	{"0x00b", validateInput, true, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},
 }

--- a/blockchain/vm/evm_test.go
+++ b/blockchain/vm/evm_test.go
@@ -63,7 +63,7 @@ var PrecompiledContractAddressMappingTestData = []struct {
 	{"0x3fd", vmLogInput, false, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},
 	{"0x3fe", feePayerInput, false, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},
 	{"0x3ff", validateInput, false, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},
-	// Condition 2. Caller Contract Deploy - after IstanbulCompatible Change, Call - after istanbulCompatible
+	// Condition 3. Caller Contract Deploy - after IstanbulCompatible Change, Call - after istanbulCompatible
 	{"0x009", vmLogInput, true, Block5, math.MaxUint64, "", errors.New("invalid input length")},
 	{"0x00a", feePayerInput, true, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},
 	{"0x00b", validateInput, true, Block5, 0, "", kerrors.ErrPrecompiledContractAddress},


### PR DESCRIPTION
## Proposed changes

- TestPrecompiledContractAddressMapping is introduced at https://github.com/klaytn/klaytn/pull/912.
- One of tc is failed and this PR fixes it by replacing expected error and gas.
- The fixed tc is the test that calls the contract after the istanbul compatible, and it is deployed after the istanbul compatible. It passes 0x09 address, and vmLog input(however, 0x09 runs blake2f and expects blake2f input). So, blake2f precompiled contract returned the error that input length is not an expected length.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
