### PR TITLE
Implemented eth namespace api newHeads

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -211,8 +211,37 @@ func (api *EthereumAPI) NewBlockFilter() rpc.ID {
 
 // NewHeads send a notification each time a new (header) block is appended to the chain.
 func (api *EthereumAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
-	// TODO-Klaytn: Not implemented yet.
-	return nil, nil
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+	go func() {
+		headers := make(chan *types.Header)
+		headersSub := api.publicFilterAPI.Events().SubscribeNewHeads(headers)
+
+		for {
+			select {
+			case h := <-headers:
+				header, err := api.rpcMarshalHeader(h)
+				if err != nil {
+					logger.Error("Failed to marshal header during newHeads subscription", "err", err)
+					headersSub.Unsubscribe()
+					return
+				}
+				notifier.Notify(rpcSub.ID, header)
+			case <-rpcSub.Err():
+				headersSub.Unsubscribe()
+				return
+			case <-notifier.Closed():
+				headersSub.Unsubscribe()
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
 }
 
 // Logs creates a subscription that fires for all new log that match the given filter criteria.

--- a/node/cn/filters/api.go
+++ b/node/cn/filters/api.go
@@ -426,6 +426,11 @@ func (api *PublicFilterAPI) GetFilterChanges(id rpc.ID) (interface{}, error) {
 	return []interface{}{}, fmt.Errorf("filter not found")
 }
 
+// Events return private field events of PublicFilterAPI.
+func (api *PublicFilterAPI) Events() *EventSystem {
+	return api.events
+}
+
 // returnHashes is a helper that will return an empty hash array case the given hash array is nil,
 // otherwise the given hashes array is returned.
 func returnHashes(hashes []common.Hash) []common.Hash {


### PR DESCRIPTION
## Proposed changes

NewHeads subscribe heads newly created and return it as
Ethereum Header data structure.

To access events which is private field of publicFilterAPI,
I added public getter method `Events()` .

| Api  | Ethereum Source Code |
| ------------- | ------------- |
| Subscription: NewHeads | [NewHeads](https://github.com/ethereum/go-ethereum/blob/eae3b1946a276ac099e0018fc792d9e8c3bfda6d/eth/filters/api.go#L213-L241) |

### How to test this PR

First, please clone my [origin repo](https://github.com/aeharvlee/klaytn/tree/add-eth-newHeads-1).

**1. Build ken with source codes related with this PR.**
* Run `make ken`

**2. Run ken**
* In my case, I tested with CN 1 - PN 1 - EN 1 in my local.
* Please note that you should enable `eth` namepsace to RPC_API and WS_API in kend.conf


### Test Logs

**KEN**
```shell
➜  klaytn wscat -c ws://localhost:8552
Connected (press CTRL+C to quit)
> {"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
< {"jsonrpc":"2.0","id":1,"result":"0x16f4bbbd0c4496f270227cea32696d4"}
< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x16f4bbbd0c4496f270227cea32696d4","result":{"baseFeePerGas":"0x0","difficulty":"0x1","extraData":"0x","gasLimit":"0x3b9ac9ff","gasUsed":"0x0","hash":"0xc71ddc9061a0a61f0eeb5161d57511bbbcd098a8c059eebbf87d053c78413622","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","miner":"0x9712f943b296758aaae79944ec975884188d3a96","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","number":"0x7b079","parentHash":"0x56ce36b988cc1555a553345638f4585ca6a4ec567e3ade2a49fa1f38fcb2060f","receiptsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x2ce","stateRoot":"0xee559e11be4b19ad92737c668e2bc0afb223d8e2504f1689e0d80d02b1c590d3","timestamp":"0x61ed3603","totalDifficulty":"0x7b07a","transactionsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"}}}
< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x16f4bbbd0c4496f270227cea32696d4","result":{"baseFeePerGas":"0x0","difficulty":"0x1","extraData":"0x","gasLimit":"0x3b9ac9ff","gasUsed":"0x0","hash":"0x198a2de60514bc8e203624484db53274bcebec2f95181e5f94ea66527eb87b88","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","miner":"0x9712f943b296758aaae79944ec975884188d3a96","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","number":"0x7b07a","parentHash":"0xc71ddc9061a0a61f0eeb5161d57511bbbcd098a8c059eebbf87d053c78413622","receiptsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x2ce","stateRoot":"0x34e70dfab621377d79ad1df3daaa3993285347339298865157793ac5cc51669b","timestamp":"0x61ed3604","totalDifficulty":"0x7b07b","transactionsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"}}}
< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x16f4bbbd0c4496f270227cea32696d4","result":{"baseFeePerGas":"0x0","difficulty":"0x1","extraData":"0x","gasLimit":"0x3b9ac9ff","gasUsed":"0x0","hash":"0x29d499eee52717803c1e6490b4b3b7f68285dcd4008ff2f89826ec1b58a9ddba","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","miner":"0x9712f943b296758aaae79944ec975884188d3a96","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","number":"0x7b07b","parentHash":"0x198a2de60514bc8e203624484db53274bcebec2f95181e5f94ea66527eb87b88","receiptsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x2ce","stateRoot":"0xc1e41ac1c39cf0029e19c18421f37f1ae5ff040a4288e67bd22879acad27e9a2","timestamp":"0x61ed3605","totalDifficulty":"0x7b07c","transactionsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"}}}
< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x16f4bbbd0c4496f270227cea32696d4","result":{"baseFeePerGas":"0x0","difficulty":"0x1","extraData":"0x","gasLimit":"0x3b9ac9ff","gasUsed":"0x0","hash":"0x68c224c09c54ea3df41f9b4d5ffd97dc7f26d11eb40b77500eb13dd3b646e2fc","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","miner":"0x9712f943b296758aaae79944ec975884188d3a96","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","number":"0x7b07c","parentHash":"0x29d499eee52717803c1e6490b4b3b7f68285dcd4008ff2f89826ec1b58a9ddba","receiptsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x2ce","stateRoot":"0xad46eec525643f479517a5db6cf35f6f04bc11c8e67c9f5024fa1268944134eb","timestamp":"0x61ed3606","totalDifficulty":"0x7b07d","transactionsRoot":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"}}}
```
**Beautified Result Sample**
```json
{
  "subscription": "0x16f4bbbd0c4496f270227cea32696d4",
  "result": {
    "baseFeePerGas": "0x0",
    "difficulty": "0x1",
    "extraData": "0x",
    "gasLimit": "0x3b9ac9ff",
    "gasUsed": "0x0",
    "hash": "0xc71ddc9061a0a61f0eeb5161d57511bbbcd098a8c059eebbf87d053c78413622",
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "miner": "0x9712f943b296758aaae79944ec975884188d3a96",
    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "nonce": "0x0000000000000000",
    "number": "0x7b079",
    "parentHash": "0x56ce36b988cc1555a553345638f4585ca6a4ec567e3ade2a49fa1f38fcb2060f",
    "receiptsRoot": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "size": "0x2ce",
    "stateRoot": "0xee559e11be4b19ad92737c668e2bc0afb223d8e2504f1689e0d80d02b1c590d3",
    "timestamp": "0x61ed3603",
    "totalDifficulty": "0x7b07a",
    "transactionsRoot": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
  }
}
```


**Error situation**
Unlike Geth, there a point where error can occur before notifying heads.
But it is hard to produce the error during test, so we can test it by generating an error in the code like below.
```go
// ... 
go func() {
    headers := make(chan *types.Header)
    headersSub := api.publicFilterAPI.Events().SubscribeNewHeads(headers)

    var i = 0
    for {
	    select {
	    case h := <-headers:
		    i++
		    header, err := api.rpcMarshalHeader(h)
		    if err != nil || i >= 5 {
			    err = errors.New("cannot fetch miner")
			    logger.Error("Failed to marshal header during newHeads subscription", "err", err)
			    headersSub.Unsubscribe()
			    return
		    }
// ...
``` 

In that case, the error happen and subscription channel is closed after 5 head arrived with below log.
```
ERROR[01/23,20:03:35 +09] [3] Failed to marshal header during newHeads subscription  err="cannot fetch miner"
```

**GETH**
```shell
➜  ethereum wscat -c wss://mainnet.infura.io/ws/v3/cd51ed2ce47b482db5b52956e0130b9e
Connected (press CTRL+C to quit)
> {"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
< {"jsonrpc":"2.0","id":1,"result":"0x41000e7af0d2f0092466fc55c05ac112aa31fba52482"}
< {"JSONRPC":"2.0", "method":"eth_subscription", "params": {"subscription":"0x41000e7af0d2f0092466fc55c05ac112aa31fba52482","result":{"number":"0xd69049","hash":"0x5136963f43a8d5f57e747d3aba764615a6f95267223e2990213ec683590e7165","parentHash":"0x78cb3f322792b5c4b38316fe9cf20601a96936ea628e94191604abf644578eb3","sha3Uncles":"0xbff5f0a5930d82bfd373d5b7bbf32be016b092aedce5973aef0be83cf87bd245","logsBloom":"0xa8200d030048112990316c9080031a2050890001110400001022a08210660c05010d0142402040050200131bc3ca19050344b8000808a880028008100b762100016c540200160b3acac6c40c85000c240448a000044e024130801ed0840021a092160180623440210140104048212bc8ca41203010150e30420000910418040006001123121c1530002c8d80110400470c04120145000079142458c00810802006400029028024000911408280878408846000410250882000f406021c74b82c44103047004408440204a888bd00840cc080024c1080603864dc0142141068100032ad09201260808a00d00400b408050cc1083a860800c4010e8c900dcb103f","transactionsRoot":"0x7202ac4e6bba36cbf62b729e067e78b23282605958626bdc0901b0ce602abb07","stateRoot":"0x6be8e578dbb4137e9a761c9d30b0b617af870bb7872055d4e7591067e8ddd0c1","receiptsRoot":"0xae7b16c8326979993e4dfee032573964d7ca3c1558fab1732794726349fcdf72","miner":"0x1ad91ee08f21be3de0ba2ba6918e714da6b45836","difficulty":"0x2b96c69522b4e7","extraData":"0x486976656f6e2075732d6865617679","gasLimit":"0x1c9c380","gasUsed":"0x655c8a","timestamp":"0x61ed3ec7","baseFeePerGas":"0x16d28563ef","nonce":"0x8a1c5571e2ad9455","mixHash":"0xfa878f311c492dd56bbdb7980656bac497f5f99cd7008a887c89b1ca2644301d"}}}
< {"JSONRPC":"2.0", "method":"eth_subscription", "params": {"subscription":"0x41000e7af0d2f0092466fc55c05ac112aa31fba52482","result":{"number":"0xd6904a","hash":"0x32a3004e5866b58fc3fdb5c14529d8082f238cba18c71f43f6ae755e52b26681","parentHash":"0x5136963f43a8d5f57e747d3aba764615a6f95267223e2990213ec683590e7165","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","logsBloom":"0xd4f3fd359768c8cfd7ec56edfe192671f1fad6adfe16d3a1fb1f71adf7fae77fb90545bd38f2abf1d53ecfef3faf5bac7a5bf4c3cf4ea184febb4ec21d7eefaa462f7c8f27e4d9efedbb8b0f5499b6ff38883d1abd727cd69fdf1958d17b11f8da6616fd7374abb4d6f67dc155e8fc7fb68abfd3ff55679d0ef5ff326befd5b57fccbff13b593b6ddc5d49f8ef907bf6cea7ef6ba9b54fae5aaf086537ff5cb4fb8ba0321783afee2a3dd0f7064f17625ce32203a7eb5b0d676f0ab6fdcff65c59cea6baf209b4d3e9e1cf2e83ad2105613fde6037ae37376ebebdbe8f3ebb13867b7e9c3ef78fb3f8454d6973e2caa154e3d06be944bbf4827febbfc7286efd","transactionsRoot":"0xbe5c1d750e93ae2cc64f6e9709088c7be8276cecb4988009f0317895e0c3c50f","stateRoot":"0xf0459da1984811b0b04ba6d6b3f36191f649c9f3c83e25aaf6b8e1da5a19a982","receiptsRoot":"0x8936f9cfe98297b92e3a1d25fe544db6c0ca86fc1931ee2a679b2a88766c2c72","miner":"0x1ad91ee08f21be3de0ba2ba6918e714da6b45836","difficulty":"0x2b96c71522b4e7","extraData":"0x486976656f6e2073672d6865617679","gasLimit":"0x1c9c380","gasUsed":"0x1c98130","timestamp":"0x61ed3ede","baseFeePerGas":"0x153ba132c0","nonce":"0xbc622e91f4fd9777","mixHash":"0x17f5bb239c07b04cf79b3fcc3a038498b0ed07cf72de7d4b60e95f96b17af55d"}}}
```

**Beautified Result Sample**
```json
{
  "subscription": "0x41000e7af0d2f0092466fc55c05ac112aa31fba52482",
  "result": {
    "number": "0xd6904a",
    "hash": "0x32a3004e5866b58fc3fdb5c14529d8082f238cba18c71f43f6ae755e52b26681",
    "parentHash": "0x5136963f43a8d5f57e747d3aba764615a6f95267223e2990213ec683590e7165",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "logsBloom": "0xd4f3fd359768c8cfd7ec56edfe192671f1fad6adfe16d3a1fb1f71adf7fae77fb90545bd38f2abf1d53ecfef3faf5bac7a5bf4c3cf4ea184febb4ec21d7eefaa462f7c8f27e4d9efedbb8b0f5499b6ff38883d1abd727cd69fdf1958d17b11f8da6616fd7374abb4d6f67dc155e8fc7fb68abfd3ff55679d0ef5ff326befd5b57fccbff13b593b6ddc5d49f8ef907bf6cea7ef6ba9b54fae5aaf086537ff5cb4fb8ba0321783afee2a3dd0f7064f17625ce32203a7eb5b0d676f0ab6fdcff65c59cea6baf209b4d3e9e1cf2e83ad2105613fde6037ae37376ebebdbe8f3ebb13867b7e9c3ef78fb3f8454d6973e2caa154e3d06be944bbf4827febbfc7286efd",
    "transactionsRoot": "0xbe5c1d750e93ae2cc64f6e9709088c7be8276cecb4988009f0317895e0c3c50f",
    "stateRoot": "0xf0459da1984811b0b04ba6d6b3f36191f649c9f3c83e25aaf6b8e1da5a19a982",
    "receiptsRoot": "0x8936f9cfe98297b92e3a1d25fe544db6c0ca86fc1931ee2a679b2a88766c2c72",
    "miner": "0x1ad91ee08f21be3de0ba2ba6918e714da6b45836",
    "difficulty": "0x2b96c71522b4e7",
    "extraData": "0x486976656f6e2073672d6865617679",
    "gasLimit": "0x1c9c380",
    "gasUsed": "0x1c98130",
    "timestamp": "0x61ed3ede",
    "baseFeePerGas": "0x153ba132c0",
    "nonce": "0xbc622e91f4fd9777",
    "mixHash": "0x17f5bb239c07b04cf79b3fcc3a038498b0ed07cf72de7d4b60e95f96b17af55d"
  }
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
