### PR TITLE
Add a txpool flag denying remote txs from peers

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -103,6 +103,7 @@ type blockChain interface {
 type TxPoolConfig struct {
 	NoLocals           bool          // Whether local transaction handling should be disabled
 	AllowLocalAnchorTx bool          // if this is true, the txpool allow locally submitted anchor transactions
+	DenyRemoteTx       bool          // Denies remote transactions receiving from other peers
 	Journal            string        // Journal of local transactions to survive node restarts
 	JournalInterval    time.Duration // Time interval to regenerate the local transaction journal
 
@@ -920,6 +921,9 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 // HandleTxMsg transfers transactions to a channel where handleTxMsg calls AddRemotes
 // to handle them. This is made not to wait from the results from TxPool.AddRemotes.
 func (pool *TxPool) HandleTxMsg(txs types.Transactions) {
+	if pool.config.DenyRemoteTx {
+		return
+	}
 	senderCacher.recover(pool.signer, txs)
 	pool.txMsgCh <- txs
 }

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -66,6 +66,7 @@ var FlagGroups = []FlagGroup{
 		Flags: []cli.Flag{
 			TxPoolNoLocalsFlag,
 			TxPoolAllowLocalAnchorTxFlag,
+			TxPoolDenyRemoteTxFlag,
 			TxPoolJournalFlag,
 			TxPoolJournalIntervalFlag,
 			TxPoolPriceLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -152,6 +152,10 @@ var (
 		Name:  "txpool.allow-local-anchortx",
 		Usage: "Allow locally submitted anchoring transactions",
 	}
+	TxPoolDenyRemoteTxFlag = cli.BoolFlag{
+		Name:  "txpool.deny.remotetx",
+		Usage: "Deny remote transaction receiving from other peers. Use only for emergency cases",
+	}
 	TxPoolJournalFlag = cli.StringFlag{
 		Name:  "txpool.journal",
 		Usage: "Disk journal for local transaction to survive node restarts",
@@ -1397,6 +1401,9 @@ func setTxPool(ctx *cli.Context, cfg *blockchain.TxPoolConfig) {
 	}
 	if ctx.GlobalIsSet(TxPoolAllowLocalAnchorTxFlag.Name) {
 		cfg.AllowLocalAnchorTx = ctx.GlobalBool(TxPoolAllowLocalAnchorTxFlag.Name)
+	}
+	if ctx.GlobalIsSet(TxPoolDenyRemoteTxFlag.Name) {
+		cfg.DenyRemoteTx = ctx.GlobalBool(TxPoolDenyRemoteTxFlag.Name)
 	}
 	if ctx.GlobalIsSet(TxPoolJournalFlag.Name) {
 		cfg.Journal = ctx.GlobalString(TxPoolJournalFlag.Name)

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -40,6 +40,7 @@ var CommonNodeFlags = []cli.Flag{
 	utils.KeyStoreDirFlag,
 	utils.TxPoolNoLocalsFlag,
 	utils.TxPoolAllowLocalAnchorTxFlag,
+	utils.TxPoolDenyRemoteTxFlag,
 	utils.TxPoolJournalFlag,
 	utils.TxPoolJournalIntervalFlag,
 	utils.TxPoolPriceLimitFlag,


### PR DESCRIPTION
## Proposed changes

If this flag is on, txpool denies remote txs from other peers. 
This flag is recommended to be used in emergency cases in which other peers keep sending harmful txs. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
