### PR TITLE
Set Hard-fork block numbers for v1.8.0

### DIFF
--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -127,7 +127,7 @@ func TestHardCodedChainConfigUpdate(t *testing.T) {
 			wantStoredConfig: params.CypressChainConfig,
 			wantErr: &params.ConfigCompatError{
 				What:         "Istanbul Block",
-				StoredConfig: nil,
+				StoredConfig: params.CypressChainConfig.IstanbulCompatibleBlock,
 				NewConfig:    big.NewInt(3),
 				RewindTo:     2,
 			},

--- a/params/config.go
+++ b/params/config.go
@@ -40,9 +40,9 @@ var (
 	// CypressChainConfig is the chain parameters to run a node on the cypress main network.
 	CypressChainConfig = &ChainConfig{
 		ChainID:                  big.NewInt(int64(CypressNetworkId)),
-		IstanbulCompatibleBlock:  nil,
-		LondonCompatibleBlock:    nil,
-		EthTxTypeCompatibleBlock: nil,
+		IstanbulCompatibleBlock:  big.NewInt(86816005),
+		LondonCompatibleBlock:    big.NewInt(86816005),
+		EthTxTypeCompatibleBlock: big.NewInt(86816005),
 		DeriveShaImpl:            2,
 		Governance: &GovernanceConfig{
 			GoverningNode:  common.HexToAddress("0x52d41ca72af615a1ac3301b0a93efa222ecc7541"),
@@ -70,7 +70,7 @@ var (
 		ChainID:                  big.NewInt(int64(BaobabNetworkId)),
 		IstanbulCompatibleBlock:  big.NewInt(75373312),
 		LondonCompatibleBlock:    big.NewInt(80295291),
-		EthTxTypeCompatibleBlock: nil,
+		EthTxTypeCompatibleBlock: big.NewInt(86513895),
 		DeriveShaImpl:            2,
 		Governance: &GovernanceConfig{
 			GoverningNode:  common.HexToAddress("0x99fb17d324fa0e07f23b49d09028ac0919414db6"),

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -1,3 +1,19 @@
+// Copyright 2022 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
 package params
 
 import (

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -1,0 +1,12 @@
+package params
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChainConfig_CheckConfigForkOrder(t *testing.T) {
+	assert.Nil(t, BaobabChainConfig.CheckConfigForkOrder())
+	assert.Nil(t, CypressChainConfig.CheckConfigForkOrder())
+}


### PR DESCRIPTION
## Proposed changes

The hard-fork block numbers are calculated estimating 3/24 (Baobab) or 3/31 (Cypress). 
Reviewers, please calculate block numbers again for double check. 

Baobab
3/10, 10:00:00 (UTC+9): [85304295](https://baobab.scope.klaytn.com/block/85304295) 
3/24, 10:00:00 (UTC+9): 85304295 + 60 * 60 * 24 * 14 = 86513895 

Cypress 
3/10, 10:00:00 (UTC+9): [85001605](https://scope.klaytn.com/block/85001605?tabId=txList) 
3/31, 10:00:00 (UTC+9): 85001605 + 60 * 60 * 24 * 21 = 86816005


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
