### PR TITLE
Updated chaindatafetcher consumer logger

### DIFF
--- a/datasync/chaindatafetcher/kafka/consumer.go
+++ b/datasync/chaindatafetcher/kafka/consumer.go
@@ -21,15 +21,15 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/Shopify/sarama"
 )
 
 // Logger is the instance of a sarama.StdLogger interface that chaindatafetcher leaves the SDK level information.
-// By default it is set to discard all log messages via ioutil.Discard, but you can set it to redirect wherever you want.
-var Logger sarama.StdLogger = log.New(ioutil.Discard, "[Chaindatafetcher] ", log.LstdFlags)
+// By default it is set to print all log messages as standard output, but you can set it to redirect wherever you want.
+var Logger sarama.StdLogger = log.New(os.Stdout, "[Chaindatafetcher] ", log.LstdFlags)
 
 //go:generate mockgen -destination=./mocks/consumer_group_session_mock.go -package=mocks github.com/klaytn/klaytn/datasync/chaindatafetcher/kafka ConsumerGroupSession
 // ConsumerGroupSession is for mocking sarama.ConsumerGroupSession for better testing.

--- a/datasync/chaindatafetcher/kafka/consumer.go
+++ b/datasync/chaindatafetcher/kafka/consumer.go
@@ -106,7 +106,7 @@ func NewConsumer(config *KafkaConfig, groupId string) (*Consumer, error) {
 	if err != nil {
 		return nil, err
 	}
-	Logger.Printf("the chaindatafetcher consumer is created. [groupId: %s, config: %s]", groupId, config.String())
+	Logger.Printf("[INFO] the chaindatafetcher consumer is created. [groupId: %s, config: %s]", groupId, config.String())
 	return &Consumer{
 		config:   config,
 		group:    group,
@@ -117,7 +117,7 @@ func NewConsumer(config *KafkaConfig, groupId string) (*Consumer, error) {
 // Close stops the ConsumerGroup and detaches any running sessions. It is required to call
 // this function before the object passes out of scope, as it will otherwise leak memory.
 func (c *Consumer) Close() error {
-	Logger.Println("the chaindatafetcher consumer is closed")
+	Logger.Println("[INFO] the chaindatafetcher consumer is closed")
 	return c.group.Close()
 }
 
@@ -147,12 +147,12 @@ func (c *Consumer) Subscribe(ctx context.Context) error {
 
 	// Iterate over consumer sessions.
 	for {
-		Logger.Println("started to consume Kafka message")
+		Logger.Println("[INFO] started to consume Kafka message")
 		if err := c.group.Consume(ctx, c.topics, c); err == sarama.ErrClosedConsumerGroup {
-			Logger.Println("the consumer group is closed")
+			Logger.Println("[INFO] the consumer group is closed")
 			return nil
 		} else if err != nil {
-			Logger.Printf("the consumption is failed [err: %s]\n", err.Error())
+			Logger.Printf("[ERROR] the consumption is failed [err: %s]\n", err.Error())
 			return err
 		}
 		// TODO-Chaindatafetcher add retry logic and error callback here
@@ -189,13 +189,13 @@ func insertSegment(newSegment *Segment, buffer [][]*Segment) ([][]*Segment, erro
 		if numBuffered > 0 && bufferedSegments[0].key == newSegment.key {
 			// there is a missing segment which should not exist.
 			if newSegment.index > uint64(numBuffered) {
-				Logger.Printf("there may be a missing segment [numBuffered: %d, newSegment: %s]\n", numBuffered, newSegment.String())
+				Logger.Printf("[ERROR] there may be a missing segment [numBuffered: %d, newSegment: %s]\n", numBuffered, newSegment.String())
 				return buffer, errors.New(missingSegmentErrorMsg)
 			}
 
 			// the segment is already inserted to buffer.
 			if newSegment.index < uint64(numBuffered) {
-				Logger.Printf("the message is duplicated [newSegment: %s]\n", newSegment.String())
+				Logger.Printf("[WARN] the message is duplicated [newSegment: %s]\n", newSegment.String())
 				return buffer, nil
 			}
 
@@ -210,7 +210,7 @@ func insertSegment(newSegment *Segment, buffer [][]*Segment) ([][]*Segment, erro
 		buffer = append(buffer, []*Segment{newSegment})
 	} else {
 		// the segment may be already handled.
-		Logger.Printf("the message may be inserted already. drop the segment [segment: %s]\n", newSegment.String())
+		Logger.Printf("[WARN] the message may be inserted already. drop the segment [segment: %s]\n", newSegment.String())
 	}
 	return buffer, nil
 }
@@ -237,12 +237,12 @@ func (c *Consumer) handleBufferedMessages(buffer [][]*Segment) ([][]*Segment, er
 
 		f, ok := c.handlers[firstSegment.orig.Topic]
 		if !ok {
-			Logger.Printf("getting handler is failed with the given topic. [topic: %s]\n", msg.Topic)
+			Logger.Printf("[ERROR] getting handler is failed with the given topic. [topic: %s]\n", msg.Topic)
 			return buffer, fmt.Errorf("%v: %v", noHandlerErrorMsg, msg.Topic)
 		}
 
 		if err := f(msg); err != nil {
-			Logger.Printf("the handler is failed [key: %s]\n", string(msg.Key))
+			Logger.Printf("[ERROR] the handler is failed [key: %s]\n", string(msg.Key))
 			return buffer, err
 		}
 
@@ -258,7 +258,7 @@ func (c *Consumer) handleBufferedMessages(buffer [][]*Segment) ([][]*Segment, er
 func (c *Consumer) updateOffset(buffer [][]*Segment, lastMsg *sarama.ConsumerMessage, session ConsumerGroupSession) error {
 	if len(buffer) > 0 {
 		if len(buffer[0]) <= 0 {
-			Logger.Println("no segment exists in the given buffer slice")
+			Logger.Println("[ERROR] no segment exists in the given buffer slice")
 			return errors.New(emptySegmentErrorMsg)
 		}
 

--- a/datasync/chaindatafetcher/kafka/consumer.go
+++ b/datasync/chaindatafetcher/kafka/consumer.go
@@ -21,9 +21,15 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"log"
 
 	"github.com/Shopify/sarama"
 )
+
+// Logger is the instance of a sarama.StdLogger interface that chaindatafetcher leaves the SDK level information.
+// By default it is set to discard all log messages via ioutil.Discard, but you can set it to redirect wherever you want.
+var Logger sarama.StdLogger = log.New(ioutil.Discard, "[Chaindatafetcher] ", log.LstdFlags)
 
 //go:generate mockgen -destination=./mocks/consumer_group_session_mock.go -package=mocks github.com/klaytn/klaytn/datasync/chaindatafetcher/kafka ConsumerGroupSession
 // ConsumerGroupSession is for mocking sarama.ConsumerGroupSession for better testing.
@@ -100,6 +106,7 @@ func NewConsumer(config *KafkaConfig, groupId string) (*Consumer, error) {
 	if err != nil {
 		return nil, err
 	}
+	Logger.Printf("the chaindatafetcher consumer is created. [groupId: %s, config: %s]", groupId, config.String())
 	return &Consumer{
 		config:   config,
 		group:    group,
@@ -110,6 +117,7 @@ func NewConsumer(config *KafkaConfig, groupId string) (*Consumer, error) {
 // Close stops the ConsumerGroup and detaches any running sessions. It is required to call
 // this function before the object passes out of scope, as it will otherwise leak memory.
 func (c *Consumer) Close() error {
+	Logger.Println("the chaindatafetcher consumer is closed")
 	return c.group.Close()
 }
 
@@ -125,9 +133,9 @@ func (c *Consumer) AddTopicAndHandler(event string, handler TopicHandler) error 
 }
 
 func (c *Consumer) Errors() <-chan error {
-	// c.config.SaramaConfig.Consumer.Return.Errors has to be set to true, and
-	// read the errors from c.member.Errors() channel.
-	// Currently, it leaves only error logs as default.
+	// If c.config.SaramaConfig.Consumer.Return.Errors is set to true, then
+	// the errors while consuming the messages can be read from c.group.Errors() channel.
+	// Otherwise, it leaves only error logs using sarama.Logger as default.
 	return c.group.Errors()
 }
 
@@ -139,11 +147,15 @@ func (c *Consumer) Subscribe(ctx context.Context) error {
 
 	// Iterate over consumer sessions.
 	for {
+		Logger.Println("started to consume Kafka message")
 		if err := c.group.Consume(ctx, c.topics, c); err == sarama.ErrClosedConsumerGroup {
+			Logger.Println("the consumer group is closed")
 			return nil
 		} else if err != nil {
+			Logger.Printf("the consumption is failed [err: %s]\n", err.Error())
 			return err
 		}
+		// TODO-Chaindatafetcher add retry logic and error callback here
 	}
 }
 
@@ -177,13 +189,13 @@ func insertSegment(newSegment *Segment, buffer [][]*Segment) ([][]*Segment, erro
 		if numBuffered > 0 && bufferedSegments[0].key == newSegment.key {
 			// there is a missing segment which should not exist.
 			if newSegment.index > uint64(numBuffered) {
-				logger.Error("there may be a missing segment", "numBuffered", numBuffered, "newSegment", newSegment)
+				Logger.Printf("there may be a missing segment [numBuffered: %d, newSegment: %s]\n", numBuffered, newSegment.String())
 				return buffer, errors.New(missingSegmentErrorMsg)
 			}
 
 			// the segment is already inserted to buffer.
 			if newSegment.index < uint64(numBuffered) {
-				logger.Warn("the message is duplicated", "newSegment", newSegment)
+				Logger.Printf("the message is duplicated [newSegment: %s]\n", newSegment.String())
 				return buffer, nil
 			}
 
@@ -198,7 +210,7 @@ func insertSegment(newSegment *Segment, buffer [][]*Segment) ([][]*Segment, erro
 		buffer = append(buffer, []*Segment{newSegment})
 	} else {
 		// the segment may be already handled.
-		logger.Warn("the message may be inserted already. drop the segment", "segment", newSegment)
+		Logger.Printf("the message may be inserted already. drop the segment [segment: %s]\n", newSegment.String())
 	}
 	return buffer, nil
 }
@@ -225,10 +237,12 @@ func (c *Consumer) handleBufferedMessages(buffer [][]*Segment) ([][]*Segment, er
 
 		f, ok := c.handlers[firstSegment.orig.Topic]
 		if !ok {
+			Logger.Printf("getting handler is failed with the given topic. [topic: %s]\n", msg.Topic)
 			return buffer, fmt.Errorf("%v: %v", noHandlerErrorMsg, msg.Topic)
 		}
 
 		if err := f(msg); err != nil {
+			Logger.Printf("the handler is failed [key: %s]\n", string(msg.Key))
 			return buffer, err
 		}
 
@@ -244,6 +258,7 @@ func (c *Consumer) handleBufferedMessages(buffer [][]*Segment) ([][]*Segment, er
 func (c *Consumer) updateOffset(buffer [][]*Segment, lastMsg *sarama.ConsumerMessage, session ConsumerGroupSession) error {
 	if len(buffer) > 0 {
 		if len(buffer[0]) <= 0 {
+			Logger.Println("no segment exists in the given buffer slice")
 			return errors.New(emptySegmentErrorMsg)
 		}
 


### PR DESCRIPTION
## Proposed changes

The problem was that the logs do not remain in the client side. The standard logger is added to global variable so that the user may be able to inject the costumized logger. The `Logger` is the same type as `sarama.Logger` for consistency.

The following logs are the examples printed to standard output.
```
[Chaindatafetcher] 2021/06/28 16:31:56 [INFO] the chaindatafetcher consumer is created. [groupId: test-group-id2, config: brokers: [kafka:9094], topicEnvironment: local, topicResourceName: en-0, partitions: 1, replicas: 1, maxMessageBytes: 1000000, requiredAcks: 1, segmentSize: 1000000, msgVersion: 1.0, producerId: producer-766423d73557c0ff]
[Chaindatafetcher] 2021/06/28 16:31:56 [INFO] started to consume Kafka message
```

```
[Chaindatafetcher] 2021/06/28 16:45:36 [INFO] started to consume Kafka message
[Chaindatafetcher] 2021/06/28 16:45:37 [ERROR] kafka: error while consuming local.klaytn.chaindatafetcher.en-0.blockgroup.v1/0: the number of header is not expected [header length: 4]
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
