### PR TITLE
Implemented eth namespace tx read api (Reopen based on https://github.com/klaytn/klaytn/pull/1087)

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -503,8 +503,8 @@ type EthRPCTransaction struct {
 	S                *hexutil.Big    `json:"s"`
 }
 
-// newEthRPCTransactionFromBlockAndIndex creates an EthRPCTransaction from block and index parameters.
-func newEthRPCTransactionFromBlockAndIndex(b *types.Block, index uint64) (*EthRPCTransaction, error) {
+// newEthRPCTransactionFromBlockIndex creates an EthRPCTransaction from block and index parameters.
+func newEthRPCTransactionFromBlockIndex(b *types.Block, index uint64) (*EthRPCTransaction, error) {
 	txs := b.Transactions()
 	if index >= uint64(len(txs)) {
 		return nil, errors.New("invalid transaction index")
@@ -580,7 +580,7 @@ func (api *EthereumAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context,
 		return nil
 	}
 
-	ethTx, err := newEthRPCTransactionFromBlockAndIndex(block, uint64(index))
+	ethTx, err := newEthRPCTransactionFromBlockIndex(block, uint64(index))
 	if ethTx == nil || err != nil {
 		return nil
 	}
@@ -592,7 +592,7 @@ func (api *EthereumAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context,
 func (api *EthereumAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *EthRPCTransaction {
 	block, err := api.publicTransactionPoolAPI.b.BlockByHash(ctx, blockHash)
 	if block != nil && err == nil {
-		ethTx, err := newEthRPCTransactionFromBlockAndIndex(block, uint64(index))
+		ethTx, err := newEthRPCTransactionFromBlockIndex(block, uint64(index))
 		if ethTx == nil || err != nil {
 			return nil
 		}

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -572,14 +572,16 @@ func newEthRPCPendingTransaction(tx *types.Transaction) (*EthRPCTransaction, err
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
 func (api *EthereumAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *EthRPCTransaction {
 	block, err := api.publicTransactionPoolAPI.b.BlockByNumber(ctx, blockNr)
-	if block != nil && err == nil {
-		ethTx, err := newEthRPCTransactionFromBlockAndIndex(block, uint64(index))
-		if ethTx == nil || err != nil {
-			return nil
-		}
-		return ethTx
+	if block == nil || err != nil {
+		return nil
 	}
-	return nil
+
+	ethTx, err := newEthRPCTransactionFromBlockAndIndex(block, uint64(index))
+	if ethTx == nil || err != nil {
+		return nil
+	}
+
+	return ethTx
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -677,10 +677,14 @@ func newEthTransactionReceipt(tx *types.Transaction, blockHash common.Hash, bloc
 	}
 
 	from := getFrom(tx)
-
-	// If to is nil, it is fills with from.
 	to := tx.To()
-	if to == nil {
+
+	switch tx.Type() {
+	case types.TxTypeAccountUpdate, types.TxTypeFeeDelegatedAccountUpdate, types.TxTypeFeeDelegatedAccountUpdateWithRatio,
+		types.TxTypeCancel, types.TxTypeFeeDelegatedCancel, types.TxTypeFeeDelegatedCancelWithRatio,
+		types.TxTypeChainDataAnchoring, types.TxTypeFeeDelegatedChainDataAnchoring, types.TxTypeFeeDelegatedChainDataAnchoringWithRatio:
+		// These type of transactions actually do not have `to` address, but Ethereum always have `to` field,
+		// so we Klaytn developers decided to fill the `to` field with `from` address value in these case.
 		to = &from
 	}
 

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -640,25 +640,16 @@ func (api *EthereumAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context,
 		return nil
 	}
 
-	ethTx := newEthRPCTransactionFromBlockIndex(block, uint64(index))
-	if ethTx == nil {
-		return nil
-	}
-
-	return ethTx
+	return newEthRPCTransactionFromBlockIndex(block, uint64(index))
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
 func (api *EthereumAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *EthRPCTransaction {
 	block, err := api.publicTransactionPoolAPI.b.BlockByHash(ctx, blockHash)
-	if block != nil && err == nil {
-		ethTx := newEthRPCTransactionFromBlockIndex(block, uint64(index))
-		if ethTx == nil {
-			return nil
-		}
-		return ethTx
+	if err != nil || block == nil {
+		return nil	
 	}
-	return nil
+	return newEthRPCTransactionFromBlockIndex(block, uint64(index))
 }
 
 // GetRawTransactionByBlockNumberAndIndex returns the bytes of the transaction for the given block number and index.

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -598,7 +598,7 @@ func (api *EthereumAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, b
 // GetRawTransactionByBlockNumberAndIndex returns the bytes of the transaction for the given block number and index.
 func (api *EthereumAPI) GetRawTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) hexutil.Bytes {
 	rawTx, err := api.publicTransactionPoolAPI.GetRawTransactionByBlockNumberAndIndex(ctx, blockNr, index)
-	if rawTx == nil || err != nil {
+	if err != nil {
 		return nil
 	}
 

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"sync/atomic"
 	"time"
@@ -502,52 +503,218 @@ type EthRPCTransaction struct {
 	S                *hexutil.Big    `json:"s"`
 }
 
+// newEthRPCTransactionFromBlockAndIndex creates an EthRPCTransaction from block and index parameters.
+func newEthRPCTransactionFromBlockAndIndex(b *types.Block, index uint64) (*EthRPCTransaction, error) {
+	txs := b.Transactions()
+	if index >= uint64(len(txs)) {
+		return nil, errors.New("invalid transaction index")
+	}
+	return newEthRPCTransaction(txs[index], b.Hash(), b.NumberU64(), index)
+}
+
+// newEthRPCTransaction creates an EthRPCTransaction from Klaytn transaction.
+func newEthRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber, index uint64) (*EthRPCTransaction, error) {
+	// When an unknown transaction is requested through rpc call,
+	// nil is returned by Klaytn API, and it is handled.
+	if tx == nil {
+		return nil, nil
+	}
+
+	from := getFrom(tx)
+
+	// If to is nil, it is fills with from.
+	to := tx.To()
+	if to == nil {
+		to = &from
+	}
+
+	// If tx is not TxTypeLegacyTransaction, the type is converted to TxTypeLegacyTransaction.
+	// TODO-Klaytn: In the case of Ethereum transaction type,
+	//  it must be returned as it is without converting the type.
+	typeInt := hexutil.Uint64(tx.Type())
+	if types.TxType(typeInt) != types.TxTypeLegacyTransaction {
+		typeInt = hexutil.Uint64(types.TxTypeLegacyTransaction)
+	}
+
+	signature := tx.GetTxInternalData().RawSignatureValues()[0]
+
+	result := &EthRPCTransaction{
+		Type:     typeInt,
+		From:     from,
+		Gas:      hexutil.Uint64(tx.Gas()),
+		GasPrice: (*hexutil.Big)(tx.GasPrice()),
+		Hash:     tx.Hash(),
+		Input:    tx.Data(),
+		Nonce:    hexutil.Uint64(tx.Nonce()),
+		To:       to,
+		Value:    (*hexutil.Big)(tx.Value()),
+		V:        (*hexutil.Big)(signature.V),
+		R:        (*hexutil.Big)(signature.R),
+		S:        (*hexutil.Big)(signature.S),
+	}
+
+	if blockHash != (common.Hash{}) {
+		result.BlockHash = &blockHash
+		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
+		result.TransactionIndex = (*hexutil.Uint64)(&index)
+	}
+
+	// TODO-Klaytn: Have to add additional fields for ethereum transaction types.
+
+	return result, nil
+}
+
+// newEthRPCPendingTransaction creates an EthRPCTransaction for pending tx.
+func newEthRPCPendingTransaction(tx *types.Transaction) (*EthRPCTransaction, error) {
+	return newEthRPCTransaction(tx, common.Hash{}, 0, 0)
+}
+
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
 func (api *EthereumAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *EthRPCTransaction {
-	// TODO-Klaytn: Not implemented yet.
+	block, err := api.publicTransactionPoolAPI.b.BlockByNumber(ctx, blockNr)
+	if block != nil && err == nil {
+		ethTx, err := newEthRPCTransactionFromBlockAndIndex(block, uint64(index))
+		if ethTx == nil || err != nil {
+			return nil
+		}
+		return ethTx
+	}
 	return nil
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
 func (api *EthereumAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *EthRPCTransaction {
-	// TODO-Klaytn: Not implemented yet.
+	block, err := api.publicTransactionPoolAPI.b.BlockByHash(ctx, blockHash)
+	if block != nil && err == nil {
+		ethTx, err := newEthRPCTransactionFromBlockAndIndex(block, uint64(index))
+		if ethTx == nil || err != nil {
+			return nil
+		}
+		return ethTx
+	}
 	return nil
 }
 
 // GetRawTransactionByBlockNumberAndIndex returns the bytes of the transaction for the given block number and index.
 func (api *EthereumAPI) GetRawTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) hexutil.Bytes {
-	// TODO-Klaytn: Not implemented yet.
-	return nil
+	rawTx, err := api.publicTransactionPoolAPI.GetRawTransactionByBlockNumberAndIndex(ctx, blockNr, index)
+	if rawTx == nil || err != nil {
+		return nil
+	}
+
+	return rawTx
 }
 
 // GetRawTransactionByBlockHashAndIndex returns the bytes of the transaction for the given block hash and index.
 func (api *EthereumAPI) GetRawTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) hexutil.Bytes {
-	// TODO-Klaytn: Not implemented yet.
-	return nil
+	rawTx, err := api.publicTransactionPoolAPI.GetRawTransactionByBlockHashAndIndex(ctx, blockHash, index)
+	if rawTx == nil || err != nil {
+		return nil
+	}
+
+	return rawTx
 }
 
 // GetTransactionCount returns the number of transactions the given address has sent for the given block number.
 func (api *EthereumAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicTransactionPoolAPI.GetTransactionCount(ctx, address, blockNrOrHash)
 }
 
 // GetTransactionByHash returns the transaction for the given hash.
 func (api *EthereumAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) (*EthRPCTransaction, error) {
-	// TODO-Klaytn: Not implemented yet.
+	// Try to return an already finalized transaction
+	if tx, blockHash, blockNumber, index := api.publicTransactionPoolAPI.b.ChainDB().ReadTxAndLookupInfo(hash); tx != nil {
+		return newEthRPCTransaction(tx, blockHash, blockNumber, index)
+	}
+	// No finalized transaction, try to retrieve it from the pool
+	if tx := api.publicTransactionPoolAPI.b.GetPoolTransaction(hash); tx != nil {
+		return newEthRPCPendingTransaction(tx)
+	}
+	// Transaction unknown, return as such
 	return nil, nil
 }
 
 // GetRawTransactionByHash returns the bytes of the transaction for the given hash.
 func (api *EthereumAPI) GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutil.Bytes, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	rawTx, err := api.publicTransactionPoolAPI.GetRawTransactionByHash(ctx, hash)
+	if rawTx == nil || err != nil {
+		return nil, err
+	}
+
+	return rawTx, nil
 }
 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash.
 func (api *EthereumAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	// Formats return Klaytn Transaction Receipt to the Ethereum Transaction Receipt.
+	tx, blockHash, blockNumber, index, receipt := api.publicTransactionPoolAPI.b.GetTxLookupInfoAndReceipt(ctx, hash)
+
+	receipts := api.publicTransactionPoolAPI.b.GetBlockReceipts(ctx, blockHash)
+	cumulativeGasUsed := uint64(0)
+	for i := uint64(0); i <= index; i++ {
+		cumulativeGasUsed += receipts[i].GasUsed
+	}
+
+	ethTx, err := newEthTransactionReceipt(tx, blockHash, blockNumber, index, cumulativeGasUsed, receipt)
+	if ethTx == nil || err != nil {
+		return nil, err
+	}
+	return ethTx, nil
+}
+
+// newEthTransactionReceipt creates a transaction receipt in Ethereum format.
+func newEthTransactionReceipt(tx *types.Transaction, blockHash common.Hash, blockNumber, index, cumulativeGasUsed uint64, receipt *types.Receipt) (map[string]interface{}, error) {
+	// When an unknown transaction receipt is requested through rpc call,
+	// nil is returned by Klaytn API, and it is handled.
+	if tx == nil || receipt == nil {
+		return nil, nil
+	}
+
+	from := getFrom(tx)
+
+	// If to is nil, it is fills with from.
+	to := tx.To()
+	if to == nil {
+		to = &from
+	}
+
+	// If tx is not TxTypeLegacyTransaction, the type is converted to TxTypeLegacyTransaction.
+	// TODO-Klaytn: In the case of Ethereum transaction type,
+	//  it must be returned as it is without converting the type.
+	typeInt := tx.Type()
+	if typeInt != types.TxTypeLegacyTransaction {
+		typeInt = types.TxTypeLegacyTransaction
+	}
+
+	fields := map[string]interface{}{
+		"blockHash":         blockHash,
+		"blockNumber":       hexutil.Uint64(blockNumber),
+		"transactionHash":   tx.Hash(),
+		"transactionIndex":  hexutil.Uint64(index),
+		"from":              getFrom(tx),
+		"to":                to,
+		"gasUsed":           hexutil.Uint64(receipt.GasUsed),
+		"cumulativeGasUsed": hexutil.Uint64(cumulativeGasUsed),
+		"contractAddress":   nil,
+		"logs":              receipt.Logs,
+		"logsBloom":         receipt.Bloom,
+		"type":              hexutil.Uint(typeInt),
+	}
+
+	fields["effectiveGasPrice"] = tx.GasPrice()
+
+	// Always use the "status" field and Ignore the "root" field.
+	fields["status"] = hexutil.Uint(receipt.Status)
+
+	if receipt.Logs == nil {
+		fields["logs"] = [][]*types.Log{}
+	}
+	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
+	if receipt.ContractAddress != (common.Address{}) {
+		fields["contractAddress"] = receipt.ContractAddress
+	}
+
+	return fields, nil
 }
 
 // EthTransactionArgs represents the arguments to construct a new transaction
@@ -634,8 +801,7 @@ func (api *EthereumAPI) FillTransaction(ctx context.Context, args EthTransaction
 // SendRawTransaction will add the signed transaction to the transaction pool.
 // The sender is responsible for signing the transaction and using the correct nonce.
 func (api *EthereumAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return common.HexToHash("0x"), nil
+	return api.publicTransactionPoolAPI.SendRawTransaction(ctx, input)
 }
 
 // Sign calculates an ECDSA signature for:
@@ -648,8 +814,7 @@ func (api *EthereumAPI) SendRawTransaction(ctx context.Context, input hexutil.By
 //
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
 func (api *EthereumAPI) Sign(addr common.Address, data hexutil.Bytes) (hexutil.Bytes, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicTransactionPoolAPI.Sign(addr, data)
 }
 
 // SignTransaction will sign the given transaction with the from account.
@@ -663,8 +828,23 @@ func (api *EthereumAPI) SignTransaction(ctx context.Context, args EthTransaction
 // PendingTransactions returns the transactions that are in the transaction pool
 // and have a from address that is one of the accounts this node manages.
 func (api *EthereumAPI) PendingTransactions() ([]*EthRPCTransaction, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	pending, err := api.publicTransactionPoolAPI.b.GetPoolTransactions()
+	if err != nil {
+		return nil, err
+	}
+	accounts := getAccountsFromWallets(api.publicTransactionPoolAPI.b.AccountManager().Wallets())
+	transactions := make([]*EthRPCTransaction, 0, len(pending))
+	for _, tx := range pending {
+		from := getFrom(tx)
+		if _, exists := accounts[from]; exists {
+			ethTx, err := newEthRPCPendingTransaction(tx)
+			if err != nil {
+				return nil, err
+			}
+			transactions = append(transactions, ethTx)
+		}
+	}
+	return transactions, nil
 }
 
 // Resend accepts an existing transaction and a new gas price and limit. It will remove

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -647,7 +647,7 @@ func (api *EthereumAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context,
 func (api *EthereumAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *EthRPCTransaction {
 	block, err := api.publicTransactionPoolAPI.b.BlockByHash(ctx, blockHash)
 	if err != nil || block == nil {
-		return nil	
+		return nil
 	}
 	return newEthRPCTransactionFromBlockIndex(block, uint64(index))
 }

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -521,10 +521,14 @@ func newEthRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNum
 	}
 
 	from := getFrom(tx)
-
-	// If to is nil, it is fills with from.
 	to := tx.To()
-	if to == nil {
+
+	switch tx.Type() {
+	case types.TxTypeAccountUpdate, types.TxTypeFeeDelegatedAccountUpdate, types.TxTypeFeeDelegatedAccountUpdateWithRatio,
+		types.TxTypeCancel, types.TxTypeFeeDelegatedCancel, types.TxTypeFeeDelegatedCancelWithRatio,
+		types.TxTypeChainDataAnchoring, types.TxTypeFeeDelegatedChainDataAnchoring, types.TxTypeFeeDelegatedChainDataAnchoringWithRatio:
+		// These type of transactions actually do not have `to` address, but Ethereum always have `to` field,
+		// so we Klaytn developers decided to fill the `to` field with `from` address value in these case.
 		to = &from
 	}
 

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -579,7 +579,7 @@ func newEthRPCPendingTransaction(tx *types.Transaction) *EthRPCTransaction {
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
 func (api *EthereumAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *EthRPCTransaction {
 	block, err := api.publicTransactionPoolAPI.b.BlockByNumber(ctx, blockNr)
-	if block == nil || err != nil {
+	if err != nil {
 		return nil
 	}
 
@@ -617,7 +617,7 @@ func (api *EthereumAPI) GetRawTransactionByBlockNumberAndIndex(ctx context.Conte
 // GetRawTransactionByBlockHashAndIndex returns the bytes of the transaction for the given block hash and index.
 func (api *EthereumAPI) GetRawTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) hexutil.Bytes {
 	rawTx, err := api.publicTransactionPoolAPI.GetRawTransactionByBlockHashAndIndex(ctx, blockHash, index)
-	if rawTx == nil || err != nil {
+	if err != nil {
 		return nil
 	}
 
@@ -646,7 +646,7 @@ func (api *EthereumAPI) GetTransactionByHash(ctx context.Context, hash common.Ha
 // GetRawTransactionByHash returns the bytes of the transaction for the given hash.
 func (api *EthereumAPI) GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutil.Bytes, error) {
 	rawTx, err := api.publicTransactionPoolAPI.GetRawTransactionByHash(ctx, hash)
-	if rawTx == nil || err != nil {
+	if err != nil {
 		return nil, err
 	}
 
@@ -665,7 +665,7 @@ func (api *EthereumAPI) GetTransactionReceipt(ctx context.Context, hash common.H
 	}
 
 	ethTx, err := newEthTransactionReceipt(tx, blockHash, blockNumber, index, cumulativeGasUsed, receipt)
-	if ethTx == nil || err != nil {
+	if err != nil {
 		return nil, err
 	}
 	return ethTx, nil

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -1,0 +1,1097 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"github.com/klaytn/klaytn/accounts"
+	"github.com/klaytn/klaytn/accounts/mocks"
+	"github.com/klaytn/klaytn/storage/database"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/klaytn/klaytn/api/mocks"
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/blockchain/types/accountkey"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/networks/rpc"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/rlp"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEthereumAPI_GetTransactionByBlockNumberAndIndex tests GetTransactionByBlockNumberAndIndex.
+func TestEthereumAPI_GetTransactionByBlockNumberAndIndex(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	block, txs, _, _, _ := createTestData(t)
+
+	// Mock Backend functions.
+	mockBackend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil).Times(txs.Len())
+
+	// Get transaction by block number and index for each transaction types.
+	for i := 0; i < txs.Len(); i++ {
+		ethTx := api.GetTransactionByBlockNumberAndIndex(context.Background(), rpc.BlockNumber(block.NumberU64()), hexutil.Uint(i))
+		checkEthRPCTransactionFormat(t, block, ethTx, txs[i], hexutil.Uint64(i))
+	}
+
+	mockCtrl.Finish()
+}
+
+// TestEthereumAPI_GetTransactionByBlockHashAndIndex tests GetTransactionByBlockHashAndIndex.
+func TestEthereumAPI_GetTransactionByBlockHashAndIndex(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	block, txs, _, _, _ := createTestData(t)
+
+	// Mock Backend functions.
+	mockBackend.EXPECT().BlockByHash(gomock.Any(), gomock.Any()).Return(block, nil).Times(txs.Len())
+
+	// Get transaction by block hash and index for each transaction types.
+	for i := 0; i < txs.Len(); i++ {
+		ethTx := api.GetTransactionByBlockHashAndIndex(context.Background(), block.Hash(), hexutil.Uint(i))
+		checkEthRPCTransactionFormat(t, block, ethTx, txs[i], hexutil.Uint64(i))
+	}
+
+	mockCtrl.Finish()
+}
+
+// TestEthereumAPI_GetTransactionByHash tests GetTransactionByHash.
+func TestEthereumAPI_GetTransactionByHash(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	block, txs, txHashMap, _, _ := createTestData(t)
+
+	// Define queryFromPool for ReadTxAndLookupInfo function return tx from hash map.
+	// MockDatabaseManager will initiate data with txHashMap, block and queryFromPool.
+	// If queryFromPool is true, MockDatabaseManager will return nil to query transactions from transaction pool,
+	// otherwise return a transaction from txHashMap.
+	mockDBManager := &MockDatabaseManager{txHashMap: txHashMap, blockData: block, queryFromPool: false}
+
+	// Mock Backend functions.
+	mockBackend.EXPECT().ChainDB().Return(mockDBManager).Times(txs.Len())
+
+	// Get transaction by hash for each transaction types.
+	for i := 0; i < txs.Len(); i++ {
+		ethTx, err := api.GetTransactionByHash(context.Background(), txs[i].Hash())
+		if err != nil {
+			t.Fatal(err)
+		}
+		checkEthRPCTransactionFormat(t, block, ethTx, txs[i], hexutil.Uint64(i))
+	}
+
+	mockCtrl.Finish()
+}
+
+// TestEthereumAPI_GetTransactionByHash tests GetTransactionByHash from transaction pool.
+func TestEthereumAPI_GetTransactionByHashFromPool(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	block, txs, txHashMap, _, _ := createTestData(t)
+
+	// Define queryFromPool for ReadTxAndLookupInfo function return nil.
+	// MockDatabaseManager will initiate data with txHashMap, block and queryFromPool.
+	// If queryFromPool is true, MockDatabaseManager will return nil to query transactions from transaction pool,
+	// otherwise return a transaction from txHashMap.
+	mockDBManager := &MockDatabaseManager{txHashMap: txHashMap, blockData: block, queryFromPool: true}
+
+	// Mock Backend functions.
+	mockBackend.EXPECT().ChainDB().Return(mockDBManager).Times(txs.Len())
+	mockBackend.EXPECT().GetPoolTransaction(gomock.Any()).DoAndReturn(
+		func(hash common.Hash) *types.Transaction {
+			return txHashMap[hash]
+		},
+	).Times(txs.Len())
+
+	//  Get transaction by hash from the transaction pool for each transaction types.
+	for i := 0; i < txs.Len(); i++ {
+		ethTx, err := api.GetTransactionByHash(context.Background(), txs[i].Hash())
+		if err != nil {
+			t.Fatal(err)
+		}
+		checkEthRPCTransactionFormat(t, nil, ethTx, txs[i], 0)
+	}
+
+	mockCtrl.Finish()
+}
+
+// TestEthereumAPI_PendingTransactionstests PendingTransactions.
+func TestEthereumAPI_PendingTransactions(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	_, txs, txHashMap, _, _ := createTestData(t)
+
+	mockAccountManager := mock_accounts.NewMockAccountManager(mockCtrl)
+	mockBackend.EXPECT().AccountManager().Return(mockAccountManager)
+
+	mockBackend.EXPECT().GetPoolTransactions().Return(txs, nil)
+
+	wallets := make([]accounts.Wallet, 1)
+	wallets[0] = NewMockWallet(txs)
+	mockAccountManager.EXPECT().Wallets().Return(wallets)
+
+	pendingTxs, err := api.PendingTransactions()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, pt := range pendingTxs {
+		checkEthRPCTransactionFormat(t, nil, pt, txHashMap[pt.Hash], 0)
+	}
+
+	mockCtrl.Finish()
+}
+
+// TestEthereumAPI_GetTransactionReceipt tests GetTransactionReceipt.
+func TestEthereumAPI_GetTransactionReceipt(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	block, txs, txHashMap, receiptMap, receipts := createTestData(t)
+
+	// Mock Backend functions.
+	mockBackend.EXPECT().GetTxLookupInfoAndReceipt(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, *types.Receipt) {
+			txLookupInfo := txHashMap[hash]
+			idx := txLookupInfo.Nonce() // Assume idx of the transaction is nonce
+			return txLookupInfo, block.Hash(), block.NumberU64(), idx, receiptMap[hash]
+		},
+	).Times(txs.Len())
+	mockBackend.EXPECT().GetBlockReceipts(gomock.Any(), gomock.Any()).Return(receipts).Times(txs.Len())
+
+	// Get receipt for each transaction types.
+	for i := 0; i < txs.Len(); i++ {
+		receipt, err := api.GetTransactionReceipt(context.Background(), txs[i].Hash())
+		if err != nil {
+			t.Fatal(err)
+		}
+		txIdx := uint64(i)
+		checkEthTransactionReceiptFormat(t, block, receipts, receipt, RpcOutputReceipt(txs[i], block.Hash(), block.NumberU64(), txIdx, receiptMap[txs[i].Hash()]), txIdx)
+	}
+
+	mockCtrl.Finish()
+}
+
+func testInitForEthApi(t *testing.T) (*gomock.Controller, *mock_api.MockBackend, EthereumAPI) {
+	mockCtrl := gomock.NewController(t)
+	mockBackend := mock_api.NewMockBackend(mockCtrl)
+
+	blockchain.InitDeriveSha(types.ImplDeriveShaOriginal)
+
+	api := EthereumAPI{
+		publicTransactionPoolAPI: NewPublicTransactionPoolAPI(mockBackend, new(AddrLocker)),
+	}
+	return mockCtrl, mockBackend, api
+}
+
+func checkEthRPCTransactionFormat(t *testing.T, block *types.Block, ethTx *EthRPCTransaction, tx *types.Transaction, expectedIndex hexutil.Uint64) {
+	// All Klaytn transaction types must be returned as TxTypeLegacyTransaction types.
+	assert.Equal(t, types.TxType(ethTx.Type), types.TxTypeLegacyTransaction)
+
+	// Check the data of common fields of the transaction.
+	from := getFrom(tx)
+	assert.Equal(t, from, ethTx.From)
+	assert.Equal(t, hexutil.Uint64(tx.Gas()), ethTx.Gas)
+	assert.Equal(t, tx.GasPrice(), ethTx.GasPrice.ToInt())
+	assert.Equal(t, tx.Hash(), ethTx.Hash)
+	assert.Equal(t, tx.GetTxInternalData().RawSignatureValues()[0].V, ethTx.V.ToInt())
+	assert.Equal(t, tx.GetTxInternalData().RawSignatureValues()[0].R, ethTx.R.ToInt())
+	assert.Equal(t, tx.GetTxInternalData().RawSignatureValues()[0].S, ethTx.S.ToInt())
+	assert.Equal(t, hexutil.Uint64(tx.Nonce()), ethTx.Nonce)
+
+	// Check the optional field of Klaytn transactions.
+	assert.Equal(t, 0, bytes.Compare(ethTx.Input, tx.Data()))
+	// Klaytn transactions that do not use the 'To' field
+	// fill in 'To' with from during converting to EthereumRPCTransaction.
+	to := tx.To()
+	if to == nil {
+		to = &from
+	}
+	assert.Equal(t, to, ethTx.To)
+	value := tx.Value()
+	assert.Equal(t, value, ethTx.Value.ToInt())
+
+	// If it is not a pending transaction and has already been processed and added into a block,
+	// the following fields should be returned.
+	if block != nil {
+		assert.Equal(t, block.Hash().String(), ethTx.BlockHash.String())
+		assert.Equal(t, block.NumberU64(), ethTx.BlockNumber.ToInt().Uint64())
+		assert.Equal(t, expectedIndex, *ethTx.TransactionIndex)
+	}
+
+	// Fields additionally used for Ethereum transaction types are not used
+	// when returning Klaytn transactions.
+	assert.Equal(t, true, reflect.ValueOf(ethTx.Accesses).IsNil())
+	assert.Equal(t, true, reflect.ValueOf(ethTx.ChainID).IsNil())
+	assert.Equal(t, true, reflect.ValueOf(ethTx.GasFeeCap).IsNil())
+	assert.Equal(t, true, reflect.ValueOf(ethTx.GasTipCap).IsNil())
+}
+
+func checkEthTransactionReceiptFormat(t *testing.T, block *types.Block, receipts []*types.Receipt, ethReceipt map[string]interface{}, kReceipt map[string]interface{}, idx uint64) {
+	tx := block.Transactions()[idx]
+	// Check the common receipt fields.
+	blockHash, ok := ethReceipt["blockHash"]
+	if !ok {
+		t.Fatal("blockHash is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, blockHash, kReceipt["blockHash"])
+
+	blockNumber, ok := ethReceipt["blockNumber"]
+	if !ok {
+		t.Fatal("blockNumber is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, blockNumber.(hexutil.Uint64), hexutil.Uint64(kReceipt["blockNumber"].(*hexutil.Big).ToInt().Uint64()))
+
+	transactionHash, ok := ethReceipt["transactionHash"]
+	if !ok {
+		t.Fatal("transactionHash is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, transactionHash, kReceipt["transactionHash"])
+
+	transactionIndex, ok := ethReceipt["transactionIndex"]
+	if !ok {
+		t.Fatal("transactionIndex is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, transactionIndex, hexutil.Uint64(kReceipt["transactionIndex"].(hexutil.Uint)))
+
+	from, ok := ethReceipt["from"]
+	if !ok {
+		t.Fatal("from is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, from, kReceipt["from"])
+
+	// Klaytn transactions that do not use the 'To' field
+	// fill in 'To' with from during converting format.
+	toInTx := tx.To()
+	fromAddress := getFrom(tx)
+	if toInTx == nil {
+		toInTx = &fromAddress
+	}
+	to, ok := ethReceipt["to"]
+	if !ok {
+		t.Fatal("to is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, to.(*common.Address).String(), toInTx.String())
+
+	gasUsed, ok := ethReceipt["gasUsed"]
+	if !ok {
+		t.Fatal("gasUsed is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, gasUsed, kReceipt["gasUsed"])
+
+	// Compare with the calculated cumulative gas used value
+	// to check whether the cumulativeGasUsed value is calculated properly.
+	cumulativeGasUsed, ok := ethReceipt["cumulativeGasUsed"]
+	if !ok {
+		t.Fatal("cumulativeGasUsed is not defined in Ethereum transaction receipt format.")
+	}
+	calculatedCumulativeGas := uint64(0)
+	for i := 0; i <= int(idx); i++ {
+		calculatedCumulativeGas += receipts[i].GasUsed
+	}
+	assert.Equal(t, cumulativeGasUsed, hexutil.Uint64(calculatedCumulativeGas))
+
+	contractAddress, ok := ethReceipt["contractAddress"]
+	if !ok {
+		t.Fatal("contractAddress is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, contractAddress, kReceipt["contractAddress"])
+
+	logs, ok := ethReceipt["logs"]
+	if !ok {
+		t.Fatal("logs is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, logs, kReceipt["logs"])
+
+	logsBloom, ok := ethReceipt["logsBloom"]
+	if !ok {
+		t.Fatal("logsBloom is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, logsBloom, kReceipt["logsBloom"])
+
+	typeInt, ok := ethReceipt["type"]
+	if !ok {
+		t.Fatal("type is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, types.TxType(typeInt.(hexutil.Uint)), types.TxTypeLegacyTransaction)
+
+	effectiveGasPrice, ok := ethReceipt["effectiveGasPrice"]
+	if !ok {
+		t.Fatal("effectiveGasPrice is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, effectiveGasPrice, kReceipt["gasPrice"].(*hexutil.Big).ToInt())
+
+	status, ok := ethReceipt["status"]
+	if !ok {
+		t.Fatal("status is not defined in Ethereum transaction receipt format.")
+	}
+	assert.Equal(t, status, kReceipt["status"])
+
+	// Check the receipt fields that should be removed.
+	var shouldNotExisted []string
+	shouldNotExisted = append(shouldNotExisted, "gas", "gasPrice", "senderTxHash", "signatures", "txError", "typeInt", "feePayer", "feePayerSignatures", "feeRatio", "input", "value", "codeFormat", "humanReadable", "key", "inputJSON")
+	for i := 0; i < len(shouldNotExisted); i++ {
+		k := shouldNotExisted[i]
+		_, ok = ethReceipt[k]
+		if ok {
+			t.Fatal(k, " should not be defined in the Ethereum transaction receipt format.")
+		}
+	}
+}
+
+func createTestData(t *testing.T) (*types.Block, types.Transactions, map[common.Hash]*types.Transaction, map[common.Hash]*types.Receipt, []*types.Receipt) {
+	var txs types.Transactions
+
+	var gasPrice = big.NewInt(25 * params.Ston)
+	var deployData = "0x60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb0029"
+	var executeData = "0xa9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039"
+	var anchorData []byte
+
+	var txHashMap = make(map[common.Hash]*types.Transaction)
+	var receiptMap = make(map[common.Hash]*types.Receipt)
+	var receipts []*types.Receipt
+
+	// Create test data for chainDataAnchoring tx
+	{
+		dummyBlock := types.NewBlock(&types.Header{}, nil, nil)
+		scData, err := types.NewAnchoringDataType0(dummyBlock, 0, uint64(dummyBlock.Transactions().Len()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		anchorData, _ = rlp.EncodeToBytes(scData)
+	}
+
+	// Make test transactions data
+	{
+		// TxTypeLegacyTransaction
+		values := map[types.TxValueKeyType]interface{}{
+			// Simply set the nonce to txs.Len() to have a different nonce for each transaction type.
+			types.TxValueKeyNonce:    uint64(txs.Len()),
+			types.TxValueKeyTo:       common.StringToAddress("0xe0680cfce04f80a386f1764a55c833b108770490"),
+			types.TxValueKeyAmount:   big.NewInt(0),
+			types.TxValueKeyGasLimit: uint64(30000000),
+			types.TxValueKeyGasPrice: gasPrice,
+			types.TxValueKeyData:     []byte("0xe3197e8f000000000000000000000000e0bef99b4a22286e27630b485d06c5a147cee931000000000000000000000000158beff8c8cdebd64654add5f6a1d9937e73536c0000000000000000000000000000000000000000000029bb5e7fb6beae32cf8000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000180000000000000000000000000000000000000000000000000001b60fb4614a22e000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000158beff8c8cdebd64654add5f6a1d9937e73536c00000000000000000000000074ba03198fed2b15a51af242b9c63faf3c8f4d3400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeLegacyTransaction, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+
+	}
+	{
+		// TxTypeValueTransfer
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    uint64(txs.Len()),
+			types.TxValueKeyFrom:     common.StringToAddress("0x520af902892196a3449b06ead301daeaf67e77e8"),
+			types.TxValueKeyTo:       common.StringToAddress("0xa06fa690d92788cac4953da5f2dfbc4a2b3871db"),
+			types.TxValueKeyAmount:   big.NewInt(5),
+			types.TxValueKeyGasLimit: uint64(10000000),
+			types.TxValueKeyGasPrice: gasPrice,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeValueTransfer, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeValueTransferMemo
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    uint64(txs.Len()),
+			types.TxValueKeyFrom:     common.StringToAddress("0xc05e11f9075d453b4fc87023f815fa6a63f7aa0c"),
+			types.TxValueKeyTo:       common.StringToAddress("0xb5a2d79e9228f3d278cb36b5b15930f24fe8bae8"),
+			types.TxValueKeyAmount:   big.NewInt(3),
+			types.TxValueKeyGasLimit: uint64(20000000),
+			types.TxValueKeyGasPrice: gasPrice,
+			types.TxValueKeyData:     []byte(string("hello")),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeValueTransferMemo, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeAccountUpdate
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:      uint64(txs.Len()),
+			types.TxValueKeyFrom:       common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyGasLimit:   uint64(20000000),
+			types.TxValueKeyGasPrice:   gasPrice,
+			types.TxValueKeyAccountKey: accountkey.NewAccountKeyLegacy(),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeAccountUpdate, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeSmartContractDeploy
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:         uint64(txs.Len()),
+			types.TxValueKeyFrom:          common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyTo:            (*common.Address)(nil),
+			types.TxValueKeyAmount:        big.NewInt(0),
+			types.TxValueKeyGasLimit:      uint64(100000000),
+			types.TxValueKeyGasPrice:      gasPrice,
+			types.TxValueKeyData:          common.Hex2Bytes(deployData),
+			types.TxValueKeyHumanReadable: false,
+			types.TxValueKeyCodeFormat:    params.CodeFormatEVM,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeSmartContractDeploy, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		var r = createReceipt(t, tx, tx.Gas())
+		fromAddress, err := tx.From()
+		if err != nil {
+			t.Fatal(err)
+		}
+		tx.FillContractAddress(fromAddress, r)
+		receiptMap[tx.Hash()] = r
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeSmartContractExecution
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    uint64(txs.Len()),
+			types.TxValueKeyFrom:     common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyTo:       common.StringToAddress("0x00ca1eee49a4d2b04e6562222eab95e9ed29c4bf"),
+			types.TxValueKeyAmount:   big.NewInt(0),
+			types.TxValueKeyGasLimit: uint64(50000000),
+			types.TxValueKeyGasPrice: gasPrice,
+			types.TxValueKeyData:     common.Hex2Bytes(executeData),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeSmartContractExecution, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeCancel
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    uint64(txs.Len()),
+			types.TxValueKeyFrom:     common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyGasLimit: uint64(50000000),
+			types.TxValueKeyGasPrice: gasPrice,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeCancel, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeChainDataAnchoring
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:        uint64(txs.Len()),
+			types.TxValueKeyFrom:         common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyGasLimit:     uint64(50000000),
+			types.TxValueKeyGasPrice:     gasPrice,
+			types.TxValueKeyAnchoredData: anchorData,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeChainDataAnchoring, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedValueTransfer
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    uint64(txs.Len()),
+			types.TxValueKeyFrom:     common.StringToAddress("0x520af902892196a3449b06ead301daeaf67e77e8"),
+			types.TxValueKeyTo:       common.StringToAddress("0xa06fa690d92788cac4953da5f2dfbc4a2b3871db"),
+			types.TxValueKeyAmount:   big.NewInt(5),
+			types.TxValueKeyGasLimit: uint64(10000000),
+			types.TxValueKeyGasPrice: gasPrice,
+			types.TxValueKeyFeePayer: common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedValueTransfer, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedValueTransferMemo
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    uint64(txs.Len()),
+			types.TxValueKeyFrom:     common.StringToAddress("0xc05e11f9075d453b4fc87023f815fa6a63f7aa0c"),
+			types.TxValueKeyTo:       common.StringToAddress("0xb5a2d79e9228f3d278cb36b5b15930f24fe8bae8"),
+			types.TxValueKeyAmount:   big.NewInt(3),
+			types.TxValueKeyGasLimit: uint64(20000000),
+			types.TxValueKeyGasPrice: gasPrice,
+			types.TxValueKeyData:     []byte(string("hello")),
+			types.TxValueKeyFeePayer: common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedValueTransferMemo, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedAccountUpdate
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:      uint64(txs.Len()),
+			types.TxValueKeyFrom:       common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyGasLimit:   uint64(20000000),
+			types.TxValueKeyGasPrice:   gasPrice,
+			types.TxValueKeyAccountKey: accountkey.NewAccountKeyLegacy(),
+			types.TxValueKeyFeePayer:   common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedAccountUpdate, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedSmartContractDeploy
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:         uint64(txs.Len()),
+			types.TxValueKeyFrom:          common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyTo:            (*common.Address)(nil),
+			types.TxValueKeyAmount:        big.NewInt(0),
+			types.TxValueKeyGasLimit:      uint64(100000000),
+			types.TxValueKeyGasPrice:      gasPrice,
+			types.TxValueKeyData:          common.Hex2Bytes(deployData),
+			types.TxValueKeyHumanReadable: false,
+			types.TxValueKeyCodeFormat:    params.CodeFormatEVM,
+			types.TxValueKeyFeePayer:      common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedSmartContractDeploy, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		var r = createReceipt(t, tx, tx.Gas())
+		fromAddress, err := tx.From()
+		if err != nil {
+			t.Fatal(err)
+		}
+		tx.FillContractAddress(fromAddress, r)
+		receiptMap[tx.Hash()] = r
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedSmartContractExecution
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    uint64(txs.Len()),
+			types.TxValueKeyFrom:     common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyTo:       common.StringToAddress("0x00ca1eee49a4d2b04e6562222eab95e9ed29c4bf"),
+			types.TxValueKeyAmount:   big.NewInt(0),
+			types.TxValueKeyGasLimit: uint64(50000000),
+			types.TxValueKeyGasPrice: gasPrice,
+			types.TxValueKeyData:     common.Hex2Bytes(executeData),
+			types.TxValueKeyFeePayer: common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedSmartContractExecution, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedCancel
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:    uint64(txs.Len()),
+			types.TxValueKeyFrom:     common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyGasLimit: uint64(50000000),
+			types.TxValueKeyGasPrice: gasPrice,
+			types.TxValueKeyFeePayer: common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedCancel, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedChainDataAnchoring
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:        uint64(txs.Len()),
+			types.TxValueKeyFrom:         common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyGasLimit:     uint64(50000000),
+			types.TxValueKeyGasPrice:     gasPrice,
+			types.TxValueKeyAnchoredData: anchorData,
+			types.TxValueKeyFeePayer:     common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedChainDataAnchoring, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedValueTransferWithRatio
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:              uint64(txs.Len()),
+			types.TxValueKeyFrom:               common.StringToAddress("0x520af902892196a3449b06ead301daeaf67e77e8"),
+			types.TxValueKeyTo:                 common.StringToAddress("0xa06fa690d92788cac4953da5f2dfbc4a2b3871db"),
+			types.TxValueKeyAmount:             big.NewInt(5),
+			types.TxValueKeyGasLimit:           uint64(10000000),
+			types.TxValueKeyGasPrice:           gasPrice,
+			types.TxValueKeyFeePayer:           common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+			types.TxValueKeyFeeRatioOfFeePayer: types.FeeRatio(20),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedValueTransferWithRatio, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedValueTransferMemoWithRatio
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:              uint64(txs.Len()),
+			types.TxValueKeyFrom:               common.StringToAddress("0xc05e11f9075d453b4fc87023f815fa6a63f7aa0c"),
+			types.TxValueKeyTo:                 common.StringToAddress("0xb5a2d79e9228f3d278cb36b5b15930f24fe8bae8"),
+			types.TxValueKeyAmount:             big.NewInt(3),
+			types.TxValueKeyGasLimit:           uint64(20000000),
+			types.TxValueKeyGasPrice:           gasPrice,
+			types.TxValueKeyData:               []byte(string("hello")),
+			types.TxValueKeyFeePayer:           common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+			types.TxValueKeyFeeRatioOfFeePayer: types.FeeRatio(20),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedValueTransferMemoWithRatio, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedAccountUpdateWithRatio
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:              uint64(txs.Len()),
+			types.TxValueKeyFrom:               common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyGasLimit:           uint64(20000000),
+			types.TxValueKeyGasPrice:           gasPrice,
+			types.TxValueKeyAccountKey:         accountkey.NewAccountKeyLegacy(),
+			types.TxValueKeyFeePayer:           common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+			types.TxValueKeyFeeRatioOfFeePayer: types.FeeRatio(20),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedAccountUpdateWithRatio, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedSmartContractDeployWithRatio
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:              uint64(txs.Len()),
+			types.TxValueKeyFrom:               common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyTo:                 (*common.Address)(nil),
+			types.TxValueKeyAmount:             big.NewInt(0),
+			types.TxValueKeyGasLimit:           uint64(100000000),
+			types.TxValueKeyGasPrice:           gasPrice,
+			types.TxValueKeyData:               common.Hex2Bytes(deployData),
+			types.TxValueKeyHumanReadable:      false,
+			types.TxValueKeyCodeFormat:         params.CodeFormatEVM,
+			types.TxValueKeyFeePayer:           common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+			types.TxValueKeyFeeRatioOfFeePayer: types.FeeRatio(20),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedSmartContractDeployWithRatio, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		var r = createReceipt(t, tx, tx.Gas())
+		fromAddress, err := tx.From()
+		if err != nil {
+			t.Fatal(err)
+		}
+		tx.FillContractAddress(fromAddress, r)
+		receiptMap[tx.Hash()] = r
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedSmartContractExecutionWithRatio
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:              uint64(txs.Len()),
+			types.TxValueKeyFrom:               common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyTo:                 common.StringToAddress("0x00ca1eee49a4d2b04e6562222eab95e9ed29c4bf"),
+			types.TxValueKeyAmount:             big.NewInt(0),
+			types.TxValueKeyGasLimit:           uint64(50000000),
+			types.TxValueKeyGasPrice:           gasPrice,
+			types.TxValueKeyData:               common.Hex2Bytes(executeData),
+			types.TxValueKeyFeePayer:           common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+			types.TxValueKeyFeeRatioOfFeePayer: types.FeeRatio(20),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedSmartContractExecutionWithRatio, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedCancelWithRatio
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:              uint64(txs.Len()),
+			types.TxValueKeyFrom:               common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyGasLimit:           uint64(50000000),
+			types.TxValueKeyGasPrice:           gasPrice,
+			types.TxValueKeyFeePayer:           common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+			types.TxValueKeyFeeRatioOfFeePayer: types.FeeRatio(20),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedCancelWithRatio, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeFeeDelegatedChainDataAnchoringWithRatio
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:              uint64(txs.Len()),
+			types.TxValueKeyFrom:               common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			types.TxValueKeyGasLimit:           uint64(50000000),
+			types.TxValueKeyGasPrice:           gasPrice,
+			types.TxValueKeyAnchoredData:       anchorData,
+			types.TxValueKeyFeePayer:           common.StringToAddress("0xa142f7b24a618778165c9b06e15a61f100c51400"),
+			types.TxValueKeyFeeRatioOfFeePayer: types.FeeRatio(20),
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedChainDataAnchoringWithRatio, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		feePayerSignatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(3), R: big.NewInt(4), S: big.NewInt(5)},
+			&types.TxSignature{V: big.NewInt(4), R: big.NewInt(5), S: big.NewInt(6)},
+		}
+		tx.SetFeePayerSignatures(feePayerSignatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+
+	// Create a block which includes all transaction data.
+	block := types.NewBlock(&types.Header{Number: big.NewInt(1)}, txs, nil)
+
+	return block, txs, txHashMap, receiptMap, receipts
+}
+
+func createReceipt(t *testing.T, tx *types.Transaction, gasUsed uint64) *types.Receipt {
+	rct := types.NewReceipt(uint(0), tx.Hash(), gasUsed)
+	rct.Logs = []*types.Log{}
+	rct.Bloom = types.Bloom{}
+	return rct
+}
+
+// MockDatabaseManager is a mock of database.DBManager interface for overriding the ReadTxAndLookupInfo function.
+type MockDatabaseManager struct {
+	database.DBManager
+
+	txHashMap     map[common.Hash]*types.Transaction
+	blockData     *types.Block
+	queryFromPool bool
+}
+
+// GetTxLookupInfoAndReceipt retrieves a tx and lookup info and receipt for a given transaction hash.
+func (dbm *MockDatabaseManager) ReadTxAndLookupInfo(hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64) {
+	// If queryFromPool, return nil to query from pool after this function
+	if dbm.queryFromPool {
+		return nil, common.Hash{}, 0, 0
+	}
+
+	txFromHashMap := dbm.txHashMap[hash]
+	if txFromHashMap == nil {
+		return nil, common.Hash{}, 0, 0
+	}
+	return txFromHashMap, dbm.blockData.Hash(), dbm.blockData.NumberU64(), txFromHashMap.Nonce()
+}
+
+// MockWallet is a mock of accounts.Wallet interface for overriding the Accounts function.
+type MockWallet struct {
+	accounts.Wallet
+
+	accounts []accounts.Account
+}
+
+// NewMockWallet prepares accounts based on tx from.
+func NewMockWallet(txs types.Transactions) *MockWallet {
+	mw := &MockWallet{}
+
+	for _, t := range txs {
+		mw.accounts = append(mw.accounts, accounts.Account{Address: getFrom(t)})
+	}
+	return mw
+}
+
+// Accounts implements accounts.Wallet, returning an account list.
+func (mw *MockWallet) Accounts() []accounts.Account {
+	return mw.accounts
+}

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -198,13 +198,16 @@ func checkEthRPCTransactionFormat(t *testing.T, block *types.Block, ethTx *EthRP
 
 	// Check the optional field of Klaytn transactions.
 	assert.Equal(t, 0, bytes.Compare(ethTx.Input, tx.Data()))
-	// Klaytn transactions that do not use the 'To' field
-	// fill in 'To' with from during converting to EthereumRPCTransaction.
+
 	to := tx.To()
-	if to == nil {
-		to = &from
+	switch tx.Type() {
+	case types.TxTypeAccountUpdate, types.TxTypeFeeDelegatedAccountUpdate, types.TxTypeFeeDelegatedAccountUpdateWithRatio,
+		types.TxTypeCancel, types.TxTypeFeeDelegatedCancel, types.TxTypeFeeDelegatedCancelWithRatio,
+		types.TxTypeChainDataAnchoring, types.TxTypeFeeDelegatedChainDataAnchoring, types.TxTypeFeeDelegatedChainDataAnchoringWithRatio:
+		assert.Equal(t, &from, ethTx.To)
+	default:
+		assert.Equal(t, to, ethTx.To)
 	}
-	assert.Equal(t, to, ethTx.To)
 	value := tx.Value()
 	assert.Equal(t, value, ethTx.Value.ToInt())
 

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"math/big"
 	"reflect"
@@ -142,7 +143,6 @@ func checkEthereumBlockOrHeaderFormat(
 	t.Logf("actualResult: %s\n", marshaledEthBlockOrHeader)
 	assert.Equal(t, marshaledExpectedResult, marshaledEthBlockOrHeader)
 }
-
 
 // TestEthereumAPI_GetTransactionByBlockNumberAndIndex tests GetTransactionByBlockNumberAndIndex.
 func TestEthereumAPI_GetTransactionByBlockNumberAndIndex(t *testing.T) {

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -7,11 +7,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/klaytn/klaytn/accounts"
 	mock_accounts "github.com/klaytn/klaytn/accounts/mocks"
-	"github.com/klaytn/klaytn/storage/database"
-
-	"github.com/golang/mock/gomock"
 	mock_api "github.com/klaytn/klaytn/api/mocks"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -21,6 +19,7 @@ import (
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
+	"github.com/klaytn/klaytn/storage/database"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -3,15 +3,16 @@ package api
 import (
 	"bytes"
 	"context"
-	"github.com/klaytn/klaytn/accounts"
-	"github.com/klaytn/klaytn/accounts/mocks"
-	"github.com/klaytn/klaytn/storage/database"
 	"math/big"
 	"reflect"
 	"testing"
 
+	"github.com/klaytn/klaytn/accounts"
+	mock_accounts "github.com/klaytn/klaytn/accounts/mocks"
+	"github.com/klaytn/klaytn/storage/database"
+
 	"github.com/golang/mock/gomock"
-	"github.com/klaytn/klaytn/api/mocks"
+	mock_api "github.com/klaytn/klaytn/api/mocks"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/types/accountkey"
@@ -225,6 +226,7 @@ func checkEthRPCTransactionFormat(t *testing.T, block *types.Block, ethTx *EthRP
 
 func checkEthTransactionReceiptFormat(t *testing.T, block *types.Block, receipts []*types.Receipt, ethReceipt map[string]interface{}, kReceipt map[string]interface{}, idx uint64) {
 	tx := block.Transactions()[idx]
+
 	// Check the common receipt fields.
 	blockHash, ok := ethReceipt["blockHash"]
 	if !ok {

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -265,14 +265,18 @@ func checkEthTransactionReceiptFormat(t *testing.T, block *types.Block, receipts
 	// fill in 'To' with from during converting format.
 	toInTx := tx.To()
 	fromAddress := getFrom(tx)
-	if toInTx == nil {
-		toInTx = &fromAddress
-	}
 	to, ok := ethReceipt["to"]
 	if !ok {
 		t.Fatal("to is not defined in Ethereum transaction receipt format.")
 	}
-	assert.Equal(t, to.(*common.Address).String(), toInTx.String())
+	switch tx.Type() {
+	case types.TxTypeAccountUpdate, types.TxTypeFeeDelegatedAccountUpdate, types.TxTypeFeeDelegatedAccountUpdateWithRatio,
+		types.TxTypeCancel, types.TxTypeFeeDelegatedCancel, types.TxTypeFeeDelegatedCancelWithRatio,
+		types.TxTypeChainDataAnchoring, types.TxTypeFeeDelegatedChainDataAnchoring, types.TxTypeFeeDelegatedChainDataAnchoringWithRatio:
+		assert.Equal(t, &fromAddress, to)
+	default:
+		assert.Equal(t, toInTx, to)
+	}
 
 	gasUsed, ok := ethReceipt["gasUsed"]
 	if !ok {

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -504,9 +504,7 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 	return RpcOutputBlock(b, s.b.GetTd(b.Hash()), inclTx, fullTx)
 }
 
-// newRPCTransaction returns a transaction that will serialize to the RPC
-// representation, with the given location metadata set (if available).
-func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64) map[string]interface{} {
+func getFrom(tx *types.Transaction) common.Address {
 	var from common.Address
 	if tx.IsLegacyTransaction() {
 		signer := types.NewEIP155Signer(tx.ChainId())
@@ -514,6 +512,13 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	} else {
 		from, _ = tx.From()
 	}
+	return from
+}
+
+// newRPCTransaction returns a transaction that will serialize to the RPC
+// representation, with the given location metadata set (if available).
+func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64) map[string]interface{} {
+	from := getFrom(tx)
 
 	output := tx.MakeRPCOutput()
 

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -451,6 +451,16 @@ func (s *PublicTransactionPoolAPI) SignTransactionAsFeePayer(ctx context.Context
 	return &SignTransactionResult{data, feePayerSignedTx}, nil
 }
 
+func getAccountsFromWallets(wallets []accounts.Wallet) map[common.Address]struct{} {
+	accounts := make(map[common.Address]struct{})
+	for _, wallet := range wallets {
+		for _, account := range wallet.Accounts() {
+			accounts[account.Address] = struct{}{}
+		}
+	}
+	return accounts
+}
+
 // PendingTransactions returns the transactions that are in the transaction pool
 // and have a from address that is one of the accounts this node manages.
 func (s *PublicTransactionPoolAPI) PendingTransactions() ([]map[string]interface{}, error) {
@@ -458,16 +468,10 @@ func (s *PublicTransactionPoolAPI) PendingTransactions() ([]map[string]interface
 	if err != nil {
 		return nil, err
 	}
-	accounts := make(map[common.Address]struct{})
-	for _, wallet := range s.b.AccountManager().Wallets() {
-		for _, account := range wallet.Accounts() {
-			accounts[account.Address] = struct{}{}
-		}
-	}
+	accounts := getAccountsFromWallets(s.b.AccountManager().Wallets())
 	transactions := make([]map[string]interface{}, 0, len(pending))
 	for _, tx := range pending {
-		signer := types.NewEIP155Signer(tx.ChainId())
-		from, _ := types.Sender(signer, tx)
+		from := getFrom(tx)
 		if _, exists := accounts[from]; exists {
 			transactions = append(transactions, newRPCPendingTransaction(tx))
 		}

--- a/api/mocks/backend_mock.go
+++ b/api/mocks/backend_mock.go
@@ -60,6 +60,21 @@ func (mr *MockBackendMockRecorder) AccountManager() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountManager", reflect.TypeOf((*MockBackend)(nil).AccountManager))
 }
 
+// BlockByHash mocks base method
+func (m *MockBackend) BlockByHash(arg0 context.Context, arg1 common.Hash) (*types.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockByHash", arg0, arg1)
+	ret0, _ := ret[0].(*types.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BlockByHash indicates an expected call of BlockByHash
+func (mr *MockBackendMockRecorder) BlockByHash(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHash", reflect.TypeOf((*MockBackend)(nil).BlockByHash), arg0, arg1)
+}
+
 // BlockByNumber mocks base method
 func (m *MockBackend) BlockByNumber(arg0 context.Context, arg1 rpc.BlockNumber) (*types.Block, error) {
 	m.ctrl.T.Helper()
@@ -144,21 +159,6 @@ func (m *MockBackend) EventMux() *event.TypeMux {
 func (mr *MockBackendMockRecorder) EventMux() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventMux", reflect.TypeOf((*MockBackend)(nil).EventMux))
-}
-
-// GetBlock mocks base method
-func (m *MockBackend) BlockByHash(arg0 context.Context, arg1 common.Hash) (*types.Block, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockByHash", arg0, arg1)
-	ret0, _ := ret[0].(*types.Block)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBlock indicates an expected call of GetBlock
-func (mr *MockBackendMockRecorder) GetBlock(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHash", reflect.TypeOf((*MockBackend)(nil).BlockByHash), arg0, arg1)
 }
 
 // GetBlockReceipts mocks base method
@@ -332,21 +332,6 @@ func (mr *MockBackendMockRecorder) GetTxLookupInfoAndReceiptInCache(arg0 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTxLookupInfoAndReceiptInCache", reflect.TypeOf((*MockBackend)(nil).GetTxLookupInfoAndReceiptInCache), arg0)
 }
 
-// HeaderByNumber mocks base method
-func (m *MockBackend) HeaderByNumber(arg0 context.Context, arg1 rpc.BlockNumber) (*types.Header, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HeaderByNumber", arg0, arg1)
-	ret0, _ := ret[0].(*types.Header)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// HeaderByNumber indicates an expected call of HeaderByNumber
-func (mr *MockBackendMockRecorder) HeaderByNumber(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByNumber", reflect.TypeOf((*MockBackend)(nil).HeaderByNumber), arg0, arg1)
-}
-
 // HeaderByHash mocks base method
 func (m *MockBackend) HeaderByHash(arg0 context.Context, arg1 common.Hash) (*types.Header, error) {
 	m.ctrl.T.Helper()
@@ -360,6 +345,21 @@ func (m *MockBackend) HeaderByHash(arg0 context.Context, arg1 common.Hash) (*typ
 func (mr *MockBackendMockRecorder) HeaderByHash(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByHash", reflect.TypeOf((*MockBackend)(nil).HeaderByHash), arg0, arg1)
+}
+
+// HeaderByNumber mocks base method
+func (m *MockBackend) HeaderByNumber(arg0 context.Context, arg1 rpc.BlockNumber) (*types.Header, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HeaderByNumber", arg0, arg1)
+	ret0, _ := ret[0].(*types.Header)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HeaderByNumber indicates an expected call of HeaderByNumber
+func (mr *MockBackendMockRecorder) HeaderByNumber(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByNumber", reflect.TypeOf((*MockBackend)(nil).HeaderByNumber), arg0, arg1)
 }
 
 // HeaderByNumberOrHash mocks base method
@@ -492,7 +492,7 @@ func (mr *MockBackendMockRecorder) StateAndHeaderByNumber(arg0, arg1 interface{}
 // StateAndHeaderByNumberOrHash mocks base method
 func (m *MockBackend) StateAndHeaderByNumberOrHash(arg0 context.Context, arg1 rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StateAndHeaderByNumber", arg0, arg1)
+	ret := m.ctrl.Call(m, "StateAndHeaderByNumberOrHash", arg0, arg1)
 	ret0, _ := ret[0].(*state.StateDB)
 	ret1, _ := ret[1].(*types.Header)
 	ret2, _ := ret[2].(error)


### PR DESCRIPTION
## Proposed changes

This PR introduces eth namespace read transaction api.
Below apis are implemented newly to return in ethereum format (different with Klaytn return format)
- GetTransactionByBlockNumberAndIndex
- GetTransactionByBlockHashAndIndex
- GetTransactionByHash
- GetTransactionReceipt
- PendingTransactions

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...