### PR TITLE
Optional baseFeePerGas field in header rpc depends on IsEthTxTypeForkEnabled

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1440,7 +1440,10 @@ func (api *EthereumAPI) rpcMarshalHeader(head *types.Header) (map[string]interfa
 		"timestamp":        hexutil.Big(*head.Time),
 		"transactionsRoot": head.TxHash,
 		"receiptsRoot":     head.ReceiptHash,
-		"baseFeePerGas":    (*hexutil.Big)(new(big.Int).SetUint64(params.BaseFee)),
+	}
+
+	if api.publicBlockChainAPI.b.ChainConfig().IsEthTxTypeForkEnabled(head.Number) {
+		result["baseFeePerGas"] = (*hexutil.Big)(new(big.Int).SetUint64(params.BaseFee))
 	}
 
 	return result, nil

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -274,6 +274,7 @@ func testGetBlock(t *testing.T, testAPIName string, fullTxs bool) {
 	mockEngine := mocks.NewMockEngine(mockCtrl)
 	// GetHeader APIs calls internally below methods.
 	mockBackend.EXPECT().Engine().Return(mockEngine)
+	mockBackend.EXPECT().ChainConfig().Return(dummyChainConfigForEthereumAPITest)
 	// Author is called when calculates miner field of Header.
 	dummyMiner := common.HexToAddress("0x9712f943b296758aaae79944ec975884188d3a96")
 	mockEngine.EXPECT().Author(gomock.Any()).Return(dummyMiner, nil)

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -136,23 +136,46 @@ func TestTestEthereumAPI_GetUncleCountByBlockHash(t *testing.T) {
 
 // TestEthereumAPI_GetHeaderByNumber tests GetHeaderByNumber.
 func TestEthereumAPI_GetHeaderByNumber(t *testing.T) {
-	testGetHeader(t, "GetHeaderByNumber")
+	testGetHeader(t, "GetHeaderByNumber", true)
 }
 
 // TestEthereumAPI_GetHeaderByHash tests GetHeaderByNumber.
 func TestEthereumAPI_GetHeaderByHash(t *testing.T) {
-	testGetHeader(t, "GetHeaderByHash")
+	testGetHeader(t, "GetHeaderByHash", true)
+}
+
+// TestEthereumAPI_GetHeaderByNumber tests GetHeaderByNumber.
+func TestEthereumAPI_GetHeaderByNumber_BeforeEnableFork(t *testing.T) {
+	testGetHeader(t, "GetHeaderByNumber", false)
+}
+
+// TestEthereumAPI_GetHeaderByHash tests GetHeaderByNumber.
+func TestEthereumAPI_GetHeaderByHash_BeforeEnableFork(t *testing.T) {
+	testGetHeader(t, "GetHeaderByHash", false)
 }
 
 // testGetHeader generates data to test GetHeader related functions in EthereumAPI
 // and actually tests the API function passed as a parameter.
-func testGetHeader(t *testing.T, testAPIName string) {
+func testGetHeader(t *testing.T, testAPIName string, forkEnabled bool) {
 	mockCtrl, mockBackend, api := testInitForEthApi(t)
 
 	// Creates a MockEngine.
 	mockEngine := mocks.NewMockEngine(mockCtrl)
 	// GetHeader APIs calls internally below methods.
 	mockBackend.EXPECT().Engine().Return(mockEngine)
+	if forkEnabled {
+		mockBackend.EXPECT().ChainConfig().Return(dummyChainConfigForEthereumAPITest)
+	} else {
+		chainConfigForNotCompatibleEthBlock := &params.ChainConfig{
+			ChainID:                  dummyChainConfigForEthereumAPITest.ChainID,
+			IstanbulCompatibleBlock:  dummyChainConfigForEthereumAPITest.IstanbulCompatibleBlock,
+			LondonCompatibleBlock:    dummyChainConfigForEthereumAPITest.LondonCompatibleBlock,
+			EthTxTypeCompatibleBlock: nil,
+			UnitPrice:                dummyChainConfigForEthereumAPITest.UnitPrice,
+		}
+		mockBackend.EXPECT().ChainConfig().Return(chainConfigForNotCompatibleEthBlock)
+	}
+
 	// Author is called when calculates miner field of Header.
 	dummyMiner := common.HexToAddress("0x9712f943b296758aaae79944ec975884188d3a96")
 	mockEngine.EXPECT().Author(gomock.Any()).Return(dummyMiner, nil)
@@ -203,7 +226,6 @@ func testGetHeader(t *testing.T, testAPIName string) {
 	  "jsonrpc": "2.0",
 	  "id": 1,
 	  "result": {
-		"baseFeePerGas": "0x0",
 		"difficulty": "0x1",
 		"extraData": "0x",
 		"gasLimit": "0xe8d4a50fff",
@@ -225,6 +247,9 @@ func testGetHeader(t *testing.T, testAPIName string) {
 	  }
 	}
     `), &expected))
+	if forkEnabled {
+		expected["baseFeePerGas"] = "0x0"
+	}
 	checkEthereumBlockOrHeaderFormat(t, expected, ethHeader)
 }
 


### PR DESCRIPTION
## Proposed changes

This PR introduces returning `baseFeePerGas` field in the header rpc depends on chain config.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
