### PR TITLE
Fixed governance votes application

### DIFF
--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -808,10 +808,10 @@ func checkInCommitteeBlocks(seq int64, round int64) bool {
 func newTestBackend() (b *backend) {
 	config := getTestConfig()
 	config.Istanbul.ProposerPolicy = params.WeightedRandom
-	return newTestBackendWithConfig(config, nil)
+	return newTestBackendWithConfig(config, istanbul.DefaultConfig.BlockPeriod, nil)
 }
 
-func newTestBackendWithConfig(chainConfig *params.ChainConfig, key *ecdsa.PrivateKey) (b *backend) {
+func newTestBackendWithConfig(chainConfig *params.ChainConfig, blockPeriod uint64, key *ecdsa.PrivateKey) (b *backend) {
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
 	if key == nil {
 		// if key is nil, generate new key for a test account
@@ -823,11 +823,13 @@ func newTestBackendWithConfig(chainConfig *params.ChainConfig, key *ecdsa.Privat
 	}
 	gov := governance.NewGovernanceInitialize(chainConfig, dbm)
 	istanbulConfig := istanbul.DefaultConfig
+	istanbulConfig.BlockPeriod = blockPeriod
 	istanbulConfig.ProposerPolicy = istanbul.ProposerPolicy(chainConfig.Istanbul.ProposerPolicy)
 	istanbulConfig.Epoch = chainConfig.Istanbul.Epoch
 	istanbulConfig.SubGroupSize = chainConfig.Istanbul.SubGroupSize
 
 	backend := New(getTestRewards()[0], istanbulConfig, key, dbm, gov, common.CONSENSUSNODE).(*backend)
+	gov.SetNodeAddress(crypto.PubkeyToAddress(key.PublicKey))
 	return backend
 }
 

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -840,22 +840,24 @@ func TestGovernance_Votes(t *testing.T) {
 	testcases := []testcase{
 		{
 			votes: []vote{
-				{"governance.governancemode", "none"},     // voted on 1 block
-				{"istanbul.committeesize", uint64(4)},     // voted on 2 block
-				{"governance.unitprice", uint64(2000000)}, // voted on 3 block
-				{"reward.mintingamount", "96000000000"},   // voted on 4 block
-				{"reward.ratio", "34/33/33"},              // voted on 5 block
-				{"reward.useginicoeff", true},             // voted on 6 block
-				{"reward.minimumstake", "5000000"},        // voted on 7 block
+				{"governance.governancemode", "none"},     // voted on block 1
+				{"istanbul.committeesize", uint64(4)},     // voted on block 2
+				{"governance.unitprice", uint64(2000000)}, // voted on block 3
+				{},                                      // voted on block 4
+				{"reward.mintingamount", "96000000000"}, // voted on block 5
+				{"reward.ratio", "34/33/33"},            // voted on block 6
+				{},                                      // voted on block 7
+				{"reward.useginicoeff", true},           // voted on block 8
+				{"reward.minimumstake", "5000000"},      // voted on block 9
 			},
 			expected: []governanceItem{
-				{vote{"governance.governancemode", "none"}, 4},
+				{vote{"governance.governancemode", "none"}, 6},
 				{vote{"istanbul.committeesize", uint64(4)}, 6},
-				{vote{"governance.unitprice", uint64(2000000)}, 6},
-				{vote{"reward.mintingamount", "96000000000"}, 8},
-				{vote{"reward.ratio", "34/33/33"}, 8},
-				{vote{"reward.useginicoeff", true}, 10},
-				{vote{"reward.minimumstake", "5000000"}, 10},
+				{vote{"governance.unitprice", uint64(2000000)}, 9},
+				{vote{"reward.mintingamount", "96000000000"}, 9},
+				{vote{"reward.ratio", "34/33/33"}, 12},
+				{vote{"reward.useginicoeff", true}, 12},
+				{vote{"reward.minimumstake", "5000000"}, 15},
 				// check governance items on current block
 				{vote{"governance.governancemode", "none"}, 0},
 				{vote{"istanbul.committeesize", uint64(4)}, 0},
@@ -868,46 +870,55 @@ func TestGovernance_Votes(t *testing.T) {
 		},
 		{
 			votes: []vote{
-				{"governance.governancemode", "none"},   // voted on 1 block
-				{"governance.governancemode", "single"}, // voted on 2 block
-				{"governance.governancemode", "none"},   // voted on 3 block
-				{"governance.governancemode", "single"}, // voted on 4 block
-				{"governance.governancemode", "none"},   // voted on 5 block
-				{"governance.governancemode", "single"}, // voted on 6 block
-				{"governance.governancemode", "none"},   // voted on 7 block
+				{"governance.governancemode", "none"},   // voted on block 1
+				{"governance.governancemode", "single"}, // voted on block 2
+				{"governance.governancemode", "none"},   // voted on block 3
+				{},                                      // voted on block 4
+				{"governance.governancemode", "single"}, // voted on block 5
+				{"governance.governancemode", "none"},   // voted on block 6
+				{},                                      // voted on block 7
+				{"governance.governancemode", "single"}, // voted on block 8
+				{"governance.governancemode", "none"},   // voted on block 9
 			},
 			expected: []governanceItem{
-				{vote{"governance.governancemode", "none"}, 4},
-				{vote{"governance.governancemode", "none"}, 6},
-				{vote{"governance.governancemode", "none"}, 8},
-				{vote{"governance.governancemode", "none"}, 10},
+				{vote{"governance.governancemode", "single"}, 6},
+				{vote{"governance.governancemode", "single"}, 9},
+				{vote{"governance.governancemode", "single"}, 12},
+				{vote{"governance.governancemode", "none"}, 15},
 				// check governance items on current block
 				{vote{"governance.governancemode", "none"}, 0},
 			},
 		},
 		{
 			votes: []vote{
-				{"governance.governancemode", "none"},     // voted on 1 block
-				{"istanbul.committeesize", uint64(4)},     // voted on 2 block
-				{"governance.unitprice", uint64(2000000)}, // voted on 3 block
-				{"governance.governancemode", "single"},   // voted on 5 block
-				{"istanbul.committeesize", uint64(22)},    // voted on 4 block
-				{"governance.unitprice", uint64(2)},       // voted on 6 block
-				{"governance.governancemode", "none"},     // voted on 7 block
+				{"governance.governancemode", "none"},     // voted on block 1
+				{"istanbul.committeesize", uint64(4)},     // voted on block 2
+				{"governance.unitprice", uint64(2000000)}, // voted on block 3
+				{},                                      // voted on block 4
+				{"governance.governancemode", "single"}, // voted on block 5
+				{"istanbul.committeesize", uint64(22)},  // voted on block 6
+				{},                                      // voted on block 7
+				{"governance.unitprice", uint64(2)},     // voted on block 8
+				{"governance.governancemode", "none"},   // voted on block 9
 			},
 			expected: []governanceItem{
 				// governance mode for all blocks
 				{vote{"governance.governancemode", "single"}, 1},
 				{vote{"governance.governancemode", "single"}, 2},
 				{vote{"governance.governancemode", "single"}, 3},
-				{vote{"governance.governancemode", "none"}, 4},
-				{vote{"governance.governancemode", "none"}, 5},
+				{vote{"governance.governancemode", "single"}, 4},
+				{vote{"governance.governancemode", "single"}, 5},
 				{vote{"governance.governancemode", "none"}, 6},
 				{vote{"governance.governancemode", "none"}, 7},
-				{vote{"governance.governancemode", "single"}, 8},
+				{vote{"governance.governancemode", "none"}, 8},
 				{vote{"governance.governancemode", "single"}, 9},
-				{vote{"governance.governancemode", "none"}, 10},
-				{vote{"governance.governancemode", "none"}, 11},
+				{vote{"governance.governancemode", "single"}, 10},
+				{vote{"governance.governancemode", "single"}, 11},
+				{vote{"governance.governancemode", "single"}, 12},
+				{vote{"governance.governancemode", "single"}, 13},
+				{vote{"governance.governancemode", "single"}, 14},
+				{vote{"governance.governancemode", "none"}, 15},
+				{vote{"governance.governancemode", "none"}, 16},
 
 				// committee size for all blocks
 				{vote{"istanbul.committeesize", uint64(21)}, 1},
@@ -917,10 +928,15 @@ func TestGovernance_Votes(t *testing.T) {
 				{vote{"istanbul.committeesize", uint64(21)}, 5},
 				{vote{"istanbul.committeesize", uint64(4)}, 6},
 				{vote{"istanbul.committeesize", uint64(4)}, 7},
-				{vote{"istanbul.committeesize", uint64(22)}, 8},
-				{vote{"istanbul.committeesize", uint64(22)}, 9},
-				{vote{"istanbul.committeesize", uint64(22)}, 10},
-				{vote{"istanbul.committeesize", uint64(22)}, 11},
+				{vote{"istanbul.committeesize", uint64(4)}, 8},
+				{vote{"istanbul.committeesize", uint64(4)}, 9},
+				{vote{"istanbul.committeesize", uint64(4)}, 10},
+				{vote{"istanbul.committeesize", uint64(4)}, 11},
+				{vote{"istanbul.committeesize", uint64(22)}, 12},
+				{vote{"istanbul.committeesize", uint64(22)}, 13},
+				{vote{"istanbul.committeesize", uint64(22)}, 14},
+				{vote{"istanbul.committeesize", uint64(22)}, 15},
+				{vote{"istanbul.committeesize", uint64(22)}, 16},
 
 				// unitprice for all blocks
 				{vote{"governance.unitprice", uint64(1)}, 1},
@@ -928,26 +944,31 @@ func TestGovernance_Votes(t *testing.T) {
 				{vote{"governance.unitprice", uint64(1)}, 3},
 				{vote{"governance.unitprice", uint64(1)}, 4},
 				{vote{"governance.unitprice", uint64(1)}, 5},
-				{vote{"governance.unitprice", uint64(2000000)}, 6},
-				{vote{"governance.unitprice", uint64(2000000)}, 7},
-				{vote{"governance.unitprice", uint64(2000000)}, 8},
+				{vote{"governance.unitprice", uint64(1)}, 6},
+				{vote{"governance.unitprice", uint64(1)}, 7},
+				{vote{"governance.unitprice", uint64(1)}, 8},
 				{vote{"governance.unitprice", uint64(2000000)}, 9},
-				{vote{"governance.unitprice", uint64(2)}, 10},
-				{vote{"governance.unitprice", uint64(2)}, 11},
+				{vote{"governance.unitprice", uint64(2000000)}, 10},
+				{vote{"governance.unitprice", uint64(2000000)}, 11},
+				{vote{"governance.unitprice", uint64(2)}, 12},
+				{vote{"governance.unitprice", uint64(2)}, 13},
+				{vote{"governance.unitprice", uint64(2)}, 14},
+				{vote{"governance.unitprice", uint64(2)}, 15},
+				{vote{"governance.unitprice", uint64(2)}, 16},
 			},
 		},
 	}
 
 	var configItems []interface{}
 	configItems = append(configItems, proposerPolicy(params.WeightedRandom))
-	configItems = append(configItems, epoch(2))
+	configItems = append(configItems, epoch(3))
 	configItems = append(configItems, governanceMode("single"))
 	configItems = append(configItems, blockPeriod(0)) // set block period to 0 to prevent creating future block
 	for _, tc := range testcases {
 		chain, engine := newBlockChain(1, configItems...)
 
 		// test initial governance items
-		assert.Equal(t, uint64(2), engine.governance.Epoch())
+		assert.Equal(t, uint64(3), engine.governance.Epoch())
 		assert.Equal(t, "single", engine.governance.GovernanceMode())
 		assert.Equal(t, uint64(21), engine.governance.CommitteeSize())
 		assert.Equal(t, uint64(1), engine.governance.UnitPrice())
@@ -962,8 +983,10 @@ func TestGovernance_Votes(t *testing.T) {
 			err                         error
 		)
 
-		for _, vote := range tc.votes {
-			engine.governance.AddVote(vote.key, vote.value)
+		for _, v := range tc.votes {
+			if v != (vote{}) {
+				engine.governance.AddVote(v.key, v.value)
+			}
 			previousBlock = currentBlock
 			currentBlock = makeBlockWithSeal(chain, engine, previousBlock)
 			_, err = chain.InsertChain(types.Blocks{currentBlock})
@@ -971,7 +994,7 @@ func TestGovernance_Votes(t *testing.T) {
 		}
 
 		// insert blocks until the vote is applied
-		for i := 0; i < 4; i++ {
+		for i := 0; i < 6; i++ {
 			previousBlock = currentBlock
 			currentBlock = makeBlockWithSeal(chain, engine, previousBlock)
 			_, err = chain.InsertChain(types.Blocks{currentBlock})

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -834,7 +834,6 @@ func TestGovernance_Votes(t *testing.T) {
 	type testcase struct {
 		votes    []vote
 		expected []governanceItem
-		final    []vote
 	}
 
 	testcases := []testcase{
@@ -843,21 +842,19 @@ func TestGovernance_Votes(t *testing.T) {
 				{"governance.governancemode", "none"},     // voted on block 1
 				{"istanbul.committeesize", uint64(4)},     // voted on block 2
 				{"governance.unitprice", uint64(2000000)}, // voted on block 3
-				{},                                      // voted on block 4
-				{"reward.mintingamount", "96000000000"}, // voted on block 5
-				{"reward.ratio", "34/33/33"},            // voted on block 6
-				{},                                      // voted on block 7
-				{"reward.useginicoeff", true},           // voted on block 8
-				{"reward.minimumstake", "5000000"},      // voted on block 9
+				{"reward.mintingamount", "96000000000"},   // voted on block 4
+				{"reward.ratio", "34/33/33"},              // voted on block 5
+				{"reward.useginicoeff", true},             // voted on block 6
+				{"reward.minimumstake", "5000000"},        // voted on block 7
 			},
 			expected: []governanceItem{
 				{vote{"governance.governancemode", "none"}, 6},
 				{vote{"istanbul.committeesize", uint64(4)}, 6},
 				{vote{"governance.unitprice", uint64(2000000)}, 9},
 				{vote{"reward.mintingamount", "96000000000"}, 9},
-				{vote{"reward.ratio", "34/33/33"}, 12},
+				{vote{"reward.ratio", "34/33/33"}, 9},
 				{vote{"reward.useginicoeff", true}, 12},
-				{vote{"reward.minimumstake", "5000000"}, 15},
+				{vote{"reward.minimumstake", "5000000"}, 12},
 				// check governance items on current block
 				{vote{"governance.governancemode", "none"}, 0},
 				{vote{"istanbul.committeesize", uint64(4)}, 0},
@@ -873,20 +870,18 @@ func TestGovernance_Votes(t *testing.T) {
 				{"governance.governancemode", "none"},   // voted on block 1
 				{"governance.governancemode", "single"}, // voted on block 2
 				{"governance.governancemode", "none"},   // voted on block 3
-				{},                                      // voted on block 4
-				{"governance.governancemode", "single"}, // voted on block 5
-				{"governance.governancemode", "none"},   // voted on block 6
-				{},                                      // voted on block 7
+				{"governance.governancemode", "single"}, // voted on block 4
+				{"governance.governancemode", "none"},   // voted on block 5
+				{"governance.governancemode", "single"}, // voted on block 6
+				{"governance.governancemode", "none"},   // voted on block 7
 				{"governance.governancemode", "single"}, // voted on block 8
 				{"governance.governancemode", "none"},   // voted on block 9
 			},
 			expected: []governanceItem{
 				{vote{"governance.governancemode", "single"}, 6},
-				{vote{"governance.governancemode", "single"}, 9},
+				{vote{"governance.governancemode", "none"}, 9},
 				{vote{"governance.governancemode", "single"}, 12},
 				{vote{"governance.governancemode", "none"}, 15},
-				// check governance items on current block
-				{vote{"governance.governancemode", "none"}, 0},
 			},
 		},
 		{
@@ -894,12 +889,10 @@ func TestGovernance_Votes(t *testing.T) {
 				{"governance.governancemode", "none"},     // voted on block 1
 				{"istanbul.committeesize", uint64(4)},     // voted on block 2
 				{"governance.unitprice", uint64(2000000)}, // voted on block 3
-				{},                                      // voted on block 4
-				{"governance.governancemode", "single"}, // voted on block 5
-				{"istanbul.committeesize", uint64(22)},  // voted on block 6
-				{},                                      // voted on block 7
-				{"governance.unitprice", uint64(2)},     // voted on block 8
-				{"governance.governancemode", "none"},   // voted on block 9
+				{"governance.governancemode", "single"},   // voted on block 4
+				{"istanbul.committeesize", uint64(22)},    // voted on block 5
+				{"governance.unitprice", uint64(2)},       // voted on block 6
+				{"governance.governancemode", "none"},     // voted on block 7
 			},
 			expected: []governanceItem{
 				// governance mode for all blocks
@@ -914,11 +907,10 @@ func TestGovernance_Votes(t *testing.T) {
 				{vote{"governance.governancemode", "single"}, 9},
 				{vote{"governance.governancemode", "single"}, 10},
 				{vote{"governance.governancemode", "single"}, 11},
-				{vote{"governance.governancemode", "single"}, 12},
-				{vote{"governance.governancemode", "single"}, 13},
-				{vote{"governance.governancemode", "single"}, 14},
-				{vote{"governance.governancemode", "none"}, 15},
-				{vote{"governance.governancemode", "none"}, 16},
+				{vote{"governance.governancemode", "none"}, 12},
+				{vote{"governance.governancemode", "none"}, 13},
+				{vote{"governance.governancemode", "none"}, 14},
+				{vote{"governance.governancemode", "none"}, 0}, // check on current
 
 				// committee size for all blocks
 				{vote{"istanbul.committeesize", uint64(21)}, 1},
@@ -929,14 +921,13 @@ func TestGovernance_Votes(t *testing.T) {
 				{vote{"istanbul.committeesize", uint64(4)}, 6},
 				{vote{"istanbul.committeesize", uint64(4)}, 7},
 				{vote{"istanbul.committeesize", uint64(4)}, 8},
-				{vote{"istanbul.committeesize", uint64(4)}, 9},
-				{vote{"istanbul.committeesize", uint64(4)}, 10},
-				{vote{"istanbul.committeesize", uint64(4)}, 11},
+				{vote{"istanbul.committeesize", uint64(22)}, 9},
+				{vote{"istanbul.committeesize", uint64(22)}, 10},
+				{vote{"istanbul.committeesize", uint64(22)}, 11},
 				{vote{"istanbul.committeesize", uint64(22)}, 12},
 				{vote{"istanbul.committeesize", uint64(22)}, 13},
 				{vote{"istanbul.committeesize", uint64(22)}, 14},
-				{vote{"istanbul.committeesize", uint64(22)}, 15},
-				{vote{"istanbul.committeesize", uint64(22)}, 16},
+				{vote{"istanbul.committeesize", uint64(22)}, 0}, // check on current
 
 				// unitprice for all blocks
 				{vote{"governance.unitprice", uint64(1)}, 1},
@@ -953,8 +944,7 @@ func TestGovernance_Votes(t *testing.T) {
 				{vote{"governance.unitprice", uint64(2)}, 12},
 				{vote{"governance.unitprice", uint64(2)}, 13},
 				{vote{"governance.unitprice", uint64(2)}, 14},
-				{vote{"governance.unitprice", uint64(2)}, 15},
-				{vote{"governance.unitprice", uint64(2)}, 16},
+				{vote{"governance.unitprice", uint64(2)}, 0}, // check on current
 			},
 		},
 	}
@@ -984,9 +974,7 @@ func TestGovernance_Votes(t *testing.T) {
 		)
 
 		for _, v := range tc.votes {
-			if v != (vote{}) {
-				engine.governance.AddVote(v.key, v.value)
-			}
+			engine.governance.AddVote(v.key, v.value)
 			previousBlock = currentBlock
 			currentBlock = makeBlockWithSeal(chain, engine, previousBlock)
 			_, err = chain.InsertChain(types.Blocks{currentBlock})

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -178,6 +178,19 @@ func (s *Snapshot) apply(headers []*types.Header, gov *governance.Governance, ad
 			return nil, errUnauthorized
 		}
 
+		if number%snap.Epoch == 0 {
+			if len(header.Governance) > 0 {
+				gov.UpdateGovernance(number, header.Governance)
+			}
+			gov.UpdateCurrentGovernance(number)
+			gov.ClearVotes(number)
+
+			// Reload governance values because epoch changed
+			snap.Epoch, snap.Policy, snap.CommitteeSize = getGovernanceValue(gov, number)
+			snap.Votes = make([]governance.GovernanceVote, 0)
+			snap.Tally = make([]governance.GovernanceTallyItem, 0)
+		}
+
 		snap.ValSet, snap.Votes, snap.Tally = gov.HandleGovernanceVote(snap.ValSet, snap.Votes, snap.Tally, header, validator, addr)
 		if policy == uint64(params.WeightedRandom) {
 			// Snapshot of block N (Snapshot_N) should contain proposers for N+1 and following blocks.
@@ -203,19 +216,6 @@ func (s *Snapshot) apply(headers []*types.Header, gov *governance.Governance, ad
 			} else {
 				logger.Trace("Can't refreshing proposers while creating snapshot due to lack of required header", "snap.Number", snap.Number)
 			}
-		}
-
-		if number%snap.Epoch == 0 {
-			if len(header.Governance) > 0 {
-				gov.UpdateGovernance(number, header.Governance)
-			}
-			gov.UpdateCurrentGovernance(number)
-			gov.ClearVotes(number)
-
-			// Reload governance values because epoch changed
-			snap.Epoch, snap.Policy, snap.CommitteeSize = getGovernanceValue(gov, number)
-			snap.Votes = make([]governance.GovernanceVote, 0)
-			snap.Tally = make([]governance.GovernanceTallyItem, 0)
 		}
 	}
 	snap.Number += uint64(len(headers))

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -179,10 +179,10 @@ func (s *Snapshot) apply(headers []*types.Header, gov *governance.Governance, ad
 		}
 
 		if number%snap.Epoch == 0 {
+			gov.UpdateCurrentSet(number)
 			if len(header.Governance) > 0 {
-				gov.UpdateGovernance(number, header.Governance)
+				gov.WriteGovernanceForNextEpoch(number, header.Governance)
 			}
-			gov.UpdateCurrentGovernance(number)
 			gov.ClearVotes(number)
 
 			// Reload governance values because epoch changed

--- a/governance/default.go
+++ b/governance/default.go
@@ -750,7 +750,9 @@ func (g *Governance) GetGovernanceChange() map[string]interface{} {
 	return nil
 }
 
-func (gov *Governance) UpdateGovernance(number uint64, governance []byte) {
+// WriteGovernanceForNextEpoch creates governance items for next epoch and writes them to the database.
+// The governance items on next epoch will be the given `governance` items applied on the top of past epoch items.
+func (gov *Governance) WriteGovernanceForNextEpoch(number uint64, governance []byte) {
 	var epoch uint64
 	var ok bool
 
@@ -787,7 +789,7 @@ func (gov *Governance) UpdateGovernance(number uint64, governance []byte) {
 			govSet := NewGovernanceSet()
 			govSet.Import(govItems)
 
-			// Store new currentSet to governance database
+			// Store new governance items for next epoch to governance database
 			if err := gov.WriteGovernance(number, govSet, tempSet); err != nil {
 				logger.Crit("Failed to store new governance data", "number", number, "err", err)
 			}
@@ -799,7 +801,7 @@ func (gov *Governance) removeDuplicatedVote(vote *GovernanceVote, number uint64)
 	gov.RemoveVote(vote.Key, vote.Value, number)
 }
 
-func (gov *Governance) UpdateCurrentGovernance(num uint64) {
+func (gov *Governance) UpdateCurrentSet(num uint64) {
 	newNumber, newGovernanceSet, _ := gov.ReadGovernance(num)
 	// Do the change only when the governance actually changed
 	if newGovernanceSet != nil && newNumber > gov.actualGovernanceBlock.Load().(uint64) {

--- a/governance/default.go
+++ b/governance/default.go
@@ -266,7 +266,14 @@ func (vl *VoteMap) Clear() {
 	vl.mu.Lock()
 	defer vl.mu.Unlock()
 
-	vl.items = make(map[string]VoteStatus)
+	// TODO-Governance if vote is not casted, it can remain forever. So, it would be better to add expiration.
+	newItems := make(map[string]VoteStatus)
+	for k, v := range vl.items {
+		if !v.Casted {
+			newItems[k] = v
+		}
+	}
+	vl.items = newItems
 }
 
 func (vl *VoteMap) Size() int {

--- a/governance/default.go
+++ b/governance/default.go
@@ -266,14 +266,7 @@ func (vl *VoteMap) Clear() {
 	vl.mu.Lock()
 	defer vl.mu.Unlock()
 
-	// TODO-Governance if vote is not casted, it can remain forever. So, it would be better to add expiration.
-	newItems := make(map[string]VoteStatus)
-	for k, v := range vl.items {
-		if !v.Casted {
-			newItems[k] = v
-		}
-	}
-	vl.items = newItems
+	vl.items = make(map[string]VoteStatus)
 }
 
 func (vl *VoteMap) Size() int {

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -240,6 +240,8 @@ func TestGovernance_ClearVotes(t *testing.T) {
 		if ret != val.e {
 			t.Errorf("Want %v, got %v for %v and %v", val.e, ret, val.k, val.v)
 		}
+		avt := gov.adjustValueType(val.k, val.v)
+		gov.RemoveVote(val.k, avt, 0)
 	}
 	gov.ClearVotes(0)
 	if gov.voteMap.Size() != 0 {
@@ -636,6 +638,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
 	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.RemoveVote("governance.unitprice", uint64(22000), 0)
 
 	if _, ok := gov.changeSet.items["governance.unitprice"]; !ok {
 		t.Errorf("Vote had to be applied but it wasn't")
@@ -652,7 +655,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
 	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
-
+	gov.RemoveVote("istanbul.timeout", newValue, 0)
 	assert.Equal(t, istanbul.DefaultConfig.Timeout, newValue, "Vote had to be applied but it wasn't")
 
 	gov.voteMap.Clear()
@@ -664,6 +667,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
 	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.RemoveVote("governance.removevalidator", validators[1], 0)
 	if i, _ := valSet.GetByAddress(validators[1]); i != -1 {
 		t.Errorf("Validator removal failed, %d validators remains", valSet.Size())
 	}
@@ -676,6 +680,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
 	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.RemoveVote("governance.addvalidator", validators[1], 0)
 	if i, _ := valSet.GetByAddress(validators[1]); i == -1 {
 		t.Errorf("Validator addition failed, %d validators remains", valSet.Size())
 	}
@@ -688,6 +693,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
 	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.RemoveVote("governance.removevalidator", demotedValidators[1], 0)
 	if i, _ := valSet.GetDemotedByAddress(demotedValidators[1]); i != -1 {
 		t.Errorf("Demoted validator removal failed, %d demoted validators remains", len(valSet.DemotedList()))
 	}
@@ -700,6 +706,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
 	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.RemoveVote("governance.addvalidator", demotedValidators[1], 0)
 	// At first, demoted validator is added to the validators, but it will be refreshed right after
 	// So, we here check only if the adding demoted validator to validators
 	if i, _ := valSet.GetByAddress(demotedValidators[1]); i == -1 {
@@ -753,6 +760,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	}
 
 	gov.RemoveVote("governance.unitprice", uint64(22000), blockCounter.Uint64())
+	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Test for "istanbul.timeout" in "ballot" mode
@@ -773,7 +781,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self)
 
 	assert.Equal(t, istanbul.DefaultConfig.Timeout, newValue, "Vote should be applied but it was not")
-
+	gov.RemoveVote("istanbul.timeout", newValue, blockCounter.Uint64())
 	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -798,6 +806,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	if i, _ := valSet.GetByAddress(validators[1]); i != -1 {
 		t.Errorf("Validator removal failed, %d validators remains", valSet.Size())
 	}
+	gov.RemoveVote("governance.removevalidator", validators[1], blockCounter.Uint64())
 	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -818,6 +827,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	if i, _ := valSet.GetByAddress(validators[1]); i == -1 {
 		t.Errorf("Validator addition failed, %d validators remains", valSet.Size())
 	}
+	gov.RemoveVote("governance.addvalidator", validators[1], blockCounter.Uint64())
 	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Proposed changes

The multiple votes on consecutive epochs are not applied properly. The votes on the previous epoch are ignored. The order of governance items is not right and this PR updates it to handle votes properly.

This PR updated the following.
1. The governance items are applied on the `currentSet`, but it should be the one read from database.
2. The votes are not removed if they are not casted yet.
3. The governance items are applied first before the votes are handled on epoch block.

Briefly, the governance votes moves in the following order.
1. The user cast a vote by API call.
2. The vote is added to the governance structure `voteMap`.
3. When the node creates a block, the vote is attached to the block header `voteData`.
4. The block is propagated and inserted.
5. The snapshot is created and the vote is decoded and added to the `changeSet` of governance structure.
6. When a block is created on epoch period, the `changeSet` is encoded and added to the block header `governanceData`.
7. The block is propagated and inserted.
8. The snapshot is created and the governance data is decoded
9. The governance data is overwritten on the `currentSet` which is applied governance items at the moment.
10. The `currentSet` is updated to the set saved on the previous epoch.
11. It clears all temporary data including `voteMap` and `changeSet`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

