### PR TITLE
Lower log level for anchoring data decoding failures

### DIFF
--- a/blockchain/types/tx_internal_data_chain_data_anchoring.go
+++ b/blockchain/types/tx_internal_data_chain_data_anchoring.go
@@ -284,7 +284,7 @@ func (t *TxInternalDataChainDataAnchoring) Execute(sender ContractRef, vm VM, st
 func (t *TxInternalDataChainDataAnchoring) MakeRPCOutput() map[string]interface{} {
 	decoded, err := DecodeAnchoringDataToJSON(t.Payload)
 	if err != nil {
-		logger.Error("decode anchor payload", "err", err)
+		logger.Trace("decode anchor payload", "err", err)
 	}
 
 	return map[string]interface{}{
@@ -302,7 +302,7 @@ func (t *TxInternalDataChainDataAnchoring) MakeRPCOutput() map[string]interface{
 func (t *TxInternalDataChainDataAnchoring) MarshalJSON() ([]byte, error) {
 	decoded, err := DecodeAnchoringDataToJSON(t.Payload)
 	if err != nil {
-		logger.Error("decode anchor payload", "err", err)
+		logger.Trace("decode anchor payload", "err", err)
 	}
 	return json.Marshal(TxInternalDataChainDataAnchoringJSON{
 		t.Type(),

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
@@ -319,7 +319,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoring) Execute(sender ContractRe
 func (t *TxInternalDataFeeDelegatedChainDataAnchoring) MakeRPCOutput() map[string]interface{} {
 	decoded, err := DecodeAnchoringDataToJSON(t.Payload)
 	if err != nil {
-		logger.Error("decode anchor payload", "err", err)
+		logger.Trace("decode anchor payload", "err", err)
 	}
 	return map[string]interface{}{
 		"typeInt":            t.Type(),
@@ -338,7 +338,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoring) MakeRPCOutput() map[strin
 func (t *TxInternalDataFeeDelegatedChainDataAnchoring) MarshalJSON() ([]byte, error) {
 	decoded, err := DecodeAnchoringDataToJSON(t.Payload)
 	if err != nil {
-		logger.Error("decode anchor payload", "err", err)
+		logger.Trace("decode anchor payload", "err", err)
 	}
 	return json.Marshal(TxInternalDataFeeDelegatedChainDataAnchoringJSON{
 		t.Type(),

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
@@ -343,7 +343,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) Execute(sender C
 func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MakeRPCOutput() map[string]interface{} {
 	decoded, err := DecodeAnchoringDataToJSON(t.Payload)
 	if err != nil {
-		logger.Error("decode anchor payload", "err", err)
+		logger.Trace("decode anchor payload", "err", err)
 	}
 
 	return map[string]interface{}{
@@ -364,7 +364,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MakeRPCOutput() 
 func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) MarshalJSON() ([]byte, error) {
 	decoded, err := DecodeAnchoringDataToJSON(t.Payload)
 	if err != nil {
-		logger.Error("decode anchor payload", "err", err)
+		logger.Trace("decode anchor payload", "err", err)
 	}
 	return json.Marshal(TxInternalDataFeeDelegatedChainDataAnchoringWithRatioJSON{
 		t.Type(),


### PR DESCRIPTION
## Proposed changes

Change log level for anchoring data decoding failures from `ERROR` to `TRACE`.

Normally anchoring data has JSON format, but Klaytn does not strictly deny the other formats. 
So, `DecodeAnchoringDataToJSON` may fail in some cases and it's not a critical error for Klaytn.  

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
