### PR TITLE
When fetching non-existing block using eth namespace APIs, it must return null

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -466,14 +466,17 @@ func (api *EthereumAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNu
 	if err != nil {
 		return nil, nil
 	}
-	response, err := api.rpcMarshalBlock(klaytnBlock, true, fullTx)
-	if err == nil && number == rpc.PendingBlockNumber {
-		// Pending blocks need to nil out a few fields
-		for _, field := range []string{"hash", "nonce", "miner"} {
-			response[field] = nil
+	if klaytnBlock != nil {
+		response, err := api.rpcMarshalBlock(klaytnBlock, true, fullTx)
+		if err == nil && number == rpc.PendingBlockNumber {
+			// Pending blocks need to nil out a few fields
+			for _, field := range []string{"hash", "nonce", "miner"} {
+				response[field] = nil
+			}
 		}
+		return response, err
 	}
-	return response, err
+	return nil, nil
 }
 
 // GetBlockByHash returns the requested block. When fullTx is true all transactions in the block are returned in full

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -462,10 +462,7 @@ func (api *EthereumAPI) GetHeaderByHash(ctx context.Context, hash common.Hash) m
 func (api *EthereumAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	// Klaytn backend returns error when there is no matched block but
 	// Ethereum returns it as nil without error, so we should return is as nil when there is no matched block.
-	klaytnBlock, err := api.publicBlockChainAPI.b.BlockByNumber(ctx, number)
-	if err != nil {
-		return nil, nil
-	}
+	klaytnBlock, _ := api.publicBlockChainAPI.b.BlockByNumber(ctx, number)
 	if klaytnBlock != nil {
 		response, err := api.rpcMarshalBlock(klaytnBlock, true, fullTx)
 		if err == nil && number == rpc.PendingBlockNumber {


### PR DESCRIPTION
## Proposed changes

eth namespace APIs fetching non-existing block must returns null based on its spec.

### As-Is
Is must returns `null`, but currently it returns error like below.
```js
> eth.getBlockByNumber(50000000)
Error: the block does not exist (block number: 50000000)
    at web3.js:3278:20
    at web3.js:6805:15
    at web3.js:5216:36
    at <anonymous>:1:1
```

### To-be (If this PR is merged.)
**Geth**
```js
> eth.getBlockByNumber(99999999)
null
```

**Klaytn**
* Returns `null` for non-existing block.
```js
> eth.getBlockByNumber(9999999999)
null
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
