### PR TITLE
Added CumulativeGasUsed in Receipt struct

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2443,7 +2443,7 @@ func (bc *BlockChain) ApplyTransaction(chainConfig *params.ChainConfig, author *
 	statedb.Finalise(true, false)
 	*usedGas += gas
 
-	receipt := types.NewReceipt(kerr.Status, tx.Hash(), gas)
+	receipt := types.NewReceipt(kerr.Status, tx.Hash(), gas, *usedGas)
 	// if the transaction created a contract, store the creation address in the receipt.
 	msg.FillContractAddress(vmenv.Context.Origin, receipt)
 	// Set the receipt logs and create a bloom for filtering

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2443,7 +2443,8 @@ func (bc *BlockChain) ApplyTransaction(chainConfig *params.ChainConfig, author *
 	statedb.Finalise(true, false)
 	*usedGas += gas
 
-	receipt := types.NewReceipt(kerr.Status, tx.Hash(), gas, *usedGas)
+	receipt := types.NewReceipt(kerr.Status, tx.Hash(), gas)
+	receipt.SetCumulativeGasUsed(*usedGas)
 	// if the transaction created a contract, store the creation address in the receipt.
 	msg.FillContractAddress(vmenv.Context.Origin, receipt)
 	// Set the receipt logs and create a bloom for filtering

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2444,7 +2444,7 @@ func (bc *BlockChain) ApplyTransaction(chainConfig *params.ChainConfig, author *
 	*usedGas += gas
 
 	receipt := types.NewReceipt(kerr.Status, tx.Hash(), gas)
-	receipt.SetCumulativeGasUsed(*usedGas)
+	receipt.CumulativeGasUsed = *usedGas
 	// if the transaction created a contract, store the creation address in the receipt.
 	msg.FillContractAddress(vmenv.Context.Origin, receipt)
 	// Set the receipt logs and create a bloom for filtering

--- a/blockchain/types/receipt.go
+++ b/blockchain/types/receipt.go
@@ -101,6 +101,8 @@ type Receipt struct {
 	TxHash          common.Hash    `json:"transactionHash" gencodec:"required"`
 	ContractAddress common.Address `json:"contractAddress"`
 	GasUsed         uint64         `json:"gasUsed" gencodec:"required"`
+
+	CumulativeGasUsed uint64 `json:"cumulativeGasUsed"`
 }
 
 type receiptMarshaling struct {
@@ -126,11 +128,12 @@ type receiptStorageRLP struct {
 }
 
 // NewReceipt creates a barebone transaction receipt, copying the init fields.
-func NewReceipt(status uint, txHash common.Hash, gasUsed uint64) *Receipt {
+func NewReceipt(status uint, txHash common.Hash, gasUsed uint64, cumulativeGasUsed uint64) *Receipt {
 	return &Receipt{
-		Status:  status,
-		TxHash:  txHash,
-		GasUsed: gasUsed,
+		Status:            status,
+		TxHash:            txHash,
+		GasUsed:           gasUsed,
+		CumulativeGasUsed: cumulativeGasUsed,
 	}
 }
 

--- a/blockchain/types/receipt.go
+++ b/blockchain/types/receipt.go
@@ -129,13 +129,16 @@ type receiptStorageRLP struct {
 }
 
 // NewReceipt creates a barebone transaction receipt, copying the init fields.
-func NewReceipt(status uint, txHash common.Hash, gasUsed uint64, cumulativeGasUsed uint64) *Receipt {
+func NewReceipt(status uint, txHash common.Hash, gasUsed uint64) *Receipt {
 	return &Receipt{
-		Status:            status,
-		TxHash:            txHash,
-		GasUsed:           gasUsed,
-		CumulativeGasUsed: cumulativeGasUsed,
+		Status:  status,
+		TxHash:  txHash,
+		GasUsed: gasUsed,
 	}
+}
+
+func (r *Receipt) SetCumulativeGasUsed(cumulativeGasUsed uint64) {
+	r.CumulativeGasUsed = cumulativeGasUsed
 }
 
 // EncodeRLP implements rlp.Encoder, and flattens the consensus fields of a receipt

--- a/blockchain/types/receipt.go
+++ b/blockchain/types/receipt.go
@@ -119,12 +119,13 @@ type receiptRLP struct {
 }
 
 type receiptStorageRLP struct {
-	Status          uint
-	Bloom           Bloom
-	TxHash          common.Hash
-	ContractAddress common.Address
-	Logs            []*LogForStorage
-	GasUsed         uint64
+	Status            uint
+	Bloom             Bloom
+	TxHash            common.Hash
+	ContractAddress   common.Address
+	Logs              []*LogForStorage
+	GasUsed           uint64
+	CumulativeGasUsed uint64
 }
 
 // NewReceipt creates a barebone transaction receipt, copying the init fields.
@@ -180,12 +181,13 @@ type ReceiptForStorage Receipt
 // into an RLP stream.
 func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
 	enc := &receiptStorageRLP{
-		Status:          r.Status,
-		Bloom:           r.Bloom,
-		TxHash:          r.TxHash,
-		ContractAddress: r.ContractAddress,
-		Logs:            make([]*LogForStorage, len(r.Logs)),
-		GasUsed:         r.GasUsed,
+		Status:            r.Status,
+		Bloom:             r.Bloom,
+		TxHash:            r.TxHash,
+		ContractAddress:   r.ContractAddress,
+		Logs:              make([]*LogForStorage, len(r.Logs)),
+		GasUsed:           r.GasUsed,
+		CumulativeGasUsed: r.CumulativeGasUsed,
 	}
 	for i, log := range r.Logs {
 		enc.Logs[i] = (*LogForStorage)(log)
@@ -209,7 +211,7 @@ func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
 		r.Logs[i] = (*Log)(log)
 	}
 	// Assign the implementation fields
-	r.TxHash, r.ContractAddress, r.GasUsed = dec.TxHash, dec.ContractAddress, dec.GasUsed
+	r.TxHash, r.ContractAddress, r.GasUsed, r.CumulativeGasUsed = dec.TxHash, dec.ContractAddress, dec.GasUsed, dec.CumulativeGasUsed
 	return nil
 }
 

--- a/blockchain/types/receipt.go
+++ b/blockchain/types/receipt.go
@@ -137,10 +137,6 @@ func NewReceipt(status uint, txHash common.Hash, gasUsed uint64) *Receipt {
 	}
 }
 
-func (r *Receipt) SetCumulativeGasUsed(cumulativeGasUsed uint64) {
-	r.CumulativeGasUsed = cumulativeGasUsed
-}
-
 // EncodeRLP implements rlp.Encoder, and flattens the consensus fields of a receipt
 // into an RLP stream. If no post state is present, byzantium fork is assumed.
 func (r *Receipt) EncodeRLP(w io.Writer) error {

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -132,7 +132,7 @@ func newBlockWithParentHash(blockNum int, parentHash common.Hash) *types.Block {
 }
 
 func newReceipt(gasUsed int) *types.Receipt {
-	rct := types.NewReceipt(uint(gasUsed), common.Hash{}, uint64(gasUsed), uint64(gasUsed))
+	rct := types.NewReceipt(uint(gasUsed), common.Hash{}, uint64(gasUsed))
 	rct.Logs = []*types.Log{}
 	rct.Bloom = types.Bloom{}
 	return rct

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -132,7 +132,7 @@ func newBlockWithParentHash(blockNum int, parentHash common.Hash) *types.Block {
 }
 
 func newReceipt(gasUsed int) *types.Receipt {
-	rct := types.NewReceipt(uint(gasUsed), common.Hash{}, uint64(gasUsed))
+	rct := types.NewReceipt(uint(gasUsed), common.Hash{}, uint64(gasUsed), uint64(gasUsed))
 	rct.Logs = []*types.Log{}
 	rct.Bloom = types.Bloom{}
 	return rct

--- a/tests/klay_scenario_test.go
+++ b/tests/klay_scenario_test.go
@@ -2001,7 +2001,15 @@ func compileSolidity(filename string) (code []string, abiStr []string) {
 
 // applyTransaction setups variables to call block.ApplyTransaction() for tests.
 // It directly returns values from block.ApplyTransaction().
+// This function uses uint64(0) as the default usedGas value.
 func applyTransaction(t *testing.T, bcdata *BCData, tx *types.Transaction) (*types.Receipt, uint64, error) {
+	usedGas := uint64(0)
+	return applyTransactionWithUsedGas(t, bcdata, tx, &usedGas)
+}
+
+// applyTransaction setups variables to call block.ApplyTransaction() for tests.
+// It directly returns values from block.ApplyTransaction().
+func applyTransactionWithUsedGas(t *testing.T, bcdata *BCData, tx *types.Transaction, usedGas *uint64) (*types.Receipt, uint64, error) {
 	state, err := bcdata.bc.State()
 	assert.Equal(t, nil, err)
 
@@ -2018,7 +2026,6 @@ func applyTransaction(t *testing.T, bcdata *BCData, tx *types.Transaction) (*typ
 		Time:       new(big.Int).Add(parent.Time(), common.Big1),
 		BlockScore: big.NewInt(0),
 	}
-	usedGas := uint64(0)
-	receipt, gas, _, err := bcdata.bc.ApplyTransaction(bcdata.bc.Config(), author, state, header, tx, &usedGas, vmConfig)
+	receipt, gas, _, err := bcdata.bc.ApplyTransaction(bcdata.bc.Config(), author, state, header, tx, usedGas, vmConfig)
 	return receipt, gas, err
 }


### PR DESCRIPTION
## Proposed changes

This PR introduces adding `CumulativeGasUsed` field in Receipt struct for compatibility with Ethereum rpc call return type.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
