### PR TITLE
Introduce a txpool spam throttler prototype

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1770,6 +1770,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		}
 		atomic.StoreUint32(&followupInterrupt, 1)
 
+		// Update to-address based spam throttler when spamThrottler is enabled and a single block is fetched.
+		spamThrottler := GetSpamThrottler()
+		if spamThrottler != nil && len(chain) == 1 {
+			spamThrottler.updateThrottlerState(block.Transactions(), receipts)
+		}
+
 		// Update the metrics subsystem with all the measurements
 		accountReadTimer.Update(stateDB.AccountReads)
 		accountHashTimer.Update(stateDB.AccountHashes)

--- a/blockchain/spam_throttler.go
+++ b/blockchain/spam_throttler.go
@@ -30,9 +30,8 @@ import (
 // TODO-Klaytn: move these variables into TxPool when BlockChain struct contains a TxPool interface
 // spamThrottler need to be accessed by both of TxPool and BlockChain.
 var (
-	DisableSpamThrottlerAtRuntime            = false
-	spamThrottler                 *throttler = nil
-	spamThrottlerMu                          = new(sync.RWMutex)
+	spamThrottler   *throttler = nil
+	spamThrottlerMu            = new(sync.RWMutex)
 )
 
 var (

--- a/blockchain/spam_throttler.go
+++ b/blockchain/spam_throttler.go
@@ -40,6 +40,7 @@ var (
 	throttledSizeGauge       = metrics.NewRegisteredGauge("txpool/throttler/throttled/size", nil)
 	allowedSizeGauge         = metrics.NewRegisteredGauge("txpool/throttler/allowed/size", nil)
 	throttlerUpdateTimeGauge = metrics.NewRegisteredGauge("txpool/throttler/update/time", nil)
+	throttlerDropCount       = metrics.NewRegisteredCounter("txpool/throttler/dropped/count", nil)
 )
 
 type throttler struct {

--- a/blockchain/spam_throttler.go
+++ b/blockchain/spam_throttler.go
@@ -110,18 +110,19 @@ func (t *throttler) adjustThreshold(ratio uint) {
 	var newThreshold int
 	// Decrease threshold if a fail ratio is bigger than target value to put more addresses in throttled map
 	if ratio > t.config.TargetFailRatio {
-		newThreshold = t.threshold - t.config.IncreaseWeight
-
-		// Set minimum threshold
-		if newThreshold < t.config.MinimumThreshold {
+		if t.threshold > t.config.IncreaseWeight {
+			newThreshold = t.threshold - t.config.IncreaseWeight
+		} else {
+			// Set minimum threshold
 			newThreshold = t.config.MinimumThreshold
 		}
 
 		// Increase threshold if a fail ratio is smaller than target ratio until it exceeds InitialThreshold
 	} else {
-		newThreshold = t.threshold + t.config.IncreaseWeight
-
-		if newThreshold > t.config.InitialThreshold {
+		if t.threshold < t.config.InitialThreshold-t.config.IncreaseWeight {
+			newThreshold = t.threshold + t.config.IncreaseWeight
+		} else {
+			// Set maximum threshold
 			newThreshold = t.config.InitialThreshold
 		}
 	}

--- a/blockchain/spam_throttler.go
+++ b/blockchain/spam_throttler.go
@@ -259,12 +259,12 @@ func (t *throttler) classifyTxs(txs types.Transactions) (types.Transactions, typ
 }
 
 // SetAllowed resets the allowed list of throttler. The previous list will be abandoned.
-func (t *throttler) SetAllowed(addrs []common.Address) {
+func (t *throttler) SetAllowed(list []common.Address) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.allowed = make(map[common.Address]bool)
-	for _, addr := range addrs {
+	for _, addr := range list {
 		t.allowed[addr] = true
 	}
 }
@@ -273,22 +273,22 @@ func (t *throttler) GetAllowed() []common.Address {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	var addrs []common.Address
+	allowList := make([]common.Address, 0)
 	for addr := range t.allowed {
-		addrs = append(addrs, addr)
+		allowList = append(allowList, addr)
 	}
-	return addrs
+	return allowList
 }
 
 func (t *throttler) GetThrottled() []common.Address {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	var addrs []common.Address
+	throttledList := make([]common.Address, 0)
 	for addr := range t.throttled {
-		addrs = append(addrs, addr)
+		throttledList = append(throttledList, addr)
 	}
-	return addrs
+	return throttledList
 }
 
 func (t *throttler) GetCandidates() map[common.Address]int {

--- a/blockchain/spam_throttler.go
+++ b/blockchain/spam_throttler.go
@@ -1,0 +1,258 @@
+// Copyright 2021 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package blockchain
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/rcrowley/go-metrics"
+
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+)
+
+// TODO-Klaytn: move these variables into txpool when blockchain struct contains a txpool interface
+// spamThrottler need to be accessed by both of TxPool and BlockChain.
+var (
+	DisableSpamThrottlerAtRuntime            = false
+	spamThrottler                 *throttler = nil
+	spamThrottlerMu                          = new(sync.RWMutex)
+)
+
+var (
+	thresholdGauge     = metrics.NewRegisteredGauge("txpool/throttler/threshold", nil)
+	candidateSizeGauge = metrics.NewRegisteredGauge("txpool/throttler/candidate/size", nil)
+	throttledSizeGauge = metrics.NewRegisteredGauge("txpool/throttler/throttled/size", nil)
+	allowedSizeGauge   = metrics.NewRegisteredGauge("txpool/throttler/allowed/size", nil)
+)
+
+type throttler struct {
+	config *throttlerConfig
+
+	candidates map[*common.Address]int  // throttle candidates with spam weight. Not for concurrent use
+	throttled  map[*common.Address]int  // throttled addresses. It requires mu.lock for concurrent use
+	allowed    map[*common.Address]bool // white listed addresses. It requires mu.lock for concurrent use
+	mu         *sync.RWMutex            // mutex for throttled and allowed
+
+	threshold  int
+	throttleCh chan *types.Transaction
+	quitCh     chan struct{}
+}
+
+type throttlerConfig struct {
+	activateTxPoolSize uint `json:"activate_tx_pool_size"`
+	targetFailRatio    uint `json:"target_fail_ratio"`
+	throttleTPS        uint `json:"throttle_tps"`
+	weightMapSize      uint `json:"weight_map_size"`
+
+	increaseWeight   int `json:"increase_weight"`
+	decreaseWeight   int `json:"decrease_weight"`
+	initialThreshold int `json:"initial_threshold"` // initialThreshold <= threshold <= throttledWeight
+	throttledWeight  int `json:"throttled_weight"`
+}
+
+var DefaultSpamThrottlerConfig = &throttlerConfig{
+	activateTxPoolSize: 1000,
+	targetFailRatio:    10,
+	throttleTPS:        10,    // len(throttleCh) = throttleTPS * 3 = 32KB * 10 * 3 = 960KB
+	weightMapSize:      10000, // (20 + 4)B * 10000 = 240KB
+
+	increaseWeight:   5,
+	decreaseWeight:   1,
+	initialThreshold: 100,
+	throttledWeight:  300,
+}
+
+func GetSpamThrottler() *throttler {
+	spamThrottlerMu.RLock()
+	t := spamThrottler
+	spamThrottlerMu.RUnlock()
+	return t
+}
+
+func validateConfig(conf *throttlerConfig) error {
+	if conf == nil {
+		return errors.New("nil throttlerConfig")
+	}
+
+	if conf.targetFailRatio > 100 {
+		return errors.New("invalid throttlerConfig. 0 <= targetFailRatio <= 100")
+	}
+
+	if conf.initialThreshold > conf.increaseWeight && conf.initialThreshold < conf.throttledWeight {
+		return errors.New("invalid throttlerConfig. increaseWeight < initialThreshold < throttledWeight")
+	}
+
+	return nil
+}
+
+// adjustThreshold adjusts the spam weight threshold of throttler in an adaptive way.
+func (t *throttler) adjustThreshold(ratio uint) {
+	var newThreshold int
+	// Decrease threshold if a fail ratio is bigger than target value to put more addresses in throttled map
+	if ratio > t.config.targetFailRatio {
+		newThreshold = t.threshold - t.config.increaseWeight
+
+		// Set minimum threshold
+		if newThreshold < t.config.increaseWeight {
+			newThreshold = t.config.increaseWeight
+		}
+
+		// Increase threshold if a fail ratio is smaller than target ratio until it exceeds initialThreshold
+	} else {
+		newThreshold = t.threshold + t.config.increaseWeight
+
+		if newThreshold > t.config.initialThreshold {
+			newThreshold = t.config.initialThreshold
+		}
+	}
+
+	t.threshold = newThreshold
+
+	// Update metrics
+	thresholdGauge.Update(int64(newThreshold))
+}
+
+// newAllowed generates a new allowed list of throttler.
+func (t *throttler) newAllowed(allowed []*common.Address) {
+	t.mu.Lock()
+
+	a := make(map[*common.Address]bool, len(allowed))
+	for _, addr := range allowed {
+		a[addr] = true
+	}
+	t.allowed = a
+	allowedSize := len(allowed)
+
+	t.mu.Unlock()
+
+	// Update metrics
+	allowedSizeGauge.Update(int64(allowedSize))
+}
+
+// updateThrottled removes outdated addresses from the throttle list and adds new addresses to the list.
+func (t *throttler) updateThrottled(newThrottled []*common.Address) {
+	var removeThrottled []*common.Address
+	t.mu.Lock()
+
+	// Decrease spam weight for all throttled addresses.
+	for addr, remained := range t.throttled {
+		t.throttled[addr] = remained - t.config.decreaseWeight
+		if t.throttled[addr] < 0 {
+			removeThrottled = append(removeThrottled, addr)
+		}
+	}
+
+	// Remove throttled addresses from throttled map.
+	for _, addr := range removeThrottled {
+		delete(t.throttled, addr)
+	}
+
+	for _, addr := range newThrottled {
+		t.throttled[addr] = t.config.throttledWeight
+	}
+
+	size := len(t.throttled)
+	t.mu.Unlock()
+
+	// Update metrics
+	throttledSizeGauge.Update(int64(size))
+}
+
+// updateThrottlerState updates the throttle list by calculating spam weight of candidates.
+func (t *throttler) updateThrottlerState(txs types.Transactions, receipts types.Receipts) {
+	var removeCandidate []*common.Address
+	var newThrottled []*common.Address
+
+	numFailed := 0
+	failRatio := uint(0)
+	mapSize := uint(len(t.candidates))
+
+	// Increase spam weight of throttle candidates who generate failed txs.
+	for i, receipt := range receipts {
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			numFailed++
+
+			toAddr := txs[i].To()
+			if toAddr == nil {
+				continue
+			}
+
+			weight := t.candidates[toAddr]
+			if weight == 0 {
+				if mapSize >= t.config.weightMapSize {
+					continue
+				}
+				mapSize++
+			}
+			t.candidates[toAddr] = weight + t.config.increaseWeight
+		}
+	}
+
+	// Decrease spam weight for all candidates and update throttle lists in throttled.
+	for addr, weight := range t.candidates {
+		newWeight := weight - t.config.decreaseWeight
+
+		switch {
+		case newWeight < 0:
+			removeCandidate = append(removeCandidate, addr)
+
+		case newWeight > t.threshold:
+			removeCandidate = append(removeCandidate, addr)
+			newThrottled = append(newThrottled, addr)
+
+		default:
+			t.candidates[addr] = newWeight
+		}
+	}
+
+	// Remove throttle candidates from candidates map.
+	for _, addr := range removeCandidate {
+		delete(t.candidates, addr)
+	}
+
+	if len(receipts) != 0 {
+		failRatio = uint(100 * numFailed / len(receipts))
+	}
+
+	// Update throttled and threshold
+	t.updateThrottled(newThrottled)
+	t.adjustThreshold(failRatio)
+
+	// Update metrics
+	candidateSizeGauge.Update(int64(len(t.candidates)))
+}
+
+// classifyTxs classifies given txs into allowTxs and throttleTxs.
+// If to-address of tx is listed in the throttle list, it is classified as throttleTx.
+func (t *throttler) classifyTxs(txs types.Transactions) (types.Transactions, types.Transactions) {
+	allowTxs := txs[:0]
+	throttleTxs := txs[:0]
+
+	t.mu.RLock()
+	for _, tx := range txs {
+		if tx.To() != nil && t.throttled[tx.To()] > 0 && t.allowed[tx.To()] == false {
+			throttleTxs = append(throttleTxs, tx)
+		} else {
+			allowTxs = append(allowTxs, tx)
+		}
+	}
+	t.mu.RUnlock()
+
+	return allowTxs, throttleTxs
+}

--- a/blockchain/spam_throttler.go
+++ b/blockchain/spam_throttler.go
@@ -297,6 +297,13 @@ func (t *throttler) GetThrottled() []*common.Address {
 	return addrs
 }
 
+func (t *throttler) GetCandidates() map[*common.Address]int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.candidates
+}
+
 func (t *throttler) GetConfig() *ThrottlerConfig {
 	return t.config
 }

--- a/blockchain/spam_throttler_test.go
+++ b/blockchain/spam_throttler_test.go
@@ -1,0 +1,97 @@
+package blockchain
+
+import (
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestThrottler(config *ThrottlerConfig) *throttler {
+	return &throttler{
+		config:     config,
+		candidates: make(map[common.Address]int),
+		throttled:  make(map[common.Address]int),
+		allowed:    make(map[common.Address]bool),
+		mu:         new(sync.RWMutex),
+		threshold:  config.InitialThreshold,
+		throttleCh: make(chan *types.Transaction, config.ThrottleTPS*3),
+		quitCh:     make(chan struct{}),
+	}
+}
+
+func TestThrottler_updateThrottlerState(t *testing.T) {
+	testConfig := DefaultSpamThrottlerConfig
+	testCases := []struct {
+		tcName          string
+		txFailNum       int
+		candidateNum    int
+		candidateWeight int
+		throttledNum    int
+		throttledWeight int
+	}{
+		{
+			tcName:          "one address generates enough fail txs to be throttled",
+			txFailNum:       testConfig.InitialThreshold/testConfig.IncreaseWeight + 1,
+			candidateNum:    0,
+			candidateWeight: 0,
+			throttledNum:    1,
+			throttledWeight: testConfig.ThrottledWeight,
+		},
+		{
+			tcName:       "one address generates not enough fail txs to be throttled",
+			txFailNum:    testConfig.InitialThreshold / testConfig.IncreaseWeight,
+			candidateNum: 1,
+			// th.config.IncreaseWeight * th.config.InitialThreshold / th.config.IncreaseWeight - th.config.DecreaseWeight
+			candidateWeight: testConfig.InitialThreshold - testConfig.DecreaseWeight,
+			throttledNum:    0,
+			throttledWeight: 0,
+		},
+	}
+
+	txNum := 1000
+	amount := big.NewInt(0)
+	gasLimit := uint64(10000)
+	gasPrice := big.NewInt(25 * params.Ston)
+	toFail := common.BytesToAddress(common.MakeRandomBytes(20))
+	toSuccess := common.BytesToAddress(common.MakeRandomBytes(20))
+
+	for _, tc := range testCases {
+		var txs types.Transactions
+		var receipts types.Receipts
+
+		// Reset throttler
+		th := newTestThrottler(testConfig)
+
+		// Generates fail txs
+		for i := 0; i < tc.txFailNum; i++ {
+			tx := types.NewTransaction(0, toFail, amount, gasLimit, gasPrice, nil)
+			receipt := &types.Receipt{
+				Status: types.ReceiptStatusFailed,
+			}
+			txs = append(txs, tx)
+			receipts = append(receipts, receipt)
+		}
+
+		// Generate success txs
+		for i := 0; i < txNum-tc.txFailNum; i++ {
+			tx := types.NewTransaction(0, toSuccess, amount, gasLimit, gasPrice, nil)
+			receipt := &types.Receipt{
+				Status: types.ReceiptStatusSuccessful,
+			}
+			txs = append(txs, tx)
+			receipts = append(receipts, receipt)
+		}
+
+		th.updateThrottlerState(txs, receipts)
+
+		assert.Equal(t, tc.candidateNum, len(th.candidates))
+		assert.Equal(t, tc.candidateWeight, th.candidates[toFail])
+		assert.Equal(t, tc.throttledNum, len(th.throttled))
+		assert.Equal(t, tc.throttledWeight, th.throttled[toFail])
+	}
+}

--- a/blockchain/spam_throttler_test.go
+++ b/blockchain/spam_throttler_test.go
@@ -19,7 +19,7 @@ func newTestThrottler(config *ThrottlerConfig) *throttler {
 		allowed:    make(map[common.Address]bool),
 		mu:         new(sync.RWMutex),
 		threshold:  config.InitialThreshold,
-		throttleCh: make(chan *types.Transaction, config.ThrottleTPS*3),
+		throttleCh: make(chan *types.Transaction, config.ThrottleTPS*5),
 		quitCh:     make(chan struct{}),
 	}
 }
@@ -40,7 +40,7 @@ func TestThrottler_updateThrottlerState(t *testing.T) {
 			candidateNum:    0,
 			candidateWeight: 0,
 			throttledNum:    1,
-			throttledWeight: testConfig.ThrottledWeight,
+			throttledWeight: testConfig.ThrottleSeconds,
 		},
 		{
 			tcName:       "one address generates not enough fail txs to be throttled",

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -118,7 +118,8 @@ type TxPoolConfig struct {
 	KeepLocals bool          // Disables removing timed-out local transactions
 	Lifetime   time.Duration // Maximum amount of time non-executable transaction are queued
 
-	NoAccountCreation bool // Whether account creation transactions should be disabled
+	NoAccountCreation            bool // Whether account creation transactions should be disabled
+	EnableSpamThrottlerAtRuntime bool // Enable txpool spam throttler at runtime
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -244,7 +245,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 	go pool.loop()
 	go pool.handleTxMsg()
 
-	if !DisableSpamThrottlerAtRuntime {
+	if config.EnableSpamThrottlerAtRuntime {
 		if err := pool.StartSpamThrottler(DefaultSpamThrottlerConfig); err != nil {
 			logger.Error("Failed to start spam throttler", "err", err)
 		}

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -950,6 +950,7 @@ func (pool *TxPool) HandleTxMsg(txs types.Transactions) {
 				case spamThrottler.throttleCh <- tx:
 				default:
 					logger.Trace("drop a tx when throttleTxs channel is full", "txHash", tx.Hash())
+					throttlerDropCount.Inc(1)
 				}
 			}
 
@@ -1039,6 +1040,7 @@ func (pool *TxPool) StopSpamThrottler() {
 	throttledSizeGauge.Update(0)
 	allowedSizeGauge.Update(0)
 	throttlerUpdateTimeGauge.Update(0)
+	throttlerDropCount.Clear()
 }
 
 // handleTxMsg calls TxPool.AddRemotes by retrieving transactions from TxPool.txMsgCh.

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1015,7 +1015,7 @@ func (pool *TxPool) StartSpamThrottler(conf *ThrottlerConfig) error {
 		allowed:    make(map[common.Address]bool),
 		mu:         new(sync.RWMutex),
 		threshold:  conf.InitialThreshold,
-		throttleCh: make(chan *types.Transaction, conf.ThrottleTPS*3),
+		throttleCh: make(chan *types.Transaction, conf.ThrottleTPS*5),
 		quitCh:     make(chan struct{}),
 	}
 
@@ -1028,13 +1028,17 @@ func (pool *TxPool) StartSpamThrottler(conf *ThrottlerConfig) error {
 
 func (pool *TxPool) StopSpamThrottler() {
 	spamThrottlerMu.Lock()
+	defer spamThrottlerMu.Unlock()
 
 	if spamThrottler != nil {
 		close(spamThrottler.quitCh)
 	}
 
 	spamThrottler = nil
-	spamThrottlerMu.Unlock()
+	candidateSizeGauge.Update(0)
+	throttledSizeGauge.Update(0)
+	allowedSizeGauge.Update(0)
+	throttlerUpdateTimeGauge.Update(0)
 }
 
 // handleTxMsg calls TxPool.AddRemotes by retrieving transactions from TxPool.txMsgCh.

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1010,9 +1010,9 @@ func (pool *TxPool) StartSpamThrottler(conf *ThrottlerConfig) error {
 
 	t := &throttler{
 		config:     conf,
-		candidates: make(map[*common.Address]int),
-		throttled:  make(map[*common.Address]int),
-		allowed:    make(map[*common.Address]bool),
+		candidates: make(map[common.Address]int),
+		throttled:  make(map[common.Address]int),
+		allowed:    make(map[common.Address]bool),
 		mu:         new(sync.RWMutex),
 		threshold:  conf.InitialThreshold,
 		throttleCh: make(chan *types.Transaction, conf.ThrottleTPS*3),

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -244,6 +244,12 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 	go pool.loop()
 	go pool.handleTxMsg()
 
+	if !DisableSpamThrottlerAtRuntime {
+		if err := pool.StartSpamThrottler(DefaultSpamThrottlerConfig); err != nil {
+			logger.Error("Failed to start spam throttler", "err", err)
+		}
+	}
+
 	return pool
 }
 
@@ -454,6 +460,8 @@ func (pool *TxPool) Stop() {
 	if pool.journal != nil {
 		pool.journal.close()
 	}
+
+	pool.StopThrottler()
 	logger.Info("Transaction pool stopped")
 }
 
@@ -924,8 +932,102 @@ func (pool *TxPool) HandleTxMsg(txs types.Transactions) {
 	if pool.config.DenyRemoteTx {
 		return
 	}
+
+	// Filter spam txs based on to-address of failed txs
+	spamThrottler := GetSpamThrottler()
+	if spamThrottler != nil {
+		pool.mu.RLock()
+		poolSize := uint64(len(pool.all))
+		pool.mu.RUnlock()
+
+		// Activate spam throttler when pool has enough txs
+		if poolSize > uint64(spamThrottler.config.activateTxPoolSize) {
+			allowTxs, throttleTxs := spamThrottler.classifyTxs(txs)
+
+			for _, tx := range throttleTxs {
+				select {
+				case spamThrottler.throttleCh <- tx:
+				default:
+					logger.Trace("drop a tx when throttleTxs channel is full", "txHash", tx.Hash())
+				}
+			}
+
+			txs = allowTxs
+		}
+	}
+
+	// TODO-Klaytn: Consider removing the next line and move the above logic to `addTx` or `AddRemotes`
 	senderCacher.recover(pool.signer, txs)
 	pool.txMsgCh <- txs
+}
+
+func (pool *TxPool) throttleLoop(spamThrottler *throttler) {
+	ticker := time.Tick(time.Second)
+
+	for {
+		select {
+		case <-spamThrottler.quitCh:
+			logger.Info("Stop a throttle loop")
+			return
+
+		case <-ticker:
+			txs := types.Transactions{}
+			for tx := range spamThrottler.throttleCh {
+				txs = append(txs, tx)
+
+				if txs.Len() > int(spamThrottler.config.throttleTPS) {
+					break
+				}
+			}
+			if len(txs) > 0 {
+				pool.AddRemotes(txs)
+			}
+		}
+	}
+}
+
+func (pool *TxPool) StartSpamThrottler(conf *throttlerConfig) error {
+	spamThrottlerMu.Lock()
+	defer spamThrottlerMu.Unlock()
+
+	if spamThrottler != nil {
+		return errors.New("A spam throttler is already started")
+	}
+
+	if conf == nil {
+		conf = DefaultSpamThrottlerConfig
+	}
+
+	if err := validateConfig(conf); err != nil {
+		return err
+	}
+
+	t := &throttler{
+		config:     conf,
+		candidates: make(map[*common.Address]int),
+		throttled:  make(map[*common.Address]int),
+		allowed:    make(map[*common.Address]bool),
+		mu:         new(sync.RWMutex),
+		threshold:  conf.initialThreshold,
+		throttleCh: make(chan *types.Transaction, conf.throttleTPS*3),
+		quitCh:     make(chan struct{}),
+	}
+
+	go pool.throttleLoop(t)
+
+	spamThrottler = t
+	return nil
+}
+
+func (pool *TxPool) StopThrottler() {
+	spamThrottlerMu.Lock()
+
+	if spamThrottler != nil {
+		close(spamThrottler.quitCh)
+	}
+
+	spamThrottler = nil
+	spamThrottlerMu.Unlock()
 }
 
 // handleTxMsg calls TxPool.AddRemotes by retrieving transactions from TxPool.txMsgCh.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1450,8 +1450,8 @@ func setTxPool(ctx *cli.Context, cfg *blockchain.TxPoolConfig) {
 	}
 
 	// PN specific txpool setting
-	if ctx.GlobalIsSet(TxPoolSpamThrottlerDisableFlag.Name) && NodeTypeFlag.Value == "pn" {
-		cfg.EnableSpamThrottlerAtRuntime = ctx.GlobalBool(TxPoolSpamThrottlerDisableFlag.Name)
+	if NodeTypeFlag.Value == "pn" {
+		cfg.EnableSpamThrottlerAtRuntime = !ctx.GlobalIsSet(TxPoolSpamThrottlerDisableFlag.Name)
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -205,6 +205,12 @@ var (
 		Usage: "Maximum amount of time non-executable transaction are queued",
 		Value: cn.GetDefaultConfig().TxPool.Lifetime,
 	}
+	// PN specific txpool settings
+	TxPoolSpamThrottlerDisalbleFlag = cli.BoolFlag{
+		Name:  "txpool.spamthrottler.disable",
+		Usage: "Disable txpool spam throttler prototype",
+	}
+
 	// KES
 	KESNodeTypeServiceFlag = cli.BoolFlag{
 		Name:  "kes.nodetype.service",
@@ -1441,6 +1447,11 @@ func setTxPool(ctx *cli.Context, cfg *blockchain.TxPoolConfig) {
 
 	if ctx.GlobalIsSet(TxPoolLifetimeFlag.Name) {
 		cfg.Lifetime = ctx.GlobalDuration(TxPoolLifetimeFlag.Name)
+	}
+
+	// PN specific txpool setting
+	if ctx.GlobalIsSet(TxPoolSpamThrottlerDisalbleFlag.Name) {
+		blockchain.DisableSpamThrottlerAtRuntime = ctx.GlobalBool(TxPoolSpamThrottlerDisalbleFlag.Name)
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -206,7 +206,7 @@ var (
 		Value: cn.GetDefaultConfig().TxPool.Lifetime,
 	}
 	// PN specific txpool settings
-	TxPoolSpamThrottlerDisalbleFlag = cli.BoolFlag{
+	TxPoolSpamThrottlerDisableFlag = cli.BoolFlag{
 		Name:  "txpool.spamthrottler.disable",
 		Usage: "Disable txpool spam throttler prototype",
 	}
@@ -1450,8 +1450,8 @@ func setTxPool(ctx *cli.Context, cfg *blockchain.TxPoolConfig) {
 	}
 
 	// PN specific txpool setting
-	if ctx.GlobalIsSet(TxPoolSpamThrottlerDisalbleFlag.Name) {
-		blockchain.DisableSpamThrottlerAtRuntime = ctx.GlobalBool(TxPoolSpamThrottlerDisalbleFlag.Name)
+	if ctx.GlobalIsSet(TxPoolSpamThrottlerDisableFlag.Name) && NodeTypeFlag.Value == "pn" {
+		cfg.EnableSpamThrottlerAtRuntime = ctx.GlobalBool(TxPoolSpamThrottlerDisableFlag.Name)
 	}
 }
 

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -156,6 +156,7 @@ var KPNFlags = []cli.Flag{
 	utils.TxResendUseLegacyFlag,
 	utils.CypressFlag,
 	utils.BaobabFlag,
+	utils.TxPoolSpamThrottlerDisalbleFlag,
 }
 
 var KENFlags = []cli.Flag{
@@ -246,6 +247,7 @@ var KSPNFlags = []cli.Flag{
 	utils.TxResendIntervalFlag,
 	utils.TxResendCountFlag,
 	utils.TxResendUseLegacyFlag,
+	utils.TxPoolSpamThrottlerDisalbleFlag,
 	utils.ServiceChainSignerFlag,
 	utils.AnchoringPeriodFlag,
 	utils.SentChainTxsLimit,

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -156,7 +156,7 @@ var KPNFlags = []cli.Flag{
 	utils.TxResendUseLegacyFlag,
 	utils.CypressFlag,
 	utils.BaobabFlag,
-	utils.TxPoolSpamThrottlerDisalbleFlag,
+	utils.TxPoolSpamThrottlerDisableFlag,
 }
 
 var KENFlags = []cli.Flag{
@@ -247,7 +247,7 @@ var KSPNFlags = []cli.Flag{
 	utils.TxResendIntervalFlag,
 	utils.TxResendCountFlag,
 	utils.TxResendUseLegacyFlag,
-	utils.TxPoolSpamThrottlerDisalbleFlag,
+	utils.TxPoolSpamThrottlerDisableFlag,
 	utils.ServiceChainSignerFlag,
 	utils.AnchoringPeriodFlag,
 	utils.SentChainTxsLimit,

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -341,6 +341,10 @@ web3._extend({
 			name: 'getSpamThrottlerThrottleList',
 			call: 'admin_getSpamThrottlerThrottleList',
 		}),
+		new web3._extend.Method({
+			name: 'getSpamThrottlerCandidateList',
+			call: 'admin_getSpamThrottlerCandidateList',
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -318,6 +318,29 @@ web3._extend({
 			call: 'admin_setMaxSubscriptionPerWSConn',
 			params: 1
 		}),
+		new web3._extend.Method({
+			name: 'startSpamThrottler',
+			call: 'admin_startSpamThrottler',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
+			name: 'stopSpamThrottler',
+			call: 'admin_stopSpamThrottler',
+		}),
+		new web3._extend.Method({
+			name: 'setSpamThrottlerWhiteList',
+			call: 'admin_setSpamThrottlerWhiteList',
+			params: 1,
+		}),
+		new web3._extend.Method({
+			name: 'getSpamThrottlerWhiteList',
+			call: 'admin_getSpamThrottlerWhiteList',
+		}),
+		new web3._extend.Method({
+			name: 'getSpamThrottlerThrottleList',
+			call: 'admin_getSpamThrottlerThrottleList',
+		}),
 	],
 	properties: [
 		new web3._extend.Property({
@@ -335,6 +358,10 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'stateMigrationStatus',
 			getter: 'admin_stateMigrationStatus'
+		}),
+		new web3._extend.Property({
+			name: 'spamThrottlerConfig',
+			getter: 'admin_spamThrottlerConfig'
 		}),
 	]
 });

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -251,6 +251,14 @@ func (api *PrivateAdminAPI) GetSpamThrottlerThrottleList(ctx context.Context) ([
 	return throttler.GetThrottled(), nil
 }
 
+func (api *PrivateAdminAPI) GetSpamThrottlerCandidateList(ctx context.Context) (map[*common.Address]int, error) {
+	throttler := blockchain.GetSpamThrottler()
+	if throttler == nil {
+		return nil, errors.New("spam throttler is not running")
+	}
+	return throttler.GetCandidates(), nil
+}
+
 // PublicDebugAPI is the collection of Klaytn full node APIs exposed
 // over the public debugging endpoint.
 type PublicDebugAPI struct {

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -226,7 +226,7 @@ func (api *PrivateAdminAPI) StartSpamThrottler(ctx context.Context, config *bloc
 	return api.cn.txPool.StartSpamThrottler(config)
 }
 
-func (api *PrivateAdminAPI) SetSpamThrottlerWhiteList(ctx context.Context, addrs []*common.Address) error {
+func (api *PrivateAdminAPI) SetSpamThrottlerWhiteList(ctx context.Context, addrs []common.Address) error {
 	throttler := blockchain.GetSpamThrottler()
 	if throttler == nil {
 		return errors.New("spam throttler is not running")
@@ -235,7 +235,7 @@ func (api *PrivateAdminAPI) SetSpamThrottlerWhiteList(ctx context.Context, addrs
 	return nil
 }
 
-func (api *PrivateAdminAPI) GetSpamThrottlerWhiteList(ctx context.Context) ([]*common.Address, error) {
+func (api *PrivateAdminAPI) GetSpamThrottlerWhiteList(ctx context.Context) ([]common.Address, error) {
 	throttler := blockchain.GetSpamThrottler()
 	if throttler == nil {
 		return nil, errors.New("spam throttler is not running")
@@ -243,7 +243,7 @@ func (api *PrivateAdminAPI) GetSpamThrottlerWhiteList(ctx context.Context) ([]*c
 	return throttler.GetAllowed(), nil
 }
 
-func (api *PrivateAdminAPI) GetSpamThrottlerThrottleList(ctx context.Context) ([]*common.Address, error) {
+func (api *PrivateAdminAPI) GetSpamThrottlerThrottleList(ctx context.Context) ([]common.Address, error) {
 	throttler := blockchain.GetSpamThrottler()
 	if throttler == nil {
 		return nil, errors.New("spam throttler is not running")
@@ -251,7 +251,7 @@ func (api *PrivateAdminAPI) GetSpamThrottlerThrottleList(ctx context.Context) ([
 	return throttler.GetThrottled(), nil
 }
 
-func (api *PrivateAdminAPI) GetSpamThrottlerCandidateList(ctx context.Context) (map[*common.Address]int, error) {
+func (api *PrivateAdminAPI) GetSpamThrottlerCandidateList(ctx context.Context) (map[common.Address]int, error) {
 	throttler := blockchain.GetSpamThrottler()
 	if throttler == nil {
 		return nil, errors.New("spam throttler is not running")

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -201,6 +201,56 @@ func (api *PrivateAdminAPI) SaveTrieNodeCacheToDisk() error {
 	return api.cn.BlockChain().SaveTrieNodeCacheToDisk()
 }
 
+func (api *PrivateAdminAPI) SpamThrottlerConfig(ctx context.Context) (*blockchain.ThrottlerConfig, error) {
+	throttler := blockchain.GetSpamThrottler()
+	if throttler == nil {
+		return nil, errors.New("spam throttler is not running")
+	}
+	return throttler.GetConfig(), nil
+}
+
+func (api *PrivateAdminAPI) StopSpamThrottler(ctx context.Context) error {
+	throttler := blockchain.GetSpamThrottler()
+	if throttler == nil {
+		return errors.New("spam throttler was already stopped")
+	}
+	api.cn.txPool.StopSpamThrottler()
+	return nil
+}
+
+func (api *PrivateAdminAPI) StartSpamThrottler(ctx context.Context, config *blockchain.ThrottlerConfig) error {
+	throttler := blockchain.GetSpamThrottler()
+	if throttler != nil {
+		return errors.New("spam throttler is already running")
+	}
+	return api.cn.txPool.StartSpamThrottler(config)
+}
+
+func (api *PrivateAdminAPI) SetSpamThrottlerWhiteList(ctx context.Context, addrs []*common.Address) error {
+	throttler := blockchain.GetSpamThrottler()
+	if throttler == nil {
+		return errors.New("spam throttler is not running")
+	}
+	throttler.SetAllowed(addrs)
+	return nil
+}
+
+func (api *PrivateAdminAPI) GetSpamThrottlerWhiteList(ctx context.Context) ([]*common.Address, error) {
+	throttler := blockchain.GetSpamThrottler()
+	if throttler == nil {
+		return nil, errors.New("spam throttler is not running")
+	}
+	return throttler.GetAllowed(), nil
+}
+
+func (api *PrivateAdminAPI) GetSpamThrottlerThrottleList(ctx context.Context) ([]*common.Address, error) {
+	throttler := blockchain.GetSpamThrottler()
+	if throttler == nil {
+		return nil, errors.New("spam throttler is not running")
+	}
+	return throttler.GetThrottled(), nil
+}
+
 // PublicDebugAPI is the collection of Klaytn full node APIs exposed
 // over the public debugging endpoint.
 type PublicDebugAPI struct {

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -215,7 +215,7 @@ func (mr *MockBlockChainMockRecorder) Genesis() *gomock.Call {
 // GetBlock mocks base method
 func (m *MockBlockChain) GetBlock(arg0 common.Hash, arg1 uint64) *types.Block {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockByHash", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetBlock", arg0, arg1)
 	ret0, _ := ret[0].(*types.Block)
 	return ret0
 }
@@ -223,7 +223,7 @@ func (m *MockBlockChain) GetBlock(arg0 common.Hash, arg1 uint64) *types.Block {
 // GetBlock indicates an expected call of GetBlock
 func (mr *MockBlockChainMockRecorder) GetBlock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHash", reflect.TypeOf((*MockBlockChain)(nil).GetBlock), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlock", reflect.TypeOf((*MockBlockChain)(nil).GetBlock), arg0, arg1)
 }
 
 // GetBlockByHash mocks base method

--- a/work/mocks/txpool_mock.go
+++ b/work/mocks/txpool_mock.go
@@ -162,6 +162,20 @@ func (mr *MockTxPoolMockRecorder) SetGasPrice(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGasPrice", reflect.TypeOf((*MockTxPool)(nil).SetGasPrice), arg0)
 }
 
+// StartSpamThrottler mocks base method
+func (m *MockTxPool) StartSpamThrottler(arg0 *blockchain.ThrottlerConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartSpamThrottler", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartSpamThrottler indicates an expected call of StartSpamThrottler
+func (mr *MockTxPoolMockRecorder) StartSpamThrottler(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSpamThrottler", reflect.TypeOf((*MockTxPool)(nil).StartSpamThrottler), arg0)
+}
+
 // Stats mocks base method
 func (m *MockTxPool) Stats() (int, int) {
 	m.ctrl.T.Helper()
@@ -187,6 +201,18 @@ func (m *MockTxPool) Stop() {
 func (mr *MockTxPoolMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockTxPool)(nil).Stop))
+}
+
+// StopSpamThrottler mocks base method
+func (m *MockTxPool) StopSpamThrottler() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StopSpamThrottler")
+}
+
+// StopSpamThrottler indicates an expected call of StopSpamThrottler
+func (mr *MockTxPoolMockRecorder) StopSpamThrottler() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopSpamThrottler", reflect.TypeOf((*MockTxPool)(nil).StopSpamThrottler))
 }
 
 // SubscribeNewTxsEvent mocks base method

--- a/work/work.go
+++ b/work/work.go
@@ -67,6 +67,8 @@ type TxPool interface {
 	Get(hash common.Hash) *types.Transaction
 	Stats() (int, int)
 	Content() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
+	StartSpamThrottler(conf *blockchain.ThrottlerConfig) error
+	StopSpamThrottler()
 }
 
 // Backend wraps all methods required for mining.

--- a/work/work/mocks/txpool_mock.go
+++ b/work/work/mocks/txpool_mock.go
@@ -162,6 +162,20 @@ func (mr *MockTxPoolMockRecorder) SetGasPrice(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGasPrice", reflect.TypeOf((*MockTxPool)(nil).SetGasPrice), arg0)
 }
 
+// StartSpamThrottler mocks base method
+func (m *MockTxPool) StartSpamThrottler(arg0 *blockchain.ThrottlerConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartSpamThrottler", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartSpamThrottler indicates an expected call of StartSpamThrottler
+func (mr *MockTxPoolMockRecorder) StartSpamThrottler(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSpamThrottler", reflect.TypeOf((*MockTxPool)(nil).StartSpamThrottler), arg0)
+}
+
 // Stats mocks base method
 func (m *MockTxPool) Stats() (int, int) {
 	m.ctrl.T.Helper()
@@ -187,6 +201,18 @@ func (m *MockTxPool) Stop() {
 func (mr *MockTxPoolMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockTxPool)(nil).Stop))
+}
+
+// StopSpamThrottler mocks base method
+func (m *MockTxPool) StopSpamThrottler() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StopSpamThrottler")
+}
+
+// StopSpamThrottler indicates an expected call of StopSpamThrottler
+func (mr *MockTxPoolMockRecorder) StopSpamThrottler() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopSpamThrottler", reflect.TypeOf((*MockTxPool)(nil).StopSpamThrottler))
 }
 
 // SubscribeNewTxsEvent mocks base method


### PR DESCRIPTION
## Proposed changes

- Implement a prototype of txpool spam throttler. 
- admin namespace APIs: startSpamThrottler, stopSpamThrottler, spamThrottlerConfig, setSpamThrottlerWhiteList, getSpamThrottlerWhiteList, getSpamThrottlerThrottleList, getSpamThrottlerCandidateList
- Add a unit test for spam throttle 

### Test Results 
**Environment** 
- 1 CN / 2 PN / 4 EN (m5.2xlarge)
  - EN1, EN2, and EN3 receives massive revert txs (revertTxTC)
  - EN4, receives normal txs (newValueTransferTC)
- Request: 100 RPS normal txs + 3000 RPS revert txs  with 1000 to addresses
- Spam throttler configuration: DefaultSpamThrottlerConfig

**Applying spam throttler result**
- Average TPS: 100 TPS normal txs + 100 TPS revert txs 
- TPS of revert txs peak every 300 seconds (Default throttling duration)
- Some EN's txpool that keep receiving massive revert txs are continuously full of txs 
- The throttler threshold decreased to MinimumThreshold because  the revert ratio of blocks keep exceeding TargetFailRatio
![image](https://user-images.githubusercontent.com/48199072/147424629-8aa79e0d-6108-4a51-a159-e976482dfe86.png)
![image](https://user-images.githubusercontent.com/48199072/147424725-f167c3ef-a4e5-4ed9-8123-79b9e2e9ad43.png)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
