### PR TITLE
Handle optional values for Ethereum transaction types

### DIFF
--- a/api/api_private_account.go
+++ b/api/api_private_account.go
@@ -222,7 +222,7 @@ func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args SendTxArgs
 		return nil, err
 	}
 	// Assemble the transaction and sign with the wallet
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}
@@ -344,12 +344,18 @@ func (s *PrivateAccountAPI) SendValueTransfer(ctx context.Context, args ValueTra
 // try to sign it with the key associated with args.From. If the given password isn't able to
 // decrypt the key, it fails. The transaction is returned in RLP-form, not broadcast to other nodes
 func (s *PrivateAccountAPI) SignTransaction(ctx context.Context, args SendTxArgs, passwd string) (*SignTransactionResult, error) {
+	if args.TypeInt != nil && args.TypeInt.IsEthTypedTransaction() {
+		if args.Price == nil && (args.MaxPriorityFeePerGas == nil || args.MaxFeePerGas == nil) {
+			return nil, fmt.Errorf("missing gasPrice or maxFeePerGas/maxPriorityFeePerGas")
+		}
+	}
+
 	// No need to obtain the noncelock mutex, since we won't be sending this
 	// tx into the transaction pool, but right back to the user
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +379,7 @@ func (s *PrivateAccountAPI) SignTransactionAsFeePayer(ctx context.Context, args 
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}

--- a/api/api_private_account.go
+++ b/api/api_private_account.go
@@ -222,7 +222,7 @@ func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args SendTxArgs
 		return nil, err
 	}
 	// Assemble the transaction and sign with the wallet
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +349,7 @@ func (s *PrivateAccountAPI) SignTransaction(ctx context.Context, args SendTxArgs
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (s *PrivateAccountAPI) SignTransactionAsFeePayer(ctx context.Context, args 
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}

--- a/api/api_private_account.go
+++ b/api/api_private_account.go
@@ -222,7 +222,7 @@ func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args SendTxArgs
 		return nil, err
 	}
 	// Assemble the transaction and sign with the wallet
-	tx, err := args.toTransaction()
+	tx, err := args.toTransaction(s.b)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +349,7 @@ func (s *PrivateAccountAPI) SignTransaction(ctx context.Context, args SendTxArgs
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction()
+	tx, err := args.toTransaction(s.b)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (s *PrivateAccountAPI) SignTransactionAsFeePayer(ctx context.Context, args 
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction()
+	tx, err := args.toTransaction(s.b)
 	if err != nil {
 		return nil, err
 	}

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -400,6 +400,12 @@ type SignTransactionResult struct {
 // The node needs to have the private key of the account corresponding with
 // the given from address and it needs to be unlocked.
 func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args SendTxArgs) (*SignTransactionResult, error) {
+	if args.TypeInt.IsEthTypedTransaction() {
+		if args.Price == nil && (args.MaxPriorityFeePerGas == nil || args.MaxFeePerGas == nil) {
+			return nil, fmt.Errorf("missing gasPrice or maxFeePerGas/maxPriorityFeePerGas")
+		}
+	}
+
 	// No need to obtain the noncelock mutex, since we won't be sending this
 	// tx into the transaction pool, but right back to the user
 	if err := args.setDefaults(ctx, s.b); err != nil {

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -405,7 +405,7 @@ func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args Sen
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction()
+	tx, err := args.toTransaction(s.b)
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func (s *PublicTransactionPoolAPI) SignTransactionAsFeePayer(ctx context.Context
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction()
+	tx, err := args.toTransaction(s.b)
 	if err != nil {
 		return nil, err
 	}
@@ -488,7 +488,7 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 	if err := sendArgs.setDefaults(ctx, s.b); err != nil {
 		return common.Hash{}, err
 	}
-	matchTx, err := sendArgs.toTransaction()
+	matchTx, err := sendArgs.toTransaction(s.b)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -509,7 +509,7 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 			if gasLimit != nil && *gasLimit != 0 {
 				sendArgs.GasLimit = gasLimit
 			}
-			tx, err := sendArgs.toTransaction()
+			tx, err := sendArgs.toTransaction(s.b)
 			if err != nil {
 				return common.Hash{}, err
 			}

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -405,7 +405,7 @@ func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args Sen
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func (s *PublicTransactionPoolAPI) SignTransactionAsFeePayer(ctx context.Context
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}
@@ -488,7 +488,7 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 	if err := sendArgs.setDefaults(ctx, s.b); err != nil {
 		return common.Hash{}, err
 	}
-	matchTx, err := sendArgs.toTransaction(s.b)
+	matchTx, err := sendArgs.toTransaction()
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -509,7 +509,7 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 			if gasLimit != nil && *gasLimit != 0 {
 				sendArgs.GasLimit = gasLimit
 			}
-			tx, err := sendArgs.toTransaction(s.b)
+			tx, err := sendArgs.toTransaction()
 			if err != nil {
 				return common.Hash{}, err
 			}

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -400,7 +400,7 @@ type SignTransactionResult struct {
 // The node needs to have the private key of the account corresponding with
 // the given from address and it needs to be unlocked.
 func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args SendTxArgs) (*SignTransactionResult, error) {
-	if args.TypeInt.IsEthTypedTransaction() {
+	if args.TypeInt != nil && args.TypeInt.IsEthTypedTransaction() {
 		if args.Price == nil && (args.MaxPriorityFeePerGas == nil || args.MaxFeePerGas == nil) {
 			return nil, fmt.Errorf("missing gasPrice or maxFeePerGas/maxPriorityFeePerGas")
 		}
@@ -411,7 +411,7 @@ func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args Sen
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +434,7 @@ func (s *PublicTransactionPoolAPI) SignTransactionAsFeePayer(ctx context.Context
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := args.toTransaction(s.b)
+	tx, err := args.toTransaction()
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +494,7 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 	if err := sendArgs.setDefaults(ctx, s.b); err != nil {
 		return common.Hash{}, err
 	}
-	matchTx, err := sendArgs.toTransaction(s.b)
+	matchTx, err := sendArgs.toTransaction()
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -515,7 +515,7 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 			if gasLimit != nil && *gasLimit != 0 {
 				sendArgs.GasLimit = gasLimit
 			}
-			tx, err := sendArgs.toTransaction(s.b)
+			tx, err := sendArgs.toTransaction()
 			if err != nil {
 				return common.Hash{}, err
 			}

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -226,7 +226,7 @@ func (args *SendTxArgs) checkArgs() error {
 // genTxValuesMap generates a value map used used in "NewTransactionWithMap" function.
 // This function assigned all non-nil values regardless of the tx type.
 // Invalid values in the map will be validated in "NewTransactionWithMap" function.
-func (args *SendTxArgs) genTxValuesMap(b Backend) map[types.TxValueKeyType]interface{} {
+func (args *SendTxArgs) genTxValuesMap() map[types.TxValueKeyType]interface{} {
 	values := make(map[types.TxValueKeyType]interface{})
 
 	// common tx fields. They should have values after executing "setDefaults" function.
@@ -262,8 +262,6 @@ func (args *SendTxArgs) genTxValuesMap(b Backend) map[types.TxValueKeyType]inter
 	}
 	if args.Amount != nil {
 		values[types.TxValueKeyAmount] = (*big.Int)(args.Amount)
-	} else if args.TypeInt.IsEthereumTransaction() {
-		values[types.TxValueKeyAmount] = common.Big0
 	}
 	if args.Payload != nil {
 		// chain data anchoring type uses the TxValueKeyAnchoredData field
@@ -290,8 +288,6 @@ func (args *SendTxArgs) genTxValuesMap(b Backend) map[types.TxValueKeyType]inter
 	}
 	if args.ChainID != nil {
 		values[types.TxValueKeyChainID] = (*big.Int)(args.ChainID)
-	} else if args.TypeInt.IsEthTypedTransaction() {
-		values[types.TxValueKeyChainID] = b.ChainConfig().ChainID
 	}
 	if args.AccessList != nil {
 		values[types.TxValueKeyAccessList] = *args.AccessList
@@ -307,7 +303,7 @@ func (args *SendTxArgs) genTxValuesMap(b Backend) map[types.TxValueKeyType]inter
 }
 
 // toTransaction returns an unsigned transaction filled with values in SendTxArgs.
-func (args *SendTxArgs) toTransaction(b Backend) (*types.Transaction, error) {
+func (args *SendTxArgs) toTransaction() (*types.Transaction, error) {
 	var input []byte
 
 	// provide detailed error messages to users (optional)
@@ -337,7 +333,7 @@ func (args *SendTxArgs) toTransaction(b Backend) (*types.Transaction, error) {
 	}
 
 	// for other tx types except TxTypeLegacyTransaction
-	values := args.genTxValuesMap(b)
+	values := args.genTxValuesMap()
 	return types.NewTransactionWithMap(*args.TypeInt, values)
 }
 


### PR DESCRIPTION
## Proposed changes

### 1. Set Amount(field name: `value` and ChainId(field name: `chainId`) for eth typed tx by default.

`Amount` and `chainId` are optional fields for newly added Ethereum typed txs(accessList, dynamicFee) and those must be set automatically when user does not pass it as argument by default.

I used `IsEthereumTransaction` for checking `value` field 
but used `IsEthTypedTransaction` for checking gasPrice or `maxPriorityFeePerGas/maxFeePerGas` to ensure that `LegacyTransaction` is working same way.

### 2. Checks gasPrice or maxPriorityFeePerGas/maxFeePerGas before signing

Like Ethereum does, we should check both arguments before processing eth typed transactions in `klay_signTrasnaction`.

### Test logs
#### 1. Set Amount(field name: `value` and ChainId(field name: `chainId`) for eth typed tx by default.
**Before**
```js
> klay.signTransaction({from: sender, input: bytecode, gas: 500000, gasPrice: gasPrice, accessList: accessList, nonce: nonce, typeInt: 30721, chainId: "0x7e3"})
Error: Amount must be a type of *big.Int
    at web3.js:3278:20
    at web3.js:6805:15
    at web3.js:5216:36
    at <anonymous>:1:1
> klay.signTransaction({from: sender, input: bytecode, gas: 500000, gasPrice: gasPrice, accessList: accessList, nonce: nonce, typeInt: 30721})
Error: ChainID must be a type of ChainID
    at web3.js:3278:20
    at web3.js:6805:15
    at web3.js:5216:36
    at <anonymous>:1:1
```
**After**
fields `value` and `chainId` are missed but works OK like Geth does.
**Klaytn**
```js
> klay.signTransaction({from: sender, input: bytecode, gas: 500000, gasPrice: gasPrice, accessList: accessList, nonce: nonce, typeInt: 30721})
{
  raw: "0x7801f901918207e3048505d21dba008307a1208080b8df6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680632e64cec114604e5780636057361d146076575b600080fd5b348015605957600080fd5b50606060a0565b6040518082815260200191505060405180910390f35b348015608157600080fd5b50609e6004803603810190808035906020019092919050505060a9565b005b60008054905090565b80600081905550505600a165627a7a723058207783dba41884f73679e167576362b7277f88458815141651f48ca38c25b498f80029f85bf85994ca7a99380131e6c76cfa622396347107aeedca2df842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000780a018f78773d93bddf95c15478df90d110a6a568c77366ebd211c675e0fd30e3529a0156aa3d330208c15847bd8d700db14de573b3ced2c3abdc7a209f09cc2b77d55",
  tx: {
    accessList: [{
        address: "0xca7a99380131e6c76cfa622396347107aeedca2d",
        storageKeys: [...]
    }],
    chainId: "0x7e3",
    gas: "0x7a120",
    gasPrice: "0x5d21dba00",
    hash: "0xc9081d933bd3a0dd4dc167c8a5d8a325b929773c48cfb46f420310f91a37d382",
    input: "0x6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680632e64cec114604e5780636057361d146076575b600080fd5b348015605957600080fd5b50606060a0565b6040518082815260200191505060405180910390f35b348015608157600080fd5b50609e6004803603810190808035906020019092919050505060a9565b005b60008054905090565b80600081905550505600a165627a7a723058207783dba41884f73679e167576362b7277f88458815141651f48ca38c25b498f80029",
    nonce: "0x4",
    signatures: [{
        R: "0x18f78773d93bddf95c15478df90d110a6a568c77366ebd211c675e0fd30e3529",
        S: "0x156aa3d330208c15847bd8d700db14de573b3ced2c3abdc7a209f09cc2b77d55",
        V: "0x0"
    }],
    to: null,
    type: "TxTypeEthereumAccessList",
    typeInt: 30721,
    value: "0x0"
  }
}
```
Geth
```js
> eth.signTransaction({from: sender, input: input, accessList: accessList, gas: 600000, gasPrice: 25000000000, nonce: 3})
{
  raw: "0x01f901928302edaf038505d21dba00830927c08080b8df6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680632e64cec114604e5780636057361d146076575b600080fd5b348015605957600080fd5b50606060a0565b6040518082815260200191505060405180910390f35b348015608157600080fd5b50609e6004803603810190808035906020019092919050505060a9565b005b60008054905090565b80600081905550505600a165627a7a723058207783dba41884f73679e167576362b7277f88458815141651f48ca38c25b498f80029f85bf85994ca7a99380131e6c76cfa622396347107aeedca2df842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000701a04b938ee4eb6c208b1cccc8ba0220d0bbf2a56d5c6f40105fd0e4ce969b6e62e4a06e1eb9412f27c29414704658724a8860084be6a087fb61a1d1758407850dac70",
  tx: {
    accessList: [{
        address: "0xca7a99380131e6c76cfa622396347107aeedca2d",
        storageKeys: [...]
    }],
    chainId: "0x2edaf",
    gas: "0x927c0",
    gasPrice: "0x5d21dba00",
    hash: "0x38f7760bff8f6db07a1570f70c8b9dc4088c6a3313fd1e09930bb5143d2a34a1",
    input: "0x6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680632e64cec114604e5780636057361d146076575b600080fd5b348015605957600080fd5b50606060a0565b6040518082815260200191505060405180910390f35b348015608157600080fd5b50609e6004803603810190808035906020019092919050505060a9565b005b60008054905090565b80600081905550505600a165627a7a723058207783dba41884f73679e167576362b7277f88458815141651f48ca38c25b498f80029",
    maxFeePerGas: null,
    maxPriorityFeePerGas: null,
    nonce: "0x3",
    r: "0x4b938ee4eb6c208b1cccc8ba0220d0bbf2a56d5c6f40105fd0e4ce969b6e62e4",
    s: "0x6e1eb9412f27c29414704658724a8860084be6a087fb61a1d1758407850dac70",
    to: null,
    type: "0x1",
    v: "0x1",
    value: "0x0"
  }
}
```

#### 2. Checks gasPrice or maxPriorityFeePerGas/maxFeePerGas before signing
**Before**
maxFeePerGas is also needed but it works. 
```js
> klay.signTransaction({from: sender, input: bytecode, gas: 500000, maxPriorityFeePerGas: gasPrice, accessList: accessList, nonce: nonce, typeInt: 30722})
Working!
```

**After**
**Klaytn**
missing `maxFeePerGas` field for DynamicFee tx. Both `maxPriorityFeePerGas` and `maxFeePerGas` are needed.
```js
> klay.signTransaction({from: sender, input: bytecode, gas: 500000, maxPriorityFeePerGas: gasPrice, accessList: accessList, nonce: nonce, typeInt: 30722})
Error: missing gasPrice or maxFeePerGas/maxPriorityFeePerGas
    at web3.js:3278:20
    at web3.js:6805:15
    at web3.js:5216:36
    at <anonymous>:1:1
```
missing `gasPrice` field for AccessList tx
```js
> klay.signTransaction({from: sender, input: bytecode, accessList: accessList, gas: 500000, typeInt: 30721})

Error: missing gasPrice or maxFeePerGas/maxPriorityFeePerGas
    at web3.js:3278:20
    at web3.js:6805:15
    at web3.js:5216:36
    at <anonymous>:1:1
```


**Geth**
```js
missing `maxFeePerGas` field for DynamicFee tx. Both `maxPriorityFeePerGas` and `maxFeePerGas` are needed.
> eth.signTransaction({from: sender, input: input, accessList: accessList, gas: 600000, maxPriorityFeePerGas: 25000000000, nonce: 3})
Error: missing gasPrice or maxFeePerGas/maxPriorityFeePerGas
	at web3.js:6357:37(47)
	at web3.js:5091:62(37)
	at <eval>:1:20(16)
```
missing `gasPrice` field for AccessList tx
```js
> eth.signTransaction({from: sender, input: input, accessList: accessList, gas: 600000, nonce: 3})

Error: missing gasPrice or maxFeePerGas/maxPriorityFeePerGas
	at web3.js:6357:37(47)
	at web3.js:5091:62(37)
	at <eval>:1:20(14)
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
