### PR TITLE
Block APIs try not to get block proposer when formatting Genensis Block

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1398,7 +1398,7 @@ func (api *EthereumAPI) Accounts() []common.Address {
 func (api *EthereumAPI) rpcMarshalHeader(head *types.Header) (map[string]interface{}, error) {
 	var proposer common.Address
 	var err error
-	if head.Number.BitLen() != 0 {
+	if head.Number.Sign() != 0 {
 		proposer, err = api.publicKlayAPI.b.Engine().Author(head)
 		if err != nil {
 			// miner is the field Klaytn should provide the correct value. It's not the field dummy value is allowed.

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1396,11 +1396,15 @@ func (api *EthereumAPI) Accounts() []common.Address {
 // rpcMarshalHeader marshal block header as Ethereum compatible format.
 // It returns error when fetching Author which is block proposer is failed.
 func (api *EthereumAPI) rpcMarshalHeader(head *types.Header) (map[string]interface{}, error) {
-	proposer, err := api.publicKlayAPI.b.Engine().Author(head)
-	if err != nil {
-		// miner is the field Klaytn should provide the correct value. It's not the field dummy value is allowed.
-		logger.Error("Failed to fetch author during marshaling header", "err", err.Error())
-		return nil, err
+	var proposer common.Address
+	var err error
+	if head.Number.BitLen() != 0 {
+		proposer, err = api.publicKlayAPI.b.Engine().Author(head)
+		if err != nil {
+			// miner is the field Klaytn should provide the correct value. It's not the field dummy value is allowed.
+			logger.Error("Failed to fetch author during marshaling header", "err", err.Error())
+			return nil, err
+		}
 	}
 	result := map[string]interface{}{
 		"number":          (*hexutil.Big)(head.Number),


### PR DESCRIPTION
## Proposed changes

When formatting a block header to serve eth namespace APIs related block, [Author()](https://github.com/klaytn/klaytn/blob/d7d4c7cec40ecf796851597286d63f8fe2d94d1f/consensus/istanbul/backend/engine.go#L118-L121) is called internally for `miner` field  but there is no actual Author of Genesis Block so it always returns error.

So we need to serve `miner` field as zero address `0x0000000000000000000000000000000000000000` just like Ethereum.

**Before:**
```shell
curl http://localhost:8553 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":[0, true],"id":1}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"recovery failed"}}
```


**After:**
```shell
curl http://localhost:8553 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0", true],"id":1}'
```
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "baseFeePerGas": "0x0",
    "difficulty": "0x1",
    "extraData": "0x",
    "gasLimit": "0xe8d4a50fff",
    "gasUsed": "0x0",
    "hash": "0xe9ba9a39a1daf161f225b805292354213a378a2b78423d10474918e9ca363746",
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "miner": "0x0000000000000000000000000000000000000000",
    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "nonce": "0x0000000000000000",
    "number": "0x0",
    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "receiptsRoot": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "size": "0x3e8",
    "stateRoot": "0xdbad79f8cd6b9608123a382f4906c5ed1f7027b29239df141065bc57fbf4ac12",
    "timestamp": "0x6020908f",
    "totalDifficulty": "0x1",
    "transactions": [],
    "transactionsRoot": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
    "uncles": []
  }
}
```

**FYI**
**Response from Geth when fetching Genesis Block**
```shell
curl http://localhost:8545 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0", true],"id":1}'
```
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "baseFeePerGas": "0x3b9aca00",
    "difficulty": "0x1",
    "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000ca7a99380131e6c76cfa622396347107aeedca2d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "gasLimit": "0x47b760",
    "gasUsed": "0x0",
    "hash": "0x818f43ebfd0d02607b8417ceb44629759d8af4350d1683c98d04e7243533627b",
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "miner": "0x0000000000000000000000000000000000000000",
    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "nonce": "0x0000000000000000",
    "number": "0x0",
    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "size": "0x273",
    "stateRoot": "0x9654783f4527a11a35ad22297b9421391b2c177f7d05c077b224ce0378014ec9",
    "timestamp": "0x0",
    "totalDifficulty": "0x1",
    "transactions": [],
    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "uncles": []
  }
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
