### PR TITLE
A draft structure of eth namespace API for compatibility

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/klaytn/klaytn/datasync/downloader"
 	"github.com/klaytn/klaytn/governance"
 	"github.com/klaytn/klaytn/node/cn/filters"
 )
@@ -8,8 +9,9 @@ import (
 // EthereumAPI provides an API to access the Klaytn through the `eth` namespace.
 // TODO-Klaytn: Removed unused variable
 type EthereumAPI struct {
-	publicFilterAPI   *filters.PublicFilterAPI
-	governanceKlayAPI *governance.GovernanceKlayAPI
+	publicFilterAPI     *filters.PublicFilterAPI
+	governanceKlayAPI   *governance.GovernanceKlayAPI
+	publicDownloaderAPI *downloader.PublicDownloaderAPI
 
 	publicKlayAPI            *PublicKlayAPI
 	publicBlockChainAPI      *PublicBlockChainAPI
@@ -22,7 +24,7 @@ type EthereumAPI struct {
 // Therefore, it is necessary to use APIs defined in two different packages(cn and api),
 // so those apis will be defined through a setter.
 func NewEthereumAPI() *EthereumAPI {
-	return &EthereumAPI{nil, nil, nil, nil, nil, nil}
+	return &EthereumAPI{nil, nil, nil, nil, nil, nil, nil}
 }
 
 // SetPublicFilterAPI sets publicFilterAPI
@@ -33,6 +35,11 @@ func (api *EthereumAPI) SetPublicFilterAPI(publicFilterAPI *filters.PublicFilter
 // SetGovernanceKlayAPI sets governanceKlayAPI
 func (api *EthereumAPI) SetGovernanceKlayAPI(governanceKlayAPI *governance.GovernanceKlayAPI) {
 	api.governanceKlayAPI = governanceKlayAPI
+}
+
+// SetPublicDownloaderAPI sets publicDownloaderAPI
+func (api *EthereumAPI) SetPublicDownloaderAPI(publicDownloaderAPI *downloader.PublicDownloaderAPI) {
+	api.publicDownloaderAPI = publicDownloaderAPI
 }
 
 // SetPublicKlayAPI sets publicKlayAPI

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"github.com/klaytn/klaytn/governance"
+	"github.com/klaytn/klaytn/node/cn"
+	"github.com/klaytn/klaytn/node/cn/filters"
+)
+
+// EthereumAPI provides an API to access the Klaytn through the `eth` namespace.
+// TODO-Klaytn: Removed unused variable
+type EthereumAPI struct {
+	cn *cn.CN
+
+	publicCNKlayAPI   *cn.PublicKlayAPI
+	publicFilterAPI   *filters.PublicFilterAPI
+	governanceKlayAPI *governance.GovernanceKlayAPI
+
+	publicKlayAPI            *PublicKlayAPI
+	publicBlockChainAPI      *PublicBlockChainAPI
+	publicTransactionPoolAPI *PublicTransactionPoolAPI
+	publicAccountAPI         *PublicAccountAPI
+}
+
+// NewEthereumAPI creates a new ethereum API.
+// EthereumAPI operates using Klaytn's API internally without overriding.
+// Therefore, it is necessary to use APIs defined in two different packages(cn and api),
+// so those apis will be defined through a setter.
+func NewEthereumAPI(cn *cn.CN) *EthereumAPI {
+	return &EthereumAPI{cn, nil, nil, nil, nil, nil, nil, nil}
+}
+
+// SetCNPublicKlayAPI sets publicCNKlayAPI
+func (api *EthereumAPI) SetPublicCNKlayAPI(publicCNKlayAPI *cn.PublicKlayAPI) {
+	api.publicCNKlayAPI = publicCNKlayAPI
+}
+
+// SetPublicFilterAPI sets publicFilterAPI
+func (api *EthereumAPI) SetPublicFilterAPI(publicFilterAPI *filters.PublicFilterAPI) {
+	api.publicFilterAPI = publicFilterAPI
+}
+
+// SetGovernanceKlayAPI sets governanceKlayAPI
+func (api *EthereumAPI) SetGovernanceKlayAPI(governanceKlayAPI *governance.GovernanceKlayAPI) {
+	api.governanceKlayAPI = governanceKlayAPI
+}
+
+// SetPublicKlayAPI sets publicKlayAPI
+func (api *EthereumAPI) SetPublicKlayAPI(publicKlayAPI *PublicKlayAPI) {
+	api.publicKlayAPI = publicKlayAPI
+}
+
+// SetPublicBlockChainAPI sets publicBlockChainAPI
+func (api *EthereumAPI) SetPublicBlockChainAPI(publicBlockChainAPI *PublicBlockChainAPI) {
+	api.publicBlockChainAPI = publicBlockChainAPI
+}
+
+// SetPublicTransactionPoolAPI sets publicTransactionPoolAPI
+func (api *EthereumAPI) SetPublicTransactionPoolAPI(publicTransactionPoolAPI *PublicTransactionPoolAPI) {
+	api.publicTransactionPoolAPI = publicTransactionPoolAPI
+}
+
+// SetPublicAccountAPI sets publicAccountAPI
+func (api *EthereumAPI) SetPublicAccountAPI(publicAccountAPI *PublicAccountAPI) {
+	api.publicAccountAPI = publicAccountAPI
+}

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"github.com/klaytn/klaytn/datasync/downloader"
 	"github.com/klaytn/klaytn/governance"
 	"github.com/klaytn/klaytn/node/cn/filters"
 )
@@ -9,9 +8,8 @@ import (
 // EthereumAPI provides an API to access the Klaytn through the `eth` namespace.
 // TODO-Klaytn: Removed unused variable
 type EthereumAPI struct {
-	publicFilterAPI     *filters.PublicFilterAPI
-	governanceKlayAPI   *governance.GovernanceKlayAPI
-	publicDownloaderAPI *downloader.PublicDownloaderAPI
+	publicFilterAPI   *filters.PublicFilterAPI
+	governanceKlayAPI *governance.GovernanceKlayAPI
 
 	publicKlayAPI            *PublicKlayAPI
 	publicBlockChainAPI      *PublicBlockChainAPI
@@ -24,7 +22,7 @@ type EthereumAPI struct {
 // Therefore, it is necessary to use APIs defined in two different packages(cn and api),
 // so those apis will be defined through a setter.
 func NewEthereumAPI() *EthereumAPI {
-	return &EthereumAPI{nil, nil, nil, nil, nil, nil, nil}
+	return &EthereumAPI{nil, nil, nil, nil, nil, nil}
 }
 
 // SetPublicFilterAPI sets publicFilterAPI
@@ -35,11 +33,6 @@ func (api *EthereumAPI) SetPublicFilterAPI(publicFilterAPI *filters.PublicFilter
 // SetGovernanceKlayAPI sets governanceKlayAPI
 func (api *EthereumAPI) SetGovernanceKlayAPI(governanceKlayAPI *governance.GovernanceKlayAPI) {
 	api.governanceKlayAPI = governanceKlayAPI
-}
-
-// SetPublicDownloaderAPI sets publicDownloaderAPI
-func (api *EthereumAPI) SetPublicDownloaderAPI(publicDownloaderAPI *downloader.PublicDownloaderAPI) {
-	api.publicDownloaderAPI = publicDownloaderAPI
 }
 
 // SetPublicKlayAPI sets publicKlayAPI

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1,3 +1,19 @@
+// Copyright 2021 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
 package api
 
 import (

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -2,16 +2,12 @@ package api
 
 import (
 	"github.com/klaytn/klaytn/governance"
-	"github.com/klaytn/klaytn/node/cn"
 	"github.com/klaytn/klaytn/node/cn/filters"
 )
 
 // EthereumAPI provides an API to access the Klaytn through the `eth` namespace.
 // TODO-Klaytn: Removed unused variable
 type EthereumAPI struct {
-	cn *cn.CN
-
-	publicCNKlayAPI   *cn.PublicKlayAPI
 	publicFilterAPI   *filters.PublicFilterAPI
 	governanceKlayAPI *governance.GovernanceKlayAPI
 
@@ -25,13 +21,8 @@ type EthereumAPI struct {
 // EthereumAPI operates using Klaytn's API internally without overriding.
 // Therefore, it is necessary to use APIs defined in two different packages(cn and api),
 // so those apis will be defined through a setter.
-func NewEthereumAPI(cn *cn.CN) *EthereumAPI {
-	return &EthereumAPI{cn, nil, nil, nil, nil, nil, nil, nil}
-}
-
-// SetCNPublicKlayAPI sets publicCNKlayAPI
-func (api *EthereumAPI) SetPublicCNKlayAPI(publicCNKlayAPI *cn.PublicKlayAPI) {
-	api.publicCNKlayAPI = publicCNKlayAPI
+func NewEthereumAPI() *EthereumAPI {
+	return &EthereumAPI{nil, nil, nil, nil, nil, nil}
 }
 
 // SetPublicFilterAPI sets publicFilterAPI

--- a/api/backend.go
+++ b/api/backend.go
@@ -89,23 +89,34 @@ type Backend interface {
 	GetTxLookupInfoAndReceiptInCache(Hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, *types.Receipt)
 }
 
-func GetAPIs(apiBackend Backend) []rpc.API {
+func GetAPIs(apiBackend Backend, ethAPI *EthereumAPI) []rpc.API {
 	nonceLock := new(AddrLocker)
+
+	publicKlayAPI := NewPublicKlayAPI(apiBackend)
+	publicBlockChainAPI := NewPublicBlockChainAPI(apiBackend)
+	publicTransactionPoolAPI := NewPublicTransactionPoolAPI(apiBackend, nonceLock)
+	publicAccountAPI := NewPublicAccountAPI(apiBackend.AccountManager())
+
+	ethAPI.SetPublicKlayAPI(publicKlayAPI)
+	ethAPI.SetPublicBlockChainAPI(publicBlockChainAPI)
+	ethAPI.SetPublicTransactionPoolAPI(publicTransactionPoolAPI)
+	ethAPI.SetPublicAccountAPI(publicAccountAPI)
+
 	return []rpc.API{
 		{
 			Namespace: "klay",
 			Version:   "1.0",
-			Service:   NewPublicKlayAPI(apiBackend),
+			Service:   publicKlayAPI,
 			Public:    true,
 		}, {
 			Namespace: "klay",
 			Version:   "1.0",
-			Service:   NewPublicBlockChainAPI(apiBackend),
+			Service:   publicBlockChainAPI,
 			Public:    true,
 		}, {
 			Namespace: "klay",
 			Version:   "1.0",
-			Service:   NewPublicTransactionPoolAPI(apiBackend, nonceLock),
+			Service:   publicTransactionPoolAPI,
 			Public:    true,
 		}, {
 			Namespace: "txpool",
@@ -124,7 +135,7 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 		}, {
 			Namespace: "klay",
 			Version:   "1.0",
-			Service:   NewPublicAccountAPI(apiBackend.AccountManager()),
+			Service:   publicAccountAPI,
 			Public:    true,
 		}, {
 			Namespace: "personal",

--- a/api/backend.go
+++ b/api/backend.go
@@ -89,8 +89,10 @@ type Backend interface {
 	GetTxLookupInfoAndReceiptInCache(Hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, *types.Receipt)
 }
 
-func GetAPIs(apiBackend Backend, ethAPI *EthereumAPI) []rpc.API {
+func GetAPIs(apiBackend Backend) ([]rpc.API, *EthereumAPI) {
 	nonceLock := new(AddrLocker)
+
+	ethAPI := NewEthereumAPI()
 
 	publicKlayAPI := NewPublicKlayAPI(apiBackend)
 	publicBlockChainAPI := NewPublicBlockChainAPI(apiBackend)
@@ -143,5 +145,5 @@ func GetAPIs(apiBackend Backend, ethAPI *EthereumAPI) []rpc.API {
 			Service:   NewPrivateAccountAPI(apiBackend, nonceLock),
 			Public:    false,
 		},
-	}
+	}, ethAPI
 }

--- a/cmd/utils/nodecmd/consolecmd_test.go
+++ b/cmd/utils/nodecmd/consolecmd_test.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 debug:1.0 governance:1.0 istanbul:1.0 klay:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0"
-	httpAPIs = "klay:1.0 net:1.0 rpc:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 governance:1.0 istanbul:1.0 klay:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0"
+	httpAPIs = "eth:1.0 klay:1.0 net:1.0 rpc:1.0 web3:1.0"
 )
 
 // Tests that a node embedded within a console can be started up properly and

--- a/cmd/utils/nodecmd/dumpconfigcmd.go
+++ b/cmd/utils/nodecmd/dumpconfigcmd.go
@@ -99,8 +99,8 @@ func defaultNodeConfig() node.Config {
 	cfg := node.DefaultConfig
 	cfg.Name = clientIdentifier
 	cfg.Version = params.VersionWithCommit(gitCommit)
-	cfg.HTTPModules = append(cfg.HTTPModules, "klay", "shh")
-	cfg.WSModules = append(cfg.WSModules, "klay", "shh")
+	cfg.HTTPModules = append(cfg.HTTPModules, "klay", "shh", "eth")
+	cfg.WSModules = append(cfg.WSModules, "klay", "shh", "eth")
 	cfg.IPCPath = "klay.ipc"
 	return cfg
 }

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -465,8 +465,7 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 // APIs returns the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *CN) APIs() []rpc.API {
-	ethAPI := api.NewEthereumAPI()
-	apis := api.GetAPIs(s.APIBackend, ethAPI)
+	apis, ethAPI := api.GetAPIs(s.APIBackend)
 
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -493,7 +493,7 @@ func (s *CN) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   publicFilterAPI,
+			Service:   publicDownloaderAPI,
 			Public:    true,
 		}, {
 			Namespace: "admin",

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -477,7 +477,6 @@ func (s *CN) APIs() []rpc.API {
 
 	ethAPI.SetPublicFilterAPI(publicFilterAPI)
 	ethAPI.SetGovernanceKlayAPI(governanceKlayAPI)
-	ethAPI.SetPublicDownloaderAPI(publicDownloaderAPI)
 
 	// Append all the local APIs and return
 	return append(apis, []rpc.API{
@@ -492,7 +491,7 @@ func (s *CN) APIs() []rpc.API {
 			Service:   publicDownloaderAPI,
 			Public:    true,
 		}, {
-			Namespace: "klay",
+			Namespace: "eth",
 			Version:   "1.0",
 			Service:   publicFilterAPI,
 			Public:    true,

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -465,17 +465,15 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 // APIs returns the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *CN) APIs() []rpc.API {
-	ethAPI := api.NewEthereumAPI(s)
+	ethAPI := api.NewEthereumAPI()
 	apis := api.GetAPIs(s.APIBackend, ethAPI)
 
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)
 
-	publicCNKlayAPI := NewPublicKlayAPI(s)
 	publicFilterAPI := filters.NewPublicFilterAPI(s.APIBackend, false)
 	governanceKlayAPI := governance.NewGovernanceKlayAPI(s.governance, s.blockchain)
 
-	ethAPI.SetPublicCNKlayAPI(publicCNKlayAPI)
 	ethAPI.SetPublicFilterAPI(publicFilterAPI)
 	ethAPI.SetGovernanceKlayAPI(governanceKlayAPI)
 
@@ -486,7 +484,7 @@ func (s *CN) APIs() []rpc.API {
 		{
 			Namespace: "klay",
 			Version:   "1.0",
-			Service:   publicCNKlayAPI,
+			Service:   NewPublicKlayAPI(s),
 			Public:    true,
 		}, {
 			Namespace: "klay",

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -465,27 +465,43 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 // APIs returns the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *CN) APIs() []rpc.API {
-	apis := api.GetAPIs(s.APIBackend)
+	ethAPI := api.NewEthereumAPI(s)
+	apis := api.GetAPIs(s.APIBackend, ethAPI)
 
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)
+
+	publicCNKlayAPI := NewPublicKlayAPI(s)
+	publicFilterAPI := filters.NewPublicFilterAPI(s.APIBackend, false)
+	governanceKlayAPI := governance.NewGovernanceKlayAPI(s.governance, s.blockchain)
+
+	ethAPI.SetPublicCNKlayAPI(publicCNKlayAPI)
+	ethAPI.SetPublicFilterAPI(publicFilterAPI)
+	ethAPI.SetGovernanceKlayAPI(governanceKlayAPI)
+
+	publicDownloaderAPI := downloader.NewPublicDownloaderAPI(s.protocolManager.Downloader(), s.eventMux)
 
 	// Append all the local APIs and return
 	return append(apis, []rpc.API{
 		{
 			Namespace: "klay",
 			Version:   "1.0",
-			Service:   NewPublicKlayAPI(s),
+			Service:   publicCNKlayAPI,
 			Public:    true,
 		}, {
 			Namespace: "klay",
 			Version:   "1.0",
-			Service:   downloader.NewPublicDownloaderAPI(s.protocolManager.Downloader(), s.eventMux),
+			Service:   publicDownloaderAPI,
+			Public:    true,
+		}, {
+			Namespace: "eth",
+			Version:   "1.0",
+			Service:   publicDownloaderAPI,
 			Public:    true,
 		}, {
 			Namespace: "klay",
 			Version:   "1.0",
-			Service:   filters.NewPublicFilterAPI(s.APIBackend, false),
+			Service:   publicFilterAPI,
 			Public:    true,
 		}, {
 			Namespace: "admin",
@@ -513,7 +529,12 @@ func (s *CN) APIs() []rpc.API {
 		}, {
 			Namespace: "klay",
 			Version:   "1.0",
-			Service:   governance.NewGovernanceKlayAPI(s.governance, s.blockchain),
+			Service:   governanceKlayAPI,
+			Public:    true,
+		}, {
+			Namespace: "eth",
+			Version:   "1.0",
+			Service:   ethAPI,
 			Public:    true,
 		},
 	}...)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -473,11 +473,11 @@ func (s *CN) APIs() []rpc.API {
 
 	publicFilterAPI := filters.NewPublicFilterAPI(s.APIBackend, false)
 	governanceKlayAPI := governance.NewGovernanceKlayAPI(s.governance, s.blockchain)
+	publicDownloaderAPI := downloader.NewPublicDownloaderAPI(s.protocolManager.Downloader(), s.eventMux)
 
 	ethAPI.SetPublicFilterAPI(publicFilterAPI)
 	ethAPI.SetGovernanceKlayAPI(governanceKlayAPI)
-
-	publicDownloaderAPI := downloader.NewPublicDownloaderAPI(s.protocolManager.Downloader(), s.eventMux)
+	ethAPI.SetPublicDownloaderAPI(publicDownloaderAPI)
 
 	// Append all the local APIs and return
 	return append(apis, []rpc.API{
@@ -488,11 +488,6 @@ func (s *CN) APIs() []rpc.API {
 			Public:    true,
 		}, {
 			Namespace: "klay",
-			Version:   "1.0",
-			Service:   publicDownloaderAPI,
-			Public:    true,
-		}, {
-			Namespace: "eth",
 			Version:   "1.0",
 			Service:   publicDownloaderAPI,
 			Public:    true,


### PR DESCRIPTION
## Proposed changes

This PR introduces a draft of the structure to support `eth` namespace APIs.

`EthereumAPI` is newly implemented to support this, and this will be implemented using Klaytn API functions.
For using Klaytn API functions, the current draft implementation has all the `klay` namespace APIs as variables. (except for `PublicKlayAPI` because eth API does not support `Rewardbase`)
However, after the implementation is completed, unused variables will be cleaned up.
Please let me know if there is better idea for this. :) 

After this PR, another PR that defines API functions to be supported will be uploaded.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
