### PR TITLE
blockchain/vm: modify opcode computation costs for istanbulCompatible change

### DIFF
--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -50,11 +50,6 @@ func enable1884(jt *JumpTable) {
 	jt[BALANCE].constantGas = params.BalanceGasEIP1884
 	jt[EXTCODEHASH].constantGas = params.ExtcodeHashGasEIP1884
 
-	// Computation cost changes
-	jt[SLOAD].computationCost = params.SloadComputationCostEIP1884
-	jt[BALANCE].computationCost = params.BalanceComputationCostEIP1884
-	jt[EXTCODEHASH].computationCost = params.ExtCodeHashComputationCostEIP1884
-
 	// New opcode
 	jt[SELFBALANCE] = &operation{
 		execute:         opSelfBalance,
@@ -95,4 +90,16 @@ func opChainID(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *
 func enable2200(jt *JumpTable) {
 	jt[SLOAD].constantGas = params.SloadGasEIP2200
 	jt[SSTORE].dynamicGas = gasSStoreEIP2200
+}
+
+// enableIstanbulComputationCostModification modifies ADDMOD, MULMOD, NOT, XOR, SHL, SHR, SAR computation cost
+// The modification is activated with istanbulCompatible change activation.
+func enableIstanbulComputationCostModification(jt *JumpTable) {
+	jt[ADDMOD].computationCost = params.AddmodComputationCostIstanbul
+	jt[MULMOD].computationCost = params.MulmodComputationCostIstanbul
+	jt[NOT].computationCost = params.NotComputationCostIstanbul
+	jt[XOR].computationCost = params.XorComputationCostIstanbul
+	jt[SHL].computationCost = params.ShlComputationCostIstanbul
+	jt[SHR].computationCost = params.ShrComputationCostIstanbul
+	jt[SAR].computationCost = params.SarComputationCostIstanbul
 }

--- a/blockchain/vm/instructions_test.go
+++ b/blockchain/vm/instructions_test.go
@@ -998,6 +998,14 @@ func BenchmarkOpSuicide(b *testing.B) {
 	opBenchmark(b, opSuicide, addr)
 }
 
+func BenchmarkOpChainID(b *testing.B) {
+	opBenchmark(b, opChainID)
+}
+
+func BenchmarkOpSelfBalance(b *testing.B) {
+	opBenchmark(b, opSelfBalance)
+}
+
 func BenchmarkOpPush1(b *testing.B) {
 	opBenchmark(b, opPush1)
 }

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -73,6 +73,7 @@ func newIstanbulInstructionSet() JumpTable {
 	enable1344(&instructionSet)
 	enable1884(&instructionSet)
 	enable2200(&instructionSet)
+	enableIstanbulComputationCostModification(&instructionSet)
 	return instructionSet
 }
 
@@ -106,7 +107,7 @@ func newConstantinopleInstructionSet() JumpTable {
 		constantGas:     params.ExtcodeHashGasConstantinople,
 		minStack:        minStack(1, 1),
 		maxStack:        maxStack(1, 1),
-		computationCost: params.ExtCodeHashComputationCostConstantinople,
+		computationCost: params.ExtCodeHashComputationCost,
 	}
 	instructionSet[CREATE2] = &operation{
 		execute:         opCreate2,
@@ -370,7 +371,7 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas:     params.BalanceGasEIP150,
 			minStack:        minStack(1, 1),
 			maxStack:        maxStack(1, 1),
-			computationCost: params.BalanceComputationCostEIP150,
+			computationCost: params.BalanceComputationCost,
 		},
 		ORIGIN: {
 			execute:         opOrigin,
@@ -536,7 +537,7 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas:     params.SloadGasEIP150,
 			minStack:        minStack(1, 1),
 			maxStack:        maxStack(1, 1),
-			computationCost: params.SloadComputationCostEIP150,
+			computationCost: params.SloadComputationCost,
 		},
 		SSTORE: {
 			execute:         opSstore,

--- a/params/computation_cost_params.go
+++ b/params/computation_cost_params.go
@@ -22,9 +22,7 @@ package params
 
 const (
 	// Computation cost for opcodes
-	ShlComputationCost            = 1603
-	ShrComputationCost            = 1346
-	SarComputationCost            = 1815
+	ExtCodeHashComputationCost    = 1000
 	Create2ComputationCost        = 10000
 	StaticCallComputationCost     = 10000
 	ReturnDataSizeComputationCost = 10
@@ -39,8 +37,6 @@ const (
 	SdivComputationCost           = 739
 	ModComputationCost            = 812
 	SmodComputationCost           = 560
-	AddmodComputationCost         = 3349
-	MulmodComputationCost         = 4757
 	ExpComputationCost            = 5000
 	SignExtendComputationCost     = 481
 	LtComputationCost             = 201
@@ -50,19 +46,18 @@ const (
 	EqComputationCost             = 220
 	IszeroComputationCost         = 165
 	AndComputationCost            = 288
-	XorComputationCost            = 657
 	OrComputationCost             = 160
-	NotComputationCost            = 1289
 	ByteComputationCost           = 589
 	Sha3ComputationCost           = 2465
 	AddressComputationCost        = 284
+	BalanceComputationCost        = 1407
 	OriginComputationCost         = 210
 	CallerComputationCost         = 188
 	CallValueComputationCost      = 149
 	CallDataLoadComputationCost   = 596
 	CallDataSizeComputationCost   = 194
 	CallDataCopyComputationCost   = 100
-	ChainIDComputationCost        = 150
+	ChainIDComputationCost        = 120
 	CodeSizeComputationCost       = 145
 	CodeCopyComputationCost       = 898
 	GasPriceComputationCost       = 131
@@ -78,6 +73,7 @@ const (
 	MloadComputationCost          = 376
 	MstoreComputationCost         = 288
 	Mstore8ComputationCost        = 5142
+	SloadComputationCost          = 835
 	SstoreComputationCost         = 1548
 	JumpComputationCost           = 253
 	JumpiComputationCost          = 176
@@ -102,7 +98,7 @@ const (
 	Dup14ComputationCost          = 143
 	Dup15ComputationCost          = 237
 	Dup16ComputationCost          = 149
-	SelfBalanceComputationCost    = 150
+	SelfBalanceComputationCost    = 374
 	Swap1ComputationCost          = 141
 	Swap2ComputationCost          = 156
 	Swap3ComputationCost          = 145
@@ -130,13 +126,21 @@ const (
 	ReturnComputationCost         = 0
 	SelfDestructComputationCost   = 0
 
-	// Istanbul version of BalanceGas, SloadGas, ExtcodeHash is added.
-	BalanceComputationCostEIP150             = 1407
-	BalanceComputationCostEIP1884            = 2462
-	SloadComputationCostEIP150               = 835
-	SloadComputationCostEIP1884              = 3340
-	ExtCodeHashComputationCostConstantinople = 1000
-	ExtCodeHashComputationCostEIP1884        = 1750
+	// Opcode Computation Cost Modification
+	AddmodComputationCost         = 3349
+	AddmodComputationCostIstanbul = 1410
+	MulmodComputationCost         = 4757
+	MulmodComputationCostIstanbul = 1760
+	NotComputationCost            = 1289
+	NotComputationCostIstanbul    = 364
+	ShlComputationCost            = 1603
+	ShlComputationCostIstanbul    = 478
+	ShrComputationCost            = 1346
+	ShrComputationCostIstanbul    = 498
+	SarComputationCost            = 1815
+	SarComputationCostIstanbul    = 834
+	XorComputationCost            = 657
+	XorComputationCostIstanbul    = 454
 
 	// Computation cost for precompiled contracts
 	EcrecoverComputationCost            = 113150


### PR DESCRIPTION
## Proposed changes
Some opcode computation costs are modified and it is activated with istanbulCompatible change activation.
- Modification1. Reset computation cost modification of `sload`, `balance`, `extcodehash`. It is the revert of the computation cost modification which is applied at #958.
- Modification2. Redefine computation cost of `selfBalance` and `chainId`  based on the execution time.
- Modification3. Redefine computation cost of `addmod`, `mulmod`, `not`, `xor`, `shl`, `shr`, `sar` based on the execution time.

The computation cost is calculated based on the instructions_test.go benchmark test. Double the average execution time when benchtime is 200x.
```
ubuntu@ip-10-63-239-152:~/klaytn/blockchain/vm$ go test -bench=SelfBalance -benchtime=200x
goos: linux
goarch: amd64
pkg: github.com/klaytn/klaytn/blockchain/vm
cpu: Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
BenchmarkOpSelfBalance-8   	     200	       186.2 ns/op
PASS
ok  	github.com/klaytn/klaytn/blockchain/vm	0.189s
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
