### PR TITLE
governance: remove address length checking logic in parseVoteValue

### DIFF
--- a/governance/default.go
+++ b/governance/default.go
@@ -536,16 +536,13 @@ func (g *Governance) ParseVoteValue(gVote *GovernanceVote) (*GovernanceVote, err
 		val = string(v)
 	case params.GoverningNode:
 		v, ok := gVote.Value.([]uint8)
-		if !ok || len(v) != common.AddressLength {
+		if !ok {
 			return nil, ErrValueTypeMismatch
 		}
 		val = common.BytesToAddress(v)
 	case params.AddValidator, params.RemoveValidator:
 		if v, ok := gVote.Value.([]uint8); ok {
 			// if value contains single address, gVote.Value type should be []uint8{}
-			if len(v) != common.AddressLength {
-				return nil, ErrValueTypeMismatch
-			}
 			val = common.BytesToAddress(v)
 		} else if addresses, ok := gVote.Value.([]interface{}); ok {
 			// if value contains multiple addresses, gVote.Value type should be [][]uint8{}

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -548,7 +548,7 @@ func TestVoteValueNilInterface(t *testing.T) {
 
 		// Parse vote.Value and make it has appropriate type
 		_, err := gov.ParseVoteValue(gVote)
-		assert.Equal(t, nil, err)
+		assert.NoError(t, err)
 	}
 
 	gVote.Key = "governance.addvalidator"
@@ -572,7 +572,7 @@ func TestVoteValueNilInterface(t *testing.T) {
 
 		// Parse vote.Value and make it has appropriate type
 		_, err := gov.ParseVoteValue(gVote)
-		assert.Equal(t, ErrValueTypeMismatch, err)
+		assert.NoError(t, err)
 	}
 }
 

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -337,11 +337,11 @@ func (gov *Governance) HandleGovernanceVote(valset istanbul.ValidatorSet, votes 
 		var err error
 
 		if err := rlp.DecodeBytes(header.Vote, gVote); err != nil {
-			logger.Error("Failed to decode a vote. This vote will be ignored", "number", header.Number, "key", gVote.Key, "value", gVote.Value, "validator", gVote.Validator)
+			logger.Error("Failed to decode a vote. This vote will be ignored", "number", header.Number)
 			return valset, votes, tally
 		}
 		if gVote, err = gov.ParseVoteValue(gVote); err != nil {
-			logger.Error("Failed to parse a vote value. This vote will be ignored", "number", header.Number, "key", gVote.Key, "value", gVote.Value, "validator", gVote.Validator)
+			logger.Error("Failed to parse a vote value. This vote will be ignored", "number", header.Number)
 			return valset, votes, tally
 		}
 


### PR DESCRIPTION
## Proposed changes

- Around block 75038594, 42byte "voteData" is inserted when vote.key is `governance.addvalidator`. So, This PR removes address length checking logic, because it causes hardfork.

closes https://github.com/klaytn/klaytn/issues/1194

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
