### PR TITLE
delete unused parameter of function genDBManagerForTest

### DIFF
--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -156,7 +156,7 @@ func benchInsertChain(b *testing.B, dbType database.DBType, gen func(int, *Block
 	dir := genTempDirForDB(b)
 	defer os.RemoveAll(dir)
 
-	db := genDBManagerForTest(b, dir, dbType)
+	db := genDBManagerForTest(dir, dbType)
 	defer db.Close()
 
 	// 2. Generate a chain of b.N blocks using the supplied block generator function.
@@ -298,7 +298,7 @@ func benchWriteChain(b *testing.B, full bool, databaseType database.DBType, coun
 	for i := 0; i < b.N; i++ {
 		dir := genTempDirForDB(b)
 
-		db := genDBManagerForTest(b, dir, databaseType)
+		db := genDBManagerForTest(dir, databaseType)
 		makeChainForBench(db, full, count)
 
 		db.Close()
@@ -311,7 +311,7 @@ func benchReadChain(b *testing.B, full bool, databaseType database.DBType, count
 	dir := genTempDirForDB(b)
 	defer os.RemoveAll(dir)
 
-	db := genDBManagerForTest(b, dir, databaseType)
+	db := genDBManagerForTest(dir, databaseType)
 	makeChainForBench(db, full, count)
 	db.Close()
 
@@ -320,7 +320,7 @@ func benchReadChain(b *testing.B, full bool, databaseType database.DBType, count
 
 	for i := 0; i < b.N; i++ {
 
-		db = genDBManagerForTest(b, dir, databaseType)
+		db = genDBManagerForTest(dir, databaseType)
 
 		chain, err := NewBlockChain(db, nil, params.TestChainConfig, gxhash.NewFaker(), vm.Config{})
 		if err != nil {
@@ -350,7 +350,7 @@ func genTempDirForDB(b *testing.B) string {
 }
 
 // genDBManagerForTest returns database.Database according to entered databaseType
-func genDBManagerForTest(b *testing.B, dir string, dbType database.DBType) database.DBManager {
+func genDBManagerForTest(dir string, dbType database.DBType) database.DBManager {
 	if dbType == database.MemoryDB {
 		db := database.NewMemoryDBManager()
 		return db


### PR DESCRIPTION
## Proposed changes

There was an unused parameter in function genDBManagerForTest in bench_test.go.
So, I modified the function so that it does not use the parameter.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
