### PR TITLE
Implemented eth namespace apis (almost returning dummy or fixed values)

### DIFF
--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -471,10 +471,12 @@ func (s *CN) APIs() []rpc.API {
 
 	publicFilterAPI := filters.NewPublicFilterAPI(s.APIBackend, false)
 	governanceKlayAPI := governance.NewGovernanceKlayAPI(s.governance, s.blockchain)
+	publicGovernanceAPI := governance.NewGovernanceAPI(s.governance)
 	publicDownloaderAPI := downloader.NewPublicDownloaderAPI(s.protocolManager.Downloader(), s.eventMux)
 
 	ethAPI.SetPublicFilterAPI(publicFilterAPI)
 	ethAPI.SetGovernanceKlayAPI(governanceKlayAPI)
+	ethAPI.SetPublicGovernanceAPI(publicGovernanceAPI)
 
 	// Append all the local APIs and return
 	return append(apis, []rpc.API{


### PR DESCRIPTION
## Proposed changes

This PR Implemented `eth` namespace apis.
* Added publicGovernanceAPI which is used by `eth_etherbase`, `eth_coinbase`. Those apis return the address of operating node.
* Other apis returns dummy or fixed values. 

| Api  | Ethereum Source Code |
| ------------- | ------------- |
| eth_etherbase | [Etherbase](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/api.go#L54-L57) |
| [eth_coinbase](https://eth.wiki/json-rpc/API#eth_coinbase) | [Coinbase](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/api.go#L59-L62) |
| [eth_hashrate](https://eth.wiki/json-rpc/API#eth_hashrate) | [Hashrate](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/api.go#L64-L67) |
| [eth_mining](https://eth.wiki/json-rpc/API#eth_mining) | [Mining](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/api.go#L80-L83) |
| [eth_getWork](https://eth.wiki/json-rpc/API#eth_getwork) | [Mining](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/consensus/ethash/api.go#L34-L61) |
| [eth_submitWork](https://eth.wiki/json-rpc/API#eth_submitwork) | [SubmitWork](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/consensus/ethash/api.go#L63-L84) |
| [eth_submitHashrate](https://eth.wiki/json-rpc/API#eth_submithashrate) | [SubmitHashrate](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/consensus/ethash/api.go#L86-L107) |
| eth_getHashrate | [GetHashrate](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/consensus/ethash/api.go#L109-L112) |
| [eth_getUncleByBlockNumberAndIndex](https://eth.wiki/json-rpc/API#eth_getunclebyblocknumberandindex) | [GetUncleByBlockNumberAndIndex](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L759-L773) |
| [eth_getUncleByBlockHashAndIndex](https://eth.wiki/json-rpc/API#eth_getunclebyblockhashandindex) | [GetUncleByBlockHashAndIndex](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L775-L789) |
| [eth_getUncleCountByBlockNumber](https://eth.wiki/json-rpc/API#eth_getunclecountbyblocknumber) | [GetUncleCountByBlockNumber](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L791-L798) |
| [eth_getUncleCountByBlockHash](https://eth.wiki/json-rpc/API#eth_getunclecountbyblockhash) | [GetUncleCountByBlockHash](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L800-L807) |

Related Confluence: [How Ethereum APIs are supported in Klaytn](https://krustuniverse.atlassian.net/wiki/spaces/KG/pages/4937744407/Ethereum+API)

### How to test this PR
First, please clone my [origin repo](https://github.com/aeharvlee/klaytn/tree/add-eth-apis-returning-dummys).

#### 1. Run added tests in this PR.
* Run `go test -run "TestEthereumAPI_*" -v ./... -count=1`

#### 2. Build ken and test with it.

**1. Build ken with source codes related with this PR.**
* Run `make ken`

**2. Run ken**
* In my case, I tested with CN 1 - PN 1 - EN 1 in my local.
* Please note that you should enable `eth` namepsace to RPC_API and WS_API in kend.conf

### Test Logs
<details>
  <summary> Click to expand </summary>

```shell
➜  corecell curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_etherbase","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x9d776ff5745fd5b0df455f3259008ff3cd0eba95"}
```
```shell
➜  corecell curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_coinbase","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x9d776ff5745fd5b0df455f3259008ff3cd0eba95"}
```
```shell
➜  corecell curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_hashrate","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x0"}
```
```shell
➜  corecell curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_mining","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"result":false}
```
```shell
➜  corecell curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getWork","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"no mining work available yet"}}
```
```shell
➜  corecell curl localhost:8551 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"eth_submitWork", "params":["0x0000000000000001", "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"],"id":73}'
{"jsonrpc":"2.0","id":73,"result":false}
```
```shell
➜  corecell curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getHashrate","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"result":0}
```
```shell
➜  corecell curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockNumber","params":["0x1"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x0"}
```
```shell
➜  corecell curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockHash","params":["0xa4e7dcaedd5e5acb830180c2f05c5e95fb66908021623719c284dbf4c4262b40"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x0"}
```

</details>


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
