### PR TITLE
Add LatestSigner() and LatestSignerForChainID()

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -513,7 +513,7 @@ func (b *SimulatedBackend) SendTransaction(_ context.Context, tx *types.Transact
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	sender, err := types.Sender(types.NewEIP155Signer(b.config.ChainID), tx)
+	sender, err := types.Sender(types.LatestSignerForChainID(b.config.ChainID), tx)
 	if err != nil {
 		panic(fmt.Errorf("invalid transaction: %v", err))
 	}

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -62,7 +62,7 @@ func TestSimulatedBackend(t *testing.T) {
 	code := `6060604052600a8060106000396000f360606040526008565b00`
 	var gas uint64 = 3000000
 	tx := types.NewContractCreation(0, big.NewInt(0), gas, big.NewInt(1), common.FromHex(code))
-	tx, _ = types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), key)
+	tx, _ = types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), key)
 
 	err = sim.SendTransaction(context.Background(), tx)
 	if err != nil {
@@ -159,7 +159,7 @@ func TestNewSimulatedBackend_AdjustTimeFail(t *testing.T) {
 	sim := simTestBackend(testAddr)
 	// Create tx and send
 	tx := types.NewTransaction(0, testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestNewSimulatedBackend_AdjustTimeFail(t *testing.T) {
 	}
 	// Put a transaction after adjusting time
 	tx2 := types.NewTransaction(1, testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx2, err := types.SignTx(tx2, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx2, err := types.SignTx(tx2, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestSimulatedBackend_NonceAt(t *testing.T) {
 
 	// create a signed transaction to send
 	tx := types.NewTransaction(nonce, testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}
@@ -324,7 +324,7 @@ func TestSimulatedBackend_SendTransaction(t *testing.T) {
 
 	// create a signed transaction to send
 	tx := types.NewTransaction(uint64(0), testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}
@@ -355,7 +355,7 @@ func TestSimulatedBackend_TransactionByHash(t *testing.T) {
 
 	// create a signed transaction to send
 	tx := types.NewTransaction(uint64(0), testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}
@@ -506,7 +506,7 @@ func TestSimulatedBackend_TransactionCount(t *testing.T) {
 
 	// create a signed transaction to send
 	tx := types.NewTransaction(uint64(0), testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}
@@ -561,7 +561,7 @@ func TestSimulatedBackend_TransactionInBlock(t *testing.T) {
 
 	// create a signed transaction to send
 	tx := types.NewTransaction(uint64(0), testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}
@@ -616,7 +616,7 @@ func TestSimulatedBackend_PendingNonceAt(t *testing.T) {
 
 	// create a signed transaction to send
 	tx := types.NewTransaction(uint64(0), testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}
@@ -639,7 +639,7 @@ func TestSimulatedBackend_PendingNonceAt(t *testing.T) {
 
 	// make a new transaction with a nonce of 1
 	tx = types.NewTransaction(uint64(1), testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx, err = types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx, err = types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}
@@ -668,7 +668,7 @@ func TestSimulatedBackend_TransactionReceipt(t *testing.T) {
 
 	// create a signed transaction to send
 	tx := types.NewTransaction(uint64(0), testAddr, big.NewInt(1000), params.TxGas, big.NewInt(1), nil)
-	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(sim.config.ChainID), testKey)
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(sim.config.ChainID), testKey)
 	if err != nil {
 		t.Errorf("could not sign tx: %v", err)
 	}

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -260,7 +260,7 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 		return nil, err
 	}
 
-	signer := types.NewEIP155Signer(chainId)
+	signer := types.LatestSignerForChainID(chainId)
 	signedTx, err := opts.Signer(signer, opts.From, rawTx)
 	if err != nil {
 		return nil, err

--- a/accounts/abi/bind/util_test.go
+++ b/accounts/abi/bind/util_test.go
@@ -67,7 +67,7 @@ func TestWaitDeployed(t *testing.T) {
 
 		// Create the transaction.
 		tx := types.NewContractCreation(0, big.NewInt(0), test.gas, big.NewInt(1), common.FromHex(test.code))
-		tx, _ = types.SignTx(tx, types.NewEIP155Signer(params.AllGxhashProtocolChanges.ChainID), testKey)
+		tx, _ = types.SignTx(tx, types.LatestSignerForChainID(params.AllGxhashProtocolChanges.ChainID), testKey)
 
 		// Wait for it to get mined in the background.
 		var (
@@ -111,7 +111,7 @@ func TestWaitDeployedCornerCases(t *testing.T) {
 	// Create a transaction to an account.
 	code := "6060604052600a8060106000396000f360606040526008565b00"
 	tx := types.NewTransaction(0, common.HexToAddress("0x0"), big.NewInt(0), 3000000, big.NewInt(1), common.FromHex(code))
-	tx, _ = types.SignTx(tx, types.NewEIP155Signer(params.AllGxhashProtocolChanges.ChainID), testKey)
+	tx, _ = types.SignTx(tx, types.LatestSignerForChainID(params.AllGxhashProtocolChanges.ChainID), testKey)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	backend.SendTransaction(ctx, tx)
@@ -123,7 +123,7 @@ func TestWaitDeployedCornerCases(t *testing.T) {
 
 	// Create a transaction that is not mined.
 	tx = types.NewContractCreation(1, big.NewInt(0), 3000000, big.NewInt(1), common.FromHex(code))
-	tx, _ = types.SignTx(tx, types.NewEIP155Signer(params.AllGxhashProtocolChanges.ChainID), testKey)
+	tx, _ = types.SignTx(tx, types.LatestSignerForChainID(params.AllGxhashProtocolChanges.ChainID), testKey)
 
 	go func() {
 		contextCanceled := errors.New("context canceled")

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -282,7 +282,7 @@ func (ks *KeyStore) SignTx(a accounts.Account, tx *types.Transaction, chainID *b
 	}
 	// Depending on the presence of the chain ID, sign with EIP155 or homestead
 	if chainID != nil {
-		return types.SignTx(tx, types.NewEIP155Signer(chainID), unlockedKey.GetPrivateKey())
+		return types.SignTx(tx, types.LatestSignerForChainID(chainID), unlockedKey.GetPrivateKey())
 	}
 	return nil, ErrChainIdNil
 }
@@ -299,7 +299,7 @@ func (ks *KeyStore) SignTxAsFeePayer(a accounts.Account, tx *types.Transaction, 
 	}
 	// Depending on the presence of the chain ID, sign with EIP155 or homestead
 	if chainID != nil {
-		return types.SignTxAsFeePayer(tx, types.NewEIP155Signer(chainID), unlockedKey.GetPrivateKey())
+		return types.SignTxAsFeePayer(tx, types.LatestSignerForChainID(chainID), unlockedKey.GetPrivateKey())
 	}
 	return nil, ErrChainIdNil
 }
@@ -329,7 +329,7 @@ func (ks *KeyStore) SignTxWithPassphrase(a accounts.Account, passphrase string, 
 	if chainID == nil {
 		return nil, ErrChainIdNil
 	}
-	return types.SignTx(tx, types.NewEIP155Signer(chainID), key.GetPrivateKey())
+	return types.SignTx(tx, types.LatestSignerForChainID(chainID), key.GetPrivateKey())
 }
 
 // SignTxAsFeePayerWithPassphrase signs the transaction as a fee payer if the private key
@@ -345,7 +345,7 @@ func (ks *KeyStore) SignTxAsFeePayerWithPassphrase(a accounts.Account, passphras
 	if chainID == nil {
 		return nil, ErrChainIdNil
 	}
-	return types.SignTxAsFeePayer(tx, types.NewEIP155Signer(chainID), key.GetPrivateKey())
+	return types.SignTxAsFeePayer(tx, types.LatestSignerForChainID(chainID), key.GetPrivateKey())
 }
 
 // Unlock unlocks the given account indefinitely.

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -449,7 +449,7 @@ func TestKeyStore_SignTx(t *testing.T) {
 	sig1 := tx.RawSignatureValues()
 
 	// get another signature from a signing function in types package
-	signer := types.NewEIP155Signer(chainID)
+	signer := types.LatestSignerForChainID(chainID)
 	if tx.SignWithKeys(signer, []*ecdsa.PrivateKey{senderPrvKey}) != nil {
 		t.Fatal("Error to sign")
 	}
@@ -490,7 +490,7 @@ func TestKeyStore_SignTxAsFeePayer(t *testing.T) {
 	}
 
 	// get another signature from a signing function in types package
-	signer := types.NewEIP155Signer(chainID)
+	signer := types.LatestSignerForChainID(chainID)
 	if tx.SignFeePayerWithKeys(signer, []*ecdsa.PrivateKey{feePayerPrvKey}) != nil {
 		t.Fatal("Error to sign")
 	}

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -509,7 +509,7 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64) map[string]interface{} {
 	var from common.Address
 	if tx.IsLegacyTransaction() {
-		signer := types.NewEIP155Signer(tx.ChainId())
+		signer := types.LatestSignerForChainID(tx.ChainId())
 		from, _ = types.Sender(signer, tx)
 	} else {
 		from, _ = tx.From()

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -466,7 +466,7 @@ func (s *PublicTransactionPoolAPI) PendingTransactions() ([]map[string]interface
 	}
 	transactions := make([]map[string]interface{}, 0, len(pending))
 	for _, tx := range pending {
-		signer := types.NewEIP155Signer(tx.ChainId())
+		signer := types.LatestSignerForChainID(tx.ChainId())
 		from, _ := types.Sender(signer, tx)
 		if _, exists := accounts[from]; exists {
 			transactions = append(transactions, newRPCPendingTransaction(tx))
@@ -494,7 +494,7 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 	}
 
 	for _, p := range pending {
-		signer := types.NewEIP155Signer(p.ChainId())
+		signer := types.LatestSignerForChainID(p.ChainId())
 		wantSigHash := signer.Hash(matchTx)
 
 		if pFrom, err := types.Sender(signer, p); err == nil && pFrom == sendArgs.From && signer.Hash(p) == wantSigHash {

--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -102,7 +102,7 @@ func genValueTx(nbytes int) func(int, *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
 		gas, _ := types.IntrinsicGas(data, false, params.TestChainConfig.Rules(big.NewInt(0)))
-		signer := types.NewEIP155Signer(params.TestChainConfig.ChainID)
+		signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
 		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(benchRootAddr), toaddr, big.NewInt(1), gas, nil, data), signer, benchRootKey)
 		gen.AddTx(tx)
 	}
@@ -127,7 +127,7 @@ func init() {
 // and fills the blocks with many small transactions.
 func genTxRing(naccounts int) func(int, *BlockGen) {
 	from := 0
-	signer := types.NewEIP155Signer(params.TestChainConfig.ChainID)
+	signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
 	return func(i int, gen *BlockGen) {
 		gas := uint64(1000000)
 		for {

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -622,7 +622,7 @@ func TestFastVsFullChains(t *testing.T) {
 			Alloc:  GenesisAlloc{address: {Balance: funds}},
 		}
 		genesis = gspec.MustCommit(gendb)
-		signer  = types.NewEIP155Signer(gspec.Config.ChainID)
+		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
 	blocks, receipts := GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), gendb, 1024, func(i int, block *BlockGen) {
 		// If the block number is multiple of 3, send a few bonus transactions to the miner
@@ -788,7 +788,7 @@ func TestChainTxReorgs(t *testing.T) {
 			},
 		}
 		genesis = gspec.MustCommit(db)
-		signer  = types.NewEIP155Signer(gspec.Config.ChainID)
+		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
 
 	// Create two transactions shared between the chains:
@@ -894,7 +894,7 @@ func TestLogReorgs(t *testing.T) {
 		code    = common.Hex2Bytes("60606040525b7f24ec1d3ff24c2f6ff210738839dbc339cd45a5294d85c79361016243157aae7b60405180905060405180910390a15b600a8060416000396000f360606040526008565b00")
 		gspec   = &Genesis{Config: params.TestChainConfig, Alloc: GenesisAlloc{addr1: {Balance: big.NewInt(10000000000000)}}}
 		genesis = gspec.MustCommit(db)
-		signer  = types.NewEIP155Signer(gspec.Config.ChainID)
+		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
 
 	blockchain, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
@@ -941,7 +941,7 @@ func TestReorgSideEvent(t *testing.T) {
 			Alloc:  GenesisAlloc{addr1: {Balance: big.NewInt(10000000000000)}},
 		}
 		genesis = gspec.MustCommit(db)
-		signer  = types.NewEIP155Signer(gspec.Config.ChainID)
+		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
 
 	blockchain, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
@@ -1332,7 +1332,7 @@ func benchmarkLargeNumberOfValueToNonexisting(b *testing.B, numTxs, numBlocks in
 				}, // push 1, pop
 			},
 		}
-		signer = types.NewEIP155Signer(gspec.Config.ChainID)
+		signer = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
 	// Generate the original common chain segment and the two competing forks
 	engine := gxhash.NewFaker()
@@ -1523,7 +1523,7 @@ func TestCallTraceChainEventSubscription(t *testing.T) {
 			Alloc:  GenesisAlloc{address: {Balance: funds}},
 		}
 		genesis = testGenesis.MustCommit(gendb)
-		signer  = types.NewEIP155Signer(testGenesis.Config.ChainID)
+		signer  = types.LatestSignerForChainID(testGenesis.Config.ChainID)
 	)
 	db := database.NewMemoryDBManager()
 	testGenesis.MustCommit(db)
@@ -1585,7 +1585,7 @@ func TestBlockChain_SetCanonicalBlock(t *testing.T) {
 			Alloc:  GenesisAlloc{address: {Balance: funds}},
 		}
 		genesis = testGenesis.MustCommit(gendb)
-		signer  = types.NewEIP155Signer(testGenesis.Config.ChainID)
+		signer  = types.LatestSignerForChainID(testGenesis.Config.ChainID)
 	)
 	db := database.NewMemoryDBManager()
 	testGenesis.MustCommit(db)

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -210,7 +210,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		config:       config,
 		chainconfig:  chainconfig,
 		chain:        chain,
-		signer:       types.NewEIP155Signer(chainconfig.ChainID),
+		signer:       types.LatestSignerForChainID(chainconfig.ChainID),
 		pending:      make(map[common.Address]*txList),
 		queue:        make(map[common.Address]*txList),
 		beats:        make(map[common.Address]time.Time),

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -77,7 +77,7 @@ func transaction(nonce uint64, gaslimit uint64, key *ecdsa.PrivateKey) *types.Tr
 
 func pricedTransaction(nonce uint64, gaslimit uint64, gasprice *big.Int, key *ecdsa.PrivateKey) *types.Transaction {
 	tx, _ := types.SignTx(types.NewTransaction(nonce, common.HexToAddress("0xAAAA"), big.NewInt(100), gaslimit, gasprice, nil),
-		types.NewEIP155Signer(params.TestChainConfig.ChainID), key)
+		types.LatestSignerForChainID(params.TestChainConfig.ChainID), key)
 	return tx
 }
 
@@ -149,7 +149,7 @@ func validateEvents(events chan NewTxsEvent, count int) error {
 }
 
 func deriveSender(tx *types.Transaction) (common.Address, error) {
-	signer := types.NewEIP155Signer(params.TestChainConfig.ChainID)
+	signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
 	return types.Sender(signer, tx)
 }
 
@@ -387,7 +387,7 @@ func TestTransactionNegativeValue(t *testing.T) {
 	pool, key := setupTxPool()
 	defer pool.Stop()
 
-	signer := types.NewEIP155Signer(params.TestChainConfig.ChainID)
+	signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
 	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(-1), 100, big.NewInt(1), nil), signer, key)
 	from, _ := deriveSender(tx)
 	pool.currentState.AddBalance(from, big.NewInt(1))
@@ -441,7 +441,7 @@ func TestTransactionDoubleNonce(t *testing.T) {
 	}
 	resetState()
 
-	signer := types.NewEIP155Signer(params.TestChainConfig.ChainID)
+	signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
 	tx1, _ := types.SignTx(types.NewTransaction(0, common.HexToAddress("0xAAAA"), big.NewInt(100), 100000, big.NewInt(1), nil), signer, key)
 	tx2, _ := types.SignTx(types.NewTransaction(0, common.HexToAddress("0xAAAA"), big.NewInt(100), 1000000, big.NewInt(2), nil), signer, key)
 	tx3, _ := types.SignTx(types.NewTransaction(0, common.HexToAddress("0xAAAA"), big.NewInt(100), 1000000, big.NewInt(1), nil), signer, key)

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -51,7 +51,7 @@ var (
 
 // deriveSigner makes a *best* guess about which signer to use.
 func deriveSigner(V *big.Int) Signer {
-	return NewEIP155Signer(deriveChainId(V))
+	return LatestSignerForChainID(deriveChainId(V))
 }
 
 type Transaction struct {

--- a/blockchain/types/transaction_signing.go
+++ b/blockchain/types/transaction_signing.go
@@ -58,6 +58,24 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	return NewEIP155Signer(config.ChainID)
 }
 
+// LatestSigner returns the 'most permissive' Signer available for the given chain
+// configuration.
+//
+// Use this in transaction-handling code where the current block number is unknown. If you
+// have the current block number available, use MakeSigner instead.
+func LatestSigner(config *params.ChainConfig) Signer {
+	return NewEIP155Signer(config.ChainID)
+}
+
+// LatestSignerForChainID returns the 'most permissive' Signer available.
+//
+// Use this in transaction-handling code where the current block number and fork
+// configuration are unknown. If you have a ChainConfig, use LatestSigner instead.
+// If you have a ChainConfig and know the current block number, use MakeSigner instead.
+func LatestSignerForChainID(chainID *big.Int) Signer {
+	return NewEIP155Signer(chainID)
+}
+
 // SignTx signs the transaction using the given signer and private key
 func SignTx(tx *Transaction, s Signer, prv *ecdsa.PrivateKey) (*Transaction, error) {
 	h := s.Hash(tx)

--- a/blockchain/types/transaction_signing_test.go
+++ b/blockchain/types/transaction_signing_test.go
@@ -140,17 +140,17 @@ func TestChainId(t *testing.T) {
 	tx := NewTransaction(0, common.Address{}, new(big.Int), 0, new(big.Int), nil)
 
 	var err error
-	tx, err = SignTx(tx, NewEIP155Signer(big.NewInt(1)), key)
+	tx, err = SignTx(tx, LatestSignerForChainID(big.NewInt(1)), key)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = Sender(NewEIP155Signer(big.NewInt(2)), tx)
+	_, err = Sender(LatestSignerForChainID(big.NewInt(2)), tx)
 	if err != ErrInvalidChainId {
 		t.Error("expected error:", ErrInvalidChainId)
 	}
 
-	_, err = Sender(NewEIP155Signer(big.NewInt(1)), tx)
+	_, err = Sender(LatestSignerForChainID(big.NewInt(1)), tx)
 	if err != nil {
 		t.Error("expected no error")
 	}
@@ -220,7 +220,7 @@ func testValidateValueTransfer(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -269,7 +269,7 @@ func testValidateFeeDelegatedValueTransfer(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -356,7 +356,7 @@ func testValidateFeeDelegatedValueTransferWithRatio(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -445,7 +445,7 @@ func testValidateValueTransferMemo(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -495,7 +495,7 @@ func testValidateFeeDelegatedValueTransferMemo(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -584,7 +584,7 @@ func testValidateFeeDelegatedValueTransferMemoWithRatio(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -728,7 +728,7 @@ func testValidateAccountUpdate(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -778,7 +778,7 @@ func testValidateFeeDelegatedAccountUpdate(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -867,7 +867,7 @@ func testValidateFeeDelegatedAccountUpdateWithRatio(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -958,7 +958,7 @@ func testValidateSmartContractDeploy(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1009,7 +1009,7 @@ func testValidateFeeDelegatedSmartContractDeploy(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1100,7 +1100,7 @@ func testValidateFeeDelegatedSmartContractDeployWithRatio(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1193,7 +1193,7 @@ func testValidateSmartContractExecution(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1243,7 +1243,7 @@ func testValidateFeeDelegatedSmartContractExecution(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1332,7 +1332,7 @@ func testValidateFeeDelegatedSmartContractExecutionWithRatio(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1423,7 +1423,7 @@ func testValidateCancel(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1470,7 +1470,7 @@ func testValidateFeeDelegatedCancel(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1553,7 +1553,7 @@ func testValidateFeeDelegatedCancelWithRatio(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1638,7 +1638,7 @@ func testValidateChainDataAnchoring(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1686,7 +1686,7 @@ func testValidateFeeDelegatedChainDataAnchoring(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from
@@ -1771,7 +1771,7 @@ func testValidateFeeDelegatedChainDataAnchoringWithRatio(t *testing.T) {
 	tx := &Transaction{data: internalTx}
 
 	chainid := big.NewInt(1)
-	signer := NewEIP155Signer(chainid)
+	signer := LatestSignerForChainID(chainid)
 
 	prv, from := defaultTestKey()
 	internalTx.From = from

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -53,13 +53,13 @@ var (
 		big.NewInt(1),
 		common.FromHex("5544"),
 	).WithSignature(
-		NewEIP155Signer(common.Big1),
+		LatestSignerForChainID(common.Big1),
 		common.Hex2Bytes("98ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4a8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a301"),
 	)
 )
 
 func TestTransactionSigHash(t *testing.T) {
-	signer := NewEIP155Signer(common.Big1)
+	signer := LatestSignerForChainID(common.Big1)
 	if signer.Hash(emptyTx) != common.HexToHash("a715f8447b97e3105d2cc0a8aca1466fa3a02f7cc6d2f9a3fe89f2581c9111c5") {
 		t.Errorf("empty transaction hash mismatch, ɡot %x", signer.Hash(emptyTx))
 	}
@@ -99,7 +99,7 @@ func TestRecipientEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := NewEIP155Signer(common.Big1)
+	signer := LatestSignerForChainID(common.Big1)
 
 	from, err := Sender(signer, tx)
 	if err != nil {
@@ -118,7 +118,7 @@ func TestRecipientNormal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := NewEIP155Signer(common.Big1)
+	signer := LatestSignerForChainID(common.Big1)
 
 	from, err := Sender(signer, tx)
 	if err != nil {
@@ -140,7 +140,7 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 		keys[i], _ = crypto.GenerateKey()
 	}
 
-	signer := NewEIP155Signer(common.Big1)
+	signer := LatestSignerForChainID(common.Big1)
 	// Generate a batch of transactions with overlapping values, but shifted nonces
 	groups := map[common.Address]Transactions{}
 	for start, key := range keys {

--- a/blockchain/types/tx_internal_data_serializer_test.go
+++ b/blockchain/types/tx_internal_data_serializer_test.go
@@ -162,7 +162,7 @@ func testTransactionJSON(t *testing.T, tx TxInternalData) {
 func newRPCTransaction(tx *Transaction, blockHash common.Hash, blockNumber uint64, index uint64) map[string]interface{} {
 	var from common.Address
 	if tx.IsLegacyTransaction() {
-		signer := NewEIP155Signer(tx.ChainId())
+		signer := LatestSignerForChainID(tx.ChainId())
 		from, _ = Sender(signer, tx)
 	} else {
 		from, _ = tx.From()

--- a/datasync/chaindatafetcher/kas/repository_test.go
+++ b/datasync/chaindatafetcher/kas/repository_test.go
@@ -45,7 +45,7 @@ var (
 		Alloc:  blockchain.GenesisAlloc{address: {Balance: funds}},
 	}
 	genesis = testGenesis.MustCommit(gendb)
-	signer  = types.NewEIP155Signer(config.ChainID)
+	signer  = types.LatestSignerForChainID(config.ChainID)
 )
 
 type SuiteRepository struct {

--- a/datasync/chaindatafetcher/kas/repository_transactions.go
+++ b/datasync/chaindatafetcher/kas/repository_transactions.go
@@ -62,7 +62,7 @@ func transformToTxs(event blockchain.ChainEvent) ([]*Tx, map[common.Address]stru
 		// from
 		var from common.Address
 		if rawTx.IsLegacyTransaction() {
-			signer := types.NewEIP155Signer(rawTx.ChainId())
+			signer := types.LatestSignerForChainID(rawTx.ChainId())
 			from, _ = types.Sender(signer, rawTx)
 		} else {
 			from, _ = rawTx.From()

--- a/datasync/dbsyncer/tx_record.go
+++ b/datasync/dbsyncer/tx_record.go
@@ -65,7 +65,7 @@ func MakeTxDBRow(block *types.Block, txKey uint64, tx *types.Transaction, receip
 
 	from := ""
 	if tx.IsLegacyTransaction() {
-		signer := types.NewEIP155Signer(tx.ChainId())
+		signer := types.LatestSignerForChainID(tx.ChainId())
 		addr, err := types.Sender(signer, tx)
 		if err != nil {
 			logger.Error("fail to tx.From", "err", err)

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -140,7 +140,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err %v", err)
 	}
-	signer := types.NewEIP155Signer(big.NewInt(1))
+	signer := types.LatestSignerForChainID(big.NewInt(1))
 	tx, err := types.SignTx(unsignedTx, signer, privateKeyECDSA)
 	if err != nil {
 		t.Fatalf("err %v", err)

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -865,7 +865,7 @@ func TestBridgeManagerWithFee(t *testing.T) {
 		unsignedTx := types.NewTransaction(nonce, pBridgeAddr, big.NewInt(testKLAY+KLAYFee), testGasLimit, gasPrice, []byte{})
 
 		chainID, _ := sim.ChainID(context.Background())
-		tx, err = types.SignTx(unsignedTx, types.NewEIP155Signer(chainID), AliceKey)
+		tx, err = types.SignTx(unsignedTx, types.LatestSignerForChainID(chainID), AliceKey)
 		sim.SendTransaction(context.Background(), tx)
 		assert.Equal(t, nil, err)
 

--- a/node/sc/bridge_test.go
+++ b/node/sc/bridge_test.go
@@ -87,7 +87,7 @@ func TransferSignedTx(auth *bind.TransactOpts, backend *backends.SimulatedBacken
 		gasPrice,
 		nil)
 
-	signedTx, err := auth.Signer(types.NewEIP155Signer(chainID), auth.From, tx)
+	signedTx, err := auth.Signer(types.LatestSignerForChainID(chainID), auth.From, tx)
 	assert.Equal(t, err, nil)
 
 	fee := big.NewInt(0)

--- a/node/sc/bridgepool/bridge_tx_pool.go
+++ b/node/sc/bridgepool/bridge_tx_pool.go
@@ -114,7 +114,7 @@ func NewBridgeTxPool(config BridgeTxPoolConfig) *BridgeTxPool {
 		closed: make(chan struct{}),
 	}
 
-	pool.SetEIP155Signer(config.ParentChainID)
+	pool.SetLatestSigner(config.ParentChainID)
 
 	// load from disk
 	pool.journal = newBridgeTxJournal(config.Journal)
@@ -136,6 +136,11 @@ func NewBridgeTxPool(config BridgeTxPoolConfig) *BridgeTxPool {
 // SetEIP155Signer set signer of txpool.
 func (pool *BridgeTxPool) SetEIP155Signer(chainID *big.Int) {
 	pool.signer = types.NewEIP155Signer(chainID)
+}
+
+// SetLatestSigner set latest signer to txpool
+func (pool *BridgeTxPool) SetLatestSigner(chainID *big.Int) {
+	pool.signer = types.LatestSignerForChainID(chainID)
 }
 
 // loop is the transaction pool's main event loop, waiting for and reacting to

--- a/node/sc/bridgepool/bridge_tx_pool.go
+++ b/node/sc/bridgepool/bridge_tx_pool.go
@@ -133,6 +133,7 @@ func NewBridgeTxPool(config BridgeTxPoolConfig) *BridgeTxPool {
 	return pool
 }
 
+// Deprecated: This function is deprecated. Use SetLatestSigner instead.
 // SetEIP155Signer set signer of txpool.
 func (pool *BridgeTxPool) SetEIP155Signer(chainID *big.Int) {
 	pool.signer = types.NewEIP155Signer(chainID)

--- a/node/sc/kas/anchor_test.go
+++ b/node/sc/kas/anchor_test.go
@@ -181,7 +181,7 @@ func testBlockToAnchoringDataInternalType0(t *testing.T, period uint64) {
 func genTransactions(n uint64) (types.Transactions, error) {
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)
-	signer := types.NewEIP155Signer(big.NewInt(18))
+	signer := types.LatestSignerForChainID(big.NewInt(18))
 
 	txs := types.Transactions{}
 

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -61,12 +61,12 @@ var hash4 = common.HexToHash("5397FB1") // 87654321 in hexadecimal
 
 var key *ecdsa.PrivateKey
 var addr common.Address
-var signer types.EIP155Signer
+var signer types.Signer
 
 func init() {
 	key, _ = crypto.GenerateKey()
 	addr = crypto.PubkeyToAddress(key.PublicKey)
-	signer = types.NewEIP155Signer(big.NewInt(18))
+	signer = types.LatestSignerForChainID(big.NewInt(18))
 
 	for _, bc := range baseConfigs {
 		badgerConfig := *bc

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -358,7 +358,7 @@ func expectedTestResultForDefaultTx(accountKeyType accountkey.AccountKeyType, tx
 	return nil
 }
 
-func signTxWithVariousKeyTypes(signer types.EIP155Signer, tx *types.Transaction, sender *TestAccountType) (*types.Transaction, error) {
+func signTxWithVariousKeyTypes(signer types.Signer, tx *types.Transaction, sender *TestAccountType) (*types.Transaction, error) {
 	var err error
 	txType := tx.Type()
 	accKeyType := sender.AccKey.Type()
@@ -432,7 +432,7 @@ func TestDefaultTxsWithDefaultAccountKey(t *testing.T) {
 		code = "0x608060405234801561001057600080fd5b506101de806100206000396000f3006080604052600436106100615763ffffffff7c01000000000000000000000000000000000000000000000000000000006000350416631a39d8ef81146100805780636353586b146100a757806370a08231146100ca578063fd6b7ef8146100f8575b3360009081526001602052604081208054349081019091558154019055005b34801561008c57600080fd5b5061009561010d565b60408051918252519081900360200190f35b6100c873ffffffffffffffffffffffffffffffffffffffff60043516610113565b005b3480156100d657600080fd5b5061009573ffffffffffffffffffffffffffffffffffffffff60043516610147565b34801561010457600080fd5b506100c8610159565b60005481565b73ffffffffffffffffffffffffffffffffffffffff1660009081526001602052604081208054349081019091558154019055565b60016020526000908152604090205481565b336000908152600160205260408120805490829055908111156101af57604051339082156108fc029083906000818181858888f193505050501561019c576101af565b3360009081526001602052604090208190555b505600a165627a7a72305820627ca46bb09478a015762806cc00c431230501118c7c26c30ac58c4e09e51c4f0029"
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// create a smart contract account for contract execution test
 	{
@@ -652,7 +652,7 @@ func TestAccountUpdateMultiSigKeyMaxKey(t *testing.T) {
 		fmt.Println("multisigAddr = ", multisig.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// Transfer (reservoir -> anon) using a legacy transaction.
@@ -768,7 +768,7 @@ func TestAccountUpdateMultiSigKeyBigThreshold(t *testing.T) {
 		fmt.Println("multisigAddr = ", multisig.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// Transfer (reservoir -> anon) using a legacy transaction.
@@ -881,7 +881,7 @@ func TestAccountUpdateMultiSigKeyDupPrvKeys(t *testing.T) {
 		fmt.Println("reservoirAddr = ", reservoir.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Transfer (reservoir -> anon) using a legacy transaction.
@@ -999,7 +999,7 @@ func TestAccountUpdateMultiSigKeyWeightOverflow(t *testing.T) {
 		fmt.Println("reservoirAddr = ", reservoir.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Transfer (reservoir -> anon) using a legacy transaction.
@@ -1100,7 +1100,7 @@ func TestAccountUpdateRoleBasedKeyInvalidNumKey(t *testing.T) {
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Transfer (reservoir -> anon) using a legacy transaction.
@@ -1246,7 +1246,7 @@ func TestAccountUpdateRoleBasedKeyInvalidTypeKey(t *testing.T) {
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 	keys := genTestKeys(2)
 
@@ -1519,7 +1519,7 @@ func TestAccountUpdateRoleBasedKey(t *testing.T) {
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// Transfer (reservoir -> anon) using a legacy transaction.
@@ -1708,7 +1708,7 @@ func TestAccountUpdateRoleBasedKeyNested(t *testing.T) {
 		fmt.Println("roleAddr = ", roleKey.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// transfer (reservoir -> anon) using a legacy transaction.
@@ -1848,7 +1848,7 @@ func TestRoleBasedKeySendTx(t *testing.T) {
 		fmt.Println("roleBasedAddr = ", roleBased.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	txTypes := []types.TxType{}
 	for i := types.TxTypeLegacyTransaction; i < types.TxTypeLast; i++ {
@@ -2049,7 +2049,7 @@ func TestRoleBasedKeyFeeDelegation(t *testing.T) {
 		fmt.Println("roleBasedAddr = ", roleBased.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	feeTxTypes := []types.TxType{
 		types.TxTypeFeeDelegatedValueTransfer,
@@ -2222,7 +2222,7 @@ func TestAccountKeyUpdateLegacyToPublic(t *testing.T) {
 	var txs types.Transactions
 
 	// make TxPool to test validation in 'TxPool add' process
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	{
 		addr := *bcdata.addrs[1]

--- a/tests/apply_tx_test.go
+++ b/tests/apply_tx_test.go
@@ -287,7 +287,7 @@ func benchmarkTxPerformanceCompatible(b *testing.B, genTx genTx) {
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// Prepare a next block header.
 	author := bcdata.addrs[0]
@@ -382,7 +382,7 @@ func benchmarkTxPerformanceSmartContractExecution(b *testing.B, genTx genTx) {
 	gasPrice := new(big.Int).SetUint64(0)
 	gasLimit := uint64(100000000000)
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// Deploy smart contract (reservoir -> contract)
 	{
@@ -508,7 +508,7 @@ func benchmarkTxPerformanceNew(b *testing.B, genTx genTx, sender *TestAccountTyp
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// Create an account sender using TxTypeValueTransfer.

--- a/tests/db_write_and_read_test.go
+++ b/tests/db_write_and_read_test.go
@@ -323,7 +323,7 @@ func generateTx(t *testing.T) *types.Transaction {
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
-	signer := types.NewEIP155Signer(big.NewInt(18))
+	signer := types.LatestSignerForChainID(big.NewInt(18))
 	tx1, err := types.SignTx(types.NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil), signer, key)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/evm_op_benchmark_test.go
+++ b/tests/evm_op_benchmark_test.go
@@ -97,7 +97,7 @@ func BenchmarkEvmOp(t *testing.B) {
 	gasPrice := new(big.Int).SetUint64(0)
 	gasLimit := uint64(100000000000)
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	if !isCompilerAvailable() {
 		fmt.Println("skip this test since compiler is not available on this machine.")

--- a/tests/hard_fork_test.go
+++ b/tests/hard_fork_test.go
@@ -186,7 +186,7 @@ func genBlocks(t *testing.T) {
 		Nonce: uint64(0),
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// For smart contract

--- a/tests/klay_blockchain_test.go
+++ b/tests/klay_blockchain_test.go
@@ -197,7 +197,7 @@ func newKlaytnNode(t *testing.T, dir string, validator *TestAccountType) (*node.
 // deployRandomTxs creates a random transaction
 func deployRandomTxs(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, txNum int) {
 	var tx *types.Transaction
-	signer := types.NewEIP155Signer(chainId)
+	signer := types.LatestSignerForChainID(chainId)
 	gasPrice := big.NewInt(25 * params.Ston)
 
 	txNuminABlock := 100
@@ -221,7 +221,7 @@ func deployRandomTxs(t *testing.T, txpool work.TxPool, chainId *big.Int, sender 
 
 // deployValueTransferTx deploy value transfer transactions
 func deployValueTransferTx(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, toAcc *TestAccountType) {
-	signer := types.NewEIP155Signer(chainId)
+	signer := types.LatestSignerForChainID(chainId)
 	gasPrice := big.NewInt(25 * params.Ston)
 
 	tx, _ := genLegacyTransaction(t, signer, sender, toAcc, nil, gasPrice)
@@ -233,7 +233,7 @@ func deployValueTransferTx(t *testing.T, txpool work.TxPool, chainId *big.Int, s
 
 // deployContractDeployTx deploy contrac
 func deployContractDeployTx(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, contractDeployCode string) common.Address {
-	signer := types.NewEIP155Signer(chainId)
+	signer := types.LatestSignerForChainID(chainId)
 	gasPrice := big.NewInt(25 * params.Ston)
 
 	values := map[types.TxValueKeyType]interface{}{
@@ -264,7 +264,7 @@ func deployContractDeployTx(t *testing.T, txpool work.TxPool, chainId *big.Int, 
 }
 
 func deployContractExecutionTx(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, contractAddr common.Address) {
-	signer := types.NewEIP155Signer(chainId)
+	signer := types.LatestSignerForChainID(chainId)
 	gasPrice := big.NewInt(25 * params.Ston)
 	contractExecutionPayload := "0x197e70e40000000000000000000000000000000000000000000000000000000000000001"
 

--- a/tests/klay_scenario_test.go
+++ b/tests/klay_scenario_test.go
@@ -238,7 +238,7 @@ func TestFeeDelegatedWithSmallBalance(t *testing.T) {
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := big.NewInt(25 * params.Ston)
 
 	// 1. Transfer (reservoir -> anon) using a legacy transaction.
@@ -336,7 +336,7 @@ func TestSmartContractDeployAddress(t *testing.T) {
 	gasPrice := new(big.Int).SetUint64(0)
 	gasLimit := uint64(100000000000)
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	var code string
 
@@ -421,7 +421,7 @@ func TestSmartContractScenario(t *testing.T) {
 	contractAddr := common.Address{}
 
 	gasPrice := new(big.Int).SetUint64(0)
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	var abiStr string
 	var code string
@@ -607,7 +607,7 @@ func TestSmartContractSign(t *testing.T) {
 	gasPrice := new(big.Int).SetUint64(0)
 	gasLimit := uint64(100000000000)
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	var code string
 
@@ -762,7 +762,7 @@ func TestFeeDelegatedSmartContractScenario(t *testing.T) {
 	gasPrice := new(big.Int).SetUint64(0)
 	gasLimit := uint64(100000000000)
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	var abiStr string
 	var code string
@@ -954,7 +954,7 @@ func TestFeeDelegatedSmartContractScenarioWithRatio(t *testing.T) {
 	gasPrice := new(big.Int).SetUint64(0)
 	gasLimit := uint64(100000000000)
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	var abiStr string
 	var code string
@@ -1143,7 +1143,7 @@ func TestAccountUpdate(t *testing.T) {
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 	gasLimit := uint64(100000)
 
@@ -1342,7 +1342,7 @@ func TestFeeDelegatedAccountUpdate(t *testing.T) {
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Transfer (reservoir -> anon) using a legacy transaction.
@@ -1474,7 +1474,7 @@ func TestFeeDelegatedAccountUpdateWithRatio(t *testing.T) {
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Transfer (reservoir -> anon) using a legacy transaction.
@@ -1617,7 +1617,7 @@ func TestMultisigScenario(t *testing.T) {
 		fmt.Println("multisigAddr = ", multisig.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Create an account anon using LegacyTransaction.

--- a/tests/race_test.go
+++ b/tests/race_test.go
@@ -60,7 +60,7 @@ func TestRaceBetweenTxpoolAddAndCommitNewWork(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				signer := types.NewEIP155Signer(chainId)
+				signer := types.LatestSignerForChainID(chainId)
 				if err := tx.Sign(signer, richAccount.Keys[0]); err != nil {
 					t.Fatal(err)
 				}
@@ -71,7 +71,7 @@ func TestRaceBetweenTxpoolAddAndCommitNewWork(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				signer := types.NewEIP155Signer(chainId)
+				signer := types.LatestSignerForChainID(chainId)
 				if err := tx.Sign(signer, richAccount.Keys[0]); err != nil {
 					t.Fatal(err)
 				}
@@ -121,7 +121,7 @@ func TestRaceAsMessageWithAccountPickerForFeePayer(t *testing.T) {
 			},
 		}
 		genesis = gspec.MustCommit(gendb)
-		signer  = types.NewEIP155Signer(gspec.Config.ChainID)
+		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
 
 	iterNum := 10000

--- a/tests/role_based_account_test.go
+++ b/tests/role_based_account_test.go
@@ -110,7 +110,7 @@ func TestRoleBasedAccount(t *testing.T) {
 		AccKey:     accKey,
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 0. Transfer (reservoir -> `colin`) using a legacy transaction.
@@ -323,7 +323,7 @@ func TestAccountUpdateRoleBasedNil(t *testing.T) {
 		fmt.Println("colinAddr = ", colin.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Create an account colin using TxTypeValueTransfer.
@@ -454,7 +454,7 @@ func TestAccountUpdateRoleBasedLegacy(t *testing.T) {
 		fmt.Println("anonAddr = ", anon.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// RoleBasedKey having LegacyKeys for all roles
@@ -667,7 +667,7 @@ func TestAccountUpdateRoleBasedWrongLength(t *testing.T) {
 		fmt.Println("colinAddr = ", colin.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Create an account colin using TxTypeValueTransfer.
@@ -794,7 +794,7 @@ func TestAccountUpdateRoleBasedTransition(t *testing.T) {
 		fmt.Println("colinAddr = ", colin.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Create an account colin using TxTypeValueTransfer.
@@ -980,7 +980,7 @@ func TestAccountUpdateToRoleBasedToPub(t *testing.T) {
 		fmt.Println("colinAddr = ", colin.Addr.String())
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// 1. Create an account colin using TxTypeValueTransfer.

--- a/tests/rpc_output_test.go
+++ b/tests/rpc_output_test.go
@@ -126,7 +126,7 @@ func BenchmarkRPCOutput(t *testing.B) {
 		fmt.Println("decoupledPrvKey = ", (*hexutil.Big)(decoupled.Keys[0].D))
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	var txs types.Transactions

--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -70,7 +70,7 @@ func TestAccountCreationDisable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{
@@ -142,7 +142,7 @@ func TestContractDeployWithDisabledAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{

--- a/tests/transaction_validation_test.go
+++ b/tests/transaction_validation_test.go
@@ -58,7 +58,7 @@ func TestValidatingUnavailableContractExecution(t *testing.T) {
 	}
 	prof.Profile("main_init_accountMap", time.Now().Sub(start))
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// reservoir account

--- a/tests/tx_code_format_test.go
+++ b/tests/tx_code_format_test.go
@@ -75,7 +75,7 @@ func TestCodeFormat(t *testing.T) {
 		Nonce: uint64(0),
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	testCodeFormat := func(tx *types.Transaction, state error) {

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -122,7 +122,7 @@ func TestGasCalculation(t *testing.T) {
 		Nonce: uint64(0),
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// Preparing step. Send KLAY to a KlaytnAcount.

--- a/tests/tx_hash_benchmark_test.go
+++ b/tests/tx_hash_benchmark_test.go
@@ -55,7 +55,7 @@ func BenchmarkTxHash(b *testing.B) {
 }
 
 func benchmarkTxHash(b *testing.B, genTx genTx) {
-	signer := types.NewEIP155Signer(common.Big1)
+	signer := types.LatestSignerForChainID(common.Big1)
 
 	// Initialize blockchain
 	bcdata, err := NewBCData(6, 4)

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -129,7 +129,7 @@ func TestValidationPoolInsert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{
@@ -252,7 +252,7 @@ func TestValidationBlockTx(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{
@@ -404,7 +404,7 @@ func TestValidationInvalidSig(t *testing.T) {
 
 	var invalidCases = []struct {
 		Name string
-		fn   func(*testing.T, types.TxType, *TestAccountType, *TestAccountType, types.EIP155Signer) (*types.Transaction, error)
+		fn   func(*testing.T, types.TxType, *TestAccountType, *TestAccountType, types.Signer) (*types.Transaction, error)
 	}{
 		{"invalidSender", testInvalidSenderSig},
 		{"invalidFeePayer", testInvalidFeePayerSig},
@@ -425,7 +425,7 @@ func TestValidationInvalidSig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{
@@ -499,7 +499,7 @@ func TestValidationInvalidSig(t *testing.T) {
 }
 
 // testInvalidSenderSig generates invalid txs signed by an invalid sender.
-func testInvalidSenderSig(t *testing.T, txType types.TxType, reservoir *TestAccountType, contract *TestAccountType, signer types.EIP155Signer) (*types.Transaction, error) {
+func testInvalidSenderSig(t *testing.T, txType types.TxType, reservoir *TestAccountType, contract *TestAccountType, signer types.Signer) (*types.Transaction, error) {
 	if !txType.IsLegacyTransaction() {
 		newAcc, err := createDefaultAccount(accountkey.AccountKeyTypePublic)
 		assert.Equal(t, nil, err)
@@ -526,7 +526,7 @@ func testInvalidSenderSig(t *testing.T, txType types.TxType, reservoir *TestAcco
 }
 
 // testInvalidFeePayerSig generates invalid txs signed by an invalid fee payer.
-func testInvalidFeePayerSig(t *testing.T, txType types.TxType, reservoir *TestAccountType, contract *TestAccountType, signer types.EIP155Signer) (*types.Transaction, error) {
+func testInvalidFeePayerSig(t *testing.T, txType types.TxType, reservoir *TestAccountType, contract *TestAccountType, signer types.Signer) (*types.Transaction, error) {
 	if txType.IsFeeDelegatedTransaction() {
 		newAcc, err := createDefaultAccount(accountkey.AccountKeyTypePublic)
 		assert.Equal(t, nil, err)
@@ -568,7 +568,7 @@ func TestLegacyTxFromNonLegacyAcc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{
@@ -635,7 +635,7 @@ func TestInvalidBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{
@@ -1027,7 +1027,7 @@ func TestInvalidBalanceBlockTx(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{
@@ -1433,7 +1433,7 @@ func TestValidationTxSizeAfterRLP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{
@@ -1589,7 +1589,7 @@ func TestValidationPoolResetAfterSenderKeyChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{
@@ -1730,7 +1730,7 @@ func TestValidationPoolResetAfterFeePayerKeyChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 
 	// reservoir account
 	reservoir := &TestAccountType{

--- a/tests/validate_sender_test.go
+++ b/tests/validate_sender_test.go
@@ -95,7 +95,7 @@ func TestValidateSenderContract(t *testing.T) {
 			"c32c471b732e2f56103e2f8e8cfd52792ef548f05f326e546a7d1fbf9d0419ed"},
 		multisig2Initial.Addr)
 
-	signer := types.NewEIP155Signer(bcdata.bc.Config().ChainID)
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
 
 	// Transfer (reservoir -> multisig) using a legacy transaction.

--- a/work/worker.go
+++ b/work/worker.go
@@ -462,7 +462,7 @@ func (self *worker) makeCurrent(parent *types.Block, header *types.Header) error
 	if err != nil {
 		return err
 	}
-	work := NewTask(self.config, types.NewEIP155Signer(self.config.ChainID), stateDB, header)
+	work := NewTask(self.config, types.LatestSignerForChainID(self.config.ChainID), stateDB, header)
 	if self.nodetype != common.CONSENSUSNODE {
 		work.Block = parent
 	}


### PR DESCRIPTION
## Proposed changes

This PR added `LatestSigner()` and `LatestSignerForChainID()`.

It is currently using `EIP155Signer` type as a signer on Klaytn. 
However, for future work that porting london signer and EIP-2930 signer, the signer needs to be abstracted. 
So I replaced `NewEIP155Signer()` to `LatestSignerForChainID()`, except for tests that were explicitly tested using `EIP155Signer` type.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
