### PR TITLE
governance: initialize g.actualGovernanceBlock so nil cannot be set

### DIFF
--- a/governance/default.go
+++ b/governance/default.go
@@ -680,7 +680,11 @@ func (g *Governance) initializeCache() error {
 
 	governanceBlock, governanceStateBlock := g.actualGovernanceBlock.Load().(uint64), atomic.LoadUint64(&g.lastGovernanceStateBlock)
 	if governanceBlock >= governanceStateBlock {
-		ret, _ := g.itemCache.Get(getGovernanceCacheKey(governanceBlock))
+		ret, ok := g.itemCache.Get(getGovernanceCacheKey(governanceBlock))
+		if !ok || ret == nil {
+			logger.Error("cannot get governance data at actualGovernanceBlock", "actualGovernanceBlock", governanceBlock)
+			return errors.New("Currentset initialization failed")
+		}
 		g.currentSet.Import(ret.(map[string]interface{}))
 		g.updateGovernanceParams()
 	}

--- a/governance/default.go
+++ b/governance/default.go
@@ -677,6 +677,7 @@ func (g *Governance) initializeCache() error {
 	newBlockNumber, newGovernanceSet, _ := g.ReadGovernance(headBlockNumber)
 	g.actualGovernanceBlock.Store(newBlockNumber)
 	g.currentSet.Import(newGovernanceSet)
+	g.updateGovernanceParams()
 
 	governanceBlock, governanceStateBlock := g.actualGovernanceBlock.Load().(uint64), atomic.LoadUint64(&g.lastGovernanceStateBlock)
 	if governanceBlock >= governanceStateBlock {

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -619,16 +619,19 @@ func TestGovernance_initializeCache(t *testing.T) {
 		unitPriceInCurrentSet uint64
 		actualGovernanceBlock uint64
 	}{
-		{3, []uint64{30, 60, 90}, []uint64{2, 3, 4}, 90, 3, 60},
-		{3, []uint64{30, 60, 90}, []uint64{2, 3, 4}, 110, 3, 60},
-		{3, []uint64{30, 60, 90}, []uint64{2, 3, 4}, 130, 4, 90},
+		{0, []uint64{0}, []uint64{1}, 20, 1, 0},
+		{0, []uint64{0}, []uint64{1}, 50, 1, 0},
+		{0, []uint64{0}, []uint64{1}, 80, 1, 0},
+		{3, []uint64{0, 30, 60, 90}, []uint64{1, 2, 3, 4}, 90, 3, 60},
+		{3, []uint64{0, 30, 60, 90}, []uint64{1, 2, 3, 4}, 110, 3, 60},
+		{3, []uint64{0, 30, 60, 90}, []uint64{1, 2, 3, 4}, 130, 4, 90},
 	}
 
 	for _, tc := range testData {
 		// 1. initializing
 
 		// store governance items to the governance db for 'tc.governanceUpdateNum' times
-		for idx := 0; idx < tc.governanceUpdateNum; idx++ {
+		for idx := 1; idx <= tc.governanceUpdateNum; idx++ {
 			config.UnitPrice = tc.unitPrices[idx]
 
 			src := GetGovernanceItemsFromChainConfig(config)
@@ -657,8 +660,8 @@ func TestGovernance_initializeCache(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, tc.unitPriceInCurrentSet, v)
 
-		assert.Equal(t, tc.blockNums, gov.idxCache[1:]) // the order should be same
-		assert.True(t, gov.itemCache.Contains(getGovernanceCacheKey(tc.blockNums[tc.governanceUpdateNum-1])))
+		assert.Equal(t, tc.blockNums, gov.idxCache) // the order should be same
+		assert.True(t, gov.itemCache.Contains(getGovernanceCacheKey(tc.blockNums[tc.governanceUpdateNum])))
 		assert.Equal(t, tc.actualGovernanceBlock, gov.actualGovernanceBlock.Load().(uint64))
 	}
 }


### PR DESCRIPTION
## Proposed changes

- By https://github.com/klaytn/klaytn/pull/1117, `g.actualGovernanceBlock` can be nil because it is only set when `governanceBlock >= governanceStateBlock`
- So, this PR initializes `g.actualGovernanceBlock` first, and then check `governanceBlock >= governanceStateBlock`.
- Also, this PR restores the currentSet import from itemCache[governanceBlock] when `governanceBlock >= governanceStateBlock`. It seems unnecessary, but I restored it for cautious. It is from https://github.com/klaytn/klaytn/pull/927.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/klaytn/klaytn/issues/1106

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
