### PR TITLE
blockchain/state: utilize dirtyStorage more accurately

### DIFF
--- a/blockchain/state/state_object.go
+++ b/blockchain/state/state_object.go
@@ -90,7 +90,7 @@ type stateObject struct {
 	storageTrie Trie // storage trie, which becomes non-nil on first access
 	code        Code // contract bytecode, which gets set when code is loaded
 
-	cachedStorage Storage // Storage entry cache to avoid duplicate reads
+	cachedStorage Storage // Storage cache of original entries to dedup rewrites
 	dirtyStorage  Storage // Storage entries that need to be flushed to disk
 
 	// Cache flags.
@@ -178,17 +178,29 @@ func (c *stateObject) getStorageTrie(db Database) Trie {
 	return c.storageTrie
 }
 
-// GetState returns a value in account storage.
+// GetState retrieves a value from the account storage trie.
 func (self *stateObject) GetState(db Database, key common.Hash) common.Hash {
-	value, exists := self.cachedStorage[key]
-	if exists {
+	// If we have a dirty value for this state entry, return it
+	value, dirty := self.dirtyStorage[key]
+	if dirty {
 		return value
 	}
-	// Load from DB in case it is missing.
-	// Track the amount of time wasted on reading the storge trie
+	// Otherwise return the entry's original value
+	return self.GetCommittedState(db, key)
+}
+
+// GetCommittedState retrieves a value from the committed account storage trie.
+func (self *stateObject) GetCommittedState(db Database, key common.Hash) common.Hash {
+	// If we have the original value cached, return that
+	value, cached := self.cachedStorage[key]
+	if cached {
+		return value
+	}
+	// Track the amount of time wasted on reading the storage trie
 	if EnabledExpensive {
 		defer func(start time.Time) { self.db.StorageReads += time.Since(start) }(time.Now())
 	}
+	// Load from DB in case it is missing.
 	enc, err := self.getStorageTrie(db).TryGet(key[:])
 	if err != nil {
 		self.setError(err)
@@ -207,10 +219,16 @@ func (self *stateObject) GetState(db Database, key common.Hash) common.Hash {
 
 // SetState updates a value in account trie.
 func (self *stateObject) SetState(db Database, key, value common.Hash) {
+	// If the new value is the same as old, don't set
+	prev := self.GetState(db, key)
+	if prev == value {
+		return
+	}
+	// New value is different, update and journal the change
 	self.db.journal.append(storageChange{
 		account:  &self.address,
 		key:      key,
-		prevalue: self.GetState(db, key),
+		prevalue: prev,
 	})
 	self.setState(key, value)
 }
@@ -246,7 +264,6 @@ func (self *stateObject) GetKey() accountkey.AccountKey {
 }
 
 func (self *stateObject) setState(key, value common.Hash) {
-	self.cachedStorage[key] = value
 	self.dirtyStorage[key] = value
 }
 
@@ -263,6 +280,13 @@ func (self *stateObject) updateStorageTrie(db Database) Trie {
 	tr := self.getStorageTrie(db)
 	for key, value := range self.dirtyStorage {
 		delete(self.dirtyStorage, key)
+
+		// Skip noop changes, persist actual changes
+		if value == self.cachedStorage[key] {
+			continue
+		}
+		self.cachedStorage[key] = value
+
 		if (value == common.Hash{}) {
 			self.setError(tr.TryDelete(key[:]))
 			continue
@@ -369,7 +393,7 @@ func (self *stateObject) deepCopy(db *StateDB) *stateObject {
 	}
 	stateObject.code = self.code
 	stateObject.dirtyStorage = self.dirtyStorage.Copy()
-	stateObject.cachedStorage = self.dirtyStorage.Copy()
+	stateObject.cachedStorage = self.cachedStorage.Copy()
 	stateObject.suicided = self.suicided
 	stateObject.dirtyCode = self.dirtyCode
 	stateObject.deleted = self.deleted

--- a/blockchain/state/state_test.go
+++ b/blockchain/state/state_test.go
@@ -102,11 +102,14 @@ func (s *StateSuite) TestNull(c *checker.C) {
 	s.state.CreateSmartContractAccount(address, params.CodeFormatEVM, params.Rules{IsIstanbul: true})
 	//value := common.FromHex("0x823140710bf13990e4500136726d8b55")
 	var value common.Hash
+
 	s.state.SetState(address, common.Hash{}, value)
 	s.state.Commit(false)
-	value = s.state.GetState(address, common.Hash{})
-	if value != (common.Hash{}) {
-		c.Errorf("expected empty hash. got %x", value)
+	if value := s.state.GetState(address, common.Hash{}); value != (common.Hash{}) {
+		c.Errorf("expected empty current value, got %x", value)
+	}
+	if value := s.state.GetCommittedState(address, common.Hash{}); value != (common.Hash{}) {
+		c.Errorf("expected empty committed value, got %x", value)
 	}
 }
 
@@ -118,21 +121,24 @@ func (s *StateSuite) TestSnapshot(c *checker.C) {
 	data1 := common.BytesToHash([]byte{42})
 	data2 := common.BytesToHash([]byte{43})
 
+	// snapshot the genesis state
+	genesis := s.state.Snapshot()
+
 	// set initial state object value
 	s.state.SetState(stateobjaddr, storageaddr, data1)
-	// get snapshot of current state
 	snapshot := s.state.Snapshot()
 
-	// set new state object value
+	// set a new state object value, revert it and ensure correct content
 	s.state.SetState(stateobjaddr, storageaddr, data2)
-	// restore snapshot
 	s.state.RevertToSnapshot(snapshot)
 
-	// get state storage value
-	res := s.state.GetState(stateobjaddr, storageaddr)
+	c.Assert(s.state.GetState(stateobjaddr, storageaddr), checker.DeepEquals, data1)
+	c.Assert(s.state.GetCommittedState(stateobjaddr, storageaddr), checker.DeepEquals, common.Hash{})
 
-	// should be equal before/after restoring.
-	c.Assert(data1, checker.DeepEquals, res)
+	// revert up to the genesis state and ensure correct content
+	s.state.RevertToSnapshot(genesis)
+	c.Assert(s.state.GetState(stateobjaddr, storageaddr), checker.DeepEquals, common.Hash{})
+	c.Assert(s.state.GetCommittedState(stateobjaddr, storageaddr), checker.DeepEquals, common.Hash{})
 }
 
 // This test is to check reverting to the empty snapshot.
@@ -229,24 +235,31 @@ func compareStateObjects(so0, so1 *stateObject, t *testing.T) {
 		t.Fatalf("Code mismatch: have %v, want %v", so0.code, so1.code)
 	}
 
+	if len(so1.dirtyStorage) != len(so0.dirtyStorage) {
+		t.Errorf("Dirty storage size mismatch: have %d, want %d", len(so1.dirtyStorage), len(so0.dirtyStorage))
+	}
+	for k, v := range so1.dirtyStorage {
+		if so0.dirtyStorage[k] != v {
+			t.Errorf("Dirty storage key %x mismatch: have %v, want %v", k, so0.dirtyStorage[k], v)
+		}
+	}
+	for k, v := range so0.dirtyStorage {
+		if so1.dirtyStorage[k] != v {
+			t.Errorf("Dirty storage key %x mismatch: have %v, want none.", k, v)
+		}
+	}
+
 	if len(so1.cachedStorage) != len(so0.cachedStorage) {
-		t.Errorf("Storage size mismatch: have %d, want %d", len(so1.cachedStorage), len(so0.cachedStorage))
+		t.Errorf("Origin storage size mismatch: have %d, want %d", len(so1.cachedStorage), len(so0.cachedStorage))
 	}
 	for k, v := range so1.cachedStorage {
 		if so0.cachedStorage[k] != v {
-			t.Errorf("Storage key %x mismatch: have %v, want %v", k, so0.cachedStorage[k], v)
+			t.Errorf("Origin storage key %x mismatch: have %v, want %v", k, so0.cachedStorage[k], v)
 		}
 	}
 	for k, v := range so0.cachedStorage {
 		if so1.cachedStorage[k] != v {
-			t.Errorf("Storage key %x mismatch: have %v, want none.", k, v)
+			t.Errorf("Origin storage key %x mismatch: have %v, want none.", k, v)
 		}
-	}
-
-	if so0.suicided != so1.suicided {
-		t.Fatalf("suicided mismatch: have %v, want %v", so0.suicided, so1.suicided)
-	}
-	if so0.deleted != so1.deleted {
-		t.Fatalf("Deleted mismatch: have %v, want %v", so0.deleted, so1.deleted)
 	}
 }

--- a/blockchain/state/state_test.go
+++ b/blockchain/state/state_test.go
@@ -249,16 +249,16 @@ func compareStateObjects(so0, so1 *stateObject, t *testing.T) {
 		}
 	}
 
-	if len(so1.cachedStorage) != len(so0.cachedStorage) {
-		t.Errorf("Origin storage size mismatch: have %d, want %d", len(so1.cachedStorage), len(so0.cachedStorage))
+	if len(so1.originStorage) != len(so0.originStorage) {
+		t.Errorf("Origin storage size mismatch: have %d, want %d", len(so1.originStorage), len(so0.originStorage))
 	}
-	for k, v := range so1.cachedStorage {
-		if so0.cachedStorage[k] != v {
-			t.Errorf("Origin storage key %x mismatch: have %v, want %v", k, so0.cachedStorage[k], v)
+	for k, v := range so1.originStorage {
+		if so0.originStorage[k] != v {
+			t.Errorf("Origin storage key %x mismatch: have %v, want %v", k, so0.originStorage[k], v)
 		}
 	}
-	for k, v := range so0.cachedStorage {
-		if so1.cachedStorage[k] != v {
+	for k, v := range so0.originStorage {
+		if so1.originStorage[k] != v {
 			t.Errorf("Origin storage key %x mismatch: have %v, want none.", k, v)
 		}
 	}

--- a/blockchain/state/statedb_test.go
+++ b/blockchain/state/statedb_test.go
@@ -412,11 +412,11 @@ func (test *snapshotTest) checkEqual(state, checkstate *StateDB) error {
 		checkeq("GetCodeSize", state.GetCodeSize(addr), checkstate.GetCodeSize(addr))
 		// Check storage.
 		if obj := state.getStateObject(addr); obj != nil {
-			state.ForEachStorage(addr, func(key, val common.Hash) bool {
-				return checkeq("GetState("+key.Hex()+")", val, checkstate.GetState(addr, key))
+			state.ForEachStorage(addr, func(key, value common.Hash) bool {
+				return checkeq("GetState("+key.Hex()+")", checkstate.GetState(addr, key), value)
 			})
-			checkstate.ForEachStorage(addr, func(key, checkval common.Hash) bool {
-				return checkeq("GetState("+key.Hex()+")", state.GetState(addr, key), checkval)
+			checkstate.ForEachStorage(addr, func(key, value common.Hash) bool {
+				return checkeq("GetState("+key.Hex()+")", checkstate.GetState(addr, key), value)
 			})
 		}
 		if err != nil {


### PR DESCRIPTION
## Proposed changes

- This PR needs to be done because eip2200 (sstore gas cost change) item is implemented above this PR. 
- This PR is from [eip1283 implementation](https://github.com/ethereum/go-ethereum/commit/ee92bc537f159c2202058a33e015684cc2bca04c). There's two parts in here. One part is dirty/cached Storage refactoring, and the other part is eip1283(constantinople hf item). Importing eip1283 is unnecessary, so only refactoring part is referenced.
- Before going into the main idea, `dirtyStorage` stores the storage values that need to be flushed to disk. Item is added when functions such as `finalize` is called. `cachedStorage` stores the storage values which are read from db. It acts as a cache of db.
- Main Change: it utilizes dirtyStorage and cachedStorage(originStorage) more accurately. It would be utilized at eip2200.
  - GetState
    - dev: Check if the storage value you want to get is already in cachedStorage
    - PR: Check if the storage value you want to get is already in dirtyStorage. If not, then check cachedStorage(originStorage).
  - SetState
    - dev: append new item to the journal(storages to be flushed later) without condition.
    - PR: append new item to the journal only when new value and prev value(stored value) are different.
  - updateStorageTrie (flushing process)
    - dev: updates the items in journal without condition
    - PR: updates the item only when it is different from cachedStorage(originStorage). Also, if both are different, updating cachedStorage(originStorage) logic is updated.
- sync speed and finalize time at sync is slightly improved.

Cypress
  Head Block Num             |      Block Finalize Time
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/64360042/122843000-68378e00-d339-11eb-9563-e9e54146f6cd.png) | ![image](https://user-images.githubusercontent.com/64360042/122843013-6d94d880-d339-11eb-9d90-76769978d99f.png)

Baobab
  Head Block Num             |      Block Finalize Time
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/64360042/122842977-5c4bcc00-d339-11eb-8e50-83c054cb77d2.png) | ![image](https://user-images.githubusercontent.com/64360042/122842991-6241ad00-d339-11eb-9c8f-e78d09d4ba63.png)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
