### PR TITLE
Define a bit mask of transaction type.

### DIFF
--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -304,3 +304,20 @@ func TestIntrinsicGas(t *testing.T) {
 		assert.Equal(t, nil, err)
 	}
 }
+
+func TestIsFeeDelegation(t *testing.T) {
+	assert.False(t, TxTypeLegacyTransaction.IsFeeDelegatedTransaction())
+	assert.False(t, TxTypeLegacyTransaction.IsFeeDelegatedWithRatioTransaction())
+
+	assert.False(t, TxTypeValueTransfer.IsFeeDelegatedTransaction())
+	assert.False(t, TxTypeValueTransfer.IsFeeDelegatedWithRatioTransaction())
+
+	assert.True(t, TxTypeFeeDelegatedAccountUpdate.IsFeeDelegatedTransaction())
+	assert.False(t, TxTypeFeeDelegatedAccountUpdate.IsFeeDelegatedWithRatioTransaction())
+
+	assert.True(t, TxTypeFeeDelegatedValueTransfer.IsFeeDelegatedTransaction())
+	assert.True(t, TxTypeFeeDelegatedValueTransferWithRatio.IsFeeDelegatedWithRatioTransaction())
+
+	assert.True(t, TxTypeFeeDelegatedAccountUpdateWithRatio.IsFeeDelegatedTransaction())
+	assert.True(t, TxTypeFeeDelegatedAccountUpdateWithRatio.IsFeeDelegatedWithRatioTransaction())
+}

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -304,20 +304,3 @@ func TestIntrinsicGas(t *testing.T) {
 		assert.Equal(t, nil, err)
 	}
 }
-
-func TestIsFeeDelegation(t *testing.T) {
-	assert.False(t, TxTypeLegacyTransaction.IsFeeDelegatedTransaction())
-	assert.False(t, TxTypeLegacyTransaction.IsFeeDelegatedWithRatioTransaction())
-
-	assert.False(t, TxTypeValueTransfer.IsFeeDelegatedTransaction())
-	assert.False(t, TxTypeValueTransfer.IsFeeDelegatedWithRatioTransaction())
-
-	assert.True(t, TxTypeFeeDelegatedAccountUpdate.IsFeeDelegatedTransaction())
-	assert.False(t, TxTypeFeeDelegatedAccountUpdate.IsFeeDelegatedWithRatioTransaction())
-
-	assert.True(t, TxTypeFeeDelegatedValueTransfer.IsFeeDelegatedTransaction())
-	assert.True(t, TxTypeFeeDelegatedValueTransferWithRatio.IsFeeDelegatedWithRatioTransaction())
-
-	assert.True(t, TxTypeFeeDelegatedAccountUpdateWithRatio.IsFeeDelegatedTransaction())
-	assert.True(t, TxTypeFeeDelegatedAccountUpdateWithRatio.IsFeeDelegatedWithRatioTransaction())
-}

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -74,9 +74,11 @@ const (
 	TxValueKeyCodeFormat
 )
 
+type TxTypeMask uint8
+
 const (
-	TxFeeDelegationBitMask          uint8 = 1
-	TxFeeDelegationWithRatioBitMask uint8 = 2
+	TxFeeDelegationBitMask          TxTypeMask = 1
+	TxFeeDelegationWithRatioBitMask TxTypeMask = 2
 )
 
 var (
@@ -212,11 +214,11 @@ func (t TxType) IsLegacyTransaction() bool {
 }
 
 func (t TxType) IsFeeDelegatedTransaction() bool {
-	return (uint8(t) & (TxFeeDelegationBitMask | TxFeeDelegationWithRatioBitMask)) != 0x0
+	return (TxTypeMask(t) & (TxFeeDelegationBitMask | TxFeeDelegationWithRatioBitMask)) != 0x0
 }
 
 func (t TxType) IsFeeDelegatedWithRatioTransaction() bool {
-	return (uint8(t) & TxFeeDelegationWithRatioBitMask) != 0x0
+	return (TxTypeMask(t) & TxFeeDelegationWithRatioBitMask) != 0x0
 }
 
 func (t TxType) IsChainDataAnchoring() bool {

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -74,7 +74,6 @@ const (
 	TxValueKeyCodeFormat
 )
 
-
 const (
 	TxFeeDelegationBitMask uint8 = 1
 	TxFeeDelegationWithRatioBitMask uint8 = 2

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -75,7 +75,7 @@ const (
 )
 
 const (
-	TxFeeDelegationBitMask uint8 = 1
+	TxFeeDelegationBitMask          uint8 = 1
 	TxFeeDelegationWithRatioBitMask uint8 = 2
 )
 

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -43,7 +43,7 @@ const (
 	//   <base type>, <fee-delegated type>, and <fee-delegated type with a fee ratio>
 	// If types other than <base type> are not useful, they are declared with underscore(_).
 	// Each base type is self-descriptive.
-	TxTypeLegacyTransaction, TxTypeFeeDelegatedTransactions, TxTypeFeeDelegatedWithRatioTransactions TxType = iota << SubTxTypeBits, iota<<SubTxTypeBits + 1, iota<<SubTxTypeBits + 2
+	TxTypeLegacyTransaction, _, _ TxType = iota << SubTxTypeBits, iota<<SubTxTypeBits + 1, iota<<SubTxTypeBits + 2
 	TxTypeValueTransfer, TxTypeFeeDelegatedValueTransfer, TxTypeFeeDelegatedValueTransferWithRatio
 	TxTypeValueTransferMemo, TxTypeFeeDelegatedValueTransferMemo, TxTypeFeeDelegatedValueTransferMemoWithRatio
 	TxTypeAccountCreation, _, _
@@ -72,6 +72,12 @@ const (
 	TxValueKeyFeePayer
 	TxValueKeyFeeRatioOfFeePayer
 	TxValueKeyCodeFormat
+)
+
+
+const (
+	TxFeeDelegationBitMask uint8 = 1
+	TxFeeDelegationWithRatioBitMask uint8 = 2
 )
 
 var (
@@ -207,11 +213,11 @@ func (t TxType) IsLegacyTransaction() bool {
 }
 
 func (t TxType) IsFeeDelegatedTransaction() bool {
-	return (t & (TxTypeFeeDelegatedTransactions | TxTypeFeeDelegatedWithRatioTransactions)) != 0x0
+	return (uint8(t) & (TxFeeDelegationBitMask | TxFeeDelegationWithRatioBitMask)) != 0x0
 }
 
 func (t TxType) IsFeeDelegatedWithRatioTransaction() bool {
-	return (t & TxTypeFeeDelegatedWithRatioTransactions) != 0x0
+	return (uint8(t) & TxFeeDelegationWithRatioBitMask) != 0x0
 }
 
 func (t TxType) IsChainDataAnchoring() bool {

--- a/blockchain/types/tx_internal_data_fee_ratio_test.go
+++ b/blockchain/types/tx_internal_data_fee_ratio_test.go
@@ -23,7 +23,7 @@ import "testing"
 func TestFeeRatioCheck(t *testing.T) {
 	for i := TxTypeLegacyTransaction; i < TxTypeLast; i++ {
 		tx, err := NewTxInternalData(i)
-		if err == nil && (uint8(i)&TxFeeDelegationWithRatioBitMask != 0) {
+		if err == nil && tx.Type().IsFeeDelegatedWithRatioTransaction() {
 			if _, ok := tx.(TxInternalDataFeeRatio); !ok {
 				t.Fatalf("GetFeeRatio() is not implemented. tx=%s", tx.String())
 			}
@@ -36,7 +36,7 @@ func TestFeeRatioCheck(t *testing.T) {
 func TestFeeDelegatedCheck(t *testing.T) {
 	for i := TxTypeLegacyTransaction; i < TxTypeLast; i++ {
 		tx, err := NewTxInternalData(i)
-		if err == nil && (uint8(i)&TxFeeDelegationBitMask != 0) {
+		if err == nil && tx.Type().IsFeeDelegatedTransaction() {
 			if _, ok := tx.(TxInternalDataFeePayer); !ok {
 				t.Fatalf("GetFeePayer() is not implemented. tx=%s", tx.String())
 			}

--- a/blockchain/types/tx_internal_data_fee_ratio_test.go
+++ b/blockchain/types/tx_internal_data_fee_ratio_test.go
@@ -23,7 +23,7 @@ import "testing"
 func TestFeeRatioCheck(t *testing.T) {
 	for i := TxTypeLegacyTransaction; i < TxTypeLast; i++ {
 		tx, err := NewTxInternalData(i)
-		if err == nil && (i&TxTypeFeeDelegatedWithRatioTransactions != 0) {
+		if err == nil && (uint8(i)&TxFeeDelegationBitMask != 0) {
 			if _, ok := tx.(TxInternalDataFeeRatio); !ok {
 				t.Fatalf("GetFeeRatio() is not implemented. tx=%s", tx.String())
 			}
@@ -36,7 +36,7 @@ func TestFeeRatioCheck(t *testing.T) {
 func TestFeeDelegatedCheck(t *testing.T) {
 	for i := TxTypeLegacyTransaction; i < TxTypeLast; i++ {
 		tx, err := NewTxInternalData(i)
-		if err == nil && (i&TxTypeFeeDelegatedTransactions != 0) {
+		if err == nil && (uint8(i)&TxFeeDelegationBitMask != 0) {
 			if _, ok := tx.(TxInternalDataFeePayer); !ok {
 				t.Fatalf("GetFeePayer() is not implemented. tx=%s", tx.String())
 			}

--- a/blockchain/types/tx_internal_data_fee_ratio_test.go
+++ b/blockchain/types/tx_internal_data_fee_ratio_test.go
@@ -23,7 +23,7 @@ import "testing"
 func TestFeeRatioCheck(t *testing.T) {
 	for i := TxTypeLegacyTransaction; i < TxTypeLast; i++ {
 		tx, err := NewTxInternalData(i)
-		if err == nil && (uint8(i)&TxFeeDelegationBitMask != 0) {
+		if err == nil && (uint8(i)&TxFeeDelegationWithRatioBitMask != 0) {
 			if _, ok := tx.(TxInternalDataFeeRatio); !ok {
 				t.Fatalf("GetFeeRatio() is not implemented. tx=%s", tx.String())
 			}


### PR DESCRIPTION
## Proposed changes

This PR defined a bit mask to identify transaction type.
For Now, to identify the transaction type, Using `TxTypeFeeDelegation` and `TxTypeFeeDelegationWithRatio` constant value defined the `TxType` type. But I think it is wrong way to use these constant values to identify the transaction type.

So I defined a bitMask and use it.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
