### PR TITLE
Added rpc requests logs

### DIFF
--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -427,7 +427,7 @@ func (s *Server) handle(ctx context.Context, codec ServerCodec, req *serverReque
 			e := reply[req.callb.errPos].Interface().(error)
 			rpcErrorResponsesCounter.Inc(1)
 			res := codec.CreateErrorResponse(&req.id, &callbackError{e.Error()})
-			logger.Error("RPCError", "reqId", fmt.Sprintf("%s", req.id), "err", e, "method", fmt.Sprintf("%s%s%s", req.svcname, serviceMethodSeparator, req.callb.method.Name))
+			logger.Trace("RPCError", "reqId", fmt.Sprintf("%s", req.id), "err", e, "method", fmt.Sprintf("%s%s%s", req.svcname, serviceMethodSeparator, req.callb.method.Name))
 			return res, nil
 		}
 	}

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -332,6 +332,12 @@ var callSendTx = 0
 
 // handle executes a request and returns the response from the callback.
 func (s *Server) handle(ctx context.Context, codec ServerCodec, req *serverRequest, subCnt *int32) (interface{}, func()) {
+	method := ""
+	if req.callb != nil {
+		method = fmt.Sprintf("%s%s%s", req.svcname, serviceMethodSeparator, req.callb.method.Name)
+	}
+	logger.Trace("Request info", "reqId", fmt.Sprintf("%s", req.id), "reqErr", req.err, "isUnsubscribe", req.isUnsubscribe, "reqMethod", method)
+
 	if req.err != nil {
 		rpcErrorResponsesCounter.Inc(1)
 		return codec.CreateErrorResponse(&req.id, req.err), nil
@@ -421,6 +427,7 @@ func (s *Server) handle(ctx context.Context, codec ServerCodec, req *serverReque
 			e := reply[req.callb.errPos].Interface().(error)
 			rpcErrorResponsesCounter.Inc(1)
 			res := codec.CreateErrorResponse(&req.id, &callbackError{e.Error()})
+			logger.Error("RPCError", "reqId", fmt.Sprintf("%s", req.id), "err", e, "method", fmt.Sprintf("%s%s%s", req.svcname, serviceMethodSeparator, req.callb.method.Name))
 			return res, nil
 		}
 	}


### PR DESCRIPTION
## Proposed changes

It was hard to recognize which rpc method affects the Klaytn node. This PR leaves logs for error case of rpc requests and every request in trace level.

```
TRACE[08/18,10:34:07 +09] [39] Request info                              reqId=&1 reqErr=nil isUnsubscribe=false reqMethod=klay_GetLogs
TRACE[08/18,10:34:07 +09] [39] RPCError                                  reqId=&1 err="the header does not exist (block number: 4)" method=klay_GetLogs
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
