### PR TITLE
blockchain/types: intrinsicGas unification

### DIFF
--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -517,7 +517,14 @@ func IntrinsicGas(data []byte, contractCreation bool, r params.Rules) (uint64, e
 	} else {
 		gas = params.TxGas
 	}
-	gasPayloadWithGas, err := IntrinsicGasPayloadLegacy(gas, data)
+
+	var gasPayloadWithGas uint64
+	var err error
+	if r.IsIstanbul {
+		gasPayloadWithGas, err = IntrinsicGasPayload(gas, data)
+	} else {
+		gasPayloadWithGas, err = IntrinsicGasPayloadLegacy(gas, data)
+	}
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Proposed changes

- This PR contains istanbul compatible change item. It is not activated yet since istanbulCompatible block number is set nil.
- It is written on the https://github.com/klaytn/klaytn/pull/981.
- Main idea.
  - Klaytn has legacyTx and non-legacyTx. legacyTx is a transaction from geth, and non-legacyTx is a transaction klaytn added.
  - Gas is charged according to the input data of tx, however, legacyTx and non-legacyTx uses different input data gas metering function. 
  - It is not fair to use different function, so this PR unifies them by making legacyTx to use non-legacyTx's gas metering function, `IntrinsicGasPayload`. This change is backward incompatible, so it is included at istanbul compatible change.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
