### PR TITLE
datasync: fix create kafka topic

### DIFF
--- a/datasync/chaindatafetcher/kafka/kafka.go
+++ b/datasync/chaindatafetcher/kafka/kafka.go
@@ -103,8 +103,11 @@ func (k *Kafka) setupTopic(topicName string) error {
 	}
 
 	if err := k.CreateTopic(topicName); err != nil {
-		logger.Error("creating a topic is failed", "topicName", topicName, "err", err)
-		return err
+		if kerr, ok := err.(*sarama.TopicError); !ok || kerr.Err != sarama.ErrTopicAlreadyExists {
+			logger.Error("creating a topic is failed", "topicName", topicName, "err", err)
+			return err
+		}
+		logger.Warn("creating a topic is failed. topic already exists", "topicName", topicName)
 	}
 
 	return nil


### PR DESCRIPTION
## Proposed changes

- ignore `sarama.ErrTopicAlreadyExists` when creating a new kafka topic in chaindatafetcher

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

When configured docker compose which contains EN services with chaindatafetcher, some containers failed to start
because topic already exists i.e. concurrency problem :(