### PR TITLE
Set the request body size limit of fastHttpServer with maxRequestContentlength

### DIFF
--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -217,11 +217,12 @@ func NewFastHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, sr
 		for _, vhost := range vhosts {
 			if vhost == "*" {
 				return &fasthttp.Server{
-					Concurrency:  ConcurrencyLimit,
-					Handler:      srv.HandleFastHTTP,
-					ReadTimeout:  timeouts.ReadTimeout,
-					WriteTimeout: timeouts.WriteTimeout,
-					IdleTimeout:  timeouts.IdleTimeout,
+					Concurrency:        ConcurrencyLimit,
+					Handler:            srv.HandleFastHTTP,
+					ReadTimeout:        timeouts.ReadTimeout,
+					WriteTimeout:       timeouts.WriteTimeout,
+					IdleTimeout:        timeouts.IdleTimeout,
+					MaxRequestBodySize: common.MaxRequestContentLength,
 				}
 			}
 		}
@@ -240,11 +241,12 @@ func NewFastHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, sr
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
 	return &fasthttp.Server{
-		Concurrency:  ConcurrencyLimit,
-		Handler:      fhandler,
-		ReadTimeout:  timeouts.ReadTimeout,
-		WriteTimeout: timeouts.WriteTimeout,
-		IdleTimeout:  timeouts.IdleTimeout,
+		Concurrency:        ConcurrencyLimit,
+		Handler:            fhandler,
+		ReadTimeout:        timeouts.ReadTimeout,
+		WriteTimeout:       timeouts.WriteTimeout,
+		IdleTimeout:        timeouts.IdleTimeout,
+		MaxRequestBodySize: common.MaxRequestContentLength,
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

`maxRequestContentlength` option validates the request body size of API requests.
However, the option is not used to limit the request body size of fastHttp server.
Without the change, fastHttp server has `defaultMaxRequestBodySize`, 4MB. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
