### PR TITLE
blockchain: make chainConfig updatable by using hard-coded chainConfigs

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -255,7 +255,7 @@ func SetupGenesisBlock(db database.DBManager, genesis *Genesis, networkId uint64
 	// Special case: don't change the existing config of a non-mainnet chain if no new
 	// config is supplied. These chains would get AllProtocolChanges (and a compat error)
 	// if we just continued here.
-	if genesis == nil && isPrivate {
+	if genesis == nil && params.CypressGenesisHash != stored && params.BaobabGenesisHash != stored {
 		return storedcfg, stored, nil
 	}
 

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -255,7 +255,7 @@ func SetupGenesisBlock(db database.DBManager, genesis *Genesis, networkId uint64
 	// Special case: don't change the existing config of a non-mainnet chain if no new
 	// config is supplied. These chains would get AllProtocolChanges (and a compat error)
 	// if we just continued here.
-	if genesis == nil && stored != params.CypressGenesisHash {
+	if genesis == nil && isPrivate {
 		return storedcfg, stored, nil
 	}
 
@@ -277,6 +277,10 @@ func (g *Genesis) configOrDefault(ghash common.Hash) *params.ChainConfig {
 	switch {
 	case g != nil:
 		return g.Config
+	case ghash == params.CypressGenesisHash:
+		return params.CypressChainConfig
+	case ghash == params.BaobabGenesisHash:
+		return params.BaobabChainConfig
 	default:
 		return params.AllGxhashProtocolChanges
 	}

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -523,7 +523,7 @@ func TestVoteValueNilInterface(t *testing.T) {
 }
 
 func TestBaoBabGenesisHash(t *testing.T) {
-	baobabHash := common.HexToHash("0xe33ff05ceec2581ca9496f38a2bf9baad5d4eed629e896ccb33d1dc991bc4b4a")
+	baobabHash := params.BaobabGenesisHash
 	genesis := blockchain.DefaultBaobabGenesisBlock()
 	genesis.Governance = blockchain.SetGenesisGovernance(genesis)
 	blockchain.InitDeriveSha(genesis.Config.DeriveShaImpl)
@@ -536,7 +536,7 @@ func TestBaoBabGenesisHash(t *testing.T) {
 }
 
 func TestCypressGenesisHash(t *testing.T) {
-	cypressHash := common.HexToHash("0xc72e5293c3c3ba38ed8ae910f780e4caaa9fb95e79784f7ab74c3c262ea7137e")
+	cypressHash := params.CypressGenesisHash
 	genesis := blockchain.DefaultGenesisBlock()
 	genesis.Governance = blockchain.SetGenesisGovernance(genesis)
 	blockchain.InitDeriveSha(genesis.Config.DeriveShaImpl)

--- a/params/config.go
+++ b/params/config.go
@@ -30,8 +30,8 @@ import (
 
 // Genesis hashes to enforce below configs on.
 var (
-	CypressGenesisHash      = common.HexToHash("// todo generate new hash for cypress") // cypress genesis hash to enforce below configs on
-	BaobabGenesisHash       = common.HexToHash("// todo generate new hash for baobab")  // baobab genesis hash to enforce below configs on
+	CypressGenesisHash      = common.HexToHash("0xc72e5293c3c3ba38ed8ae910f780e4caaa9fb95e79784f7ab74c3c262ea7137e") // cypress genesis hash to enforce below configs on
+	BaobabGenesisHash       = common.HexToHash("0xe33ff05ceec2581ca9496f38a2bf9baad5d4eed629e896ccb33d1dc991bc4b4a") // baobab genesis hash to enforce below configs on
 	AuthorAddressForTesting = common.HexToAddress("0xc0ea08a2d404d3172d2add29a45be56da40e2949")
 	mintingAmount, _        = new(big.Int).SetString("9600000000000000000", 10)
 )


### PR DESCRIPTION
## Proposed changes

- When `init` or `start`, SetupGenesisBlock function is used to generate/store genesis block, and return the chainConfig to use it in the node. However, chainConfig is not updatable with hard-coded chainConfigs unlike ethereum does. However, chainConfig must be updatable if we want to update hard fork block numbers.
- There's several important variables. 
  - `genesis` is the structure which contains information of genesis block and config. When `start`, it is always nil (when `init`, it is always not nil`)
  - `storedCfg` is the chainConfig derived from stored chainConfig.
  - `newCfg` is the chainConfig newly generated in SetupGenesisBlock. If `genesis` is not nil, it is derived from `genesis`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
