### PR TITLE
Converts to for pointer type and handles when payload is not defined

### DIFF
--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -248,12 +248,8 @@ func (args *SendTxArgs) genTxValuesMap() map[types.TxValueKeyType]interface{} {
 	if args.Price != nil {
 		values[types.TxValueKeyGasPrice] = (*big.Int)(args.Price)
 	}
-	if args.TypeInt.IsContractDeploy() {
-		// contract deploy type allows nil as TxValueKeyTo value
-		values[types.TxValueKeyTo] = (*common.Address)(args.Recipient)
-	} else if args.Recipient == nil && args.TypeInt.IsEthereumTransaction() {
-		// Among the optional fields of an Ethereum transaction,
-		// if `args.Recipient == nil` and `args.Payload != nil`, it is a contract deploy transaction.
+	if args.TypeInt.IsContractDeploy() || args.TypeInt.IsEthereumTransaction() {
+		// contract deploy type and ethereum tx types allow nil as TxValueKeyTo value
 		values[types.TxValueKeyTo] = (*common.Address)(args.Recipient)
 	} else if args.Recipient != nil {
 		values[types.TxValueKeyTo] = *args.Recipient
@@ -274,6 +270,9 @@ func (args *SendTxArgs) genTxValuesMap() map[types.TxValueKeyType]interface{} {
 		} else {
 			values[types.TxValueKeyData] = ([]byte)(*args.Payload)
 		}
+	} else if args.TypeInt.IsEthereumTransaction() {
+		// For Ethereum transactions, Payload is an optional field.
+		values[types.TxValueKeyData] = []byte{}
 	}
 	if args.CodeFormat != nil {
 		values[types.TxValueKeyCodeFormat] = *args.CodeFormat


### PR DESCRIPTION
## Proposed changes

This PR introduces adding logic to converts `Recipient` for `*common.Address` type and handle when `Payload` is not defined.

So now can handle below three cases
- Simple value transfer without `input`
- Smart contract deploy without `to`
- Smart contract execution with `input` and `to`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
