### PR TITLE
Fixed receipt status values when serving eth_getTransactionReceipt

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -970,7 +970,12 @@ func newEthTransactionReceipt(tx *types.Transaction, b Backend, blockHash common
 	}
 
 	// Always use the "status" field and Ignore the "root" field.
-	fields["status"] = hexutil.Uint(receipt.Status)
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		// In Ethereum, status field can have 0(=Failure) or 1(=Success) only.
+		fields["status"] = hexutil.Uint(types.ReceiptStatusFailed)
+	} else {
+		fields["status"] = hexutil.Uint(receipt.Status)
+	}
 
 	if receipt.Logs == nil {
 		fields["logs"] = [][]*types.Log{}


### PR DESCRIPTION
## Proposed changes

The value of status field of Receipt should have `0`(=Failure) or `1`(=Success) only when served as eth namespace.

### As-Is 
**Klaytn - Get Transaction Receipt for reverted tx**
```shell
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x7247ef708a97c98e2459696afe4473a6f37cb0bc9b43e4144238d730f45a57f1"],"id":1}'
```
* status field have `"0x9"` which is not `"0x0"`.
```js
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "blockHash": "0x7bfb410e63d8f2865a2774d62f74057071aed4c0c7868af29665ddc3ae661c64",
    "blockNumber": "0xebcb",
    "contractAddress": null,
    "cumulativeGasUsed": "0x6661",
    "effectiveGasPrice": "0x5d21dba00",
    "from": "0xca7a99380131e6c76cfa622396347107aeedca2d",
    "gasUsed": "0x6661",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "status": "0x9",
    "to": "0xce9267d48d3fb8e9efabaaf6b6662dfd72187377",
    "transactionHash": "0x7247ef708a97c98e2459696afe4473a6f37cb0bc9b43e4144238d730f45a57f1",
    "transactionIndex": "0x0",
    "type": "0x0"
  }
}
```

### To-be ( If this PR merged)
**Geth - Get Transaction Receipt for reverted tx**
```shell
curl http://localhost:8545 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x261cdfabddc91b40608a16868964a353d54da547dfb722c13628e3f7df343be8"],"id":1}'
```
* status field have `"0x0"` because it is reverted tx.
```js
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "blockHash": "0xa1abc8e1c29c4bafecb040a8c4de7b8bf3aec325249811569f7835c0e3abecff",
    "blockNumber": "0xc1b",
    "contractAddress": null,
    "cumulativeGasUsed": "0x5f15",
    "effectiveGasPrice": "0x3b9aca07",
    "from": "0xca7a99380131e6c76cfa622396347107aeedca2d",
    "gasUsed": "0x5f15",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "status": "0x0",
    "to": "0x07af6e214e7deb6c3d7409fca8d81adda8151237",
    "transactionHash": "0x261cdfabddc91b40608a16868964a353d54da547dfb722c13628e3f7df343be8",
    "transactionIndex": "0x0",
    "type": "0x2"
  }
}
```

**Klaytn - Get Transaction Receipt for reverted tx**
```shell
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x7247ef708a97c98e2459696afe4473a6f37cb0bc9b43e4144238d730f45a57f1"],"id":1}'
```
* status field have `"0x0"` because it is reverted tx.
```js
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "blockHash": "0x7bfb410e63d8f2865a2774d62f74057071aed4c0c7868af29665ddc3ae661c64",
    "blockNumber": "0xebcb",
    "contractAddress": null,
    "cumulativeGasUsed": "0x6661",
    "effectiveGasPrice": "0x5d21dba00",
    "from": "0xca7a99380131e6c76cfa622396347107aeedca2d",
    "gasUsed": "0x6661",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "status": "0x0",
    "to": "0xce9267d48d3fb8e9efabaaf6b6662dfd72187377",
    "transactionHash": "0x7247ef708a97c98e2459696afe4473a6f37cb0bc9b43e4144238d730f45a57f1",
    "transactionIndex": "0x0",
    "type": "0x0"
  }
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
