### PR TITLE
Implemented error callback and expiration of message

### DIFF
--- a/datasync/chaindatafetcher/kafka/config.go
+++ b/datasync/chaindatafetcher/kafka/config.go
@@ -18,6 +18,7 @@ package kafka
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/klaytn/klaytn/common"
@@ -46,6 +47,12 @@ const (
 	DefaultMaxMessageNumber     = 100     // max number of messages in buffer
 	DefaultKafkaMessageVersion  = MsgVersion1_0
 	DefaultProducerIdPrefix     = "producer-"
+	DefaultExpirationTime       = time.Duration(0)
+)
+
+var (
+	DefaultSetup   = func(s sarama.ConsumerGroupSession) error { return nil }
+	DefaultCleanup = func(s sarama.ConsumerGroupSession) error { return nil }
 )
 
 type KafkaConfig struct {
@@ -61,6 +68,11 @@ type KafkaConfig struct {
 	// (number of partitions) * (average size of segments) * buffer size should not be greater than memory size.
 	// default max number of messages is 100
 	MaxMessageNumber int // MaxMessageNumber is the maximum number of consumer messages.
+
+	ExpirationTime time.Duration
+	ErrCallback    func(string) error
+	Setup          func(s sarama.ConsumerGroupSession) error
+	Cleanup        func(s sarama.ConsumerGroupSession) error
 }
 
 func GetDefaultKafkaConfig() *KafkaConfig {
@@ -82,6 +94,10 @@ func GetDefaultKafkaConfig() *KafkaConfig {
 		MaxMessageNumber:     DefaultMaxMessageNumber,
 		MsgVersion:           DefaultKafkaMessageVersion,
 		ProducerId:           GetDefaultProducerId(),
+		ExpirationTime:       DefaultExpirationTime,
+		Setup:                DefaultSetup,
+		Cleanup:              DefaultCleanup,
+		ErrCallback:          nil,
 	}
 }
 

--- a/datasync/chaindatafetcher/kafka/consumer.go
+++ b/datasync/chaindatafetcher/kafka/consumer.go
@@ -320,10 +320,9 @@ func (c *Consumer) renewExpireMsg(buffer [][]*Segment, timer *time.Timer, oldest
 
 	if oldestMsg != buffer[0][0].orig {
 		timer.Reset(c.config.ExpirationTime)
-		return buffer[0][0].orig
 	}
 
-	return oldestMsg
+	return buffer[0][0].orig
 }
 
 // ConsumeClaim must start a consumer loop of ConsumerGroupClaim's Messages().

--- a/datasync/chaindatafetcher/kafka/consumer_test.go
+++ b/datasync/chaindatafetcher/kafka/consumer_test.go
@@ -706,8 +706,8 @@ func TestConsumer_renewExpireMsg(t *testing.T) {
 			c := &Consumer{
 				config: tt.config,
 			}
-			if got := c.renewExpireMsg(tt.args.buffer, tt.args.timer, tt.args.oldestMsg); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("renewExpireMsg() = %v, want %v", got, tt.want)
+			if got := c.resetTimer(tt.args.buffer, tt.args.timer, tt.args.oldestMsg); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resetTimer() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/datasync/chaindatafetcher/kafka/consumer_test.go
+++ b/datasync/chaindatafetcher/kafka/consumer_test.go
@@ -18,7 +18,9 @@ package kafka
 
 import (
 	"bytes"
+	"errors"
 	"math/rand"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -554,5 +556,159 @@ func Test_V1Segment_MultiProducers(t *testing.T) {
 			buffer, err = consumer.handleBufferedMessages(buffer)
 			assert.NoError(t, err)
 		}
+	}
+}
+
+func TestConsumer_handleError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	testSegment := &Segment{
+		orig: &sarama.ConsumerMessage{
+			Topic:     "test-topic",
+			Partition: int32(1),
+			Offset:    int64(99),
+		},
+	}
+
+	testSegment2 := &Segment{
+		orig: &sarama.ConsumerMessage{
+			Topic:     "test-topic",
+			Partition: int32(1),
+			Offset:    int64(100),
+		},
+	}
+
+	session := mocks.NewMockConsumerGroupSession(ctrl)
+	parentErr := errors.New("parent error")
+	callbackErr := errors.New("callback error")
+
+	tests := []struct {
+		name      string
+		setup     func()
+		callback  func(s string) error
+		buffer    [][]*Segment
+		parentErr error
+		expected  error
+	}{
+		{
+			"no_item_in_buffer",
+			func() {},
+			func(s string) error { panic("should not be called") },
+			[][]*Segment{},
+			parentErr,
+			parentErr,
+		},
+		{
+			"no_callback",
+			func() {},
+			nil,
+			[][]*Segment{{testSegment}},
+			parentErr,
+			parentErr,
+		},
+		{
+			"callback_success_an_item_in_buffer",
+			func() { session.EXPECT().MarkMessage(gomock.Eq(testSegment.orig), gomock.Eq("")).Times(1) },
+			func(s string) error { return nil },
+			[][]*Segment{{testSegment}},
+			parentErr,
+			nil,
+		},
+		{
+			"callback_success_two_items_in_buffer",
+			func() {
+				session.EXPECT().MarkOffset(gomock.Eq(testSegment2.orig.Topic), gomock.Eq(testSegment2.orig.Partition), gomock.Eq(testSegment2.orig.Offset), gomock.Eq("")).Times(1)
+			},
+			func(s string) error { return nil },
+			[][]*Segment{{testSegment}, {testSegment2}},
+			parentErr,
+			nil,
+		},
+		{
+			"callback_failure",
+			func() {},
+			func(s string) error { return callbackErr },
+			[][]*Segment{{testSegment}, {testSegment2}},
+			parentErr,
+			callbackErr,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Consumer{}
+			c.config = GetDefaultKafkaConfig()
+			c.config.ErrCallback = tt.callback
+			tt.setup()
+			if err := c.handleError(tt.buffer, session, tt.parentErr); err != tt.expected {
+				t.Errorf("handleError() error = %v, wantErr %v", err, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConsumer_renewExpireMsg(t *testing.T) {
+	testTimer := time.NewTimer(1 * time.Second)
+	testTimer.Stop()
+
+	oldMsg := &sarama.ConsumerMessage{Key: []byte("old")}
+	newMsg := &sarama.ConsumerMessage{Key: []byte("new")}
+
+	type args struct {
+		buffer    [][]*Segment
+		timer     *time.Timer
+		oldestMsg *sarama.ConsumerMessage
+	}
+	tests := []struct {
+		name   string
+		config *KafkaConfig
+		args   args
+		want   *sarama.ConsumerMessage
+	}{
+		{
+			"no_expire_option",
+			&KafkaConfig{ExpirationTime: time.Duration(0)},
+			args{},
+			nil,
+		},
+		{
+			"all_handled",
+			&KafkaConfig{ExpirationTime: time.Duration(1)},
+			args{
+				[][]*Segment{},
+				testTimer,
+				oldMsg,
+			},
+			nil,
+		},
+		{
+			"oldest_handled",
+			&KafkaConfig{ExpirationTime: time.Duration(1)},
+			args{
+				[][]*Segment{{&Segment{orig: newMsg}}},
+				testTimer,
+				oldMsg,
+			},
+			newMsg,
+		},
+		{
+			"oldest_not_handled",
+			&KafkaConfig{ExpirationTime: time.Duration(1)},
+			args{
+				[][]*Segment{{&Segment{orig: oldMsg}}},
+				testTimer,
+				oldMsg,
+			},
+			oldMsg,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Consumer{
+				config: tt.config,
+			}
+			if got := c.renewExpireMsg(tt.args.buffer, tt.args.timer, tt.args.oldestMsg); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("renewExpireMsg() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Proposed changes

- Make `Setup` / `Cleanup` method for sarama library configurable
- Add `ExpirationTime` for a messsage to be expired if it is in buffer too long
- Add `ErrCallback` in order to handle error situation

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules


