### PR TITLE
Relocated shortcut for proposer refresh

### DIFF
--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -105,6 +105,8 @@ type weightedCouncil struct {
 	validatorMu sync.RWMutex // this validator mutex protects concurrent usage of validators and demotedValidators
 	selector    istanbul.ProposalSelector
 
+	// TODO-Klaytn-Governance proposers means that the proposers for next block, so refactor it.
+	// proposers are determined on a specific block, but it can be removed after votes.
 	proposers         []istanbul.Validator
 	proposersBlockNum uint64 // block number when proposers is determined
 
@@ -520,6 +522,7 @@ func (valSet *weightedCouncil) AddValidator(address common.Address) bool {
 		}
 	}
 
+	// TODO-Klaytn-Governance the new validator is added on validators only and demoted after `Refresh` method. It is better to update here if it is demoted ones.
 	// TODO-Klaytn-Issue1336 Update for governance implementation. How to determine initial value for rewardAddress and votingPower ?
 	valSet.validators = append(valSet.validators, newWeightedValidator(address, common.Address{}, 1000, 0))
 
@@ -617,7 +620,7 @@ func (valSet *weightedCouncil) Policy() istanbul.ProposerPolicy { return valSet.
 //   (1) already has up-do-date proposers
 //   (2) successfully calculated up-do-date proposers
 func (valSet *weightedCouncil) Refresh(hash common.Hash, blockNum uint64, config *params.ChainConfig, isSingle bool, governingNode common.Address, minStaking uint64) error {
-	// TODO-Governance divide the following logic into two parts: proposers update / validators update
+	// TODO-Klaytn-Governance divide the following logic into two parts: proposers update / validators update
 	valSet.validatorMu.Lock()
 	defer valSet.validatorMu.Unlock()
 

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -617,13 +617,9 @@ func (valSet *weightedCouncil) Policy() istanbul.ProposerPolicy { return valSet.
 //   (1) already has up-do-date proposers
 //   (2) successfully calculated up-do-date proposers
 func (valSet *weightedCouncil) Refresh(hash common.Hash, blockNum uint64, config *params.ChainConfig, isSingle bool, governingNode common.Address, minStaking uint64) error {
+	// TODO-Governance divide the following logic into two parts: proposers update / validators update
 	valSet.validatorMu.Lock()
 	defer valSet.validatorMu.Unlock()
-
-	if valSet.proposersBlockNum == blockNum {
-		// already refreshed
-		return nil
-	}
 
 	// Check errors
 	numValidators := len(valSet.validators)
@@ -661,6 +657,11 @@ func (valSet *weightedCouncil) Refresh(hash common.Hash, blockNum uint64, config
 
 		weightedValidators, stakingAmounts, demotedValidators, _ = filterValidators(isSingle, governingNode, weightedValidators, stakingAmounts, minStaking)
 		valSet.setValidators(weightedValidators, demotedValidators)
+	}
+
+	if valSet.proposersBlockNum == blockNum {
+		// proposers are already refreshed
+		return nil
 	}
 
 	totalStaking := calcTotalAmount(weightedValidators, newStakingInfo, stakingAmounts)


### PR DESCRIPTION
## Proposed changes

`Refresh` method relates to the `validators`, `demotedValidators`, and `proposers`.
The `validators` and `demotedValidators` should be updated although the proposers are calculated already, so the refresh proposers short cut logic is moved.

This resolves the problem where the validator is not demoted right after the `addvalidator` vote.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
