### PR TITLE
Allow klay,eth,net,web3 APIs on EN by default

### DIFF
--- a/build/packaging/linux/conf/kcnd.conf
+++ b/build/packaging/linux/conf/kcnd.conf
@@ -23,7 +23,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -31,7 +31,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/packaging/linux/conf/kcnd_baobab.conf
+++ b/build/packaging/linux/conf/kcnd_baobab.conf
@@ -23,7 +23,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -31,7 +31,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/packaging/linux/conf/kend.conf
+++ b/build/packaging/linux/conf/kend.conf
@@ -21,7 +21,7 @@ TXPOOL_LIFE_TIME="30m"
 
 # rpc options setting
 RPC_ENABLE=1 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -29,7 +29,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=1 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/packaging/linux/conf/kend_baobab.conf
+++ b/build/packaging/linux/conf/kend_baobab.conf
@@ -21,7 +21,7 @@ TXPOOL_LIFE_TIME="30m"
 
 # rpc options setting
 RPC_ENABLE=1 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -29,7 +29,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=1 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/packaging/linux/conf/kpnd.conf
+++ b/build/packaging/linux/conf/kpnd.conf
@@ -22,7 +22,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -30,7 +30,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/packaging/linux/conf/kpnd_baobab.conf
+++ b/build/packaging/linux/conf/kpnd_baobab.conf
@@ -22,7 +22,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -30,7 +30,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/packaging/linux/conf/kscnd.conf
+++ b/build/packaging/linux/conf/kscnd.conf
@@ -20,7 +20,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=1 # if this is set, the following options will be used
-RPC_API="klay,subbridge" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance,mainbridge,subbridge
+RPC_API="klay,eth,net,web3,subbridge" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance,mainbridge,subbridge
 RPC_PORT=8551         # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 8551, sub:7551)
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -28,7 +28,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=1 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 WS_ADDR="0.0.0.0"
 WS_PORT=8552    # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 8552, sub:7552)
 WS_ORIGINS="*"

--- a/build/packaging/linux/conf/ksend.conf
+++ b/build/packaging/linux/conf/ksend.conf
@@ -19,7 +19,7 @@ TXPOOL_LIFE_TIME="30m"
 
 # rpc options setting
 RPC_ENABLE=1 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -27,7 +27,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=1 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/packaging/linux/conf/kspnd.conf
+++ b/build/packaging/linux/conf/kspnd.conf
@@ -20,7 +20,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -28,7 +28,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/rpm/etc/kcnd/conf/kcnd.conf
+++ b/build/rpm/etc/kcnd/conf/kcnd.conf
@@ -23,7 +23,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -31,7 +31,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/rpm/etc/kcnd/conf/kcnd_baobab.conf
+++ b/build/rpm/etc/kcnd/conf/kcnd_baobab.conf
@@ -23,7 +23,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -31,7 +31,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/rpm/etc/kend/conf/kend.conf
+++ b/build/rpm/etc/kend/conf/kend.conf
@@ -21,7 +21,7 @@ TXPOOL_LIFE_TIME="30m"
 
 # rpc options setting
 RPC_ENABLE=1 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -29,7 +29,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=1 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/rpm/etc/kend/conf/kend_baobab.conf
+++ b/build/rpm/etc/kend/conf/kend_baobab.conf
@@ -21,7 +21,7 @@ TXPOOL_LIFE_TIME="30m"
 
 # rpc options setting
 RPC_ENABLE=1 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -29,7 +29,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=1 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/rpm/etc/kpnd/conf/kpnd.conf
+++ b/build/rpm/etc/kpnd/conf/kpnd.conf
@@ -22,7 +22,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -30,7 +30,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/rpm/etc/kpnd/conf/kpnd_baobab.conf
+++ b/build/rpm/etc/kpnd/conf/kpnd_baobab.conf
@@ -22,7 +22,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -30,7 +30,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/rpm/etc/kscnd/conf/kscnd.conf
+++ b/build/rpm/etc/kscnd/conf/kscnd.conf
@@ -20,7 +20,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=1 # if this is set, the following options will be used
-RPC_API="klay,subbridge" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance,mainbridge,subbridge
+RPC_API="klay,eth,net,web3,subbridge" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance,mainbridge,subbridge
 RPC_PORT=7551         # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 8551, sub:7551)
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -28,7 +28,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=1 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3,governance
 WS_ADDR="0.0.0.0"
 WS_PORT=7552    # if main-bridge and sub-bridge on same instance, use different port with main-bridge.(main: 8552, sub:7552)
 WS_ORIGINS="*"

--- a/build/rpm/etc/ksend/conf/ksend.conf
+++ b/build/rpm/etc/ksend/conf/ksend.conf
@@ -19,7 +19,7 @@ TXPOOL_LIFE_TIME="30m"
 
 # rpc options setting
 RPC_ENABLE=1 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -27,7 +27,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=1 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"

--- a/build/rpm/etc/kspnd/conf/kspnd.conf
+++ b/build/rpm/etc/kspnd/conf/kspnd.conf
@@ -20,7 +20,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=0 # if this is set, the following options will be used
-RPC_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+RPC_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -28,7 +28,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=0 # if this is set, the following options will be used
-WS_API="klay" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
+WS_API="klay,eth,net,web3" # available apis: admin,debug,klay,miner,net,personal,rpc,txpool,web3
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"


### PR DESCRIPTION
## Proposed changes

By default, allows eth, net, web3 APIs as well as klay APIs. Some important development tools use those API and they can be used as Pubilc APIs. 


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
