### PR TITLE
blockchain/vm: basefee implementation (london protocol upgrade)

### DIFF
--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -21,11 +21,12 @@
 package blockchain
 
 import (
+	"math/big"
+
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus"
-	"math/big"
 )
 
 // ChainContext supports retrieving headers and consensus parameters from the

--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -21,13 +21,11 @@
 package blockchain
 
 import (
-	"math/big"
-	"reflect"
-
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus"
+	"math/big"
 )
 
 // ChainContext supports retrieving headers and consensus parameters from the
@@ -53,9 +51,7 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author
 	} else {
 		beneficiary = *author
 	}
-	if reflect.ValueOf(header).Elem().FieldByName("baseFeePerGas").IsValid() == false {
-		baseFee = big.NewInt(0)
-	}
+	baseFee = big.NewInt(0)
 	return vm.Context{
 		CanTransfer: CanTransfer,
 		Transfer:    Transfer,

--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -103,3 +103,23 @@ func enableIstanbulComputationCostModification(jt *JumpTable) {
 	jt[SHR].computationCost = params.ShrComputationCostIstanbul
 	jt[SAR].computationCost = params.SarComputationCostIstanbul
 }
+
+// enable3198 applies EIP-3198 (BASEFEE Opcode)
+// - Adds an opcode that returns the current block's base fee.
+func enable3198(jt *JumpTable) {
+	// New opcode
+	jt[BASEFEE] = &operation{
+		execute:         opBaseFee,
+		constantGas:     GasQuickStep,
+		minStack:        minStack(0, 1),
+		maxStack:        maxStack(0, 1),
+		computationCost: params.BaseFeeComputationCost,
+	}
+}
+
+// opBaseFee implements BASEFEE opcode
+func opBaseFee(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+	baseFee := evm.interpreter.intPool.get().Set(evm.Context.BaseFee)
+	stack.push(baseFee)
+	return nil, nil
+}

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -111,6 +111,7 @@ type Context struct {
 	BlockNumber *big.Int       // Provides information for NUMBER
 	Time        *big.Int       // Provides information for TIME
 	BlockScore  *big.Int       // Provides information for DIFFICULTY
+	BaseFee     *big.Int       // Provides information for BASEFEE
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides

--- a/blockchain/vm/instructions_test.go
+++ b/blockchain/vm/instructions_test.go
@@ -312,6 +312,7 @@ func opBenchmark(bench *testing.B, op func(pc *uint64, evm *EVM, contract *Contr
 			BlockScore:  big.NewInt(0),
 			Coinbase:    common.HexToAddress("0xf4b0cb429b7d341bf467f2d51c09b64cd9add37c"),
 			GasPrice:    big.NewInt(1),
+			BaseFee:     big.NewInt(1000000000000000000),
 			GasLimit:    uint64(1000000000000000),
 			Time:        big.NewInt(1488928920),
 			GetHash: func(num uint64) common.Hash {
@@ -998,14 +999,6 @@ func BenchmarkOpSuicide(b *testing.B) {
 	opBenchmark(b, opSuicide, addr)
 }
 
-func BenchmarkOpChainID(b *testing.B) {
-	opBenchmark(b, opChainID)
-}
-
-func BenchmarkOpSelfBalance(b *testing.B) {
-	opBenchmark(b, opSelfBalance)
-}
-
 func BenchmarkOpPush1(b *testing.B) {
 	opBenchmark(b, opPush1)
 }
@@ -1354,6 +1347,18 @@ func BenchmarkOpLog4(b *testing.B) {
 	size := 4
 	stacks := genStacksForLog(size)
 	opBenchmark(b, makeLog(size), stacks...)
+}
+
+func BenchmarkOpChainID(b *testing.B) {
+	opBenchmark(b, opChainID)
+}
+
+func BenchmarkOpSelfBalance(b *testing.B) {
+	opBenchmark(b, opSelfBalance)
+}
+
+func BenchmarkOpBaseFee(b *testing.B) {
+	opBenchmark(b, opBaseFee)
 }
 
 func genStacksForDup(size int) []string {

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -73,8 +73,7 @@ type JumpTable [256]*operation
 // constantinople, istanbul, petersburg, berlin and london instructions.
 func newLondonInstructionSet() JumpTable {
 	instructionSet := newIstanbulInstructionSet()
-	// TODO-klaytn: base fee opcode will be enabled
-	//enable3198(&instructionSet) // Base fee opcode https://eips.ethereum.org/EIPS/eip-3198
+	enable3198(&instructionSet) // Base fee opcode https://eips.ethereum.org/EIPS/eip-3198
 	return instructionSet
 }
 

--- a/blockchain/vm/opcodes.go
+++ b/blockchain/vm/opcodes.go
@@ -105,6 +105,7 @@ const (
 	GASLIMIT
 	CHAINID     OpCode = 0x46
 	SELFBALANCE OpCode = 0x47
+	BASEFEE     OpCode = 0x48
 )
 
 // 0x50 range - 'storage' and execution.
@@ -283,6 +284,7 @@ var opCodeToString = map[OpCode]string{
 	GASLIMIT:    "GASLIMIT",
 	CHAINID:     "CHAINID",
 	SELFBALANCE: "SELFBALANCE",
+	BASEFEE:     "BASEFEE",
 
 	// 0x50 range - 'storage' and execution.
 	POP: "POP",
@@ -435,6 +437,7 @@ var stringToOp = map[string]OpCode{
 	"CALLDATASIZE":   CALLDATASIZE,
 	"CALLDATACOPY":   CALLDATACOPY,
 	"CHAINID":        CHAINID,
+	"BASEFEE":        BASEFEE,
 	"DELEGATECALL":   DELEGATECALL,
 	"STATICCALL":     STATICCALL,
 	"CODESIZE":       CODESIZE,

--- a/blockchain/vm/runtime/env.go
+++ b/blockchain/vm/runtime/env.go
@@ -38,6 +38,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 		BlockScore:  cfg.BlockScore,
 		GasLimit:    cfg.GasLimit,
 		GasPrice:    cfg.GasPrice,
+		BaseFee:     cfg.BaseFee,
 	}
 
 	return vm.NewEVM(context, cfg.State, cfg.ChainConfig, &cfg.EVMConfig)

--- a/blockchain/vm/runtime/runtime.go
+++ b/blockchain/vm/runtime/runtime.go
@@ -49,6 +49,7 @@ type Config struct {
 	Value       *big.Int
 	Debug       bool
 	EVMConfig   vm.Config
+	BaseFee     *big.Int
 
 	State     *state.StateDB
 	GetHashFn func(n uint64) common.Hash
@@ -58,7 +59,9 @@ type Config struct {
 func setDefaults(cfg *Config) {
 	if cfg.ChainConfig == nil {
 		cfg.ChainConfig = &params.ChainConfig{
-			ChainID: big.NewInt(1),
+			ChainID:                 big.NewInt(1),
+			IstanbulCompatibleBlock: new(big.Int),
+			LondonCompatibleBlock:   new(big.Int),
 		}
 	}
 
@@ -84,6 +87,9 @@ func setDefaults(cfg *Config) {
 		cfg.GetHashFn = func(n uint64) common.Hash {
 			return common.BytesToHash(crypto.Keccak256([]byte(new(big.Int).SetUint64(n).String())))
 		}
+	}
+	if cfg.BaseFee == nil {
+		cfg.BaseFee = big.NewInt(0)
 	}
 }
 

--- a/params/computation_cost_params.go
+++ b/params/computation_cost_params.go
@@ -57,7 +57,6 @@ const (
 	CallDataLoadComputationCost   = 596
 	CallDataSizeComputationCost   = 194
 	CallDataCopyComputationCost   = 100
-	ChainIDComputationCost        = 120
 	CodeSizeComputationCost       = 145
 	CodeCopyComputationCost       = 898
 	GasPriceComputationCost       = 131
@@ -98,7 +97,6 @@ const (
 	Dup14ComputationCost          = 143
 	Dup15ComputationCost          = 237
 	Dup16ComputationCost          = 149
-	SelfBalanceComputationCost    = 374
 	Swap1ComputationCost          = 141
 	Swap2ComputationCost          = 156
 	Swap3ComputationCost          = 145
@@ -126,22 +124,6 @@ const (
 	ReturnComputationCost         = 0
 	SelfDestructComputationCost   = 0
 
-	// Opcode Computation Cost Modification
-	AddmodComputationCost         = 3349
-	AddmodComputationCostIstanbul = 1410
-	MulmodComputationCost         = 4757
-	MulmodComputationCostIstanbul = 1760
-	NotComputationCost            = 1289
-	NotComputationCostIstanbul    = 364
-	ShlComputationCost            = 1603
-	ShlComputationCostIstanbul    = 478
-	ShrComputationCost            = 1346
-	ShrComputationCostIstanbul    = 498
-	SarComputationCost            = 1815
-	SarComputationCostIstanbul    = 834
-	XorComputationCost            = 657
-	XorComputationCostIstanbul    = 454
-
 	// Computation cost for precompiled contracts
 	EcrecoverComputationCost            = 113150
 	Sha256PerWordComputationCost        = 100
@@ -161,6 +143,29 @@ const (
 	FeePayerComputationCost             = 10
 	ValidateSenderPerSigComputationCost = 180000
 	ValidateSenderBaseComputationCost   = 10000
-	Blake2bBaseComputationCost          = 10000
-	Blake2bScaleComputationCost         = 10
+
+	// computation costs for opcode added at istanbulCompatible Protocol Upgrade
+	ChainIDComputationCost      = 120
+	SelfBalanceComputationCost  = 374
+	Blake2bBaseComputationCost  = 10000
+	Blake2bScaleComputationCost = 10
+
+	// computation costs for opcode added at londonCompatible Protocol Upgrade
+	BaseFeeComputationCost = 198
+
+	// Opcode Computation Cost Modification
+	AddmodComputationCost         = 3349
+	AddmodComputationCostIstanbul = 1410
+	MulmodComputationCost         = 4757
+	MulmodComputationCostIstanbul = 1760
+	NotComputationCost            = 1289
+	NotComputationCostIstanbul    = 364
+	ShlComputationCost            = 1603
+	ShlComputationCostIstanbul    = 478
+	ShrComputationCost            = 1346
+	ShrComputationCostIstanbul    = 498
+	SarComputationCost            = 1815
+	SarComputationCostIstanbul    = 834
+	XorComputationCost            = 657
+	XorComputationCostIstanbul    = 454
 )


### PR DESCRIPTION
## Proposed changes

- This PR implements the `basefee` opcode for the evm compatibility with Ethereum which is introduced at the london hard fork. 
- `basefee` calculation algorithm is not included and 0 is returned if there is no `basefee` in the block field.
- The computation cost of `basefee` is derived from `BenchmarkOpBaseFee`, and the result is below.
![image](https://user-images.githubusercontent.com/64360042/142552650-a60d1f8d-9689-446b-9116-5c237cf0bb32.png)

- Referenced PRs
  - ethereum london PR tracker: https://github.com/ethereum/go-ethereum/issues/22736
  - ethereum evm panic fix: https://github.com/ethereum/go-ethereum/pull/23047
 
## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
