### PR TITLE
fork: re-introduce fork package

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2411,7 +2411,7 @@ func (bc *BlockChain) ApplyTransaction(chainConfig *params.ChainConfig, author *
 		return nil, 0, nil, err
 	}
 
-	msg, err := tx.AsMessageWithAccountKeyPicker(types.MakeSigner(chainConfig, header.Number), statedb, blockNumber, chainConfig.Rules(header.Number))
+	msg, err := tx.AsMessageWithAccountKeyPicker(types.MakeSigner(chainConfig, header.Number), statedb, blockNumber)
 	if err != nil {
 		return nil, 0, nil, err
 	}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -33,8 +33,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	klaytnmetrics "github.com/klaytn/klaytn/metrics"
-
 	"github.com/go-redis/redis/v7"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/klaytn/klaytn/blockchain/state"
@@ -47,7 +45,9 @@ import (
 	"github.com/klaytn/klaytn/consensus"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/event"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/log"
+	klaytnmetrics "github.com/klaytn/klaytn/metrics"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 	"github.com/klaytn/klaytn/storage/database"
@@ -250,6 +250,13 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 		parallelDBWrite:    db.IsParallelDBWrite(),
 		stopStateMigration: make(chan struct{}),
 		prefetchTxCh:       make(chan prefetchTx, MaxPrefetchTxs),
+	}
+
+	// set hardForkBlockNumberConfig which will be used as a global variable
+	if err := fork.SetHardForkBlockNumberConfig(&params.ChainConfig{
+		IstanbulCompatibleBlock: bc.chainConfig.IstanbulCompatibleBlock,
+	}); err != nil {
+		return nil, err
 	}
 
 	bc.validator = NewBlockValidator(chainConfig, bc, engine)

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -253,9 +253,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 	}
 
 	// set hardForkBlockNumberConfig which will be used as a global variable
-	if err := fork.SetHardForkBlockNumberConfig(&params.ChainConfig{
-		IstanbulCompatibleBlock: bc.chainConfig.IstanbulCompatibleBlock,
-	}); err != nil {
+	if err := fork.SetHardForkBlockNumberConfig(bc.chainConfig); err != nil {
 		return nil, err
 	}
 

--- a/blockchain/state_prefetcher.go
+++ b/blockchain/state_prefetcher.go
@@ -97,7 +97,7 @@ func (p *statePrefetcher) PrefetchTx(block *types.Block, ti int, stateDB *state.
 // the transaction successfully, rather to warm up touched data slots.
 func precacheTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, statedb *state.StateDB, header *types.Header, tx *types.Transaction, cfg vm.Config) error {
 	// Convert the transaction into an executable message and pre-cache its sender
-	msg, err := tx.AsMessageWithAccountKeyPicker(types.MakeSigner(config, header.Number), statedb, header.Number.Uint64(), config.Rules(header.Number))
+	msg, err := tx.AsMessageWithAccountKeyPicker(types.MakeSigner(config, header.Number), statedb, header.Number.Uint64())
 	if err != nil {
 		return err
 	}

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -28,7 +28,6 @@ import (
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/kerrors"
-	"github.com/klaytn/klaytn/params"
 )
 
 var (
@@ -102,7 +101,7 @@ type Message interface {
 
 	// IntrinsicGas returns `intrinsic gas` based on the tx type.
 	// This value is used to differentiate tx fee based on the tx type.
-	IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error)
+	IntrinsicGas(currentBlockNumber uint64) (uint64, error)
 
 	// Type returns the transaction type of the message.
 	Type() types.TxType

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -693,7 +693,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 		}
 	}
 
-	intrGas, err := tx.IntrinsicGas(pool.currentBlockNumber, pool.chainconfig.Rules(new(big.Int).SetUint64(pool.currentBlockNumber)))
+	intrGas, err := tx.IntrinsicGas(pool.currentBlockNumber)
 	intrGas += gasFrom + gasFeePayer
 	if err != nil {
 		return err

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -34,7 +34,6 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/kerrors"
-	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 )
 
@@ -234,8 +233,8 @@ func (tx *Transaction) ValidatedIntrinsicGas() uint64         { return tx.valida
 func (tx *Transaction) MakeRPCOutput() map[string]interface{} { return tx.data.MakeRPCOutput() }
 func (tx *Transaction) GetTxInternalData() TxInternalData     { return tx.data }
 
-func (tx *Transaction) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
-	return tx.data.IntrinsicGas(currentBlockNumber, r)
+func (tx *Transaction) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
+	return tx.data.IntrinsicGas(currentBlockNumber)
 }
 
 func (tx *Transaction) Validate(db StateDB, blockNumber uint64) error {
@@ -408,8 +407,8 @@ func (tx *Transaction) Execute(vm VM, stateDB StateDB, currentBlockNumber uint64
 //
 // XXX Rename message to something less arbitrary?
 // TODO-Klaytn: Message is removed and this function will return *Transaction.
-func (tx *Transaction) AsMessageWithAccountKeyPicker(s Signer, picker AccountKeyPicker, currentBlockNumber uint64, r params.Rules) (*Transaction, error) {
-	intrinsicGas, err := tx.IntrinsicGas(currentBlockNumber, r)
+func (tx *Transaction) AsMessageWithAccountKeyPicker(s Signer, picker AccountKeyPicker, currentBlockNumber uint64) (*Transaction, error) {
+	intrinsicGas, err := tx.IntrinsicGas(currentBlockNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -262,7 +262,7 @@ type TxInternalData interface {
 	Equal(t TxInternalData) bool
 
 	// IntrinsicGas computes additional 'intrinsic gas' based on tx types.
-	IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error)
+	IntrinsicGas(currentBlockNumber uint64) (uint64, error)
 
 	// SerializeForSign returns a slice containing attributes to make its tx signature.
 	SerializeForSign() []interface{}

--- a/blockchain/types/tx_internal_data_account_creation.go
+++ b/blockchain/types/tx_internal_data_account_creation.go
@@ -362,7 +362,7 @@ func (t *TxInternalDataAccountCreation) SetSignature(s TxSignatures) {
 	t.TxSignatures = s
 }
 
-func (t *TxInternalDataAccountCreation) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataAccountCreation) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gasKey, err := t.Key.AccountCreationGas(currentBlockNumber)
 	if err != nil {
 		return 0, err

--- a/blockchain/types/tx_internal_data_account_update.go
+++ b/blockchain/types/tx_internal_data_account_update.go
@@ -303,7 +303,7 @@ func (t *TxInternalDataAccountUpdate) SetSignature(s TxSignatures) {
 	t.TxSignatures = s
 }
 
-func (t *TxInternalDataAccountUpdate) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataAccountUpdate) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gasKey, err := t.Key.AccountCreationGas(currentBlockNumber)
 	if err != nil {
 		return 0, err

--- a/blockchain/types/tx_internal_data_cancel.go
+++ b/blockchain/types/tx_internal_data_cancel.go
@@ -189,7 +189,7 @@ func (t *TxInternalDataCancel) SetSignature(s TxSignatures) {
 	t.TxSignatures = s
 }
 
-func (t *TxInternalDataCancel) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataCancel) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	return params.TxGasCancel, nil
 }
 

--- a/blockchain/types/tx_internal_data_chain_data_anchoring.go
+++ b/blockchain/types/tx_internal_data_chain_data_anchoring.go
@@ -257,7 +257,7 @@ func (t *TxInternalDataChainDataAnchoring) SetSignature(s TxSignatures) {
 	t.TxSignatures = s
 }
 
-func (t *TxInternalDataChainDataAnchoring) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataChainDataAnchoring) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxChainDataAnchoringGas
 
 	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)

--- a/blockchain/types/tx_internal_data_fee_delegated_account_update.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_account_update.go
@@ -349,7 +349,7 @@ func (t *TxInternalDataFeeDelegatedAccountUpdate) RecoverFeePayerPubkey(txhash c
 	return t.FeePayerSignatures.RecoverPubkey(txhash, homestead, vfunc)
 }
 
-func (t *TxInternalDataFeeDelegatedAccountUpdate) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedAccountUpdate) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gasKey, err := t.Key.AccountCreationGas(currentBlockNumber)
 	if err != nil {
 		return 0, err

--- a/blockchain/types/tx_internal_data_fee_delegated_account_update_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_account_update_with_ratio.go
@@ -374,7 +374,7 @@ func (t *TxInternalDataFeeDelegatedAccountUpdateWithRatio) RecoverFeePayerPubkey
 	return t.FeePayerSignatures.RecoverPubkey(txhash, homestead, vfunc)
 }
 
-func (t *TxInternalDataFeeDelegatedAccountUpdateWithRatio) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedAccountUpdateWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gasKey, err := t.Key.AccountCreationGas(currentBlockNumber)
 	if err != nil {
 		return 0, err

--- a/blockchain/types/tx_internal_data_fee_delegated_cancel.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_cancel.go
@@ -224,7 +224,7 @@ func (t *TxInternalDataFeeDelegatedCancel) SetSignature(s TxSignatures) {
 	t.TxSignatures = s
 }
 
-func (t *TxInternalDataFeeDelegatedCancel) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedCancel) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	return params.TxGasCancel + params.TxGasFeeDelegated, nil
 }
 

--- a/blockchain/types/tx_internal_data_fee_delegated_cancel_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_cancel_with_ratio.go
@@ -244,7 +244,7 @@ func (t *TxInternalDataFeeDelegatedCancelWithRatio) SetSignature(s TxSignatures)
 	t.TxSignatures = s
 }
 
-func (t *TxInternalDataFeeDelegatedCancelWithRatio) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedCancelWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	return params.TxGasCancel + params.TxGasFeeDelegatedWithRatio, nil
 }
 

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
@@ -291,7 +291,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoring) RecoverFeePayerPubkey(txh
 	return t.FeePayerSignatures.RecoverPubkey(txhash, homestead, vfunc)
 }
 
-func (t *TxInternalDataFeeDelegatedChainDataAnchoring) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedChainDataAnchoring) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxChainDataAnchoringGas + params.TxGasFeeDelegated
 
 	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
@@ -316,7 +316,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) RecoverFeePayerP
 	return t.FeePayerSignatures.RecoverPubkey(txhash, homestead, vfunc)
 }
 
-func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxChainDataAnchoringGas + params.TxGasFeeDelegatedWithRatio
 
 	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
@@ -301,7 +301,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeploy) String() string {
 
 }
 
-func (t *TxInternalDataFeeDelegatedSmartContractDeploy) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedSmartContractDeploy) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractCreation + params.TxGasFeeDelegated
 
 	if t.HumanReadable {

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
@@ -321,7 +321,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeployWithRatio) String() string
 
 }
 
-func (t *TxInternalDataFeeDelegatedSmartContractDeployWithRatio) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedSmartContractDeployWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractCreation + params.TxGasFeeDelegatedWithRatio
 
 	if t.HumanReadable {

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution.go
@@ -270,7 +270,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractExecution) String() string {
 		enc)
 }
 
-func (t *TxInternalDataFeeDelegatedSmartContractExecution) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedSmartContractExecution) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractExecution + params.TxGasFeeDelegated
 
 	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution_with_ratio.go
@@ -290,7 +290,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractExecutionWithRatio) String() str
 		enc)
 }
 
-func (t *TxInternalDataFeeDelegatedSmartContractExecutionWithRatio) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedSmartContractExecutionWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractExecution + params.TxGasFeeDelegatedWithRatio
 
 	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer.go
@@ -255,7 +255,7 @@ func (t *TxInternalDataFeeDelegatedValueTransfer) String() string {
 		enc)
 }
 
-func (t *TxInternalDataFeeDelegatedValueTransfer) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedValueTransfer) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	return params.TxGasValueTransfer + params.TxGasFeeDelegated, nil
 }
 

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo.go
@@ -271,7 +271,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferMemo) RecoverFeePayerPubkey(txha
 	return t.FeePayerSignatures.RecoverPubkey(txhash, homestead, vfunc)
 }
 
-func (t *TxInternalDataFeeDelegatedValueTransferMemo) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedValueTransferMemo) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasValueTransfer + params.TxGasFeeDelegated
 	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
 	if err != nil {

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo_with_ratio.go
@@ -291,7 +291,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferMemoWithRatio) RecoverFeePayerPu
 	return t.FeePayerSignatures.RecoverPubkey(txhash, homestead, vfunc)
 }
 
-func (t *TxInternalDataFeeDelegatedValueTransferMemoWithRatio) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedValueTransferMemoWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasValueTransfer + params.TxGasFeeDelegatedWithRatio
 	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
 	if err != nil {

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_with_ratio.go
@@ -273,7 +273,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferWithRatio) String() string {
 		enc)
 }
 
-func (t *TxInternalDataFeeDelegatedValueTransferWithRatio) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataFeeDelegatedValueTransferWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	return params.TxGasValueTransfer + params.TxGasFeeDelegatedWithRatio, nil
 }
 

--- a/blockchain/types/tx_internal_data_legacy.go
+++ b/blockchain/types/tx_internal_data_legacy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -232,8 +233,12 @@ func (t *TxInternalDataLegacy) RecoverPubkey(txhash common.Hash, homestead bool,
 	return []*ecdsa.PublicKey{pk}, nil
 }
 
-func (t *TxInternalDataLegacy) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
-	return IntrinsicGas(t.Payload, t.Recipient == nil, r)
+func (t *TxInternalDataLegacy) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
+	rules, err := fork.Rules(big.NewInt(int64(currentBlockNumber)))
+	if err != nil {
+		return 0, err
+	}
+	return IntrinsicGas(t.Payload, t.Recipient == nil, *rules)
 }
 
 func (t *TxInternalDataLegacy) SerializeForSign() []interface{} {

--- a/blockchain/types/tx_internal_data_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_smart_contract_deploy.go
@@ -266,7 +266,7 @@ func (t *TxInternalDataSmartContractDeploy) String() string {
 
 }
 
-func (t *TxInternalDataSmartContractDeploy) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataSmartContractDeploy) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractCreation
 
 	if t.HumanReadable {

--- a/blockchain/types/tx_internal_data_smart_contract_execution.go
+++ b/blockchain/types/tx_internal_data_smart_contract_execution.go
@@ -235,7 +235,7 @@ func (t *TxInternalDataSmartContractExecution) String() string {
 		enc)
 }
 
-func (t *TxInternalDataSmartContractExecution) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataSmartContractExecution) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractExecution
 
 	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)

--- a/blockchain/types/tx_internal_data_value_transfer.go
+++ b/blockchain/types/tx_internal_data_value_transfer.go
@@ -220,7 +220,7 @@ func (t *TxInternalDataValueTransfer) SetSignature(s TxSignatures) {
 	t.TxSignatures = s
 }
 
-func (t *TxInternalDataValueTransfer) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataValueTransfer) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	// TxInternalDataValueTransfer does not have payload, and it
 	// is not account creation. Hence, its intrinsic gas is determined by
 	// params.TxGas. Refer to types.IntrinsicGas().

--- a/blockchain/types/tx_internal_data_value_transfer_memo.go
+++ b/blockchain/types/tx_internal_data_value_transfer_memo.go
@@ -236,7 +236,7 @@ func (t *TxInternalDataValueTransferMemo) SetSignature(s TxSignatures) {
 	t.TxSignatures = s
 }
 
-func (t *TxInternalDataValueTransferMemo) IntrinsicGas(currentBlockNumber uint64, r params.Rules) (uint64, error) {
+func (t *TxInternalDataValueTransferMemo) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasValueTransfer
 	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
 	if err != nil {

--- a/fork/fork.go
+++ b/fork/fork.go
@@ -19,6 +19,7 @@ package fork
 import (
 	"errors"
 	"math/big"
+	"sync"
 
 	"github.com/klaytn/klaytn/params"
 )
@@ -26,6 +27,8 @@ import (
 var (
 	// hardForkBlockNumberConfig contains only hardFork block number
 	hardForkBlockNumberConfig *params.ChainConfig
+	// once limits the usage of `SetHardForkBlockNumberConfig`
+	once sync.Once
 )
 
 // Rules returns the hard fork information
@@ -44,6 +47,9 @@ func SetHardForkBlockNumberConfig(h *params.ChainConfig) error {
 	if h == nil {
 		return errors.New("hardForkBlockNumberConfig cannot be initialized as nil")
 	}
-	hardForkBlockNumberConfig = h
+	// ensure that this statement is executed only once
+	once.Do(func() {
+		hardForkBlockNumberConfig = h
+	})
 	return nil
 }

--- a/fork/fork.go
+++ b/fork/fork.go
@@ -29,6 +29,7 @@ var (
 )
 
 // Rules returns the hard fork information
+// CAUTIOUS: Use it when chainConfig value is not reachable
 func Rules(blockNumber *big.Int) (*params.Rules, error) {
 	if hardForkBlockNumberConfig == nil {
 		return nil, errors.New("hardForkBlockNumberConfig variable is not initialized")
@@ -38,7 +39,7 @@ func Rules(blockNumber *big.Int) (*params.Rules, error) {
 }
 
 // SetHardForkBlockNumberConfig sets values in HardForkConfig if it is not nil.
-// CAUTIOUS: Calling this function is can be dangerous, so please avoid using it except tests
+// CAUTIOUS: Calling this function is can be dangerous, so avoid using it except tests
 func SetHardForkBlockNumberConfig(h *params.ChainConfig) error {
 	if h == nil {
 		return errors.New("hardForkBlockNumberConfig cannot be initialized as nil")

--- a/fork/fork.go
+++ b/fork/fork.go
@@ -16,20 +16,33 @@
 
 package fork
 
-var (
-	// hardForkConfig will not be changed unless it is a test code.
-	// The test code can override this value via `UpdateHardForkConfig`.
-	hardForkConfig = &HardForkConfig{}
+import (
+	"errors"
+	"math/big"
+
+	"github.com/klaytn/klaytn/params"
 )
 
-// HardForkConfig defines a block number for each hard fork feature.
-type HardForkConfig struct {
+var (
+	// hardForkBlockNumberConfig contains only hardFork block number
+	hardForkBlockNumberConfig *params.ChainConfig
+)
+
+// Rules returns the hard fork information
+func Rules(blockNumber *big.Int) (*params.Rules, error) {
+	if hardForkBlockNumberConfig == nil {
+		return nil, errors.New("hardForkBlockNumberConfig variable is not initialized")
+	}
+	rules := hardForkBlockNumberConfig.Rules(blockNumber)
+	return &rules, nil
 }
 
-// UpdateHardForkConfig sets values in HardForkConfig if it is not nil.
-// NOTE: this is only for test code to give flexibility of the test code.
-func UpdateHardForkConfig(h *HardForkConfig) {
-	if h != nil {
-		hardForkConfig = h
+// SetHardForkBlockNumberConfig sets values in HardForkConfig if it is not nil.
+// CAUTIOUS: Calling this function is can be dangerous, so please avoid using it except tests
+func SetHardForkBlockNumberConfig(h *params.ChainConfig) error {
+	if h == nil {
+		return errors.New("hardForkBlockNumberConfig cannot be initialized as nil")
 	}
+	hardForkBlockNumberConfig = h
+	return nil
 }

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -215,7 +215,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
-					msg, err := tx.AsMessageWithAccountKeyPicker(signer, task.statedb, task.block.NumberU64(), api.config.Rules(task.block.Number()))
+					msg, err := tx.AsMessageWithAccountKeyPicker(signer, task.statedb, task.block.NumberU64())
 					if err != nil {
 						logger.Warn("Tracing failed", "hash", tx.Hash(), "block", task.block.NumberU64(), "err", err)
 						task.results[i] = &txTraceResult{TxHash: tx.Hash(), Error: err.Error()}
@@ -501,7 +501,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
-				msg, err := txs[task.index].AsMessageWithAccountKeyPicker(signer, task.statedb, block.NumberU64(), api.config.Rules(block.Number()))
+				msg, err := txs[task.index].AsMessageWithAccountKeyPicker(signer, task.statedb, block.NumberU64())
 				if err != nil {
 					logger.Warn("Tracing failed", "tx idx", task.index, "block", block.NumberU64(), "err", err)
 					results[task.index] = &txTraceResult{TxHash: txs[task.index].Hash(), Error: err.Error()}
@@ -526,7 +526,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		jobs <- &txTraceTask{statedb: statedb.Copy(), index: i}
 
 		// Generate the next state snapshot fast without tracing
-		msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, block.NumberU64(), api.config.Rules(block.Number()))
+		msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, block.NumberU64())
 		if err != nil {
 			logger.Warn("Tracing failed", "hash", tx.Hash(), "block", block.NumberU64(), "err", err)
 			failed = err
@@ -602,7 +602,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 	)
 	for i, tx := range block.Transactions() {
 		// Prepare the transaction for un-traced execution
-		msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, block.NumberU64(), api.config.Rules(block.Number()))
+		msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, block.NumberU64())
 		if err != nil {
 			logger.Warn("Tracing failed", "hash", tx.Hash(), "block", block.NumberU64(), "err", err)
 			return nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
@@ -882,7 +882,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 
 	for idx, tx := range block.Transactions() {
 		// Assemble the transaction call message and return if the requested offset
-		msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, block.NumberU64(), api.config.Rules(block.Number()))
+		msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, block.NumberU64())
 		if err != nil {
 			logger.Warn("ComputeTxEnv failed", "hash", tx.Hash(), "block", block.NumberU64(), "err", err)
 			return nil, vm.Context{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -185,7 +185,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	}
 	evm := vm.NewEVM(context, statedb, params.CypressChainConfig, &vm.Config{Debug: true, Tracer: tracer})
 
-	msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64(), evm.ChainConfig().Rules(evm.BlockNumber))
+	msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
@@ -351,7 +351,7 @@ func TestCallTracer(t *testing.T) {
 			}
 			evm := vm.NewEVM(context, statedb, test.Genesis.Config, &vm.Config{Debug: true, Tracer: tracer})
 
-			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64(), evm.ChainConfig().Rules(evm.BlockNumber))
+			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
@@ -449,7 +449,7 @@ func TestInternalCallTracer(t *testing.T) {
 			tracer := vm.NewInternalTxTracer()
 			evm := vm.NewEVM(context, statedb, test.Genesis.Config, &vm.Config{Debug: true, Tracer: tracer})
 
-			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64(), evm.ChainConfig().Rules(evm.BlockNumber))
+			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/common/math"
 	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 	"github.com/klaytn/klaytn/storage/database"
@@ -185,6 +186,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	}
 	evm := vm.NewEVM(context, statedb, params.CypressChainConfig, &vm.Config{Debug: true, Tracer: tracer})
 
+	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
 	msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
@@ -351,6 +353,7 @@ func TestCallTracer(t *testing.T) {
 			}
 			evm := vm.NewEVM(context, statedb, test.Genesis.Config, &vm.Config{Debug: true, Tracer: tracer})
 
+			fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
 			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
@@ -449,6 +452,7 @@ func TestInternalCallTracer(t *testing.T) {
 			tracer := vm.NewInternalTxTracer()
 			evm := vm.NewEVM(context, statedb, test.Genesis.Config, &vm.Config{Debug: true, Tracer: tracer})
 
+			fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
 			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)

--- a/tests/apply_tx_test.go
+++ b/tests/apply_tx_test.go
@@ -320,7 +320,7 @@ func benchmarkTxPerformanceCompatible(b *testing.B, genTx genTx) {
 		reservoir.Nonce += 1
 
 		// execute this to cache ecrecover.
-		tx.AsMessageWithAccountKeyPicker(signer, state, header.Number.Uint64(), bcdata.bc.Config().Rules(header.Number))
+		tx.AsMessageWithAccountKeyPicker(signer, state, header.Number.Uint64())
 	}
 
 	if isProfileEnabled() {
@@ -448,7 +448,7 @@ func benchmarkTxPerformanceSmartContractExecution(b *testing.B, genTx genTx) {
 
 		reservoir.Nonce += 1
 
-		tx.AsMessageWithAccountKeyPicker(signer, state, header.Number.Uint64(), bcdata.bc.Config().Rules(header.Number))
+		tx.AsMessageWithAccountKeyPicker(signer, state, header.Number.Uint64())
 	}
 
 	if isProfileEnabled() {
@@ -568,7 +568,7 @@ func benchmarkTxPerformanceNew(b *testing.B, genTx genTx, sender *TestAccountTyp
 
 		sender.Nonce += 1
 
-		tx.AsMessageWithAccountKeyPicker(signer, state, header.Number.Uint64(), bcdata.bc.Config().Rules(header.Number))
+		tx.AsMessageWithAccountKeyPicker(signer, state, header.Number.Uint64())
 	}
 
 	if isProfileEnabled() {

--- a/tests/klay_test_account_map_test.go
+++ b/tests/klay_test_account_map_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/contracts/reward/contract"
 	"github.com/klaytn/klaytn/crypto"
-	"github.com/klaytn/klaytn/params"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -106,7 +105,7 @@ func (a *AccountMap) Initialize(bcdata *BCData) error {
 	return nil
 }
 
-func (a *AccountMap) Update(txs types.Transactions, signer types.Signer, picker types.AccountKeyPicker, currentBlockNumber uint64, r params.Rules) error {
+func (a *AccountMap) Update(txs types.Transactions, signer types.Signer, picker types.AccountKeyPicker, currentBlockNumber uint64) error {
 	for _, tx := range txs {
 		to := tx.To()
 		v := tx.Value()
@@ -137,7 +136,7 @@ func (a *AccountMap) Update(txs types.Transactions, signer types.Signer, picker 
 
 		// TODO-Klaytn: This gas fee calculation is correct only if the transaction is a value transfer transaction.
 		// Calculate the correct transaction fee by checking the corresponding receipt.
-		intrinsicGas, err := tx.IntrinsicGas(currentBlockNumber, r)
+		intrinsicGas, err := tx.IntrinsicGas(currentBlockNumber)
 		if err != nil {
 			return err
 		}

--- a/tests/klay_test_blockchain_test.go
+++ b/tests/klay_test_blockchain_test.go
@@ -294,7 +294,7 @@ func (bcdata *BCData) GenABlockWithTxpool(accountMap *AccountMap, txpool *blockc
 
 	// Update accountMap
 	start = time.Now()
-	if err := accountMap.Update(newtxs, signer, statedb, b.NumberU64(), bcdata.bc.Config().Rules(b.Number())); err != nil {
+	if err := accountMap.Update(newtxs, signer, statedb, b.NumberU64()); err != nil {
 		return err
 	}
 	prof.Profile("main_update_accountMap", time.Now().Sub(start))
@@ -339,8 +339,7 @@ func (bcdata *BCData) GenABlockWithTransactions(accountMap *AccountMap, transact
 
 	// Update accountMap
 	start := time.Now()
-	currentBlockNumber, rules := bcdata.bc.CurrentBlock().NumberU64(), bcdata.bc.Config().Rules(bcdata.bc.CurrentBlock().Number())
-	if err := accountMap.Update(transactions, signer, statedb, currentBlockNumber, rules); err != nil {
+	if err := accountMap.Update(transactions, signer, statedb, bcdata.bc.CurrentBlock().NumberU64()); err != nil {
 		return err
 	}
 	prof.Profile("main_update_accountMap", time.Now().Sub(start))

--- a/tests/pregenerated_data_execution_test.go
+++ b/tests/pregenerated_data_execution_test.go
@@ -181,16 +181,18 @@ func dataExecutionTest(b *testing.B, tc *preGeneratedTC) {
 		b.Fatal(err)
 	}
 
-	currentBlockNumber, rules := bcData.bc.CurrentBlock().NumberU64(), bcData.bc.Config().Rules(bcData.bc.CurrentBlock().Number())
-
 	fmt.Println("Call AsMessageWithAccountKeyPicker for warmUpTxs")
 	for _, tx := range warmUpTxs {
-		tx.AsMessageWithAccountKeyPicker(signer, stateDB, currentBlockNumber, rules)
+		if _, err = tx.AsMessageWithAccountKeyPicker(signer, stateDB, bcData.bc.CurrentBlock().NumberU64()); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	fmt.Println("Call AsMessageWithAccountKeyPicker for executionTxs")
 	for _, tx := range executionTxs {
-		tx.AsMessageWithAccountKeyPicker(signer, stateDB, currentBlockNumber, rules)
+		if _, err = tx.AsMessageWithAccountKeyPicker(signer, stateDB, bcData.bc.CurrentBlock().NumberU64()); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	txPool := makeTxPool(bcData, txPoolSize)

--- a/tests/pregenerated_data_generation_test.go
+++ b/tests/pregenerated_data_generation_test.go
@@ -296,7 +296,7 @@ func dataGenerationTest(b *testing.B, tc *preGeneratedTC) {
 		}
 
 		for _, tx := range txs {
-			tx.AsMessageWithAccountKeyPicker(signer, stateDB, bcData.bc.CurrentBlock().NumberU64(), bcData.bc.Config().Rules(bcData.bc.CurrentBlock().Number()))
+			tx.AsMessageWithAccountKeyPicker(signer, stateDB, bcData.bc.CurrentBlock().NumberU64())
 		}
 
 		b.StartTimer()

--- a/tests/smartcontract_execution_test.go
+++ b/tests/smartcontract_execution_test.go
@@ -100,7 +100,7 @@ func callContract(bcdata *BCData, tx *types.Transaction) ([]byte, error) {
 	}
 
 	signer := types.MakeSigner(bcdata.bc.Config(), header.Number)
-	msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, bcdata.bc.CurrentBlock().NumberU64(), bcdata.bc.Config().Rules(header.Number))
+	msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, bcdata.bc.CurrentBlock().NumberU64())
 	if err != nil {
 		return nil, err
 	}
@@ -406,9 +406,10 @@ func executeSmartContractForStorageTrie(b *testing.B, opt *ContractExecutionOpti
 			fmt.Printf("run %v tx generated \n", run)
 
 			state, _ := bcdata.bc.State()
-			currentBlockNumber, rules := bcdata.bc.CurrentBlock().NumberU64(), bcdata.bc.Config().Rules(bcdata.bc.CurrentBlock().Number())
 			for _, tx := range transactions {
-				tx.AsMessageWithAccountKeyPicker(signer, state, currentBlockNumber, rules)
+				if _, err := tx.AsMessageWithAccountKeyPicker(signer, state, bcdata.bc.CurrentBlock().NumberU64()); err != nil {
+					b.Fatal(err)
+				}
 			}
 			fmt.Printf("run %v tx validated \n", run)
 


### PR DESCRIPTION
## Proposed changes

- It is difficult to get hard fork block number at `chainConfig` from some code(ex. `types.Transaction`). For that reason, use fork package's global variable, `hardForkBlockNumberConfig` when chainConfig is not reachable.
- commits
  - https://github.com/klaytn/klaytn/commit/05a27057f6c668b25e39eee9eff88bb100123396: re-introduce fork package
  - https://github.com/klaytn/klaytn/commit/8af459a8aead22870b077526338e3f3903330016: this commit resets some of codes in #981 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
