### PR TITLE
Added rpc.eth.noncompatible flag

### DIFF
--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -247,6 +247,7 @@ var FlagGroups = []FlagGroup{
 			RPCApiFlag,
 			RPCGlobalGasCap,
 			RPCConcurrencyLimit,
+			RPCNonEthCompatibleFlag,
 			IPCDisabledFlag,
 			IPCPathFlag,
 			WSEnabledFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -456,6 +456,10 @@ var (
 		Usage: "Sets a limit of concurrent connection number of HTTP-RPC server",
 		Value: rpc.ConcurrencyLimit,
 	}
+	RPCNonEthCompatibleFlag = cli.BoolFlag{
+		Name:  "rpc.eth.noncompatible",
+		Usage: "Disables the eth namespace API return formatting for compatibility",
+	}
 	WSEnabledFlag = cli.BoolFlag{
 		Name:  "ws",
 		Usage: "Enable the WS-RPC server",
@@ -1388,6 +1392,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.GlobalIsSet(LightKDFFlag.Name) {
 		cfg.UseLightweightKDF = ctx.GlobalBool(LightKDFFlag.Name)
+	}
+	if ctx.GlobalIsSet(RPCNonEthCompatibleFlag.Name) {
+		rpc.NonEthCompatible = ctx.GlobalBool(RPCNonEthCompatibleFlag.Name)
 	}
 }
 

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -102,6 +102,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.NetworkIdFlag,
 	utils.RPCCORSDomainFlag,
 	utils.RPCVirtualHostsFlag,
+	utils.RPCNonEthCompatibleFlag,
 	utils.MetricsEnabledFlag,
 	utils.PrometheusExporterFlag,
 	utils.PrometheusExporterPortFlag,

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -522,7 +522,7 @@ func (s *Server) readRequest(codec ServerCodec) ([]*serverRequest, bool, Error) 
 			continue
 		}
 
-		if NonEthCompatible && r.service == "eth"{
+		if NonEthCompatible && r.service == "eth" {
 			// when NonEthCompatible is true, the return formatting for the eth namespace API provided for Ethereum compatibility is disabled.
 			// convert ethereum namespace to klay namespace.
 			r.service = "klay"

--- a/networks/rpc/server.go
+++ b/networks/rpc/server.go
@@ -68,6 +68,10 @@ var (
 
 	// MaxWebsocketConnections is a maximum number of websocket connections
 	MaxWebsocketConnections int32 = 3000
+
+	// NonEthCompatible is a bool value that determines whether to use return formatting of the eth namespace API  provided for compatibility.
+	// It can be overwritten by rpc.eth.noncompatible flag
+	NonEthCompatible = false
 )
 
 // NewServer will create a new server instance with no registered handlers.
@@ -518,8 +522,9 @@ func (s *Server) readRequest(codec ServerCodec) ([]*serverRequest, bool, Error) 
 			continue
 		}
 
-		// for ethereum compatibility. convert ethereum namespace to klay namespace.
-		if r.service == "eth" {
+		if NonEthCompatible && r.service == "eth"{
+			// when NonEthCompatible is true, the return formatting for the eth namespace API provided for Ethereum compatibility is disabled.
+			// convert ethereum namespace to klay namespace.
 			r.service = "klay"
 		}
 


### PR DESCRIPTION
## Proposed changes

This PR introduces `rpc.eth.noncompatible` flag to disable eth namespace API return formatting.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
