### PR TITLE
Added timeout flag for fasthttp server

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -548,6 +548,26 @@ var (
 		Usage: "Maximum allowed number of return items for log collecting filter API",
 		Value: filters.GetLogsMaxItems,
 	}
+	RPCReadTimeout = cli.IntFlag{
+		Name:  "rpcreadtimeout",
+		Usage: "HTTP-RPC server read timeout",
+		Value: int(rpc.DefaultHTTPTimeouts.ReadTimeout),
+	}
+	RPCWriteTimeoutFlag = cli.IntFlag{
+		Name:  "rpcwritetimeout",
+		Usage: "HTTP-RPC server write timeout",
+		Value: int(rpc.DefaultHTTPTimeouts.WriteTimeout),
+	}
+	RPCIdleTimeoutFlag = cli.IntFlag{
+		Name:  "rpcidletimeout",
+		Usage: "HTTP-RPC server idle timeout",
+		Value: int(rpc.DefaultHTTPTimeouts.IdleTimeout),
+	}
+	RPCExecutionTimeoutFlag = cli.IntFlag{
+		Name:  "rpcexecutiontimeout",
+		Usage: "HTTP-RPC server execution timeout",
+		Value: int(rpc.DefaultHTTPTimeouts.ExecutionTimeout),
+	}
 
 	// Network Settings
 	NodeTypeFlag = cli.StringFlag{
@@ -1182,6 +1202,18 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(RPCConcurrencyLimit.Name) {
 		rpc.ConcurrencyLimit = ctx.GlobalInt(RPCConcurrencyLimit.Name)
 		logger.Info("Set the concurrency limit of RPC-HTTP server", "limit", rpc.ConcurrencyLimit)
+	}
+	if ctx.GlobalIsSet(RPCReadTimeout.Name) {
+		cfg.HTTPTimeouts.ReadTimeout = time.Duration(ctx.GlobalInt(RPCReadTimeout.Name)) * time.Second
+	}
+	if ctx.GlobalIsSet(RPCWriteTimeoutFlag.Name) {
+		cfg.HTTPTimeouts.WriteTimeout = time.Duration(ctx.GlobalInt(RPCWriteTimeoutFlag.Name)) * time.Second
+	}
+	if ctx.GlobalIsSet(RPCIdleTimeoutFlag.Name) {
+		cfg.HTTPTimeouts.IdleTimeout = time.Duration(ctx.GlobalInt(RPCIdleTimeoutFlag.Name)) * time.Second
+	}
+	if ctx.GlobalIsSet(RPCExecutionTimeoutFlag.Name) {
+		cfg.HTTPTimeouts.ExecutionTimeout = time.Duration(ctx.GlobalInt(RPCExecutionTimeoutFlag.Name)) * time.Second
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -550,23 +550,23 @@ var (
 	}
 	RPCReadTimeout = cli.IntFlag{
 		Name:  "rpcreadtimeout",
-		Usage: "HTTP-RPC server read timeout",
-		Value: int(rpc.DefaultHTTPTimeouts.ReadTimeout),
+		Usage: "HTTP-RPC server read timeout (seconds)",
+		Value: int(rpc.DefaultHTTPTimeouts.ReadTimeout / time.Second),
 	}
 	RPCWriteTimeoutFlag = cli.IntFlag{
 		Name:  "rpcwritetimeout",
-		Usage: "HTTP-RPC server write timeout",
-		Value: int(rpc.DefaultHTTPTimeouts.WriteTimeout),
+		Usage: "HTTP-RPC server write timeout (seconds)",
+		Value: int(rpc.DefaultHTTPTimeouts.WriteTimeout / time.Second),
 	}
 	RPCIdleTimeoutFlag = cli.IntFlag{
 		Name:  "rpcidletimeout",
-		Usage: "HTTP-RPC server idle timeout",
-		Value: int(rpc.DefaultHTTPTimeouts.IdleTimeout),
+		Usage: "HTTP-RPC server idle timeout (seconds)",
+		Value: int(rpc.DefaultHTTPTimeouts.IdleTimeout / time.Second),
 	}
 	RPCExecutionTimeoutFlag = cli.IntFlag{
 		Name:  "rpcexecutiontimeout",
-		Usage: "HTTP-RPC server execution timeout",
-		Value: int(rpc.DefaultHTTPTimeouts.ExecutionTimeout),
+		Usage: "HTTP-RPC server execution timeout (seconds)",
+		Value: int(rpc.DefaultHTTPTimeouts.ExecutionTimeout / time.Second),
 	}
 
 	// Network Settings

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -140,6 +140,10 @@ var CommonRPCFlags = []cli.Flag{
 	utils.WSMaxConnections,
 	utils.IPCDisabledFlag,
 	utils.IPCPathFlag,
+	utils.RPCReadTimeout,
+	utils.RPCWriteTimeoutFlag,
+	utils.RPCIdleTimeoutFlag,
+	utils.RPCExecutionTimeoutFlag,
 }
 
 var KCNFlags = []cli.Flag{

--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -106,9 +106,9 @@ type HTTPTimeouts struct {
 // DefaultHTTPTimeouts represents the default timeout values used if further
 // configuration is not provided.
 var DefaultHTTPTimeouts = HTTPTimeouts{
-	ReadTimeout:  30 * time.Second,
-	WriteTimeout: 30 * time.Second,
-	IdleTimeout:  120 * time.Second,
+	ReadTimeout:      30 * time.Second,
+	WriteTimeout:     30 * time.Second,
+	IdleTimeout:      120 * time.Second,
 	ExecutionTimeout: 30 * time.Second,
 }
 

--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -96,6 +96,11 @@ type HTTPTimeouts struct {
 	// is zero, the value of ReadTimeout is used. If both are
 	// zero, ReadHeaderTimeout is used.
 	IdleTimeout time.Duration
+
+	// ExecutionTimeout is the maximum duration for processing the
+	// entire request. If the process is over the time,
+	// the request is stopped immediately and timeout message is sent to client.
+	ExecutionTimeout time.Duration
 }
 
 // DefaultHTTPTimeouts represents the default timeout values used if further
@@ -104,6 +109,7 @@ var DefaultHTTPTimeouts = HTTPTimeouts{
 	ReadTimeout:  30 * time.Second,
 	WriteTimeout: 30 * time.Second,
 	IdleTimeout:  120 * time.Second,
+	ExecutionTimeout: 30 * time.Second,
 }
 
 // DialHTTPWithClient creates a new RPC client that connects to an RPC server over HTTP
@@ -238,7 +244,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, sr
 			if vhost == "*" {
 				return &fasthttp.Server{
 					Concurrency:        ConcurrencyLimit,
-					Handler:            srv.HandleFastHTTP,
+					Handler:            fasthttp.TimeoutHandler(srv.HandleFastHTTP, timeouts.ExecutionTimeout, "timeout"),
 					ReadTimeout:        timeouts.ReadTimeout,
 					WriteTimeout:       timeouts.WriteTimeout,
 					IdleTimeout:        timeouts.IdleTimeout,
@@ -258,6 +264,7 @@ func NewFastHTTPServer(cors []string, vhosts []string, timeouts HTTPTimeouts, sr
 	}
 
 	fhandler := fasthttpadaptor.NewFastHTTPHandler(handler)
+	fhandler = fasthttp.TimeoutHandler(fhandler, timeouts.ExecutionTimeout, "timeout")
 
 	// TODO-Klaytn concurreny default (256 * 1024), goroutine limit (8192)
 	return &fasthttp.Server{

--- a/networks/rpc/utils.go
+++ b/networks/rpc/utils.go
@@ -240,6 +240,10 @@ func sanitizeTimeouts(timeouts HTTPTimeouts) HTTPTimeouts {
 		logger.Warn("Sanitizing invalid HTTP idle timeout", "provided", timeouts.IdleTimeout, "updated", DefaultHTTPTimeouts.IdleTimeout)
 		timeouts.IdleTimeout = DefaultHTTPTimeouts.IdleTimeout
 	}
+	if timeouts.ExecutionTimeout < time.Second {
+		logger.Warn("Sanitizing invalid HTTP execution timeout", "provided", timeouts.ExecutionTimeout, "updated", DefaultHTTPTimeouts.ExecutionTimeout)
+		timeouts.ExecutionTimeout = DefaultHTTPTimeouts.ExecutionTimeout
+	}
 
 	return timeouts
 }


### PR DESCRIPTION
## Proposed changes

This PR introduces rpcreadtimeout, rpcwritetimeout, rpcIdletimeout, rpcexecutiontimeout flag to set the timeout of fast http server.

If the timeout flag is inserted when executing the klaytn node, it can operate as follows.

- Normal case
<img width="618" alt="Screen Shot 2021-12-20 at 11 05 01 PM" src="https://user-images.githubusercontent.com/59811055/146782056-72f5d8af-b9ae-4ad0-b944-57562bf05e04.png">

- Timeout case with the timeout flag
<img width="609" alt="Screen Shot 2021-12-20 at 11 04 44 PM" src="https://user-images.githubusercontent.com/59811055/146782031-a1bb3881-0653-4015-9377-304cdde2a632.png">


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
