### PR TITLE
eth_getBlockByHash must return nil when there is no hash matched

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -479,7 +479,7 @@ func (api *EthereumAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNu
 func (api *EthereumAPI) GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (map[string]interface{}, error) {
 	klaytnBlock, err := api.publicBlockChainAPI.b.BlockByHash(ctx, hash)
 	if err != nil {
-		return nil, err
+		return nil, nil
 	}
 	return api.rpcMarshalBlock(klaytnBlock, true, fullTx)
 }

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -477,6 +477,8 @@ func (api *EthereumAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNu
 // GetBlockByHash returns the requested block. When fullTx is true all transactions in the block are returned in full
 // detail, otherwise only the transaction hash is returned.
 func (api *EthereumAPI) GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (map[string]interface{}, error) {
+	// Klaytn backend returns error when there is no matched block but
+	// Ethereum returns it as nil without error, so we should return is as nil when there is no matched block.
 	klaytnBlock, err := api.publicBlockChainAPI.b.BlockByHash(ctx, hash)
 	if err != nil {
 		return nil, nil


### PR DESCRIPTION
## Proposed changes

Geth returns nil when there is no matched hash. 
We need to follow this rule to support Ethereum compatibility.

**Before**
```shell
> eth.getBlockByHash("0xbf1208cc877e57e0b5db9e2c5fac29244f786a328227ecf9764e3285a192ae6d")
Error: the block does not exist (block hash: 0xbf1208cc877e57e0b5db9e2c5fac29244f786a328227ecf9764e3285a192ae6d)
    at web3.js:3278:20
    at web3.js:6805:15
    at web3.js:5216:36
    at <anonymous>:1:1
```

**After**
```shell
> eth.getBlockByHash("0xbf1208cc877e57e0b5db9e2c5fac29244f786a328227ecf9764e3285a192ae6d")
null
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
