### PR TITLE
txpool: preventing dropping of local txs when node restarts

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -215,10 +215,8 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		all:          make(map[common.Hash]*types.Transaction),
 		pendingNonce: make(map[common.Address]uint64),
 		chainHeadCh:  make(chan ChainHeadEvent, chainHeadChanSize),
-		// TODO-Klaytn We use ChainConfig.UnitPrice to initialize TxPool.gasPrice,
-		//         later we have to change this rule when governance of UnitPrice is determined.
-		gasPrice: new(big.Int).SetUint64(chainconfig.UnitPrice),
-		txMsgCh:  make(chan types.Transactions, txMsgChSize),
+		gasPrice:     new(big.Int).SetUint64(chainconfig.UnitPrice),
+		txMsgCh:      make(chan types.Transactions, txMsgChSize),
 	}
 	pool.locals = newAccountSet(pool.signer)
 	pool.priced = newTxPricedList(&pool.all)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -212,12 +212,13 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	setEngineType(chainConfig)
 
-	// NOTE-Klaytn Now we use ChainConfig.UnitPrice from genesis.json.
-	//         So let's update cn.Config.GasPrice using ChainConfig.UnitPrice.
-	config.GasPrice = new(big.Int).SetUint64(chainConfig.UnitPrice)
-
-	logger.Info("Initialised chain configuration", "config", chainConfig)
+	// load governance state
 	governance := governance.NewGovernanceInitialize(chainConfig, chainDB)
+
+	// Set latest unitPrice/gasPrice
+	chainConfig.UnitPrice = governance.UnitPrice()
+	config.GasPrice = new(big.Int).SetUint64(chainConfig.UnitPrice)
+	logger.Info("Initialised chain configuration", "config", chainConfig)
 
 	cn := &CN{
 		config:            config,
@@ -291,8 +292,6 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	config.TxPool.NoAccountCreation = config.NoAccountCreation
 	cn.txPool = blockchain.NewTxPool(config.TxPool, cn.chainConfig, bc)
 	governance.SetTxPool(cn.txPool)
-	// Synchronize unitprice
-	cn.txPool.SetGasPrice(big.NewInt(0).SetUint64(governance.UnitPrice()))
 
 	// Permit the downloader to use the trie cache allowance during fast sync
 	cacheLimit := cacheConfig.TrieNodeCacheConfig.LocalCacheSizeMiB
@@ -336,7 +335,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	gpoParams := config.GPO
 
-	// NOTE-Klaytn Now we use ChainConfig.UnitPrice from genesis.json and updated config.GasPrice with same value.
+	// NOTE-Klaytn Now we use latest unitPrice
 	//         So let's override gpoParams.Default with config.GasPrice
 	gpoParams.Default = config.GasPrice
 


### PR DESCRIPTION
## Proposed changes

- This PR prevents dropping journaled local txs when node restarts. local tx means that it is sent by local accounts whose keystore file is stored in local node's keystore folder.
- Before the change, txpool.gasPrice is set to the block 0's gas Price. Then, local txs are loaded from the journal file(transactions.rlp) to the txpool data structure. Then, it is updated to the latest gas price by calling `SetGasPrice`. However, `SetGasPrice` also resets txpool data structure, so local txs are lost.
- After the change, txpool.gasPrice is set to the latest gas price, so local txs can be not lost because it does not need to call `SetGasPrice`. In the process of setting latest gas price, it also sets chainConfig.unitPrice to the latest gas price.
- The test is done by checking whether the restored local txs are inserted into the block or not after the restart.

dev: local txs are not inserted into the block
```
INFO[12/14,19:33:36 +09] [41] Initialised chain configuration           config="{ChainID: 940625 IstanbulCompatibleBlock: 0 LondonCompatibleBlock: <nil> SubGroupSize: 1 UnitPrice: 1 DeriveShaImpl: 2 Engine: istanbul}"
INFO[12/14,19:33:36 +09] [30] Successfully loaded governance state from database  blockNumber=9
INFO[12/14,19:33:36 +09] [41] Initialising Klaytn protocol              versions=[64] network=940625
INFO[12/14,19:33:36 +09] [5] Using DeriveShaConcat!                   
INFO[12/14,19:33:36 +09] [47] Initializing local trie node cache (fastCache)  MaxMiB=1024 FilePath=/Users/yumiel/home_dir/corecell/cn/data/fastcache
INFO[12/14,19:33:36 +09] [47] Initialized local trie node cache (fastCache)  LoadedMiB=0 LoadedEntries=0 elapsed=306.902µs
INFO[12/14,19:33:36 +09] [5] Loaded most recent local header           number=25 hash=e8b47d…15af5e td=26 age=17s215ms
INFO[12/14,19:33:36 +09] [5] Loaded most recent local full block       number=25 hash=e8b47d…15af5e td=26 age=17s215ms
INFO[12/14,19:33:36 +09] [5] Loaded most recent local fast block       number=25 hash=e8b47d…15af5e td=26 age=17s215ms
INFO[12/14,19:33:36 +09] [5] prefetchTxWorkers are started             num=32
INFO[12/14,19:33:36 +09] [5] Loaded local transaction journal          transactions=85 dropped=85
INFO[12/14,19:33:36 +09] [5] Regenerated local transaction journal     transactions=0  accounts=0
INFO[12/14,19:33:36 +09] [5] TxPool.SetGasPrice                        before=1 after=25000
```

PR: local txs are inserted into the block
```
INFO[12/14,19:08:51 +09] [41] Initialised chain configuration           config="{ChainID: 940625 IstanbulCompatibleBlock: 0 LondonCompatibleBlock: <nil> SubGroupSize: 1 UnitPrice: 25000 DeriveShaImpl: 2 Engine: istanbul}"
INFO[12/14,19:08:51 +09] [41] Initialising Klaytn protocol              versions=[64] network=940625
INFO[12/14,19:08:51 +09] [5] Using DeriveShaConcat!                   
INFO[12/14,19:08:51 +09] [47] Initializing local trie node cache (fastCache)  MaxMiB=1024 FilePath=/Users/yumiel/home_dir/corecell/cn/data/fastcache
INFO[12/14,19:08:51 +09] [47] Initialized local trie node cache (fastCache)  LoadedMiB=0 LoadedEntries=0 elapsed=356.121µs
INFO[12/14,19:08:51 +09] [5] Loaded most recent local header           number=38 hash=4e4fb6…cbebcb td=39 age=14s985ms
INFO[12/14,19:08:52 +09] [5] Loaded most recent local full block       number=38 hash=4e4fb6…cbebcb td=39 age=15s6ms
INFO[12/14,19:08:52 +09] [5] Loaded most recent local fast block       number=38 hash=4e4fb6…cbebcb td=39 age=15s7ms
INFO[12/14,19:08:52 +09] [5] prefetchTxWorkers are started             num=32
INFO[12/14,19:08:52 +09] [5] Loaded local transaction journal          transactions=92 dropped=60
INFO[12/14,19:08:52 +09] [5] Regenerated local transaction journal     transactions=32 accounts=1
```
## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
