### PR TITLE
[Config] Whitespace-able configuration for RPC_API and WS_API

### DIFF
--- a/build/packaging/linux/bin/kcnd
+++ b/build/packaging/linux/bin/kcnd
@@ -150,6 +150,7 @@ start_node() {
 
     if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --rpc"
+        RPC_API=`echo $RPC_API | tr -d "[:space:]"`
         if [ ! -z $RPC_API ]; then
             OPTIONS="$OPTIONS --rpcapi $RPC_API"
         fi
@@ -169,6 +170,7 @@ start_node() {
 
     if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --ws"
+        WS_API=`echo $WS_API | tr -d "[:space:]"`
         if [ ! -z $WS_API ]; then
             OPTIONS="$OPTIONS --wsapi $WS_API"
         fi

--- a/build/packaging/linux/bin/kend
+++ b/build/packaging/linux/bin/kend
@@ -146,6 +146,7 @@ __check_option() {
 
     if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --rpc"
+        RPC_API=`echo $RPC_API | tr -d "[:space:]"`
         if [ ! -z $RPC_API ]; then
             OPTIONS="$OPTIONS --rpcapi $RPC_API"
         fi
@@ -165,6 +166,7 @@ __check_option() {
 
     if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --ws"
+        WS_API=`echo $WS_API | tr -d "[:space:]"`
         if [ ! -z $WS_API ]; then
             OPTIONS="$OPTIONS --wsapi $WS_API"
         fi

--- a/build/packaging/linux/bin/kpnd
+++ b/build/packaging/linux/bin/kpnd
@@ -150,6 +150,7 @@ start_node() {
 
     if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --rpc"
+        RPC_API=`echo $RPC_API | tr -d "[:space:]"`
         if [ ! -z $RPC_API ]; then
             OPTIONS="$OPTIONS --rpcapi $RPC_API"
         fi
@@ -169,6 +170,7 @@ start_node() {
 
     if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --ws"
+        WS_API=`echo $WS_API | tr -d "[:space:]"`
         if [ ! -z $WS_API ]; then
             OPTIONS="$OPTIONS --wsapi $WS_API"
         fi

--- a/build/packaging/linux/bin/kscnd
+++ b/build/packaging/linux/bin/kscnd
@@ -150,6 +150,7 @@ start_node() {
 
     if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --rpc"
+        RPC_API=`echo $RPC_API | tr -d "[:space:]"`
         if [ ! -z $RPC_API ]; then
             OPTIONS="$OPTIONS --rpcapi $RPC_API"
         fi
@@ -169,6 +170,7 @@ start_node() {
 
     if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --ws"
+        WS_API=`echo $WS_API | tr -d "[:space:]"`
         if [ ! -z $WS_API ]; then
             OPTIONS="$OPTIONS --wsapi $WS_API"
         fi

--- a/build/packaging/linux/bin/ksend
+++ b/build/packaging/linux/bin/ksend
@@ -150,6 +150,7 @@ start_node() {
 
     if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --rpc"
+        RPC_API=`echo $RPC_API | tr -d "[:space:]"`
         if [ ! -z $RPC_API ]; then
             OPTIONS="$OPTIONS --rpcapi $RPC_API"
         fi
@@ -169,6 +170,7 @@ start_node() {
 
     if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --ws"
+        WS_API=`echo $WS_API | tr -d "[:space:]"`
         if [ ! -z $WS_API ]; then
             OPTIONS="$OPTIONS --wsapi $WS_API"
         fi

--- a/build/packaging/linux/bin/kspnd
+++ b/build/packaging/linux/bin/kspnd
@@ -150,6 +150,7 @@ start_node() {
 
     if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --rpc"
+        RPC_API=`echo $RPC_API | tr -d "[:space:]"`
         if [ ! -z $RPC_API ]; then
             OPTIONS="$OPTIONS --rpcapi $RPC_API"
         fi
@@ -169,6 +170,7 @@ start_node() {
 
     if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
         OPTIONS="$OPTIONS --ws"
+        WS_API=`echo $WS_API | tr -d "[:space:]"`
         if [ ! -z $WS_API ]; then
             OPTIONS="$OPTIONS --wsapi $WS_API"
         fi

--- a/build/rpm/etc/init.d/kcnd
+++ b/build/rpm/etc/init.d/kcnd
@@ -124,6 +124,7 @@ fi
 
 if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --rpc"
+    RPC_API=`echo $RPC_API | tr -d "[:space:]"`
     if [ ! -z $RPC_API ]; then
         OPTIONS="$OPTIONS --rpcapi $RPC_API"
     fi
@@ -143,6 +144,7 @@ fi
 
 if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --ws"
+    WS_API=`echo $WS_API | tr -d "[:space:]"`
     if [ ! -z $WS_API ]; then
         OPTIONS="$OPTIONS --wsapi $WS_API"
     fi

--- a/build/rpm/etc/init.d/kend
+++ b/build/rpm/etc/init.d/kend
@@ -124,6 +124,7 @@ fi
 
 if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --rpc"
+    RPC_API=`echo $RPC_API | tr -d "[:space:]"`
     if [ ! -z $RPC_API ]; then
         OPTIONS="$OPTIONS --rpcapi $RPC_API"
     fi
@@ -143,6 +144,7 @@ fi
 
 if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --ws"
+    WS_API=`echo $WS_API | tr -d "[:space:]"`
     if [ ! -z $WS_API ]; then
         OPTIONS="$OPTIONS --wsapi $WS_API"
     fi

--- a/build/rpm/etc/init.d/kpnd
+++ b/build/rpm/etc/init.d/kpnd
@@ -124,6 +124,7 @@ fi
 
 if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --rpc"
+    RPC_API=`echo $RPC_API | tr -d "[:space:]"`
     if [ ! -z $RPC_API ]; then
         OPTIONS="$OPTIONS --rpcapi $RPC_API"
     fi
@@ -143,6 +144,7 @@ fi
 
 if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --ws"
+    WS_API=`echo $WS_API | tr -d "[:space:]"`
     if [ ! -z $WS_API ]; then
         OPTIONS="$OPTIONS --wsapi $WS_API"
     fi

--- a/build/rpm/etc/init.d/kscnd
+++ b/build/rpm/etc/init.d/kscnd
@@ -124,6 +124,7 @@ fi
 
 if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --rpc"
+    RPC_API=`echo $RPC_API | tr -d "[:space:]"`
     if [ ! -z $RPC_API ]; then
         OPTIONS="$OPTIONS --rpcapi $RPC_API"
     fi
@@ -143,6 +144,7 @@ fi
 
 if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --ws"
+    WS_API=`echo $WS_API | tr -d "[:space:]"`
     if [ ! -z $WS_API ]; then
         OPTIONS="$OPTIONS --wsapi $WS_API"
     fi

--- a/build/rpm/etc/init.d/ksend
+++ b/build/rpm/etc/init.d/ksend
@@ -124,6 +124,7 @@ fi
 
 if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --rpc"
+    RPC_API=`echo $RPC_API | tr -d "[:space:]"`
     if [ ! -z $RPC_API ]; then
         OPTIONS="$OPTIONS --rpcapi $RPC_API"
     fi
@@ -143,6 +144,7 @@ fi
 
 if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --ws"
+    WS_API=`echo $WS_API | tr -d "[:space:]"`
     if [ ! -z $WS_API ]; then
         OPTIONS="$OPTIONS --wsapi $WS_API"
     fi

--- a/build/rpm/etc/init.d/kspnd
+++ b/build/rpm/etc/init.d/kspnd
@@ -124,6 +124,7 @@ fi
 
 if [[ ! -z $RPC_ENABLE ]] && [[ $RPC_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --rpc"
+    RPC_API=`echo $RPC_API | tr -d "[:space:]"`
     if [ ! -z $RPC_API ]; then
         OPTIONS="$OPTIONS --rpcapi $RPC_API"
     fi
@@ -143,6 +144,7 @@ fi
 
 if [[ ! -z $WS_ENABLE ]] && [[ $WS_ENABLE -eq 1 ]]; then
     OPTIONS="$OPTIONS --ws"
+    WS_API=`echo $WS_API | tr -d "[:space:]"`
     if [ ! -z $WS_API ]; then
         OPTIONS="$OPTIONS --wsapi $WS_API"
     fi


### PR DESCRIPTION
## Proposed changes

All nodes (```cn```, ```pn```, etc) read a corresponding configuration file (```xxx.conf```)—two options, ```RPC_API```and ```WS_API```stand for set multiple RPC options to be enabled. However, the options currently must not have whitespaces. We may improve readability by adding whitespace. This PR enables a configuration file to contain whitespace in ```RPC_API``` and ```WS_API``` properties.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
