### PR TITLE
Introduce EthTxTypeCompatible hardfork

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -928,7 +928,7 @@ func (args *EthTransactionArgs) setDefaults(ctx context.Context, b Backend) erro
 	// If user specifies both maxPriorityFee and maxFee, then we do not
 	// need to consult the chain for defaults. It's definitely a London tx.
 	if args.MaxPriorityFeePerGas == nil || args.MaxFeePerGas == nil {
-		if b.ChainConfig().IsLondon(head.Number) && args.GasPrice == nil {
+		if b.ChainConfig().IsEthTxTypeForkEnabled(head.Number) && args.GasPrice == nil {
 			if args.MaxPriorityFeePerGas == nil {
 				// TODO-Klaytn: Original logic of Ethereum uses b.SuggestTipCap which suggests TipCap, not a GasPrice.
 				// But Klaytn currently uses fixed unit price determined by Governance, so using b.SuggestPrice
@@ -963,7 +963,7 @@ func (args *EthTransactionArgs) setDefaults(ctx context.Context, b Backend) erro
 				if err != nil {
 					return err
 				}
-				if b.ChainConfig().IsLondon(head.Number) {
+				if b.ChainConfig().IsEthTxTypeForkEnabled(head.Number) {
 					// TODO-Klaytn: Klaytn is using fixed BaseFee(0) as now but
 					// if we apply dynamic BaseFee, we should add calculated BaseFee instead of params.BaseFee.
 					price.Add(price, new(big.Int).SetUint64(params.BaseFee))

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -451,9 +451,10 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 
 	// Update all fork indicator by next pending block number.
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
-	// TODO-Klaytn-AccessList: Make another hardfork for eip2718 instead of London
-	pool.eip2718 = pool.chainconfig.IsLondon(next)
-	pool.eip1559 = pool.chainconfig.IsLondon(next)
+
+	// Enable Ethereum tx type transactions
+	pool.eip2718 = pool.chainconfig.IsEthTxTypeForkEnabled(next)
+	pool.eip1559 = pool.chainconfig.IsEthTxTypeForkEnabled(next)
 }
 
 // Stop terminates the transaction pool.

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -59,6 +59,7 @@ func init() {
 	eip1559Config = &cpy
 	eip1559Config.IstanbulCompatibleBlock = common.Big0
 	eip1559Config.LondonCompatibleBlock = common.Big0
+	eip1559Config.EthTxTypeCompatibleBlock = common.Big0
 	fork.SetHardForkBlockNumberConfig(eip1559Config)
 }
 

--- a/blockchain/types/transaction_signing.go
+++ b/blockchain/types/transaction_signing.go
@@ -56,8 +56,7 @@ type sigCachePubkey struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
 
-	// TODO-Klaytn-AccessList: Make another hardfork for EIP2930Signer instead of London
-	if config.IsLondon(blockNumber) {
+	if config.IsEthTxTypeForkEnabled(blockNumber) {
 		signer = NewLondonSigner(config.ChainID)
 	} else {
 		signer = NewEIP155Signer(config.ChainID)
@@ -74,7 +73,9 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 // Use this in transaction-handling code where the current block number is unknown. If you
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
-	if config.LondonCompatibleBlock != nil {
+	// Be aware that it checks whether EthTxTypeCompatibleBlock is set,
+	// but doesn't check whether it is enabled on a specific block number.
+	if config.EthTxTypeCompatibleBlock != nil {
 		return NewLondonSigner(config.ChainID)
 	}
 

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -574,7 +574,7 @@ func TestIntrinsicGas(t *testing.T) {
 	for _, tc := range testData {
 		var (
 			data []byte // input data entered through the tx argument
-			gas  uint64 // the gas varies depending on what comes in as a condition(contractCreate & IsIstanbul)
+			gas  uint64 // the gas varies depending on what comes in as a condition(contractCreate & IsIstanbulForkEnabled)
 			err  error  // in this unittest, every testcase returns nil error.
 		)
 

--- a/blockchain/vm/runtime/runtime.go
+++ b/blockchain/vm/runtime/runtime.go
@@ -58,9 +58,10 @@ type Config struct {
 func setDefaults(cfg *Config) {
 	if cfg.ChainConfig == nil {
 		cfg.ChainConfig = &params.ChainConfig{
-			ChainID:                 big.NewInt(1),
-			IstanbulCompatibleBlock: new(big.Int),
-			LondonCompatibleBlock:   new(big.Int),
+			ChainID:                  big.NewInt(1),
+			IstanbulCompatibleBlock:  new(big.Int),
+			LondonCompatibleBlock:    new(big.Int),
+			EthTxTypeCompatibleBlock: new(big.Int),
 		}
 	}
 

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -508,6 +508,7 @@ func gen(ctx *cli.Context) error {
 
 	genesisJson.Config.IstanbulCompatibleBlock = big.NewInt(ctx.Int64(istanbulCompatibleBlockNumberFlag.Name))
 	genesisJson.Config.LondonCompatibleBlock = big.NewInt(ctx.Int64(londonCompatibleBlockNumberFlag.Name))
+	genesisJson.Config.EthTxTypeCompatibleBlock = big.NewInt(ctx.Int64(ethTxTypeCompatibleBlockNumberFlag.Name))
 
 	genesisJsonBytes, _ = json.MarshalIndent(genesisJson, "", "    ")
 	genValidatorKeystore(privKeys)

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -335,4 +335,10 @@ var (
 		Usage: "londonCompatible blockNumber",
 		Value: 0,
 	}
+
+	ethTxTypeCompatibleBlockNumberFlag = cli.Int64Flag{
+		Name:  "eth-tx-type-compatible-blocknumber",
+		Usage: "ethTxTypeCompatible blockNumber",
+		Value: 0,
+	}
 )

--- a/params/config.go
+++ b/params/config.go
@@ -39,10 +39,11 @@ var (
 var (
 	// CypressChainConfig is the chain parameters to run a node on the cypress main network.
 	CypressChainConfig = &ChainConfig{
-		ChainID:                 big.NewInt(int64(CypressNetworkId)),
-		IstanbulCompatibleBlock: nil,
-		LondonCompatibleBlock:   nil,
-		DeriveShaImpl:           2,
+		ChainID:                  big.NewInt(int64(CypressNetworkId)),
+		IstanbulCompatibleBlock:  nil,
+		LondonCompatibleBlock:    nil,
+		EthTxTypeCompatibleBlock: nil,
+		DeriveShaImpl:            2,
 		Governance: &GovernanceConfig{
 			GoverningNode:  common.HexToAddress("0x52d41ca72af615a1ac3301b0a93efa222ecc7541"),
 			GovernanceMode: "single",
@@ -66,10 +67,11 @@ var (
 
 	// BaobabChainConfig contains the chain parameters to run a node on the Baobab test network.
 	BaobabChainConfig = &ChainConfig{
-		ChainID:                 big.NewInt(int64(BaobabNetworkId)),
-		IstanbulCompatibleBlock: big.NewInt(75373312),
-		LondonCompatibleBlock:   big.NewInt(80295291),
-		DeriveShaImpl:           2,
+		ChainID:                  big.NewInt(int64(BaobabNetworkId)),
+		IstanbulCompatibleBlock:  big.NewInt(75373312),
+		LondonCompatibleBlock:    big.NewInt(80295291),
+		EthTxTypeCompatibleBlock: nil,
+		DeriveShaImpl:            2,
 		Governance: &GovernanceConfig{
 			GoverningNode:  common.HexToAddress("0x99fb17d324fa0e07f23b49d09028ac0919414db6"),
 			GovernanceMode: "single",
@@ -165,8 +167,9 @@ type ChainConfig struct {
 
 	// "Compatible" means that it is EVM compatible(the opcode and precompiled contracts are the same as Ethereum EVM).
 	// In other words, not all the hard fork items are included.
-	IstanbulCompatibleBlock *big.Int `json:"istanbulCompatibleBlock,omitempty"` // IstanbulCompatibleBlock switch block (nil = no fork, 0 = already on istanbul)
-	LondonCompatibleBlock   *big.Int `json:"londonCompatibleBlock,omitempty"`   // LondonCompatibleBlock switch block (nil = no fork, 0 = already on london)
+	IstanbulCompatibleBlock  *big.Int `json:"istanbulCompatibleBlock,omitempty"`  // IstanbulCompatibleBlock switch block (nil = no fork, 0 = already on istanbul)
+	LondonCompatibleBlock    *big.Int `json:"londonCompatibleBlock,omitempty"`    // LondonCompatibleBlock switch block (nil = no fork, 0 = already on london)
+	EthTxTypeCompatibleBlock *big.Int `json:"ethTxTypeCompatibleBlock,omitempty"` // EthTxTypeCompatibleBlock switch block (nil = no fork, 0 = already on ethTxType)
 
 	// Various consensus engines
 	Gxhash   *GxhashConfig   `json:"gxhash,omitempty"` // (deprecated) not supported engine
@@ -246,20 +249,22 @@ func (c *ChainConfig) String() string {
 		engine = "unknown"
 	}
 	if c.Istanbul != nil {
-		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v SubGroupSize: %d UnitPrice: %d DeriveShaImpl: %d Engine: %v}",
+		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v SubGroupSize: %d UnitPrice: %d DeriveShaImpl: %d Engine: %v}",
 			c.ChainID,
 			c.IstanbulCompatibleBlock,
 			c.LondonCompatibleBlock,
+			c.EthTxTypeCompatibleBlock,
 			c.Istanbul.SubGroupSize,
 			c.UnitPrice,
 			c.DeriveShaImpl,
 			engine,
 		)
 	} else {
-		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v UnitPrice: %d DeriveShaImpl: %d Engine: %v }",
+		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v UnitPrice: %d DeriveShaImpl: %d Engine: %v }",
 			c.ChainID,
 			c.IstanbulCompatibleBlock,
 			c.LondonCompatibleBlock,
+			c.EthTxTypeCompatibleBlock,
 			c.UnitPrice,
 			c.DeriveShaImpl,
 			engine,
@@ -267,14 +272,19 @@ func (c *ChainConfig) String() string {
 	}
 }
 
-// IsIstanbul returns whether num is either equal to the istanbul block or greater.
-func (c *ChainConfig) IsIstanbul(num *big.Int) bool {
+// IsIstanbulForkEnabled returns whether num is either equal to the istanbul block or greater.
+func (c *ChainConfig) IsIstanbulForkEnabled(num *big.Int) bool {
 	return isForked(c.IstanbulCompatibleBlock, num)
 }
 
-// IsLondon returns whether num is either equal to the london block or greater.
-func (c *ChainConfig) IsLondon(num *big.Int) bool {
+// IsLondonForkEnabled returns whether num is either equal to the london block or greater.
+func (c *ChainConfig) IsLondonForkEnabled(num *big.Int) bool {
 	return isForked(c.LondonCompatibleBlock, num)
+}
+
+// IsEthTxTypeForkEnabled returns whether num is either equal to the ethTxType block or greater.
+func (c *ChainConfig) IsEthTxTypeForkEnabled(num *big.Int) bool {
+	return isForked(c.EthTxTypeCompatibleBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -307,6 +317,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 	for _, cur := range []fork{
 		{name: "istanbulBlock", block: c.IstanbulCompatibleBlock},
 		{name: "londonBlock", block: c.LondonCompatibleBlock},
+		{name: "ethTxTypeBlock", block: c.EthTxTypeCompatibleBlock},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -335,6 +346,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	}
 	if isForkIncompatible(c.LondonCompatibleBlock, newcfg.LondonCompatibleBlock, head) {
 		return newCompatError("London Block", c.LondonCompatibleBlock, newcfg.LondonCompatibleBlock)
+	}
+	if isForkIncompatible(c.EthTxTypeCompatibleBlock, newcfg.EthTxTypeCompatibleBlock, head) {
+		return newCompatError("EthTxType Block", c.EthTxTypeCompatibleBlock, newcfg.EthTxTypeCompatibleBlock)
 	}
 	return nil
 }
@@ -460,8 +474,8 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 	}
 	return Rules{
 		ChainID:    new(big.Int).Set(chainID),
-		IsIstanbul: c.IsIstanbul(num),
-		IsLondon:   c.IsLondon(num),
+		IsIstanbul: c.IsIstanbulForkEnabled(num),
+		IsLondon:   c.IsLondonForkEnabled(num),
 	}
 }
 

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -425,6 +425,7 @@ func TestDefaultTxsWithDefaultAccountKey(t *testing.T) {
 	}
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	prof.Profile("main_init_blockchain", time.Now().Sub(start))
 	defer bcdata.Shutdown()
 

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -106,6 +106,7 @@ func TestGasCalculation(t *testing.T) {
 	assert.Equal(t, nil, err)
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	prof.Profile("main_init_blockchain", time.Now().Sub(start))
 
 	defer bcdata.Shutdown()

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -131,6 +131,7 @@ func TestValidationPoolInsert(t *testing.T) {
 	}
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	defer bcdata.Shutdown()
 
 	// Initialize address-balance map for verification
@@ -256,6 +257,7 @@ func TestValidationBlockTx(t *testing.T) {
 	}
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	defer bcdata.Shutdown()
 
 	// Initialize address-balance map for verification
@@ -439,6 +441,7 @@ func TestValidationInvalidSig(t *testing.T) {
 	}
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	defer bcdata.Shutdown()
 
 	// Initialize address-balance map for verification
@@ -651,6 +654,7 @@ func TestInvalidBalance(t *testing.T) {
 	}
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	defer bcdata.Shutdown()
 
 	// Initialize address-balance map for verification
@@ -1045,6 +1049,7 @@ func TestInvalidBalanceBlockTx(t *testing.T) {
 	}
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	defer bcdata.Shutdown()
 
 	// Initialize address-balance map for verification
@@ -1453,6 +1458,7 @@ func TestValidationTxSizeAfterRLP(t *testing.T) {
 	}
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	defer bcdata.Shutdown()
 
 	// Initialize address-balance map for verification
@@ -1611,6 +1617,7 @@ func TestValidationPoolResetAfterSenderKeyChange(t *testing.T) {
 	}
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	defer bcdata.Shutdown()
 
 	// Initialize address-balance map for verification


### PR DESCRIPTION
## Proposed changes

- Introduce the EthTxTypeCompatible hardfork that enables Ethereum tx types: TxTypeEthereumAccessList and TxTypeEthereumDynamicFee 
- The hardfork should be enabled after London hardfork and the order is guaranteed by `CheckConfigForkOrder`. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
