### PR TITLE
Enable REWARDBASE option available at kscnd.conf

### DIFF
--- a/build/packaging/linux/bin/kscnd
+++ b/build/packaging/linux/bin/kscnd
@@ -310,6 +310,10 @@ start_node() {
         OPTIONS="$OPTIONS $ADDITIONAL"
     fi
 
+    if [[ ! -z $REWARDBASE ]] && [[ $REWARDBASE != "" ]]; then
+        OPTIONS="$OPTIONS --rewardbase $REWARDBASE"
+    fi
+
     if [[ ! -z $AUTO_RESTART ]] && [[ $AUTO_RESTART -eq 1 ]]; then
         OPTIONS="$OPTIONS --autorestart.enable"
     fi

--- a/build/packaging/linux/conf/kscnd.conf
+++ b/build/packaging/linux/conf/kscnd.conf
@@ -10,6 +10,7 @@ PORT=22323 # if EN(main-bridge) and SCN(sub-bridge) on same instance, use differ
 SERVER_TYPE="fasthttp"
 SYNCMODE="full"
 VERBOSITY=3
+REWARDBASE=""
 
 # txpool options setting
 TXPOOL_EXEC_SLOTS_ALL=16384


### PR DESCRIPTION
## Proposed changes

- It was not available to use REWARDBASE option at kscnd.conf, unlike kcnd.conf. So it made confusion.
- Enable option by modifing kscnd script file.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/klaytn/klaytn/issues/1178

