### PR TITLE
Fix error checking logic, estimateGas issue and Updates revert related logic

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -585,10 +585,8 @@ func (api *EthereumAPI) Call(ctx context.Context, args EthTransactionArgs, block
 		gasCap = rpcGasCap.Uint64()
 	}
 	result, _, err := EthDoCall(ctx, api.publicBlockChainAPI.b, args, blockNrOrHash, overrides, localTxExecutionTime, gasCap)
-	if len(result) > 0 {
-		if isReverted(err) {
-			return nil, newRevertError(result)
-		}
+	if len(result) > 0 && isReverted(err) {
+		return nil, newRevertError(result)
 	}
 	return (hexutil.Bytes)(result), err
 }

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1505,6 +1505,9 @@ func EthDoCall(ctx context.Context, b Backend, args EthTransactionArgs, blockNrO
 	if err != nil {
 		return nil, 0, err
 	}
+	if msg.Gas() < intrinsicGas {
+		return nil, 0, fmt.Errorf("%w: have %d, want %d", blockchain.ErrIntrinsicGas, msg.Gas(), intrinsicGas)
+	}
 	evm, vmError, err := b.GetEVM(ctx, msg, st, header, vm.Config{})
 	if err != nil {
 		return nil, 0, err

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1505,8 +1505,12 @@ func EthDoCall(ctx context.Context, b Backend, args EthTransactionArgs, blockNrO
 	if err != nil {
 		return nil, 0, err
 	}
+	// The intrinsicGas is checked again later in the blockchain.ApplyMessage function,
+	// but we check in advance here in order to keep StateTransition.TransactionDb method as unchanged as possible
+	// and to clarify error reason correctly to serve eth namespace APIs.
+	// This case is handled by EthDoEstimateGas function.
 	if msg.Gas() < intrinsicGas {
-		return nil, 0, fmt.Errorf("%w: have %d, want %d", blockchain.ErrIntrinsicGas, msg.Gas(), intrinsicGas)
+		return nil, 0, fmt.Errorf("%w: msg.gas %d, want %d", blockchain.ErrIntrinsicGas, msg.Gas(), intrinsicGas)
 	}
 	evm, vmError, err := b.GetEVM(ctx, msg, st, header, vm.Config{})
 	if err != nil {

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1623,7 +1623,7 @@ func EthDoEstimateGas(ctx context.Context, b Backend, args EthTransactionArgs, b
 			// Returns error when it is not VM error (less balance or wrong nonce, etc...).
 			return false, nil, nil, err
 		}
-		return true, ret, nil, nil
+		return true, ret, err, nil
 	}
 	// Execute the binary search and hone in on an executable gas limit
 	for lo+1 < hi {
@@ -1646,8 +1646,9 @@ func EthDoEstimateGas(ctx context.Context, b Backend, args EthTransactionArgs, b
 			return 0, err
 		}
 		if !isExecutable {
-			if ret != nil {
-				if isReverted(vmErr) {
+			if vmErr != nil {
+				// Treat vmErr as RevertError only when there was returned data from call.
+				if isReverted(vmErr) && len(ret) > 0 {
 					return 0, newRevertError(ret)
 				}
 				return 0, vmErr

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -252,17 +252,12 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, kerr kerr
 
 	msg := st.msg
 
-	// Check before pay intrinsic gas.
-	intrinsicGas := msg.ValidatedIntrinsicGas()
-	if st.gas < intrinsicGas {
-		kerr.Status = getReceiptStatusFromErrTxFailed(nil)
-		kerr.ErrTxInvalid = fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, intrinsicGas)
-		return nil, 0, kerr
-	}
-
 	// Pay intrinsic gas.
-	if kerr.ErrTxInvalid = st.useGas(intrinsicGas); kerr.ErrTxInvalid != nil {
+	if kerr.ErrTxInvalid = st.useGas(msg.ValidatedIntrinsicGas()); kerr.ErrTxInvalid != nil {
 		kerr.Status = getReceiptStatusFromErrTxFailed(nil)
+		// The original error from useGas is out of gas error but, that is not the exact message in this case.
+		// So, overwrite the error with more suitable one.
+		kerr.ErrTxInvalid = fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, msg.ValidatedIntrinsicGas())
 		return nil, 0, kerr
 	}
 

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -22,7 +22,6 @@ package blockchain
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -255,9 +254,6 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, kerr kerr
 	// Pay intrinsic gas.
 	if kerr.ErrTxInvalid = st.useGas(msg.ValidatedIntrinsicGas()); kerr.ErrTxInvalid != nil {
 		kerr.Status = getReceiptStatusFromErrTxFailed(nil)
-		// The original error from useGas is out of gas error but, that is not the exact message in this case.
-		// So, overwrite the error with more suitable one.
-		kerr.ErrTxInvalid = fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, msg.ValidatedIntrinsicGas())
 		return nil, 0, kerr
 	}
 

--- a/blockchain/vm/errors.go
+++ b/blockchain/vm/errors.go
@@ -23,8 +23,6 @@ package vm
 import (
 	"errors"
 	"fmt"
-	"strings"
-
 	"github.com/klaytn/klaytn/params"
 )
 
@@ -52,7 +50,7 @@ var VmErrors = []error{ErrCodeStoreOutOfGas, ErrDepth, ErrTraceLimitReached, Err
 // IsVMError returns true if given error is occurred during EVM execution.
 func IsVMError(err error) bool {
 	for _, vmError := range VmErrors {
-		if err == vmError || strings.Contains(err.Error(), vmError.Error()) {
+		if errors.Is(err, vmError) {
 			return true
 		}
 	}

--- a/blockchain/vm/errors.go
+++ b/blockchain/vm/errors.go
@@ -23,6 +23,7 @@ package vm
 import (
 	"errors"
 	"fmt"
+
 	"github.com/klaytn/klaytn/params"
 )
 


### PR DESCRIPTION
## Proposed changes

**Fix error checking logic**
* When checking error, we must not use `err.Error()` in situation when err can be `nil`.
* `errors.Is` can handle above situations and is more generic way in Go to checks error.

**estimateGas issue**
* We must not treat `IntrinsicGas` error as consensus error like [Ethereum does](https://github.com/ethereum/go-ethereum/blob/d6f49bf764c48e9415b168e701b6dc26566a675c/internal/ethapi/api.go#L1071-L1073).
  * After fix this, estimating logic works fine. `IntrinsicGas` error can be happened quite a few during estimating gas.

**Before**
```javascript
> eth.estimateGas({from: "0xcA7A99380131e6C76cfa622396347107aeEDCA2D", to: "0xE6A480c067DE0C666FC71d34b71F6677b02C272f", data: '0x2ff2f55a000000000000000000000000a74c860b31bb06580ddd94f52fe503b97b9e7e3c000000000000000000000000000000000000000000000000000000000000000a'})
Error: err: intrinsic gas too low: have 24724, want 27800 (supplied gas 24724)
    at web3.js:3278:20
    at web3.js:6805:15
    at web3.js:5216:36
    at <anonymous>:1:1
```
**After**
```javascript
> eth.estimateGas({from: "0xcA7A99380131e6C76cfa622396347107aeEDCA2D", to: "0xE6A480c067DE0C666FC71d34b71F6677b02C272f", data: '0x2ff2f55a000000000000000000000000a74c860b31bb06580ddd94f52fe503b97b9e7e3c000000000000000000000000000000000000000000000000000000000000000a'})
27800
```

You can check this using [rpc-tester](https://github.com/Krustuniverse-Klaytn-Group/rpc-tester/pull/38/files#diff-bb87f6c8cfbf44333bede98499ec76f0779a4b3e5d006b5d765d046983dc8213R10024-R10025).
If we don't apply change, `estimateGas` dose not work. After apply change, it works.

* Estimate must treat revert with `RevertError` when there is a returned value from call like [Ethereum's EstimateGas](https://github.com/ethereum/go-ethereum/blob/d6f49bf764c48e9415b168e701b6dc26566a675c/internal/ethapi/api.go#L1102-L1107) does.

**Related tests**
[test_eth_estimateGas_RPC_error_evm_revert_message](https://github.com/Krustuniverse-Klaytn-Group/rpc-tester/blob/ccdd24e2c6e5d6cdad6cc7c4e683aa8cfb0c6f2e/simpleTester/simple_test_rpc.py#L9954-L9978)

Execution reverted but there is returned data from call, so return as it `RevertError`.
```shell
# Geth Response
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_estimateGas", "params": [{"from": "0x15318f21f3dee6b2c64d2a633cb8c1194877c882", "to": "0x059cdf0f685825c905c2cfe5709e750383d9c698", "data": "0xa6f9dae10000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499"}, "latest"], "id": 12}' http://localhost:8545
{
    "error": {
        "code": 3,
        "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001343616c6c6572206973206e6f74206f776e657200000000000000000000000000",
        "message": "execution reverted: Caller is not owner"
    },
    "id": 12,
    "jsonrpc": "2.0"
} 

# Ken Response
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_estimateGas", "params": [{"from": "0x15318f21f3dee6b2c64d2a633cb8c1194877c882", "to": "0xebcaaeedfc07d7e72d6b2be0feb95b23aacef785", "data": "0xa6f9dae10000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499"}, "latest"], "id": 45}' http://localhost:8551
{
    "error": {
        "code": 3,
        "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001343616c6c6572206973206e6f74206f776e657200000000000000000000000000",
        "message": "execution reverted: Caller is not owner"
    },
    "id": 45,
    "jsonrpc": "2.0"
} 

```

[test_eth_estimateGas_RPC_error_revert](https://github.com/Krustuniverse-Klaytn-Group/rpc-tester/pull/38/commits/3822d38846aa56f7c3d44419887ad7d144622a4a#diff-bb87f6c8cfbf44333bede98499ec76f0779a4b3e5d006b5d765d046983dc8213R9981-R10001)
Execution reverted but there is no returned data from call, so return as it was originally.
```shell
# Geth Response
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_estimateGas", "params": [{"to": "0x07af6e214e7deb6c3d7409fca8d81adda8151237"}, "latest"], "id": 94}' http://localhost:8545
{
    "error": {
        "code": -32000,
        "message": "execution reverted"
    },
    "id": 94,
    "jsonrpc": "2.0"
} 

# Ken Response
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_estimateGas", "params": [{"to": "0x17183c9008749d4d0b1451fce3593e0349d1c5d8"}], "id": 25}' http://localhost:8551
{
    "error": {
        "code": -32000,
        "message": "err: evm: execution reverted (supplied gas 999999999999)"
    },
    "id": 25,
    "jsonrpc": "2.0"
}
```


### Revert related logic
* Call must treat revert with `RevertError` when there is a returned value from call like [Ethereum's Call](https://github.com/ethereum/go-ethereum/blob/d6f49bf764c48e9415b168e701b6dc26566a675c/internal/ethapi/api.go#L988-L991) does.

**Related tests**
[test_eth_call_RPC_error_no_param2](https://github.com/Krustuniverse-Klaytn-Group/rpc-tester/blob/b66b339064a442eda7184fe40bc01d1053b2e33e/simpleTester/simple_test_rpc.py#L9545-L9570)

Execution reverted but there is no returned data from call, so return as it was originally.
```shell
# Geth Response
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_call", "params": [{"to": "0x07af6e214e7deb6c3d7409fca8d81adda8151237"}, "latest"], "id": 75}' http://localhost:8545
{
    "error": {
        "code": -32000,
        "message": "execution reverted"
    },
    "id": 75,
    "jsonrpc": "2.0"
} 

# Ken Response
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_call", "params": [{"to": "0x0f34f3474499eea02200f1203049c9c2148d1c2a"}, "latest"], "id": 95}' http://localhost:8551
{
    "error": {
        "code": -32000,
        "message": "err: evm: execution reverted (supplied gas 9223372036854775807)"
    },
    "id": 95,
    "jsonrpc": "2.0"
} 
```
[test_eth_call_RPC_error_evm_revert_message](https://github.com/Krustuniverse-Klaytn-Group/rpc-tester/blob/b66b339064a442eda7184fe40bc01d1053b2e33e/simpleTester/simple_test_rpc.py#L9572-L9596)
Execution reverted but there is returned data from call, so return as it `RevertError`.
```shell
# Geth Response
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_call", "params": [{"from": "0x15318f21f3dee6b2c64d2a633cb8c1194877c882", "to": "0x059cdf0f685825c905c2cfe5709e750383d9c698", "data": "0xa6f9dae10000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499"}, "latest"], "id": 84}' http://localhost:8545

{
    "error": {
        "code": 3,
        "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001343616c6c6572206973206e6f74206f776e657200000000000000000000000000",
        "message": "execution reverted: Caller is not owner"
    },
    "id": 84,
    "jsonrpc": "2.0"
} 

# Ken Response
curl -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_call", "params": [{"from": "0x15318f21f3dee6b2c64d2a633cb8c1194877c882", "to": "0xebcaaeedfc07d7e72d6b2be0feb95b23aacef785", "data": "0xa6f9dae10000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499"}, "latest"], "id": 78}' http://localhost:8551

{
    "error": {
        "code": 3,
        "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001343616c6c6572206973206e6f74206f776e657200000000000000000000000000",
        "message": "execution reverted: Caller is not owner"
    },
    "id": 78,
    "jsonrpc": "2.0"
}
```


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...