### PR TITLE
Added locks for transaction fields

### DIFF
--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -78,7 +78,7 @@ type Transaction struct {
 	markedUnexecutable int32
 
 	// lock for protecting AsMessageWithAccountKeyPicker().
-	mu sync.Mutex
+	mu sync.RWMutex
 }
 
 // NewTransactionWithMap generates a tx from tx field values.
@@ -220,16 +220,28 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (tx *Transaction) Gas() uint64                           { return tx.data.GetGasLimit() }
-func (tx *Transaction) GasPrice() *big.Int                    { return new(big.Int).Set(tx.data.GetPrice()) }
-func (tx *Transaction) Value() *big.Int                       { return new(big.Int).Set(tx.data.GetAmount()) }
-func (tx *Transaction) Nonce() uint64                         { return tx.data.GetAccountNonce() }
-func (tx *Transaction) CheckNonce() bool                      { return tx.checkNonce }
-func (tx *Transaction) Type() TxType                          { return tx.data.Type() }
-func (tx *Transaction) IsLegacyTransaction() bool             { return tx.data.IsLegacyTransaction() }
-func (tx *Transaction) ValidatedSender() common.Address       { return tx.validatedSender }
-func (tx *Transaction) ValidatedFeePayer() common.Address     { return tx.validatedFeePayer }
-func (tx *Transaction) ValidatedIntrinsicGas() uint64         { return tx.validatedIntrinsicGas }
+func (tx *Transaction) Gas() uint64               { return tx.data.GetGasLimit() }
+func (tx *Transaction) GasPrice() *big.Int        { return new(big.Int).Set(tx.data.GetPrice()) }
+func (tx *Transaction) Value() *big.Int           { return new(big.Int).Set(tx.data.GetAmount()) }
+func (tx *Transaction) Nonce() uint64             { return tx.data.GetAccountNonce() }
+func (tx *Transaction) CheckNonce() bool          { return tx.checkNonce }
+func (tx *Transaction) Type() TxType              { return tx.data.Type() }
+func (tx *Transaction) IsLegacyTransaction() bool { return tx.data.IsLegacyTransaction() }
+func (tx *Transaction) ValidatedSender() common.Address {
+	tx.mu.RLock()
+	defer tx.mu.RUnlock()
+	return tx.validatedSender
+}
+func (tx *Transaction) ValidatedFeePayer() common.Address {
+	tx.mu.RLock()
+	defer tx.mu.RUnlock()
+	return tx.validatedFeePayer
+}
+func (tx *Transaction) ValidatedIntrinsicGas() uint64 {
+	tx.mu.RLock()
+	defer tx.mu.RUnlock()
+	return tx.validatedIntrinsicGas
+}
 func (tx *Transaction) MakeRPCOutput() map[string]interface{} { return tx.data.MakeRPCOutput() }
 func (tx *Transaction) GetTxInternalData() TxInternalData     { return tx.data }
 
@@ -244,23 +256,23 @@ func (tx *Transaction) Validate(db StateDB, blockNumber uint64) error {
 // ValidateMutableValue conducts validation of the sender's account key and additional validation for each transaction type.
 func (tx *Transaction) ValidateMutableValue(db StateDB, signer Signer, currentBlockNumber uint64) error {
 	// validate the sender's account key
-	accKey := db.GetKey(tx.validatedSender)
+	accKey := db.GetKey(tx.ValidatedSender())
 	if tx.IsLegacyTransaction() {
 		if !accKey.Type().IsLegacyAccountKey() {
 			return ErrInvalidSigSender
 		}
 	} else {
 		pubkey, err := SenderPubkey(signer, tx)
-		if err != nil || accountkey.ValidateAccountKey(currentBlockNumber, tx.validatedSender, accKey, pubkey, tx.GetRoleTypeForValidation()) != nil {
+		if err != nil || accountkey.ValidateAccountKey(currentBlockNumber, tx.ValidatedSender(), accKey, pubkey, tx.GetRoleTypeForValidation()) != nil {
 			return ErrInvalidSigSender
 		}
 	}
 
 	// validate the fee payer's account key
 	if tx.IsFeeDelegatedTransaction() {
-		feePayerAccKey := db.GetKey(tx.validatedFeePayer)
+		feePayerAccKey := db.GetKey(tx.ValidatedFeePayer())
 		feePayerPubkey, err := SenderFeePayerPubkey(signer, tx)
-		if err != nil || accountkey.ValidateAccountKey(currentBlockNumber, tx.validatedFeePayer, feePayerAccKey, feePayerPubkey, accountkey.RoleFeePayer) != nil {
+		if err != nil || accountkey.ValidateAccountKey(currentBlockNumber, tx.ValidatedFeePayer(), feePayerAccKey, feePayerPubkey, accountkey.RoleFeePayer) != nil {
 			return ErrInvalidSigFeePayer
 		}
 	}
@@ -397,7 +409,7 @@ func (tx *Transaction) FillContractAddress(from common.Address, r *Receipt) {
 // Execute performs execution of the transaction. This function will be called from StateTransition.TransitionDb().
 // Since each transaction type performs different execution, this function calls TxInternalData.TransitionDb().
 func (tx *Transaction) Execute(vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) ([]byte, uint64, error) {
-	sender := NewAccountRefWithFeePayer(tx.validatedSender, tx.validatedFeePayer)
+	sender := NewAccountRefWithFeePayer(tx.ValidatedSender(), tx.ValidatedFeePayer())
 	return tx.data.Execute(sender, vm, stateDB, currentBlockNumber, gas, value)
 }
 
@@ -584,10 +596,12 @@ func (tx *Transaction) ValidateSender(signer Signer, p AccountKeyPicker, current
 		if p.GetKey(addr).Type().IsLegacyAccountKey() == false {
 			return 0, kerrors.ErrLegacyTransactionMustBeWithLegacyKey
 		}
+		tx.mu.Lock()
 		if tx.validatedSender == (common.Address{}) {
 			tx.validatedSender = addr
 			tx.validatedFeePayer = addr
 		}
+		tx.mu.Unlock()
 		return 0, err
 	}
 
@@ -611,10 +625,12 @@ func (tx *Transaction) ValidateSender(signer Signer, p AccountKeyPicker, current
 		return 0, ErrInvalidSigSender
 	}
 
+	tx.mu.Lock()
 	if tx.validatedSender == (common.Address{}) {
 		tx.validatedSender = from
 		tx.validatedFeePayer = from
 	}
+	tx.mu.Unlock()
 
 	return gasKey, nil
 }
@@ -644,9 +660,11 @@ func (tx *Transaction) ValidateFeePayer(signer Signer, p AccountKeyPicker, curre
 		return 0, ErrInvalidSigFeePayer
 	}
 
+	tx.mu.Lock()
 	if tx.validatedFeePayer == tx.validatedSender {
 		tx.validatedFeePayer = feePayer
 	}
+	tx.mu.Unlock()
 
 	return gasKey, nil
 }

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -77,7 +77,7 @@ type Transaction struct {
 	// This value is set when the tx is invalidated in block tx validation, and is used to remove pending tx in txPool.
 	markedUnexecutable int32
 
-	// lock for protecting AsMessageWithAccountKeyPicker().
+	// lock for protecting fields in Transaction struct
 	mu sync.RWMutex
 }
 


### PR DESCRIPTION
## Proposed changes

- Although we are able to access a tx concurrently, the mutex of a tx protects only `validatedIntrinsicGas` field.
- The other fields can be access by `AsMessageWithAccountPicker` method, and this PR locks other fields as well.

The added test result before this PR is attached, where it shows the fee payer is wrongly inserted.
```
> go test -race -run TestRaceAsMessageWithAccountPickerForFeePayer
...
==================
WARNING: DATA RACE
Write at 0x00c000b64255 by goroutine 85:
  github.com/klaytn/klaytn/blockchain/types.(*Transaction).ValidateFeePayer()
      /Users/ojeong-gyun/go/src/github.com/klaytn/klaytn/blockchain/types/transaction.go:648 +0x312
  github.com/klaytn/klaytn/blockchain/types.(*Transaction).AsMessageWithAccountKeyPicker()
      /Users/ojeong-gyun/go/src/github.com/klaytn/klaytn/blockchain/types/transaction.go:425 +0x295
  github.com/klaytn/klaytn/tests.TestRaceAsMessageWithAccountPickerForFeePayer.func1()
      /Users/ojeong-gyun/go/src/github.com/klaytn/klaytn/tests/race_test.go:139 +0x334

Previous read at 0x00c000b64255 by goroutine 115:
  github.com/klaytn/klaytn/tests.TestRaceAsMessageWithAccountPickerForFeePayer.func1()
      /Users/ojeong-gyun/go/src/github.com/klaytn/klaytn/tests/race_test.go:145 +0x54d

Goroutine 85 (running) created at:
  github.com/klaytn/klaytn/tests.TestRaceAsMessageWithAccountPickerForFeePayer()
      /Users/ojeong-gyun/go/src/github.com/klaytn/klaytn/tests/race_test.go:133 +0x6a4
  testing.tRunner()
      /usr/local/Cellar/go/1.15.7/libexec/src/testing/testing.go:1123 +0x202

Goroutine 115 (finished) created at:
  github.com/klaytn/klaytn/tests.TestRaceAsMessageWithAccountPickerForFeePayer()
      /Users/ojeong-gyun/go/src/github.com/klaytn/klaytn/tests/race_test.go:133 +0x6a4
  testing.tRunner()
      /usr/local/Cellar/go/1.15.7/libexec/src/testing/testing.go:1123 +0x202
==================
--- FAIL: TestRaceAsMessageWithAccountPickerForFeePayer (3.66s)
    race_test.go:155: expected: 0xFbFB65EF93E998E18a50CD08b07feEB84116F635, actual: 0xcfC6dC25c815199A716b3e4429c991b51487a62A
    testing.go:1038: race detected during execution of test
FAIL
exit status 1
```

After result:
```
> go test -race -run TestRaceAsMessageWithAccountPickerForFeePayer
PASS
ok  	github.com/klaytn/klaytn/tests	3.990s
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

