### PR TITLE
[SC] Removed unused code

### DIFF
--- a/node/sc/bridgepool/bridge_tx_pool.go
+++ b/node/sc/bridgepool/bridge_tx_pool.go
@@ -390,27 +390,17 @@ func (pool *BridgeTxPool) AddLocals(txs []*types.Transaction) []error {
 func (pool *BridgeTxPool) addTx(tx *types.Transaction) error {
 	//senderCacher.recover(pool.signer, []*types.Transaction{tx})
 	// Try to inject the transaction and update any state
-	err := pool.add(tx)
-	return err
+	return pool.add(tx)
 }
 
 // addTxs attempts to queue a batch of transactions if they are valid.
 func (pool *BridgeTxPool) addTxs(txs []*types.Transaction) []error {
 	//senderCacher.recover(pool.signer, txs)
 	// Add the batch of transaction, tracking the accepted ones
-	dirty := make(map[common.Address]struct{})
 	errs := make([]error, len(txs))
 
 	for i, tx := range txs {
-		var replace bool
-		if errs[i] = pool.add(tx); errs[i] == nil {
-			if !replace {
-				from, err := types.Sender(pool.signer, tx)
-				errs[i] = err
-
-				dirty[from] = struct{}{}
-			}
-		}
+		errs[i] = pool.add(tx)
 	}
 
 	return errs


### PR DESCRIPTION
## Proposed changes

I was reading Service Chain (SC) codebase to build up base knowledge for understanding internal behavior. This PR removes unnecessary (unused) code from ``` func (pool *BridgeTxPool) addTx(tx *types.Transaction) error ```. I found entire code scheme for SC seems similar to CN logic, but compact code blocks were brought from there. 

In my first view, the author of SC's entire scheme might have been a mistake when he pulled code blocks from CN logic. I think ```addTxs``` function in SC seemed to pull from https://github.com/klaytn/klaytn/blob/dev/blockchain/tx_pool.go#L1199.
 
One more thing, there is a lack of features like transaction validation before inserting tx to txpool, where supported in CN logic. I don't know the authors' intention whether this compact version (lack of feature compared with CN) is intended or should be improved from now on.

I would appreciate it if some experiencer advise. Thanks a lot.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
