### PR TITLE
homi: add londonCompatibleBlockNumber at a genesis.json generated by the homi tool

### DIFF
--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -125,6 +125,7 @@ Args :
 			cliqueEpochFlag,
 			cliquePeriodFlag,
 			istanbulCompatibleBlockNumberFlag,
+			londonCompatibleBlockNumberFlag,
 		},
 		ArgsUsage: "type",
 	}
@@ -506,8 +507,7 @@ func gen(ctx *cli.Context) error {
 	}
 
 	genesisJson.Config.IstanbulCompatibleBlock = big.NewInt(ctx.Int64(istanbulCompatibleBlockNumberFlag.Name))
-	// TODO-klaytn: enable below line when londonCompatible protocol upgrade implementation is finished
-	//genesisJson.Config.LondonCompatibleBlock = big.NewInt(ctx.Int64(londonCompatibleBlockNumberFlag.Name))
+	genesisJson.Config.LondonCompatibleBlock = big.NewInt(ctx.Int64(londonCompatibleBlockNumberFlag.Name))
 
 	genesisJsonBytes, _ = json.MarshalIndent(genesisJson, "", "    ")
 	genValidatorKeystore(privKeys)

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -329,4 +329,10 @@ var (
 		Usage: "istanbulCompatible blockNumber",
 		Value: 0,
 	}
+
+	londonCompatibleBlockNumberFlag = cli.Int64Flag{
+		Name:  "london-compatible-blocknumber",
+		Usage: "londonCompatible blockNumber",
+		Value: 0,
+	}
 )


### PR DESCRIPTION
## Proposed changes

- This PR adds londonCompatibleBlockNumber at a genesis.json generated by the homi tool

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
