### PR TITLE
Parameterize block generation time related values

### DIFF
--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -49,6 +49,9 @@ var FlagGroups = []FlagGroup{
 			ConfigFileFlag,
 			OverwriteGenesisFlag,
 			StartBlockNumberFlag,
+			BlockGenerationIntervalFlag,
+			BlockGenerationTimeLimitFlag,
+			OpcodeComputationCostLimitFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -996,18 +996,20 @@ var (
 	BlockGenerationIntervalFlag = cli.Int64Flag{
 		Name: "block-generation-interval",
 		Usage: "(experimental option) Set the block generation interval in seconds. " +
-			"It should be equal or larger than 1",
+			"It should be equal or larger than 1. This flag is only applicable to CN.",
 		Value: params.DefaultBlockGenerationInterval,
 	}
 	BlockGenerationTimeLimitFlag = cli.DurationFlag{
 		Name: "block-generation-time-limit",
 		Usage: "(experimental option) Set the vm execution time limit during block generation. " +
-			"Less than half of the block generation interval is recommended for this value",
+			"Less than half of the block generation interval is recommended for this value. " +
+			"This flag is only applicable to CN",
 		Value: params.DefaultBlockGenerationTimeLimit,
 	}
 	OpcodeComputationCostLimitFlag = cli.Uint64Flag{
-		Name:  "opcode-computation-cost-limit",
-		Usage: "(experimental option) Set the computation cost limit for a tx",
+		Name: "opcode-computation-cost-limit",
+		Usage: "(experimental option) Set the computation cost limit for a tx. " +
+			"Should set the same value within the network",
 		Value: params.DefaultOpcodeComputationCostLimit,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -993,6 +993,23 @@ var (
 		Name:  "config",
 		Usage: "TOML configuration file",
 	}
+	BlockGenerationIntervalFlag = cli.Int64Flag{
+		Name: "block-generation-interval",
+		Usage: "(experimental option) Set the block generation interval in seconds. " +
+			"It should be equal or larger than 1",
+		Value: params.DefaultBlockGenerationInterval,
+	}
+	BlockGenerationTimeLimitFlag = cli.DurationFlag{
+		Name: "block-generation-time-limit",
+		Usage: "(experimental option) Set the vm execution time limit during block generation. " +
+			"Less than half of the block generation interval is recommended for this value",
+		Value: params.DefaultBlockGenerationTimeLimit,
+	}
+	OpcodeComputationCostLimitFlag = cli.Uint64Flag{
+		Name:  "opcode-computation-cost-limit",
+		Usage: "(experimental option) Set the computation cost limit for a tx",
+		Value: params.DefaultOpcodeComputationCostLimit,
+	}
 
 	// TODO-Klaytn-Bootnode: Add bootnode's metric options
 	// TODO-Klaytn-Bootnode: Implements bootnode's RPC
@@ -1579,6 +1596,13 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 	if ctx.GlobalIsSet(RPCGlobalGasCap.Name) {
 		cfg.RPCGasCap = new(big.Int).SetUint64(ctx.GlobalUint64(RPCGlobalGasCap.Name))
 	}
+
+	params.BlockGenerationInterval = ctx.GlobalInt64(BlockGenerationIntervalFlag.Name)
+	if params.BlockGenerationInterval < 1 {
+		logger.Crit("Block generation interval should be equal or larger than 1")
+	}
+	params.BlockGenerationTimeLimit = ctx.GlobalDuration(BlockGenerationTimeLimitFlag.Name)
+	params.OpcodeComputationCostLimit = ctx.GlobalUint64(OpcodeComputationCostLimitFlag.Name)
 
 	// Override any default configs for hard coded network.
 	// TODO-Klaytn-Bootnode: Discuss and add `baobab` test network's genesis block

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1597,11 +1597,17 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 		cfg.RPCGasCap = new(big.Int).SetUint64(ctx.GlobalUint64(RPCGlobalGasCap.Name))
 	}
 
-	params.BlockGenerationInterval = ctx.GlobalInt64(BlockGenerationIntervalFlag.Name)
-	if params.BlockGenerationInterval < 1 {
-		logger.Crit("Block generation interval should be equal or larger than 1")
+	// Only CNs could set BlockGenerationIntervalFlag and BlockGenerationTimeLimitFlag
+	if ctx.GlobalIsSet(BlockGenerationIntervalFlag.Name) {
+		params.BlockGenerationInterval = ctx.GlobalInt64(BlockGenerationIntervalFlag.Name)
+		if params.BlockGenerationInterval < 1 {
+			logger.Crit("Block generation interval should be equal or larger than 1", "interval", params.BlockGenerationInterval)
+		}
 	}
-	params.BlockGenerationTimeLimit = ctx.GlobalDuration(BlockGenerationTimeLimitFlag.Name)
+	if ctx.GlobalIsSet(BlockGenerationTimeLimitFlag.Name) {
+		params.BlockGenerationTimeLimit = ctx.GlobalDuration(BlockGenerationTimeLimitFlag.Name)
+	}
+
 	params.OpcodeComputationCostLimit = ctx.GlobalUint64(OpcodeComputationCostLimitFlag.Name)
 
 	// Override any default configs for hard coded network.

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -113,6 +113,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.ConfigFileFlag,
 	utils.APIFilterGetLogsMaxItemsFlag,
 	utils.APIFilterGetLogsDeadlineFlag,
+	utils.OpcodeComputationCostLimitFlag,
 }
 
 // Common RPC flags
@@ -143,6 +144,8 @@ var KCNFlags = []cli.Flag{
 	utils.RewardbaseFlag,
 	utils.CypressFlag,
 	utils.BaobabFlag,
+	utils.BlockGenerationIntervalFlag,
+	utils.BlockGenerationTimeLimitFlag,
 }
 
 var KPNFlags = []cli.Flag{
@@ -210,6 +213,8 @@ var KENFlags = []cli.Flag{
 
 var KSCNFlags = []cli.Flag{
 	utils.RewardbaseFlag,
+	utils.BlockGenerationIntervalFlag,
+	utils.BlockGenerationTimeLimitFlag,
 	utils.ServiceChainSignerFlag,
 	utils.AnchoringPeriodFlag,
 	utils.SentChainTxsLimit,

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -153,19 +153,33 @@ const (
 	TxDataGas uint64 = 100
 )
 
+const (
+	DefaultBlockGenerationInterval    = int64(1) // digit: seconds
+	DefaultBlockGenerationTimeLimit   = 250 * time.Millisecond
+	DefaultOpcodeComputationCostLimit = uint64(100000000)
+)
+
 var (
-	TxGasHumanReadable     uint64 = 4000000000         // NOTE: HumanReadable related functions are inactivated now
-	BlockScoreBoundDivisor        = big.NewInt(2048)   // The bound divisor of the blockscore, used in the update calculations.
-	GenesisBlockScore             = big.NewInt(131072) // BlockScore of the Genesis block.
-	MinimumBlockScore             = big.NewInt(131072) // The minimum that the blockscore may ever be.
-	DurationLimit                 = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether blockscore should go up or not.
+	TxGasHumanReadable uint64 = 4000000000 // NOTE: HumanReadable related functions are inactivated now
+
+	// TODO-Klaytn Change the variables used in GXhash to more appropriate values for Klaytn Network
+	BlockScoreBoundDivisor = big.NewInt(2048)   // The bound divisor of the blockscore, used in the update calculations.
+	GenesisBlockScore      = big.NewInt(131072) // BlockScore of the Genesis block.
+	MinimumBlockScore      = big.NewInt(131072) // The minimum that the blockscore may ever be.
+	DurationLimit          = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether blockscore should go up or not.
 )
 
 // Parameters for execution time limit
+// These parameters will be re-assigned by init options
 var (
-	// TODO-Klaytn Determine more practical values through actual running experience
-	TotalTimeLimit             = 250 * time.Millisecond // Execution time limit for all txs in a block
-	OpcodeComputationCostLimit = uint64(100000000)      // Computation cost limit for a tx. For now, it is approximately 100 ms.
+	// Execution time limit for all txs in a block
+	BlockGenerationTimeLimit = DefaultBlockGenerationTimeLimit
+
+	// TODO-Klaytn-Governance Change the following variables to governance items which requires consensus of CCN
+	// Block generation interval in seconds. It should be equal or larger than 1
+	BlockGenerationInterval = DefaultBlockGenerationInterval
+	// Computation cost limit for a tx. For now, it is approximately 100 ms
+	OpcodeComputationCostLimit = DefaultOpcodeComputationCostLimit
 )
 
 // istanbul BFT

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -154,7 +154,7 @@ const (
 )
 
 const (
-	DefaultBlockGenerationInterval    = int64(1) // digit: seconds
+	DefaultBlockGenerationInterval    = int64(1) // unit: seconds
 	DefaultBlockGenerationTimeLimit   = 250 * time.Millisecond
 	DefaultOpcodeComputationCostLimit = uint64(100000000)
 )

--- a/work/worker.go
+++ b/work/worker.go
@@ -485,24 +485,22 @@ func (self *worker) commitNewWork() {
 	self.currentMu.Lock()
 	defer self.currentMu.Unlock()
 
-	tstart := time.Now()
 	parent := self.chain.CurrentBlock()
 
 	// TODO-Klaytn drop or missing tx
+	tstart := time.Now()
 	tstamp := tstart.Unix()
 	if self.nodetype == common.CONSENSUSNODE {
-		if parent.Time().Cmp(new(big.Int).SetInt64(tstamp)) >= 0 {
-			//if self.nodetype == p2p.ENDPOINTNODE {
-			//	tstamp = parent.Time().Int64() + 5
-			//} else {
-			tstamp = parent.Time().Int64() + 1
-			//}
-		}
-		// this will ensure we're not going off too far in the future
-		if now := time.Now().Unix(); tstamp > now+1 {
-			wait := time.Duration(tstamp-now) * time.Second
+		ideal := parent.Time().Int64() + params.BlockGenerationInterval
+		// If a timestamp of the this block is faster than the ideal timestamp,
+		// wait for a while and get a new timestamp
+		if tstamp < ideal {
+			wait := time.Duration(ideal-tstamp) * time.Second
 			logger.Info("Mining too far in the future", "wait", common.PrettyDuration(wait))
 			time.Sleep(wait)
+
+			tstart = time.Now()    // refresh for metrics
+			tstamp = tstart.Unix() // refresh for block timestamp
 		}
 	}
 
@@ -626,7 +624,7 @@ func (env *Task) ApplyTransactions(txs *types.TransactionsByPriceAndNonce, bc Bl
 	chEVM := make(chan *vm.EVM, 1)
 
 	go func() {
-		blockTimer := time.NewTimer(params.TotalTimeLimit)
+		blockTimer := time.NewTimer(params.BlockGenerationTimeLimit)
 		timeout := false
 		var evm *vm.EVM
 
@@ -668,7 +666,7 @@ CommitTransactionLoop:
 		// Retrieve the next transaction and abort if all done
 		tx := txs.Peek()
 		if tx == nil {
-			// To indicate that it does not have enough transactions for params.TotalTimeLimit.
+			// To indicate that it does not have enough transactions for params.BlockGenerationTimeLimit.
 			if numTxsChecked > 0 {
 				usedAllTxsCounter.Inc(1)
 			}

--- a/work/worker.go
+++ b/work/worker.go
@@ -492,7 +492,7 @@ func (self *worker) commitNewWork() {
 	tstamp := tstart.Unix()
 	if self.nodetype == common.CONSENSUSNODE {
 		ideal := parent.Time().Int64() + params.BlockGenerationInterval
-		// If a timestamp of the this block is faster than the ideal timestamp,
+		// If a timestamp of this block is faster than the ideal timestamp,
 		// wait for a while and get a new timestamp
 		if tstamp < ideal {
 			wait := time.Duration(ideal-tstamp) * time.Second


### PR DESCRIPTION
## Proposed changes

Three init flags are introduced
- `BlockGenerationIntervalFlag` determines block generation interval between two successive blocks (Only for CNs)
- `BlockGenerationTimeLimitFlag` sets the vm execution time limit during block generation (Only for CNs)
- `OpcodeComputationCostLimitFlag`  sets the computation cost limit for a tx

These are experimental flags for special usages. Some of them will be changed to governance items later.

**Block generation test result** 
![image](https://user-images.githubusercontent.com/48199072/121849584-788eae00-cd26-11eb-819c-4a2b24761e79.png)
- options: `--block-generation-interval 2 --block-generation-time-limit 800ms --opcode-computation-cost-limit 200000000`
- CN HW spec: m5.xlarge * 4
- Test case: cpuHeavyTx

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
