### PR TITLE
Added baseFeePerGas field in API return

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -721,6 +721,10 @@ func (fb *filterBackend) ServiceFilter(_ context.Context, _ *bloombits.MatcherSe
 	panic("not supported")
 }
 
+func (fb *filterBackend) ChainConfig() *params.ChainConfig {
+	return fb.bc.Config()
+}
+
 func nullSubscription() event.Subscription {
 	return event.NewSubscription(func(quit <-chan struct{}) error {
 		<-quit

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -423,7 +423,7 @@ func (api *EthereumAPI) GetProof(ctx context.Context, address common.Address, st
 // * When blockNr is -2 the pending chain head is returned.
 func (api *EthereumAPI) GetHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (map[string]interface{}, error) {
 	// In Ethereum, err is always nil because the backend of Ethereum always return nil.
-	klaytnHeader, _ := api.publicBlockChainAPI.GetHeaderByNumber(ctx, number)
+	klaytnHeader, _ := api.publicBlockChainAPI.b.HeaderByNumber(ctx, number)
 	if klaytnHeader != nil {
 		response, err := api.rpcMarshalHeader(klaytnHeader)
 		if err != nil {
@@ -443,7 +443,7 @@ func (api *EthereumAPI) GetHeaderByNumber(ctx context.Context, number rpc.BlockN
 // GetHeaderByHash returns the requested header by hash.
 func (api *EthereumAPI) GetHeaderByHash(ctx context.Context, hash common.Hash) map[string]interface{} {
 	// In Ethereum, err is always nil because the backend of Ethereum always return nil.
-	klaytnHeader, _ := api.publicBlockChainAPI.GetHeaderByHash(ctx, hash)
+	klaytnHeader, _ := api.publicBlockChainAPI.b.HeaderByHash(ctx, hash)
 	if klaytnHeader != nil {
 		response, err := api.rpcMarshalHeader(klaytnHeader)
 		if err != nil {

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -176,7 +176,7 @@ func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[strin
 		"hash":             head.Hash(),
 	}
 
-	if head.Vote != nil {
+	if len(head.Vote) != 0 {
 		result["voteData"] = hexutil.Bytes(head.Vote)
 	}
 

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -165,11 +165,11 @@ func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[strin
 		"transactionsRoot": head.TxHash,
 		"receiptsRoot":     head.ReceiptHash,
 		"logsBloom":        head.Bloom,
-		"blockScore":       head.BlockScore,
+		"blockScore":       (*hexutil.Big)(head.BlockScore),
 		"number":           (*hexutil.Big)(head.Number),
 		"gasUsed":          hexutil.Uint64(head.GasUsed),
 		"timestamp":        (*hexutil.Big)(head.Time),
-		"timestampFoS":     head.TimeFoS,
+		"timestampFoS":     hexutil.Uint64(head.TimeFoS),
 		"extraData":        hexutil.Bytes(head.Extra),
 		"governanceData":   hexutil.Bytes(head.Governance),
 		"hash":             head.Hash(),
@@ -180,7 +180,7 @@ func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[strin
 	}
 
 	if isEnabledEthTxTypeFork {
-		result["baseFeePerGas"] = params.BaseFee
+		result["baseFeePerGas"] = hexutil.Uint64(params.BaseFee)
 	}
 
 	return result

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -513,7 +513,7 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 	return formatted
 }
 
-func RpcOutputBlock(b *types.Block, td *big.Int, inclTx bool, fullTx bool) (map[string]interface{}, error) {
+func RpcOutputBlock(b *types.Block, td *big.Int, inclTx bool, fullTx bool, isEnabledEthTxTypeFork bool) (map[string]interface{}, error) {
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
@@ -557,6 +557,10 @@ func RpcOutputBlock(b *types.Block, td *big.Int, inclTx bool, fullTx bool) (map[
 		fields["transactions"] = transactions
 	}
 
+	if isEnabledEthTxTypeFork {
+		fields["baseFeePerGas"] = (*hexutil.Big)(new(big.Int).SetUint64(params.BaseFee))
+	}
+
 	return fields, nil
 }
 
@@ -564,7 +568,7 @@ func RpcOutputBlock(b *types.Block, td *big.Int, inclTx bool, fullTx bool) (map[
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
 func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
-	return RpcOutputBlock(b, s.b.GetTd(b.Hash()), inclTx, fullTx)
+	return RpcOutputBlock(b, s.b.GetTd(b.Hash()), inclTx, fullTx, s.b.ChainConfig().IsEthTxTypeForkEnabled(b.Header().Number))
 }
 
 func getFrom(tx *types.Transaction) common.Address {

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -158,6 +158,7 @@ func (s *PublicBlockChainAPI) rpcMarshalHeader(header *types.Header) map[string]
 
 // RPCMarshalHeader converts the given header to the RPC output that includes the baseFeePerGas field.
 func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[string]interface{} {
+	fmt.Printf("head.TimeFoS: %v / hexutil.Uint(head.TimeFoS): %v / hexutil.Uint64(head.TimeFoS): %v \n", head.TimeFoS, hexutil.Uint(head.TimeFoS), hexutil.Uint64(head.TimeFoS))
 	result := map[string]interface{}{
 		"parentHash":       head.ParentHash,
 		"reward":           head.Rewardbase,
@@ -180,7 +181,7 @@ func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[strin
 	}
 
 	if isEnabledEthTxTypeFork {
-		result["baseFeePerGas"] = hexutil.Uint64(params.BaseFee)
+		result["baseFeePerGas"] = (*hexutil.Big)(new(big.Int).SetUint64(params.BaseFee))
 	}
 
 	return result

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -158,7 +158,7 @@ func (s *PublicBlockChainAPI) rpcMarshalHeader(header *types.Header) map[string]
 }
 
 // RPCMarshalHeader converts the given header to the RPC output .
-func RPCMarshalHeader(head *types.Header, isEnabledEthFork bool) map[string]interface{} {
+func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[string]interface{} {
 	result := map[string]interface{}{
 		"parentHash":       head.ParentHash,
 		"reward":           head.Rewardbase,
@@ -180,7 +180,7 @@ func RPCMarshalHeader(head *types.Header, isEnabledEthFork bool) map[string]inte
 		result["voteData"] = hexutil.Bytes(head.Vote)
 	}
 
-	if isEnabledEthFork {
+	if isEnabledEthTxTypeFork {
 		result["baseFeePerGas"] = params.BaseFee
 	}
 

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -150,14 +150,13 @@ func (s *PublicBlockChainAPI) GetAccount(ctx context.Context, address common.Add
 	return serAcc, state.Error()
 }
 
-// rpcMarshalHeader uses the generalized output filler, then adds the total difficulty field, which requires
-// a `PublicBlockchainAPI`.
+// rpcMarshalHeader converts the given header to the RPC output.
 func (s *PublicBlockChainAPI) rpcMarshalHeader(header *types.Header) map[string]interface{} {
 	fields := RPCMarshalHeader(header, s.b.ChainConfig().IsEthTxTypeForkEnabled(header.Number))
 	return fields
 }
 
-// RPCMarshalHeader converts the given header to the RPC output .
+// RPCMarshalHeader converts the given header to the RPC output that includes the baseFeePerGas field.
 func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[string]interface{} {
 	result := map[string]interface{}{
 		"parentHash":       head.ParentHash,

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -26,6 +26,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/klaytn/klaytn/node/cn/filters"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/types/account"
@@ -152,38 +154,8 @@ func (s *PublicBlockChainAPI) GetAccount(ctx context.Context, address common.Add
 
 // rpcMarshalHeader converts the given header to the RPC output.
 func (s *PublicBlockChainAPI) rpcMarshalHeader(header *types.Header) map[string]interface{} {
-	fields := RPCMarshalHeader(header, s.b.ChainConfig().IsEthTxTypeForkEnabled(header.Number))
+	fields := filters.RPCMarshalHeader(header, s.b.ChainConfig().IsEthTxTypeForkEnabled(header.Number))
 	return fields
-}
-
-// RPCMarshalHeader converts the given header to the RPC output that includes the baseFeePerGas field.
-func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[string]interface{} {
-	result := map[string]interface{}{
-		"parentHash":       head.ParentHash,
-		"reward":           head.Rewardbase,
-		"stateRoot":        head.Root,
-		"transactionsRoot": head.TxHash,
-		"receiptsRoot":     head.ReceiptHash,
-		"logsBloom":        head.Bloom,
-		"blockScore":       (*hexutil.Big)(head.BlockScore),
-		"number":           (*hexutil.Big)(head.Number),
-		"gasUsed":          hexutil.Uint64(head.GasUsed),
-		"timestamp":        (*hexutil.Big)(head.Time),
-		"timestampFoS":     hexutil.Uint(head.TimeFoS),
-		"extraData":        hexutil.Bytes(head.Extra),
-		"governanceData":   hexutil.Bytes(head.Governance),
-		"hash":             head.Hash(),
-	}
-
-	if len(head.Vote) != 0 {
-		result["voteData"] = hexutil.Bytes(head.Vote)
-	}
-
-	if isEnabledEthTxTypeFork {
-		result["baseFeePerGas"] = (*hexutil.Big)(new(big.Int).SetUint64(params.BaseFee))
-	}
-
-	return result
 }
 
 // GetHeaderByNumber returns the requested canonical block header.

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -169,7 +169,7 @@ func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[strin
 		"number":           (*hexutil.Big)(head.Number),
 		"gasUsed":          hexutil.Uint64(head.GasUsed),
 		"timestamp":        (*hexutil.Big)(head.Time),
-		"timestampFoS":     hexutil.Uint64(head.TimeFoS),
+		"timestampFoS":     hexutil.Uint(head.TimeFoS),
 		"extraData":        hexutil.Bytes(head.Extra),
 		"governanceData":   hexutil.Bytes(head.Governance),
 		"hash":             head.Hash(),

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -158,7 +158,6 @@ func (s *PublicBlockChainAPI) rpcMarshalHeader(header *types.Header) map[string]
 
 // RPCMarshalHeader converts the given header to the RPC output that includes the baseFeePerGas field.
 func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[string]interface{} {
-	fmt.Printf("head.TimeFoS: %v / hexutil.Uint(head.TimeFoS): %v / hexutil.Uint64(head.TimeFoS): %v \n", head.TimeFoS, hexutil.Uint(head.TimeFoS), hexutil.Uint64(head.TimeFoS))
 	result := map[string]interface{}{
 		"parentHash":       head.ParentHash,
 		"reward":           head.Rewardbase,

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -350,7 +350,7 @@ func (api *APIExtension) makeRPCBlockOutput(b *types.Block,
 	if bc, ok := api.chain.(*blockchain.BlockChain); ok {
 		td = bc.GetTd(hash, b.NumberU64())
 	}
-	r, err := klaytnApi.RpcOutputBlock(b, td, false, false)
+	r, err := klaytnApi.RpcOutputBlock(b, td, false, false, api.chain.Config().IsEthTxTypeForkEnabled(b.Header().Number))
 	if err != nil {
 		logger.Error("failed to RpcOutputBlock", "err", err)
 		return nil

--- a/datasync/chaindatafetcher/kafka/utils.go
+++ b/datasync/chaindatafetcher/kafka/utils.go
@@ -71,7 +71,7 @@ func makeBlockGroupOutput(blockchain *blockchain.BlockChain, block *types.Block,
 		logger.Error("Getting the proposer and validators failed.", "blockHash", hash, "err", err)
 	}
 	td := blockchain.GetTd(hash, block.NumberU64())
-	r, _ := klaytnApi.RpcOutputBlock(block, td, false, false)
+	r, _ := klaytnApi.RpcOutputBlock(block, td, false, false, blockchain.Config().IsEthTxTypeForkEnabled(block.Header().Number))
 
 	// make transactions
 	transactions := block.Transactions()

--- a/node/cn/filters/api.go
+++ b/node/cn/filters/api.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/klaytn/klaytn/params"
+
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -207,6 +209,36 @@ func (api *PublicFilterAPI) NewBlockFilter() rpc.ID {
 	return headerSub.ID
 }
 
+// RPCMarshalHeader converts the given header to the RPC output that includes the baseFeePerGas field.
+func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[string]interface{} {
+	result := map[string]interface{}{
+		"parentHash":       head.ParentHash,
+		"reward":           head.Rewardbase,
+		"stateRoot":        head.Root,
+		"transactionsRoot": head.TxHash,
+		"receiptsRoot":     head.ReceiptHash,
+		"logsBloom":        head.Bloom,
+		"blockScore":       (*hexutil.Big)(head.BlockScore),
+		"number":           (*hexutil.Big)(head.Number),
+		"gasUsed":          hexutil.Uint64(head.GasUsed),
+		"timestamp":        (*hexutil.Big)(head.Time),
+		"timestampFoS":     hexutil.Uint(head.TimeFoS),
+		"extraData":        hexutil.Bytes(head.Extra),
+		"governanceData":   hexutil.Bytes(head.Governance),
+		"hash":             head.Hash(),
+	}
+
+	if len(head.Vote) != 0 {
+		result["voteData"] = hexutil.Bytes(head.Vote)
+	}
+
+	if isEnabledEthTxTypeFork {
+		result["baseFeePerGas"] = (*hexutil.Big)(new(big.Int).SetUint64(params.BaseFee))
+	}
+
+	return result
+}
+
 // NewHeads send a notification each time a new (header) block is appended to the chain.
 func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)
@@ -223,7 +255,8 @@ func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, er
 		for {
 			select {
 			case h := <-headers:
-				notifier.Notify(rpcSub.ID, h)
+				header := RPCMarshalHeader(h, api.backend.ChainConfig().IsEthTxTypeForkEnabled(h.Number))
+				notifier.Notify(rpcSub.ID, header)
 			case <-rpcSub.Err():
 				headersSub.Unsubscribe()
 				return

--- a/node/cn/filters/filter.go
+++ b/node/cn/filters/filter.go
@@ -27,6 +27,8 @@ import (
 	"math/big"
 	"strconv"
 
+	"github.com/klaytn/klaytn/params"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/bloombits"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -51,6 +53,8 @@ type Backend interface {
 
 	BloomStatus() (uint64, uint64)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)
+
+	ChainConfig() *params.ChainConfig
 }
 
 // Filter can be used to retrieve and filter logs.

--- a/node/cn/filters/filter_system_test.go
+++ b/node/cn/filters/filter_system_test.go
@@ -42,13 +42,14 @@ import (
 )
 
 type testBackend struct {
-	mux        *event.TypeMux
-	db         database.DBManager
-	sections   uint64
-	txFeed     *event.Feed
-	rmLogsFeed *event.Feed
-	logsFeed   *event.Feed
-	chainFeed  *event.Feed
+	mux         *event.TypeMux
+	db          database.DBManager
+	sections    uint64
+	txFeed      *event.Feed
+	rmLogsFeed  *event.Feed
+	logsFeed    *event.Feed
+	chainFeed   *event.Feed
+	chainConfig *params.ChainConfig
 }
 
 /*
@@ -162,6 +163,10 @@ func (b *testBackend) ServiceFilter(ctx context.Context, session *bloombits.Matc
 	}()
 }
 
+func (b *testBackend) ChainConfig() *params.ChainConfig {
+	return b.chainConfig
+}
+
 // TestBlockSubscription tests if a block subscription returns block hashes for posted chain events.
 // It creates multiple subscriptions:
 // - one at the start and should receive all posted chain events and a second (blockHashes)
@@ -177,7 +182,7 @@ func TestBlockSubscription(t *testing.T) {
 		rmLogsFeed  = new(event.Feed)
 		logsFeed    = new(event.Feed)
 		chainFeed   = new(event.Feed)
-		backend     = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend     = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
 		api         = NewPublicFilterAPI(backend, false)
 		genesis     = new(blockchain.Genesis).MustCommit(db)
 		chain, _    = blockchain.GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), db, 10, func(i int, gen *blockchain.BlockGen) {})
@@ -234,7 +239,7 @@ func TestPendingTxFilter(t *testing.T) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
 		api        = NewPublicFilterAPI(backend, false)
 
 		transactions = []*types.Transaction{
@@ -294,7 +299,7 @@ func TestLogFilterCreation(t *testing.T) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
 		api        = NewPublicFilterAPI(backend, false)
 
 		testCases = []struct {
@@ -343,7 +348,7 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
 		api        = NewPublicFilterAPI(backend, false)
 	)
 
@@ -403,7 +408,7 @@ func TestLogFilter(t *testing.T) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
 		api        = NewPublicFilterAPI(backend, false)
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")
@@ -522,7 +527,7 @@ func TestPendingLogsSubscription(t *testing.T) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
 		api        = NewPublicFilterAPI(backend, false)
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")

--- a/node/cn/filters/filter_test.go
+++ b/node/cn/filters/filter_test.go
@@ -169,7 +169,7 @@ func BenchmarkFilters(b *testing.B) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
 		key1, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr1      = crypto.PubkeyToAddress(key1.PublicKey)
 		addr2      = common.BytesToAddress([]byte("jeff"))
@@ -232,7 +232,7 @@ func TestFilters(t *testing.T) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
 		key1, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr       = crypto.PubkeyToAddress(key1.PublicKey)
 

--- a/node/cn/filters/mock/backend_mock.go
+++ b/node/cn/filters/mock/backend_mock.go
@@ -15,33 +15,34 @@ import (
 	common "github.com/klaytn/klaytn/common"
 	event "github.com/klaytn/klaytn/event"
 	rpc "github.com/klaytn/klaytn/networks/rpc"
+	params "github.com/klaytn/klaytn/params"
 	database "github.com/klaytn/klaytn/storage/database"
 )
 
-// MockBackend is a mock of Backend interface
+// MockBackend is a mock of Backend interface.
 type MockBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackendMockRecorder
 }
 
-// MockBackendMockRecorder is the mock recorder for MockBackend
+// MockBackendMockRecorder is the mock recorder for MockBackend.
 type MockBackendMockRecorder struct {
 	mock *MockBackend
 }
 
-// NewMockBackend creates a new mock instance
+// NewMockBackend creates a new mock instance.
 func NewMockBackend(ctrl *gomock.Controller) *MockBackend {
 	mock := &MockBackend{ctrl: ctrl}
 	mock.recorder = &MockBackendMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 	return m.recorder
 }
 
-// BloomStatus mocks base method
+// BloomStatus mocks base method.
 func (m *MockBackend) BloomStatus() (uint64, uint64) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BloomStatus")
@@ -50,13 +51,27 @@ func (m *MockBackend) BloomStatus() (uint64, uint64) {
 	return ret0, ret1
 }
 
-// BloomStatus indicates an expected call of BloomStatus
+// BloomStatus indicates an expected call of BloomStatus.
 func (mr *MockBackendMockRecorder) BloomStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BloomStatus", reflect.TypeOf((*MockBackend)(nil).BloomStatus))
 }
 
-// ChainDB mocks base method
+// ChainConfig mocks base method.
+func (m *MockBackend) ChainConfig() *params.ChainConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChainConfig")
+	ret0, _ := ret[0].(*params.ChainConfig)
+	return ret0
+}
+
+// ChainConfig indicates an expected call of ChainConfig.
+func (mr *MockBackendMockRecorder) ChainConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainConfig", reflect.TypeOf((*MockBackend)(nil).ChainConfig))
+}
+
+// ChainDB mocks base method.
 func (m *MockBackend) ChainDB() database.DBManager {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChainDB")
@@ -64,13 +79,13 @@ func (m *MockBackend) ChainDB() database.DBManager {
 	return ret0
 }
 
-// ChainDB indicates an expected call of ChainDB
+// ChainDB indicates an expected call of ChainDB.
 func (mr *MockBackendMockRecorder) ChainDB() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainDB", reflect.TypeOf((*MockBackend)(nil).ChainDB))
 }
 
-// EventMux mocks base method
+// EventMux mocks base method.
 func (m *MockBackend) EventMux() *event.TypeMux {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EventMux")
@@ -78,13 +93,13 @@ func (m *MockBackend) EventMux() *event.TypeMux {
 	return ret0
 }
 
-// EventMux indicates an expected call of EventMux
+// EventMux indicates an expected call of EventMux.
 func (mr *MockBackendMockRecorder) EventMux() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventMux", reflect.TypeOf((*MockBackend)(nil).EventMux))
 }
 
-// GetBlockReceipts mocks base method
+// GetBlockReceipts mocks base method.
 func (m *MockBackend) GetBlockReceipts(arg0 context.Context, arg1 common.Hash) types.Receipts {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockReceipts", arg0, arg1)
@@ -92,13 +107,13 @@ func (m *MockBackend) GetBlockReceipts(arg0 context.Context, arg1 common.Hash) t
 	return ret0
 }
 
-// GetBlockReceipts indicates an expected call of GetBlockReceipts
+// GetBlockReceipts indicates an expected call of GetBlockReceipts.
 func (mr *MockBackendMockRecorder) GetBlockReceipts(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockReceipts", reflect.TypeOf((*MockBackend)(nil).GetBlockReceipts), arg0, arg1)
 }
 
-// GetLogs mocks base method
+// GetLogs mocks base method.
 func (m *MockBackend) GetLogs(arg0 context.Context, arg1 common.Hash) ([][]*types.Log, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1)
@@ -107,13 +122,13 @@ func (m *MockBackend) GetLogs(arg0 context.Context, arg1 common.Hash) ([][]*type
 	return ret0, ret1
 }
 
-// GetLogs indicates an expected call of GetLogs
+// GetLogs indicates an expected call of GetLogs.
 func (mr *MockBackendMockRecorder) GetLogs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockBackend)(nil).GetLogs), arg0, arg1)
 }
 
-// HeaderByNumber mocks base method
+// HeaderByNumber mocks base method.
 func (m *MockBackend) HeaderByNumber(arg0 context.Context, arg1 rpc.BlockNumber) (*types.Header, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HeaderByNumber", arg0, arg1)
@@ -122,25 +137,25 @@ func (m *MockBackend) HeaderByNumber(arg0 context.Context, arg1 rpc.BlockNumber)
 	return ret0, ret1
 }
 
-// HeaderByNumber indicates an expected call of HeaderByNumber
+// HeaderByNumber indicates an expected call of HeaderByNumber.
 func (mr *MockBackendMockRecorder) HeaderByNumber(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByNumber", reflect.TypeOf((*MockBackend)(nil).HeaderByNumber), arg0, arg1)
 }
 
-// ServiceFilter mocks base method
+// ServiceFilter mocks base method.
 func (m *MockBackend) ServiceFilter(arg0 context.Context, arg1 *bloombits.MatcherSession) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ServiceFilter", arg0, arg1)
 }
 
-// ServiceFilter indicates an expected call of ServiceFilter
+// ServiceFilter indicates an expected call of ServiceFilter.
 func (mr *MockBackendMockRecorder) ServiceFilter(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceFilter", reflect.TypeOf((*MockBackend)(nil).ServiceFilter), arg0, arg1)
 }
 
-// SubscribeChainEvent mocks base method
+// SubscribeChainEvent mocks base method.
 func (m *MockBackend) SubscribeChainEvent(arg0 chan<- blockchain.ChainEvent) event.Subscription {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeChainEvent", arg0)
@@ -148,13 +163,13 @@ func (m *MockBackend) SubscribeChainEvent(arg0 chan<- blockchain.ChainEvent) eve
 	return ret0
 }
 
-// SubscribeChainEvent indicates an expected call of SubscribeChainEvent
+// SubscribeChainEvent indicates an expected call of SubscribeChainEvent.
 func (mr *MockBackendMockRecorder) SubscribeChainEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeChainEvent", reflect.TypeOf((*MockBackend)(nil).SubscribeChainEvent), arg0)
 }
 
-// SubscribeLogsEvent mocks base method
+// SubscribeLogsEvent mocks base method.
 func (m *MockBackend) SubscribeLogsEvent(arg0 chan<- []*types.Log) event.Subscription {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeLogsEvent", arg0)
@@ -162,13 +177,13 @@ func (m *MockBackend) SubscribeLogsEvent(arg0 chan<- []*types.Log) event.Subscri
 	return ret0
 }
 
-// SubscribeLogsEvent indicates an expected call of SubscribeLogsEvent
+// SubscribeLogsEvent indicates an expected call of SubscribeLogsEvent.
 func (mr *MockBackendMockRecorder) SubscribeLogsEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeLogsEvent", reflect.TypeOf((*MockBackend)(nil).SubscribeLogsEvent), arg0)
 }
 
-// SubscribeNewTxsEvent mocks base method
+// SubscribeNewTxsEvent mocks base method.
 func (m *MockBackend) SubscribeNewTxsEvent(arg0 chan<- blockchain.NewTxsEvent) event.Subscription {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeNewTxsEvent", arg0)
@@ -176,13 +191,13 @@ func (m *MockBackend) SubscribeNewTxsEvent(arg0 chan<- blockchain.NewTxsEvent) e
 	return ret0
 }
 
-// SubscribeNewTxsEvent indicates an expected call of SubscribeNewTxsEvent
+// SubscribeNewTxsEvent indicates an expected call of SubscribeNewTxsEvent.
 func (mr *MockBackendMockRecorder) SubscribeNewTxsEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeNewTxsEvent", reflect.TypeOf((*MockBackend)(nil).SubscribeNewTxsEvent), arg0)
 }
 
-// SubscribeRemovedLogsEvent mocks base method
+// SubscribeRemovedLogsEvent mocks base method.
 func (m *MockBackend) SubscribeRemovedLogsEvent(arg0 chan<- blockchain.RemovedLogsEvent) event.Subscription {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeRemovedLogsEvent", arg0)
@@ -190,7 +205,7 @@ func (m *MockBackend) SubscribeRemovedLogsEvent(arg0 chan<- blockchain.RemovedLo
 	return ret0
 }
 
-// SubscribeRemovedLogsEvent indicates an expected call of SubscribeRemovedLogsEvent
+// SubscribeRemovedLogsEvent indicates an expected call of SubscribeRemovedLogsEvent.
 func (mr *MockBackendMockRecorder) SubscribeRemovedLogsEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeRemovedLogsEvent", reflect.TypeOf((*MockBackend)(nil).SubscribeRemovedLogsEvent), arg0)

--- a/node/sc/local_backend.go
+++ b/node/sc/local_backend.go
@@ -338,3 +338,7 @@ func (fb *filterLocalBackend) ServiceFilter(ctx context.Context, session *bloomb
 	//	go session.Multiplex(bloomRetrievalBatch, bloomRetrievalWait, backend.bloomRequests)
 	//}
 }
+
+func (fb *filterLocalBackend) ChainConfig() *params.ChainConfig {
+	return fb.subbridge.blockchain.Config()
+}


### PR DESCRIPTION
## Proposed changes

This PR introduces adding `baseFeePerGas` field in `klay_getHeaderByHash` and `klay_getHeaderByNumber`.

To test this, i used the corecell project and enabled `ethTxTypeCompatibleBlock` in `genesis.json` file.

```
> klay.getHeaderByNumber('latest')
{
  baseFeePerGas: "0x0",
  blockScore: "0x1",
  extraData: "0xda830...",
  gasUsed: "0x0",
  governanceData: "0x",
  hash: "0x4f417b2a72c9bd0d0fa67da900340a2e170633d88945e0b949fb8b0bbdf83c3c",
  logsBloom: "0x00000...",
  number: "0x13",
  parentHash: "0xb940e9974b38d8c2ba13e6ac340d3ac5e246aaccdfa7ae9adec17f0a7a5106cc",
  receiptsRoot: "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
  reward: "0x4b2c736fd05c2e2da3ccbd001a395a444f16a861",
  stateRoot: "0xf2d7d66ac2a235945a43570d78cd382d7a812f452deceb08a2bbebbde554c34f",
  timestamp: "0x620ca3fa",
  timestampFoS: "0x3b",
  transactionsRoot: "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
}
```

```
> klay.getBlock('latest')
{
  baseFeePerGas: "0x0",
  blockscore: "0x1",
  extraData: "0xda830...",
  gasUsed: 0,
  governanceData: "0x",
  hash: "0x3aaf61ce21fcd9aebfca9778117b1641826920f7e5db0171fd1f512d6fe144be",
  logsBloom: "0x00000...",
  number: 40,
  parentHash: "0xd6822d4b1403bff1e8162aa91ee0b265d8c2df8b4c07593e43f454b23bf65ee1",
  receiptsRoot: "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
  reward: "0x4b2c736fd05c2e2da3ccbd001a395a444f16a861",
  size: 624,
  stateRoot: "0xb64deb56ba72af49621829b43c63939d5c69413579b1581b6a6a984a2643b805",
  timestamp: 1645406919,
  timestampFoS: 6,
  totalBlockScore: "0x29",
  transactions: [],
  transactionsRoot: "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
  voteData: "0x"
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
