### PR TITLE
blockchain: also check fork ordering at genesis

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -206,6 +206,9 @@ func SetupGenesisBlock(db database.DBManager, genesis *Genesis, networkId uint64
 		// Initialize DeriveSha implementation
 		InitDeriveSha(genesis.Config.DeriveShaImpl)
 		block, err := genesis.Commit(common.Hash{}, db)
+		if err != nil {
+			return genesis.Config, common.Hash{}, err
+		}
 		return genesis.Config, block.Hash(), err
 	}
 
@@ -351,6 +354,9 @@ func (g *Genesis) Commit(baseStateRoot common.Hash, db database.DBManager) (*typ
 	config := g.Config
 	if config == nil {
 		config = params.AllGxhashProtocolChanges
+	}
+	if err := config.CheckConfigForkOrder(); err != nil {
+		return nil, err
 	}
 	db.WriteChainConfig(block.Hash(), config)
 	return block, nil


### PR DESCRIPTION
## Proposed changes
- This PR solves not checking fork ordering during genesis.
- It should be included in https://github.com/klaytn/klaytn/pull/1065.

genesis.json
```
{
    "config": {
        "chainId": 940625,
        "istanbulCompatibleBlock": 50,
        "londonCompatibleBlock": 40,
        ...
    }
}
```
dev
-> with above genesis.json, `init` succeed.
```
$ ken init --datadir data genesis.json
$ kend start
$ cat kend.out
...
INFO[12/23,14:54:03 +09] [41] Initialised chain configuration           config="{ChainID: 940625 IstanbulCompatibleBlock: 50 LondonCompatibleBlock: 40 SubGroupSize: 1 UnitPrice: 1 DeriveShaImpl: 2 Engine: istanbul}"
```

PR
-> with above genesis.json, `init` failed.
```
$ ken init --datadir data genesis.json
...
CRIT[12/23,14:48:21 +09] [19] Failed to write genesis block             err="unsupported fork ordering: istanbulBlock enabled at 50, but londonBlock enabled at 40"
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
