### PR TITLE
account: remove omitEmpty at vmVersion field of smartContractAccountSerializableJSON

### DIFF
--- a/blockchain/types/account/smart_contract_account.go
+++ b/blockchain/types/account/smart_contract_account.go
@@ -56,7 +56,7 @@ type smartContractAccountSerializableJSON struct {
 	StorageRoot   common.Hash                      `json:"storageRoot"`
 	CodeHash      []byte                           `json:"codeHash"`
 	CodeFormat    params.CodeFormat                `json:"codeFormat"`
-	VmVersion     params.VmVersion                 `json:"vmVersion,omitempty"`
+	VmVersion     params.VmVersion                 `json:"vmVersion"`
 }
 
 func newSmartContractAccount() *SmartContractAccount {


### PR DESCRIPTION
## Proposed changes

- remove omitEmpty at vmVersion field of smartContractAccountSerializableJSON
- By applying this PR, it can prints vmVersion at the contracts deployed before istanbulCompatible change.
- klay_getAccount("address of the contract deployed before istanbulCompatible change") result

dev
```
{
  accType: 2,
  account: {
    ...
    codeFormat: 0
  }
}
```
PR
```
{
  accType: 2,
  account: {
    ...
    codeFormat: 0,
    vmVersion: 0
  }
}
```
## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
