### PR TITLE
BUGFIX: needs to deep copy account key

### DIFF
--- a/blockchain/types/account/account_common.go
+++ b/blockchain/types/account/account_common.go
@@ -177,7 +177,7 @@ func (e *AccountCommon) SetHumanReadable(h bool) {
 }
 
 func (e *AccountCommon) SetKey(k accountkey.AccountKey) {
-	e.key = k
+	e.key = k.DeepCopy()
 }
 
 func (e *AccountCommon) ReplaceKey(newKey accountkey.AccountKey, currentBlockNumber uint64) error {

--- a/blockchain/types/account/account_common.go
+++ b/blockchain/types/account/account_common.go
@@ -177,7 +177,7 @@ func (e *AccountCommon) SetHumanReadable(h bool) {
 }
 
 func (e *AccountCommon) SetKey(k accountkey.AccountKey) {
-	e.key = k.DeepCopy()
+	e.key = k
 }
 
 func (e *AccountCommon) ReplaceKey(newKey accountkey.AccountKey, currentBlockNumber uint64) error {
@@ -201,6 +201,7 @@ func (e *AccountCommon) DeepCopy() *AccountCommon {
 }
 
 func (e *AccountCommon) UpdateKey(newKey accountkey.AccountKey, currentBlockNumber uint64) error {
+	newKey = newKey.DeepCopy()
 	if e.key.Type() == newKey.Type() {
 		return e.key.Update(newKey, currentBlockNumber)
 	}

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -2239,7 +2239,7 @@ func TestAccountKeyUpdateLegacyToPublic(t *testing.T) {
 			types.TxValueKeyGasLimit:   gasLimit,
 			types.TxValueKeyGasPrice:   gasPrice,
 			types.TxValueKeyAccountKey: acckey,
-			types.TxValueKeyFeePayer: feepayer,
+			types.TxValueKeyFeePayer:   feepayer,
 		}
 		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedAccountUpdate, values)
 		assert.Equal(t, nil, err)
@@ -2267,7 +2267,7 @@ func TestAccountKeyUpdateLegacyToPublic(t *testing.T) {
 			types.TxValueKeyGasLimit:   gasLimit,
 			types.TxValueKeyGasPrice:   gasPrice,
 			types.TxValueKeyAccountKey: acckey,
-			types.TxValueKeyFeePayer: feepayer,
+			types.TxValueKeyFeePayer:   feepayer,
 		}
 		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedAccountUpdate, values)
 		assert.Equal(t, nil, err)

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -2192,3 +2192,100 @@ func TestRoleBasedKeyFeeDelegation(t *testing.T) {
 		prof.PrintProfileInfo()
 	}
 }
+
+func TestAccountKeyUpdateLegacyToPublic(t *testing.T) {
+	gasPrice := new(big.Int).SetUint64(25 * params.Ston)
+	gasLimit := uint64(1000000)
+
+	if testing.Verbose() {
+		enableLog()
+	}
+	prof := profile.NewProfiler()
+
+	// Initialize blockchain
+	start := time.Now()
+	bcdata, err := NewBCData(6, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prof.Profile("main_init_blockchain", time.Now().Sub(start))
+	defer bcdata.Shutdown()
+
+	// Initialize address-balance map for verification
+	start = time.Now()
+	accountMap := NewAccountMap()
+	if err := accountMap.Initialize(bcdata); err != nil {
+		t.Fatal(err)
+	}
+	prof.Profile("main_init_accountMap", time.Now().Sub(start))
+
+	var txs types.Transactions
+
+	// make TxPool to test validation in 'TxPool add' process
+	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+
+	{
+		addr := *bcdata.addrs[1]
+		feepayer := *bcdata.addrs[0]
+		acckey := accountkey.NewAccountKeyWeightedMultiSigWithValues(1,
+			accountkey.WeightedPublicKeys{
+				accountkey.NewWeightedPublicKey(1, (*accountkey.PublicKeySerializable)(&bcdata.privKeys[1].PublicKey)),
+				accountkey.NewWeightedPublicKey(1, (*accountkey.PublicKeySerializable)(&bcdata.privKeys[2].PublicKey)),
+			})
+
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:      uint64(0),
+			types.TxValueKeyFrom:       addr,
+			types.TxValueKeyGasLimit:   gasLimit,
+			types.TxValueKeyGasPrice:   gasPrice,
+			types.TxValueKeyAccountKey: acckey,
+			types.TxValueKeyFeePayer: feepayer,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedAccountUpdate, values)
+		assert.Equal(t, nil, err)
+
+		err = tx.SignWithKeys(signer, []*ecdsa.PrivateKey{bcdata.privKeys[1]})
+		assert.Equal(t, nil, err)
+
+		err = tx.SignFeePayerWithKeys(signer, []*ecdsa.PrivateKey{bcdata.privKeys[0]})
+		assert.Equal(t, nil, err)
+
+		txs = append(txs, tx)
+	}
+	{
+		addr := *bcdata.addrs[1]
+		feepayer := *bcdata.addrs[0]
+		acckey := accountkey.NewAccountKeyWeightedMultiSigWithValues(1,
+			accountkey.WeightedPublicKeys{
+				accountkey.NewWeightedPublicKey(1, (*accountkey.PublicKeySerializable)(&bcdata.privKeys[1].PublicKey)),
+				accountkey.NewWeightedPublicKey(1, (*accountkey.PublicKeySerializable)(&bcdata.privKeys[3].PublicKey)),
+			})
+
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:      uint64(1),
+			types.TxValueKeyFrom:       addr,
+			types.TxValueKeyGasLimit:   gasLimit,
+			types.TxValueKeyGasPrice:   gasPrice,
+			types.TxValueKeyAccountKey: acckey,
+			types.TxValueKeyFeePayer: feepayer,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedAccountUpdate, values)
+		assert.Equal(t, nil, err)
+
+		err = tx.SignWithKeys(signer, []*ecdsa.PrivateKey{bcdata.privKeys[1]})
+		assert.Equal(t, nil, err)
+
+		err = tx.SignFeePayerWithKeys(signer, []*ecdsa.PrivateKey{bcdata.privKeys[0]})
+		assert.Equal(t, nil, err)
+
+		txs = append(txs, tx)
+	}
+	if err := bcdata.GenABlockWithTransactions(accountMap, txs, prof); err != nil {
+		t.Fatal(err)
+	}
+
+	// select account key types to be tested
+	if testing.Verbose() {
+		prof.PrintProfileInfo()
+	}
+}

--- a/tests/klay_test_blockchain_test.go
+++ b/tests/klay_test_blockchain_test.go
@@ -352,6 +352,18 @@ func (bcdata *BCData) GenABlockWithTransactions(accountMap *AccountMap, transact
 	}
 	prof.Profile("main_mineABlock", time.Now().Sub(start))
 
+	txs := make(types.Transactions, len(b.Transactions()))
+	for i, tt := range b.Transactions() {
+		encodedTx, err := rlp.EncodeToBytes(tt)
+		if err != nil {
+			return err
+		}
+		decodedTx := types.Transaction{}
+		rlp.DecodeBytes(encodedTx, &decodedTx)
+		txs[i] = &decodedTx
+	}
+	b = b.WithBody(txs)
+
 	// Insert the block into the blockchain
 	start = time.Now()
 	if n, err := bcdata.bc.InsertChain(types.Blocks{b}); err != nil {


### PR DESCRIPTION
## Proposed changes

**PROBLEM**
- Account key object is directly assigned to the account key field of the corresponding account in StateDB.
- When the account key object of an account is updated multiple times, the transaction object itself is updated to the value of the latest account key.

**SOLUTION**
- Account key instance needs to be deep-copied.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

