### PR TITLE
Implemented eth namespace apis using internally already implemented klaytnAPI

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -479,14 +479,14 @@ func (api *EthereumAPI) EstimateGas(ctx context.Context, args EthTransactionArgs
 
 // GetBlockTransactionCountByNumber returns the number of transactions in the block with the given block number.
 func (api *EthereumAPI) GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) *hexutil.Uint {
-	// TODO-Klaytn: Not implemented yet.
-	return nil
+	transactionCount, _ := api.publicTransactionPoolAPI.GetBlockTransactionCountByNumber(ctx, blockNr)
+	return transactionCount
 }
 
 // GetBlockTransactionCountByHash returns the number of transactions in the block with the given hash.
 func (api *EthereumAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) *hexutil.Uint {
-	// TODO-Klaytn: Not implemented yet.
-	return nil
+	transactionCount, _ := api.publicTransactionPoolAPI.GetBlockTransactionCountByHash(ctx, blockHash)
+	return transactionCount
 }
 
 // accessListResult returns an optional accesslist

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -189,15 +189,13 @@ func (api *EthereumAPI) GetHashrate() uint64 {
 //
 // https://eth.wiki/json-rpc/API#eth_newpendingtransactionfilter
 func (api *EthereumAPI) NewPendingTransactionFilter() rpc.ID {
-	// TODO-Klaytn: Not implemented yet.
-	return ""
+	return api.publicFilterAPI.NewPendingTransactionFilter()
 }
 
 // NewPendingTransactions creates a subscription that is triggered each time a transaction
 // enters the transaction pool and was signed from one of the transactions this nodes manages.
 func (api *EthereumAPI) NewPendingTransactions(ctx context.Context) (*rpc.Subscription, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicFilterAPI.NewPendingTransactions(ctx)
 }
 
 // NewBlockFilter creates a filter that fetches blocks that are imported into the chain.
@@ -205,8 +203,7 @@ func (api *EthereumAPI) NewPendingTransactions(ctx context.Context) (*rpc.Subscr
 //
 // https://eth.wiki/json-rpc/API#eth_newblockfilter
 func (api *EthereumAPI) NewBlockFilter() rpc.ID {
-	// TODO-Klaytn: Not implemented yet.
-	return ""
+	return api.publicFilterAPI.NewBlockFilter()
 }
 
 // NewHeads send a notification each time a new (header) block is appended to the chain.
@@ -216,13 +213,9 @@ func (api *EthereumAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error)
 }
 
 // Logs creates a subscription that fires for all new log that match the given filter criteria.
-func (api *EthereumAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subscription, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+func (api *EthereumAPI) Logs(ctx context.Context, crit filters.FilterCriteria) (*rpc.Subscription, error) {
+	return api.publicFilterAPI.Logs(ctx, crit)
 }
-
-// FilterCriteria represents a request to create a new filter.
-type FilterCriteria filters.FilterCriteria
 
 // NewFilter creates a new filter and returns the filter id. It can be
 // used to retrieve logs when the state changes. This method cannot be
@@ -237,25 +230,22 @@ type FilterCriteria filters.FilterCriteria
 // In case "fromBlock" > "toBlock" an error is returned.
 //
 // https://eth.wiki/json-rpc/API#eth_newfilter
-func (api *EthereumAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return "", nil
+func (api *EthereumAPI) NewFilter(crit filters.FilterCriteria) (rpc.ID, error) {
+	return api.publicFilterAPI.NewFilter(crit)
 }
 
 // GetLogs returns logs matching the given argument that are stored within the state.
 //
 // https://eth.wiki/json-rpc/API#eth_getlogs
-func (api *EthereumAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*types.Log, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+func (api *EthereumAPI) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([]*types.Log, error) {
+	return api.publicFilterAPI.GetLogs(ctx, crit)
 }
 
 // UninstallFilter removes the filter with the given filter id.
 //
 // https://eth.wiki/json-rpc/API#eth_uninstallfilter
 func (api *EthereumAPI) UninstallFilter(id rpc.ID) bool {
-	// TODO-Klaytn: Not implemented yet.
-	return false
+	return api.publicFilterAPI.UninstallFilter(id)
 }
 
 // GetFilterLogs returns the logs for the filter with the given id.
@@ -263,8 +253,7 @@ func (api *EthereumAPI) UninstallFilter(id rpc.ID) bool {
 //
 // https://eth.wiki/json-rpc/API#eth_getfilterlogs
 func (api *EthereumAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.Log, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicFilterAPI.GetFilterLogs(ctx, id)
 }
 
 // GetFilterChanges returns the logs for the filter with the given id since
@@ -275,20 +264,17 @@ func (api *EthereumAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.
 //
 // https://eth.wiki/json-rpc/API#eth_getfilterchanges
 func (api *EthereumAPI) GetFilterChanges(id rpc.ID) (interface{}, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicFilterAPI.GetFilterChanges(id)
 }
 
-// GasPrice returns a suggestion for a gas price for legacy transactions.
+// GasPrice returns a suggestion for a gas price.
 func (api *EthereumAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicKlayAPI.GasPrice(ctx)
 }
 
 // MaxPriorityFeePerGas returns a suggestion for a gas tip cap for dynamic fee transactions.
 func (api *EthereumAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicKlayAPI.GasPrice(ctx)
 }
 
 type feeHistoryResult struct {
@@ -314,28 +300,24 @@ func (api *EthereumAPI) FeeHistory(ctx context.Context, blockCount DecimalOrHex,
 // - pulledStates:  number of state entries processed until now
 // - knownStates:   number of known state entries that still need to be pulled
 func (api *EthereumAPI) Syncing() (interface{}, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicKlayAPI.Syncing()
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
 func (api *EthereumAPI) ChainId() (*hexutil.Big, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicBlockChainAPI.ChainId(), nil
 }
 
 // BlockNumber returns the block number of the chain head.
 func (api *EthereumAPI) BlockNumber() hexutil.Uint64 {
-	// TODO-Klaytn: Not implemented yet.
-	return 0
+	return api.publicBlockChainAPI.BlockNumber()
 }
 
 // GetBalance returns the amount of wei for the given address in the state of the
 // given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
 // block numbers are also allowed.
 func (api *EthereumAPI) GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicBlockChainAPI.GetBalance(ctx, address, blockNrOrHash)
 }
 
 // EthAccountResult structs for GetProof
@@ -446,16 +428,14 @@ func (api *EthereumAPI) GetUncleCountByBlockHash(ctx context.Context, blockHash 
 
 // GetCode returns the code stored at the given address in the state for the given block number.
 func (api *EthereumAPI) GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicBlockChainAPI.GetCode(ctx, address, blockNrOrHash)
 }
 
 // GetStorageAt returns the storage from the state at the given address, key and
 // block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block
 // numbers are also allowed.
 func (api *EthereumAPI) GetStorageAt(ctx context.Context, address common.Address, key string, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	return api.publicBlockChainAPI.GetStorageAt(ctx, address, key, blockNrOrHash)
 }
 
 // EthOverrideAccount indicates the overriding fields of account during the execution
@@ -905,8 +885,7 @@ func (api *EthereumAPI) Resend(ctx context.Context, sendArgs EthTransactionArgs,
 
 // Accounts returns the collection of accounts this node manages.
 func (api *EthereumAPI) Accounts() []common.Address {
-	// TODO-Klaytn: Not implemented yet.
-	return nil
+	return api.publicAccountAPI.Accounts()
 }
 
 // rpcMarshalHeader marshal block header as Ethereum compatible format.


### PR DESCRIPTION
## Proposed changes

This PR Implemented `eth` namespace apis using already implemented klaytnAPI.

| Api  | Ethereum Source Code |
| ------------- | ------------- |
| [eth_getBlockTransactionCountByHash](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbyhash) | [GetBlockTransactionCountByHash](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L1504-L1511) |
| [eth_getBlockTransactionCountByNumber](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbynumber) | [GetBlockTransactionCountByNumber](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L1495-L1502) |
| [eth_newPendingTransactionFilter](https://eth.wiki/json-rpc/API#eth_newpendingtransactionfilter) | [NewPendingTransactionFilter](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L105-L141) |
| Subscription: newPendingTransactions | [NewPendingTransactions](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L143-L176) |
| [eth_newBlockFilter](https://eth.wiki/json-rpc/API#eth_newblockfilter) | [NewBlockFilter](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L178-L211) |
| Subscription: logs | [Logs](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L243-L279) |
| [eth_newFilter](https://eth.wiki/json-rpc/API#eth_newfilter) | [NewFilter](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L285-L328) |
| [eth_getLogs](https://eth.wiki/json-rpc/API#eth_getlogs) | [GetLogs](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L330-L357) |
| [eth_uninstallFilter](https://eth.wiki/json-rpc/API#eth_uninstallfilter) | [UninstallFilter](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L359-L374) |
| [eth_getFilterChanges](https://eth.wiki/json-rpc/API#eth_getfilterchanges) | [GetFilterChanges](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L414-L446) |
| eth_getFilterLogs | [GetFilterLogs](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L376-L412) |
| [eth_gasPrice](https://eth.wiki/json-rpc/API#eth_gasprice) | [GasPrice](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L62-L72) |
| eth_maxPriorityFeePerGas | [MaxPriorityFeePerGas](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L74-L81) |
| [eth_syncing](https://eth.wiki/json-rpc/API#eth_syncing) | [Syncing](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L117-L139) |
| eth_chainId | [ChainId](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L609-L616) |
| [eth_blockNumber](https://eth.wiki/json-rpc/API#eth_blocknumber) | [BlockNumber](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L618-L622) |
| [eth_getBalance](https://eth.wiki/json-rpc/API#eth_getbalance) | [GetBalance](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L624-L633) |
| [eth_getCode](https://eth.wiki/json-rpc/API#eth_getcode) | [GetCode](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L809-L817) |
| [eth_getStorageAt](https://eth.wiki/json-rpc/API#eth_getstorageat) | [GetStorageAt](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L819-L829) |
| [eth_accounts](https://eth.wiki/json-rpc/API#eth_accounts) | [Accounts](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/internal/ethapi/api.go#L256-L259) |

Related Confluence: [How Ethereum APIs are supported in Klaytn](https://krustuniverse.atlassian.net/wiki/spaces/KG/pages/4937744407/Ethereum+API)

### How to test this PR
First, please clone my [origin repo](https://github.com/aeharvlee/klaytn/tree/add-eth-apis-using-klayapi-internally).

**1. Build ken with source codes related with this PR.**
* Run `make ken`

**2. Run ken**
* In my case, I tested with CN 1 - PN 1 - EN 1 in my local.
* Please note that you should enable `eth` namepsace to RPC_API and WS_API in kend.conf

**3. Setup test scenario**
Deploy kip7 contract
> Before testing, I deployed kip7 contract and used it. Below is the my information of my test scenario and result.
* Contract address: `0x6A90F04A407258c4F516959E4f62CD2C0C309018`
* Deployer address: `0x3e2ac308cd78ac2fe162f9522deb2b56d9da9499`
* Recipient address: `0x8944d588cf8a4d255e2510f1c05b1eb4557bdaba`
* Topic: `0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef` (= `keccak256("Transfer(address,address,uint256)")`)

Deploy storage contract
> Before testing, I deployed storage contract which is described in [klay_getStorageAt](https://docs.klaytn.com/dapp/json-rpc/api-references/klay/block#klay_getstorageat) and used it. Below is the my information of my test scenario and result.
* Contract address: `0xDAf9C71C8a35b397250fb9f2ac1bD6b685E722Df`
* Byte code: `6080604052348015600f57600080fd5b506104d260008190555061162e600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002081905550603580606c6000396000f3006080604052600080fd00a165627a7a72305820372ea18474d2fe1c7f0d56ce71fac400e8f8b1ca01c83b0544b7af09b7420b850029`
* Abi: `[{"inputs":[],"payable":false,"stateMutability":"nonpayable","type":"constructor"}]`


### Test Logs
<details>
  <summary> Click to expand </summary>

**GetBlockTransactionCountByHash**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method": "eth_getBlockTransactionCountByHash", "params":["0x5f488f8b6f087befaeff257c47f1cfb25d6c91ca621acc2f89dbe355353349df"], "id": 1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":"0x1"}

# Query none existing block hash should return null like Ethereum does.
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method": "eth_getBlockTransactionCountByHash", "params":["0x5f488f8b6f087befaeff257c47f1cfb25d6c91ca621acc2f89dbe355353349de"], "id": 1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":null}
```

**GetBlockTransactionCountByNumber**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method": "eth_getBlockTransactionCountByNumber", "params":["0x7a906"], "id": 1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":"0x1"}

# Query none existing block number should return null like Ethereum does.
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method": "eth_getBlockTransactionCountByNumber", "params":["0x7a9069"], "id": 1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":null}
```

**NewPendingTransactionFilter**
```shell
➜  corecell curl localhost:8551 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_newPendingTransactionFilter","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x6380b79126fc8a83662268587c22848d"}

# Send 3 txs after transaction filter is created and check changes by using getFilterChanges
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getFilterChanges","params":["0x6380b79126fc8a83662268587c22848d"],"id":73}' http://localhost:8551
{"jsonrpc":"2.0","id":73,"result":["0x24f5c29a54d830755745d3a9ef97aee0b3e58aec164d4d23ea242b3d364a70ea","0x871bdb366e08146f888c7dccdb573855e1f7fa22c21be96b0fc3a9a503b245d0","0xe8766f87e972ff98a40b9c83b19a8584a02ac46c185934c74bf27d1b5b5add90"]}
```
**Subscription: NewPendingTransactions**
```shell
➜  klaytn wscat -c ws://localhost:8552
Connected (press CTRL+C to quit)
> {"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["newPendingTransactions"]}
< {"jsonrpc":"2.0","id":1,"result":"0x861c07be2d1c403b892a285ca7cd17c7"}
# Send 3 txs after subscription is acitvated 
< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x861c07be2d1c403b892a285ca7cd17c7","result":"0xc1147cc28fc79d60a72dcffd2977580220a74341440dd9b4eda5aa9a0b2a457c"}}
< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x861c07be2d1c403b892a285ca7cd17c7","result":"0xf10939d71e1d1d869b3df2b46b87585d30038ef8cd6fc5b5dbc558c59c2ec7f7"}}
< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x861c07be2d1c403b892a285ca7cd17c7","result":"0x3fcb3874c38c3068ae514fc1d928383c63b0901c8e1d21fbef7116858d14462b"}}
```

**NewBlockFilter***
```shell
➜  corecell curl localhost:8551 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_newBlockFilter","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0xa56230b22ae9b7dcdef8648f3dd03fba"}

# After about 30 seconds... check changes by using getFilterChanges
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getFilterChanges","params":["0xa56230b22ae9b7dcdef8648f3dd03fba"],"id":73}' http://localhost:8551

{"jsonrpc":"2.0","id":73,"result":["0x5379518ef8a75e117994bca0fec4a64f7545426f170b99c094d6667e78b69d4b","0x1b64b8491106fe91786c0022885852aa1b5d7c54a123b96535f0c162678ffff9","0xd1c35567efe1ce04a68b8d914312a4bafbf649a9d9b0a4174031038499d52b98","0xe6b3bb4c45ed5aa38489ec780165a41c008c918af0e1c1afaffda0d05015993c","0x2c485e30dd2f591e3c3d93d6ca7de0c5aa1ece656a1fa5abe719e88a5a6e3ad4","0x79fae5c94e2e376ed402b13e6d72719274a1df3a87c3b1302eff5ffc1b304814","0x7ce7a6341e18ad5eb23c20e8772de788c292d9a16abc11ad38800aad07a3ec22","0xfb592fd0fc1d5a8c26f3b68b96878d337fadff89e690191e10b1fd58b27ca2d3","0x3601767b44fcb3591b9436c75e93d7717f16a7b3922d62a5efbea7ae602a8c92","0x47bcf4ec1b4b8c525e7825d3044ed10d4ec287794f2475182a9a7406f39b2e7a","0xa872547b2ebb0121f54dc115a987719c7c024634318315c7cc25f7c5b8f894d4","0x658ca97c07efd720140d962a2489155046c994cd744455d6a19a5f8710968a59","0xa0b6182c4ff79e665f5cc4670343e9e4146641aead99175e44c19abfbdcb8890","0x91c9ca86b0ae957c092cf4ba756d9f98c55afe40dc9fc2872c1d5ff1d9062de0","0x63e3220483f42e1d45fc96f2c8292aa551dc15059d113f8ca05a4453474e005d","0x648facf60d033d816d1ce97dc7ca3edeea418e847d8ef173b4a980b39a133cc1","0x9bd6b1f8231fa7c1ba3b88d4aa83f918b156ac578346732fdbfdfdadd91b1fd9","0xba27513d07bf7f85dbfb8cbd26a74069bbb25fb44b6ecdcd59256d12492ebb74","0xeb8f7ca38659414d280b3e1d77e4aaf53abb40d18c16cc65dd6ea0670633758f","0xd7d9a3f5b09242e3e52bbca9b1f53294addb184da4897d0af5bdc5d53875c124","0x6d10801fdd4ecc1d4e496cb211074556e2ddf425836ed4ef3ec5cbfae447cd07","0xee5a29078b490a6908e2a64df14191b42851f55fd7a1463c1767f8676e31ad53","0xb575028b66925d0a159b4270ae34cac73966b431e2e2cf2d74065a31720f2c0a","0x339a327fe054117a36b26e14944d2adc604aee7e82978279dff6bcd949ac2e63"]}
```

**Subscription: Logs**
```shell
> {"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["logs", {"fromBlock":"earliest","toBlock":"latest","address":"0x6A90F04A407258c4F516959E4f62CD2C0C309018","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]}]}
< {"jsonrpc":"2.0","id":1,"result":"0x23df107ecd933fc7b9b517e5de7592d3"}
< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x23df107ecd933fc7b9b517e5de7592d3","result":{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499","0x0000000000000000000000008944d588cf8a4d255e2510f1c05b1eb4557bdaba"],"data":"0x0000000000000000000000000000000000000000000000000000000000000001","blockNumber":"0x78ee5","transactionHash":"0xb16677df0ccf494f15a6e532a223aa17a7d08624936532460d99cceb051ce0fd","transactionIndex":"0x0","blockHash":"0xebe057387c8ec7067e3010578407100858031d228f0eb38dad682a081322c11f","logIndex":"0x0","removed":false}}}
< {"jsonrpc":"2.0","method":"klay_subscription","params":{"subscription":"0x47d280b81a4ff98e453dfa42337b50aa","result":{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499","0x0000000000000000000000008944d588cf8a4d255e2510f1c05b1eb4557bdaba"],"data":"0x0000000000000000000000000000000000000000000000000000000000000001","blockNumber":"0x78ee5","transactionHash":"0xb16677df0ccf494f15a6e532a223aa17a7d08624936532460d99cceb051ce0fd","transactionIndex":"0x0","blockHash":"0xebe057387c8ec7067e3010578407100858031d228f0eb38dad682a081322c11f","logIndex":"0x0","removed":false}}}
```

**NewFilter**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"fromBlock":"0x1","toBlock":"latest","address":"0x6A90F04A407258c4F516959E4f62CD2C0C309018"}],"id":1}' http://localhost:8551
{"jsonrpc":"2.0","id":1,"result":"0xb8587d45b734f47efb14ef3dcbc88a92"}

# After sending kip7 transfer transactions...
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getFilterChanges","params":["0xb8587d45b734f47efb14ef3dcbc88a92"],"id":73}' http://localhost:8551
{"jsonrpc":"2.0","id":73,"result":[{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499","0x0000000000000000000000008944d588cf8a4d255e2510f1c05b1eb4557bdaba"],"data":"0x0000000000000000000000000000000000000000000000000000000000000001","blockNumber":"0x79041","transactionHash":"0xea3619ea1c0297927fbd091a44a58c147cba02809b2e4e3bce29a01e5d116541","transactionIndex":"0x0","blockHash":"0x32b8ed19e2fc6c58383cef5b320e28ec64ac8cee66fa7deb8d0fa4eb08fdef15","logIndex":"0x0","removed":false}]}
```

**GetLogs**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x1","toBlock":"latest","address":"0x6A90F04A407258c4F516959E4f62CD2C0C309018"}],"id":1}' http://localhost:8551
{"jsonrpc":"2.0","id":1,"result":[{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0x6ae172837ea30b801fbfcdd4108aa1d5bf8ff775444fd70256b44e6bf3dfc3f6","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499"],"data":"0x","blockNumber":"0x78beb","transactionHash":"0xeb1a35de54c2c6227ff0431854b140a64caf00a75433fb7e979e5117fc5f33ad","transactionIndex":"0x0","blockHash":"0xe834fb3f9083bfb1935520bf25614c73cdac5febc4e8fc2373e85c7691890f2a","logIndex":"0x0","removed":false},{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0x6719d08c1888103bea251a4ed56406bd0c3e69723c8a1686e017e7bbe159b6f8","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499"],"data":"0x","blockNumber":"0x78beb","transactionHash":"0xeb1a35de54c2c6227ff0431854b140a64caf00a75433fb7e979e5117fc5f33ad","transactionIndex":"0x0","blockHash":"0xe834fb3f9083bfb1935520bf25614c73cdac5febc4e8fc2373e85c7691890f2a","logIndex":"0x1","removed":false},{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000000000000000000000000000000000000000000000","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499"],"data":"0x0000000000000000000000000000000000000000000000000de0b6b3a7640000","blockNumber":"0x78beb","transactionHash":"0xeb1a35de54c2c6227ff0431854b140a64caf00a75433fb7e979e5117fc5f33ad","transactionIndex":"0x0","blockHash":"0xe834fb3f9083bfb1935520bf25614c73cdac5febc4e8fc2373e85c7691890f2a","logIndex":"0x2","removed":false},{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499","0x0000000000000000000000008944d588cf8a4d255e2510f1c05b1eb4557bdaba"],"data":"0x0000000000000000000000000000000000000000000000000000000000000001","blockNumber":"0x78bee","transactionHash":"0x3b9525dc7d010d2834a38a1ce477bd3583dc6c956da6a6c4efedfbff932420cd","transactionIndex":"0x0","blockHash":"0x86ee69260b535039abd9d18b44c0854bd015dcaa24276daba0aeccafa5056358","logIndex":"0x0","removed":false},{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499","0x0000000000000000000000008944d588cf8a4d255e2510f1c05b1eb4557bdaba"],"data":"0x0000000000000000000000000000000000000000000000000000000000000001","blockNumber":"0x78e86","transactionHash":"0x0fc448addef4332a68f2e6391fd8e4382ac741186b1f6bd67c920793164f307f","transactionIndex":"0x0","blockHash":"0x2bf49e95ed7342ee805decf505e9b2646a86df299d435f42703f8b0e2eef117f","logIndex":"0x0","removed":false},{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499","0x0000000000000000000000008944d588cf8a4d255e2510f1c05b1eb4557bdaba"],"data":"0x0000000000000000000000000000000000000000000000000000000000000001","blockNumber":"0x78ee5","transactionHash":"0xb16677df0ccf494f15a6e532a223aa17a7d08624936532460d99cceb051ce0fd","transactionIndex":"0x0","blockHash":"0xebe057387c8ec7067e3010578407100858031d228f0eb38dad682a081322c11f","logIndex":"0x0","removed":false},{"address":"0x6a90f04a407258c4f516959e4f62cd2c0c309018","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499","0x0000000000000000000000008944d588cf8a4d255e2510f1c05b1eb4557bdaba"],"data":"0x0000000000000000000000000000000000000000000000000000000000000001","blockNumber":"0x79041","transactionHash":"0xea3619ea1c0297927fbd091a44a58c147cba02809b2e4e3bce29a01e5d116541","transactionIndex":"0x0","blockHash":"0x32b8ed19e2fc6c58383cef5b320e28ec64ac8cee66fa7deb8d0fa4eb08fdef15","logIndex":"0x0","removed":false}]}
```

**UninstallFilter**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"fromBlock":"0x1","toBlock":"latest","address":"0x6A90F04A407258c4F516959E4f62CD2C0C309018"}],"id":1}' http://localhost:8551
{"jsonrpc":"2.0","id":1,"result":"0x1266f6e8a48d95f8f8bc956c7227936f"}
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_uninstallFilter","params":["0x1266f6e8a48d95f8f8bc956c7227936f"],"id":1}' http://localhost:8551
{"jsonrpc":"2.0","id":1,"result":true}
```

**GetFilterChanges**
> Already tested it above tests.

**GasPrice**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[""],"id":1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":"0x5d21dba00"}
```

**MaxPriorityFeePerGas**
```shell
MaxPriorityFeePerGas
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_maxPriorityFeePerGas","params":[""],"id":1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":"0x5d21dba00"}
```

**Syncing**
```shell

```

**ChainId**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[""],"id":1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":"0xe5a51"}
```

**BlockNumber**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[""],"id":1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":"0x79331"}
```

**GetBalance**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x3e2ac308cd78ac2fe162f9522deb2b56d9da9499","pending"],"id":1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":"0x446c3b15f9926687d2c40534fdb3f4298e5d6d0853"}
```

**GetCode**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0x6A90F04A407258c4F516959E4f62CD2C0C309018","latest"],"id":1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":"0x6080…”}
```

**GetStorageAt**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method": “eth_getStorageAt", "params": ["0xDAf9C71C8a35b397250fb9f2ac1bD6b685E722Df", "0x0", "latest"], "id": 1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":"0x00000000000000000000000000000000000000000000000000000000000004d2"}
```

**Accounts**
```shell
➜  corecell curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method": "eth_accounts", "params":[], "id": 1}' http://localhost:8551

{"jsonrpc":"2.0","id":1,"result":["0xca7a99380131e6c76cfa622396347107aeedca2d","0x3e2ac308cd78ac2fe162f9522deb2b56d9da9499","0xf7ccb6e6ef8386582c917604c0983d70dd555c0c","0xe19a5e72e8448978dbbaee284a140f67a08ac2a4","0x2eaad2bf70a070aaa2e007beee99c6148f47718e","0x59b01bfecddaee11f249bc180b804a58fd4c4728","0xb6a5f0c236c0289f4681ae6eca6959eb6172bb1d","0x72e3410a33d1c9bb0b623354309a93e9fd5e40fd"]}
```

</details>

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
