### PR TITLE
governance: accept multiple validator addresses when voting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,4 +68,5 @@ require (
 	gopkg.in/olebedev/go-duktape.v3 v3.0.0-20181125150206-ccb656ba24c2
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0
+	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -467,5 +467,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/governance/api.go
+++ b/governance/api.go
@@ -98,7 +98,7 @@ func (api *PublicGovernanceAPI) Vote(key string, val interface{}) (string, error
 		if _, ok := api.governance.ValidateVote(&GovernanceVote{Key: key, Value: val}); !ok {
 			return "", errInvalidKeyValue
 		}
-		if api.isRemovingSelf(val) {
+		if api.isRemovingSelf(val.(string)) {
 			return "", errRemoveSelf
 		}
 	}
@@ -108,8 +108,8 @@ func (api *PublicGovernanceAPI) Vote(key string, val interface{}) (string, error
 	return "", errInvalidKeyValue
 }
 
-func (api *PublicGovernanceAPI) isRemovingSelf(val interface{}) bool {
-	for _, str := range strings.Split(val.(string), ",") {
+func (api *PublicGovernanceAPI) isRemovingSelf(val string) bool {
+	for _, str := range strings.Split(val, ",") {
 		str = strings.Trim(str, " ")
 		if common.HexToAddress(str) == api.governance.nodeAddress.Load().(common.Address) {
 			return true

--- a/governance/api.go
+++ b/governance/api.go
@@ -110,6 +110,7 @@ func (api *PublicGovernanceAPI) Vote(key string, val interface{}) (string, error
 
 func (api *PublicGovernanceAPI) isRemovingSelf(val interface{}) bool {
 	for _, str := range strings.Split(val.(string), ",") {
+		str = strings.Trim(str, " ")
 		if common.HexToAddress(str) == api.governance.nodeAddress.Load().(common.Address) {
 			return true
 		}

--- a/governance/default.go
+++ b/governance/default.go
@@ -499,7 +499,6 @@ func (g *Governance) getKey(k string) string {
 func (g *Governance) RemoveVote(key string, value interface{}, number uint64) {
 	k := GovernanceKeyMap[key]
 	if isEqualValue(k, g.voteMap.GetValue(key).Value, value) {
-		//if GovernanceItems[k].isEqual(g.voteMap.GetValue(key).Value, value) {
 		g.voteMap.SetValue(key, VoteStatus{
 			Value:  value,
 			Casted: true,
@@ -519,7 +518,7 @@ func (g *Governance) ClearVotes(num uint64) {
 	logger.Info("Governance votes are cleared", "num", num)
 }
 
-// parseVoteValue parse vote.Value from []uint8 to appropriate type
+// parseVoteValue parse vote.Value from []uint8, [][]uint8 to appropriate type
 func (g *Governance) ParseVoteValue(gVote *GovernanceVote) (*GovernanceVote, error) {
 	var val interface{}
 	k, ok := GovernanceKeyMap[gVote.Key]

--- a/governance/default.go
+++ b/governance/default.go
@@ -534,7 +534,13 @@ func (g *Governance) ParseVoteValue(gVote *GovernanceVote) (*GovernanceVote, err
 			return nil, ErrValueTypeMismatch
 		}
 		val = string(v)
-	case params.GoverningNode, params.AddValidator, params.RemoveValidator:
+	case params.GoverningNode:
+		v, ok := gVote.Value.([]uint8)
+		if !ok || len(v) != common.AddressLength {
+			return nil, ErrValueTypeMismatch
+		}
+		val = common.BytesToAddress(v)
+	case params.AddValidator, params.RemoveValidator:
 		if v, ok := gVote.Value.([]uint8); ok {
 			// if value contains single address, gVote.Value type should be []uint8{}
 			if len(v) != common.AddressLength {
@@ -557,7 +563,6 @@ func (g *Governance) ParseVoteValue(gVote *GovernanceVote) (*GovernanceVote, err
 		} else {
 			return nil, ErrValueTypeMismatch
 		}
-
 	case params.Epoch, params.CommitteeSize, params.UnitPrice, params.StakeUpdateInterval, params.ProposerRefreshInterval, params.ConstTxGasHumanReadable, params.Policy, params.Timeout:
 		v, ok := gVote.Value.([]uint8)
 		if !ok {

--- a/governance/default.go
+++ b/governance/default.go
@@ -522,17 +522,23 @@ func (g *Governance) ClearVotes(num uint64) {
 func (g *Governance) ParseVoteValue(gVote *GovernanceVote) (*GovernanceVote, error) {
 	var val interface{}
 	k, ok := GovernanceKeyMap[gVote.Key]
-	if ok == false {
+	if !ok {
 		logger.Warn("Unknown key was given", "key", k)
 		return nil, ErrUnknownKey
 	}
 
-	if (k == params.AddValidator || k == params.RemoveValidator) && (reflect.TypeOf(gVote.Value) != reflect.TypeOf([]interface{}{}) && reflect.TypeOf(gVote.Value) != reflect.TypeOf([]uint8{})) {
-		return nil, ErrValueTypeMismatch
-	}
-
-	if (k != params.AddValidator && k != params.RemoveValidator) && reflect.TypeOf(gVote.Value) != reflect.TypeOf([]uint8{}) {
-		return nil, ErrValueTypeMismatch
+	// checking type of gVote.Value
+	switch k {
+	case params.AddValidator, params.RemoveValidator:
+		// gVote.Value type should be [][]interface{}(multiple node removal/addition) or []uint8(single node removal/addition)
+		if reflect.TypeOf(gVote.Value) != reflect.TypeOf([]interface{}{}) && reflect.TypeOf(gVote.Value) != reflect.TypeOf([]uint8{}) {
+			return nil, ErrValueTypeMismatch
+		}
+	default:
+		// gVote.Value type should be []uint8
+		if reflect.TypeOf(gVote.Value) != reflect.TypeOf([]uint8{}) {
+			return nil, ErrValueTypeMismatch
+		}
 	}
 
 	switch k {

--- a/governance/default.go
+++ b/governance/default.go
@@ -540,6 +540,9 @@ func (g *Governance) ParseVoteValue(gVote *GovernanceVote) (*GovernanceVote, err
 				if reflect.TypeOf(item) != reflect.TypeOf([]uint8{}) {
 					return nil, ErrValueTypeMismatch
 				}
+				if len(item.([]uint8)) != common.AddressLength {
+					return nil, ErrValueTypeMismatch
+				}
 			}
 			break
 		}
@@ -548,6 +551,9 @@ func (g *Governance) ParseVoteValue(gVote *GovernanceVote) (*GovernanceVote, err
 	default:
 		// Neither governance.addvalidator key nor governance.removevalidator key, gVote.Value type should be []uint8{}
 		if reflect.TypeOf(gVote.Value) != reflect.TypeOf([]uint8{}) {
+			return nil, ErrValueTypeMismatch
+		}
+		if GovernanceItems[k].checkValueType(common.Address{}) && len(gVote.Value.([]uint8)) != common.AddressLength {
 			return nil, ErrValueTypeMismatch
 		}
 	}

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -135,6 +135,7 @@ var tstData = []voteValue{
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c", e: true},
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c,0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c5869", e: true},
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c,0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c58", e: false},
+	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c,0x639e5ebfc483716fbac9810b230ff6ad487f366c", e: false},
 }
 
 var goodVotes = []voteValue{

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -555,7 +555,7 @@ func TestVoteValueNilInterface(t *testing.T) {
 		}
 		// Parse vote.Value and make it has appropriate type
 		_, err := gov.ParseVoteValue(gVote)
-		assert.Equal(t, nil, err)
+		assert.Equal(t, ErrValueTypeMismatch, err)
 	}
 
 	{
@@ -567,7 +567,7 @@ func TestVoteValueNilInterface(t *testing.T) {
 
 		// Parse vote.Value and make it has appropriate type
 		_, err := gov.ParseVoteValue(gVote)
-		assert.Equal(t, nil, err)
+		assert.Equal(t, ErrValueTypeMismatch, err)
 	}
 }
 

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -133,9 +133,12 @@ var tstData = []voteValue{
 	{k: "istanbul.timeout", v: "10", e: false},
 	{k: "istanbul.timeout", v: 5.3, e: false},
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c", e: true},
+	{k: "governance.addvalidator", v: " 0x639e5ebfc483716fbac9810b230ff6ad487f366c ", e: true},
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c,0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c5869", e: true},
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c,0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c58", e: false},
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c,0x639e5ebfc483716fbac9810b230ff6ad487f366c", e: false},
+	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c, 0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c5869, ", e: false},
+	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c, 0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c5869 ", e: true},
 }
 
 var goodVotes = []voteValue{

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	gotest_assert "gotest.tools/assert"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -138,6 +140,7 @@ var tstData = []voteValue{
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c,0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c58", e: false},
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c,0x639e5ebfc483716fbac9810b230ff6ad487f366c", e: false},
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c, 0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c5869, ", e: false},
+	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c,, 0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c5869, ", e: false},
 	{k: "governance.addvalidator", v: "0x639e5ebfc483716fbac9810b230ff6ad487f366c, 0x828880c5f09cc1cc6a58715e3fe2b4c4cf3c5869 ", e: true},
 }
 
@@ -299,8 +302,7 @@ func TestGovernance_GetEncodedVote(t *testing.T) {
 
 		v, err := gov.ParseVoteValue(v)
 		assert.Equal(t, nil, err)
-		assert.Equal(t, gov.voteMap.GetValue(v.Key).Value, v.Value,
-			fmt.Sprintf("Encoded vote and Decoded vote are different! Encoded: %v, Decoded: %v\n", gov.voteMap.GetValue(v.Key).Value, v.Value))
+		gotest_assert.DeepEqual(t, gov.voteMap.GetValue(v.Key).Value, v.Value)
 	}
 }
 
@@ -322,8 +324,7 @@ func TestGovernance_ParseVoteValue(t *testing.T) {
 
 		d, err := gov.ParseVoteValue(d)
 		assert.Equal(t, nil, err)
-		assert.Equal(t, reflect.DeepEqual(v, d), true,
-			fmt.Sprintf("Parse was not successful! %v %v \n", v, d))
+		gotest_assert.DeepEqual(t, v, d)
 	}
 }
 

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -184,7 +184,7 @@ func (g *Governance) adjustValueType(key string, val interface{}) interface{} {
 		return val
 	}
 
-	if (k == params.AddValidator || k == params.RemoveValidator) && reflect.TypeOf(val) == stringT {
+	if GovernanceItems[k].checkValueType(common.Address{}) && reflect.TypeOf(val) == stringT {
 		addresses := strings.Split(val.(string), ",")
 
 		if len(addresses) == 0 {
@@ -192,26 +192,24 @@ func (g *Governance) adjustValueType(key string, val interface{}) interface{} {
 		}
 
 		if len(addresses) == 1 {
-			x = common.HexToAddress(val.(string))
-			return x
-		}
-
-		var nodeAddresses []common.Address
-		for _, str := range addresses {
-			if common.IsHexAddress(str) {
-				nodeAddresses = append(nodeAddresses, common.HexToAddress(str))
+			if common.IsHexAddress(val.(string)) {
+				x = common.HexToAddress(val.(string))
+				return x
 			} else {
 				return val
 			}
 		}
-		x = nodeAddresses
-		return x
-	}
 
-	// address comes as a form of string from JS console
-	if GovernanceItems[k].checkValueType(common.Address{}) && reflect.TypeOf(val) == stringT {
-		if common.IsHexAddress(val.(string)) {
-			x = common.HexToAddress(val.(string))
+		if len(addresses) >= 2 {
+			var nodeAddresses []common.Address
+			for _, str := range addresses {
+				if common.IsHexAddress(str) {
+					nodeAddresses = append(nodeAddresses, common.HexToAddress(str))
+				} else {
+					return val
+				}
+			}
+			x = nodeAddresses
 			return x
 		}
 	}

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -175,8 +175,9 @@ func (g *Governance) adjustValueType(key string, val interface{}) interface{} {
 		}
 
 		if len(addresses) == 1 {
-			if common.IsHexAddress(val.(string)) {
-				x = common.HexToAddress(val.(string))
+			str := strings.Trim(val.(string), " ")
+			if common.IsHexAddress(str) {
+				x = common.HexToAddress(str)
 				return x
 			} else {
 				return val
@@ -186,6 +187,7 @@ func (g *Governance) adjustValueType(key string, val interface{}) interface{} {
 		if len(addresses) >= 2 {
 			var nodeAddresses []common.Address
 			for _, str := range addresses {
+				str = strings.Trim(str, " ")
 				if common.IsHexAddress(str) {
 					nodeAddresses = append(nodeAddresses, common.HexToAddress(str))
 				} else {

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -313,7 +313,7 @@ func checkAddressOrListOfUniqueAddresses(k string, v interface{}) bool {
 		return false
 	}
 
-	// there should not be identical addresses, if value contains multiple addresses
+	// there should not be duplicated addresses, if value contains multiple addresses
 	addressExists := make(map[common.Address]bool)
 	for _, address := range v.([]common.Address) {
 		if _, ok := addressExists[address]; ok {

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -47,7 +47,7 @@ var (
 
 var GovernanceItems = map[int]check{
 	params.GovernanceMode:          {stringT, checkGovernanceMode, nil},
-	params.GoverningNode:           {addressT, checkAddressOrListOfUniqueAddresses, nil},
+	params.GoverningNode:           {addressT, checkAddress, nil},
 	params.UnitPrice:               {uint64T, checkUint64andBool, updateUnitPrice},
 	params.AddValidator:            {addressT, checkAddressOrListOfUniqueAddresses, nil},
 	params.RemoveValidator:         {addressT, checkAddressOrListOfUniqueAddresses, nil},
@@ -286,8 +286,15 @@ func checkBigInt(k string, v interface{}) bool {
 	return false
 }
 
-func checkAddressOrListOfUniqueAddresses(k string, v interface{}) bool {
+func checkAddress(k string, v interface{}) bool {
 	if _, ok := v.(common.Address); ok {
+		return true
+	}
+	return false
+}
+
+func checkAddressOrListOfUniqueAddresses(k string, v interface{}) bool {
+	if checkAddress(k, v) {
 		return true
 	}
 	if _, ok := v.([]common.Address); !ok {

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -127,7 +127,6 @@ func (g *Governance) AddVote(key string, val interface{}) bool {
 
 func (g *Governance) adjustValueType(key string, val interface{}) interface{} {
 	k := GovernanceKeyMap[key]
-	var x interface{}
 
 	// When an int value comes from JS console, it comes as a float64
 	if GovernanceItems[k].t == uint64T {
@@ -135,9 +134,8 @@ func (g *Governance) adjustValueType(key string, val interface{}) interface{} {
 		if !ok {
 			return val
 		}
-		x = uint64(v)
-		if float64(x.(uint64)) == v {
-			return x
+		if float64(uint64(v)) == v {
+			return uint64(v)
 		}
 		return val
 	}
@@ -155,8 +153,7 @@ func (g *Governance) adjustValueType(key string, val interface{}) interface{} {
 		case 1:
 			str := strings.Trim(v, " ")
 			if common.IsHexAddress(str) {
-				x = common.HexToAddress(str)
-				return x
+				return common.HexToAddress(str)
 			} else {
 				return val
 			}
@@ -170,13 +167,11 @@ func (g *Governance) adjustValueType(key string, val interface{}) interface{} {
 					return val
 				}
 			}
-			x = nodeAddresses
-			return x
+			return nodeAddresses
 		}
 	} else {
 		// If a string text come as uppercase, make it into lowercase
-		x = strings.ToLower(v)
-		return x
+		return strings.ToLower(v)
 	}
 }
 
@@ -493,16 +488,16 @@ func (gov *Governance) addNewVote(valset istanbul.ValidatorSet, votes []Governan
 			switch GovernanceKeyMap[gVote.Key] {
 			case params.AddValidator:
 				//reward.GetStakingInfo()
-				if reflect.TypeOf(gVote.Value) == addressT {
-					valset.AddValidator(gVote.Value.(common.Address))
+				if addr, ok := gVote.Value.(common.Address); ok {
+					valset.AddValidator(addr)
 				} else {
 					for _, address := range gVote.Value.([]common.Address) {
 						valset.AddValidator(address)
 					}
 				}
 			case params.RemoveValidator:
-				if reflect.TypeOf(gVote.Value) == addressT {
-					valset.RemoveValidator(gVote.Value.(common.Address))
+				if addr, ok := gVote.Value.(common.Address); ok {
+					valset.RemoveValidator(addr)
 				} else {
 					for _, target := range gVote.Value.([]common.Address) {
 						valset.RemoveValidator(target)

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -311,11 +311,16 @@ func isEqualValue(k int, v1 interface{}, v2 interface{}) bool {
 		return false
 	}
 
-	if GovernanceItems[k].t != addressT || reflect.TypeOf(v1) == addressT {
-		return v1 == v2
+	if GovernanceItems[k].t == addressT && reflect.TypeOf(v1) != addressT {
+		value1, ok1 := v1.([]common.Address)
+		value2, ok2 := v2.([]common.Address)
+		if ok1 == false || ok2 == false {
+			return false
+		}
+		return reflect.DeepEqual(value1, value2)
 	}
 
-	return reflect.DeepEqual(v1.([]common.Address), v2.([]common.Address))
+	return v1 == v2
 }
 
 func (gov *Governance) HandleGovernanceVote(valset istanbul.ValidatorSet, votes []GovernanceVote, tally []GovernanceTallyItem, header *types.Header, proposer common.Address, self common.Address) (istanbul.ValidatorSet, []GovernanceVote, []GovernanceTallyItem) {

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -197,7 +197,7 @@ func (g *Governance) adjustValueType(key string, val interface{}) interface{} {
 		}
 
 		var nodeAddresses []common.Address
-		for _, str := range strings.Split(val.(string), ",") {
+		for _, str := range addresses {
 			if common.IsHexAddress(str) {
 				nodeAddresses = append(nodeAddresses, common.HexToAddress(str))
 			} else {


### PR DESCRIPTION
## Proposed changes

- This PR enables accepting multiple validator addresses when voting `governance.addvalidator` and `governance.removevalidator`
- The parsing logic of vote api (when key is `governance.addvalidator`, `governance.removevalidator`) has changed
  - dev: it transforms the value to address.
  - pr: it counts the number of node addresses. If number of node addresses is 1, it transforms the value to address. If not, it transforms the value to the address array.

closes https://github.com/klaytn/klaytn/issues/1105.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
