### PR TITLE
Remove EthereumTxTypeEnvelope from raw tx

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -865,7 +865,9 @@ func (api *EthereumAPI) GetRawTransactionByBlockNumberAndIndex(ctx context.Conte
 	if err != nil {
 		return nil
 	}
-
+	if rawTx[0] == byte(types.EthereumTxTypeEnvelope) {
+		rawTx = rawTx[1:]
+	}
 	return rawTx
 }
 
@@ -875,7 +877,9 @@ func (api *EthereumAPI) GetRawTransactionByBlockHashAndIndex(ctx context.Context
 	if err != nil {
 		return nil
 	}
-
+	if rawTx[0] == byte(types.EthereumTxTypeEnvelope) {
+		rawTx = rawTx[1:]
+	}
 	return rawTx
 }
 

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -1845,6 +1845,94 @@ func createTestData(t *testing.T, header *types.Header) (*types.Block, types.Tra
 	return block, txs, txHashMap, receiptMap, receipts
 }
 
+func createEthereumTypedTestData(t *testing.T, header *types.Header) (*types.Block, types.Transactions, map[common.Hash]*types.Transaction, map[common.Hash]*types.Receipt, []*types.Receipt) {
+	var txs types.Transactions
+
+	var gasPrice = big.NewInt(25 * params.Ston)
+	var deployData = "0x60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb0029"
+	var accessList = types.AccessList{
+		types.AccessTuple{
+			Address: common.StringToAddress("0x23a519a88e79fbc0bab796f3dce3ff79a2373e30"),
+			StorageKeys: []common.Hash{
+				common.HexToHash("0xa145cd642157a5df01f5bc3837a1bb59b3dcefbbfad5ec435919780aebeaba2b"),
+				common.HexToHash("0x12e2c26dca2fb2b8879f54a5ea1604924edf0e37965c2be8aa6133b75818da40"),
+			},
+		},
+	}
+	var chainId = new(big.Int).SetUint64(2019)
+
+	var txHashMap = make(map[common.Hash]*types.Transaction)
+	var receiptMap = make(map[common.Hash]*types.Receipt)
+	var receipts []*types.Receipt
+
+	// Make test transactions data
+	{
+		// TxTypeEthereumAccessList
+		to := common.StringToAddress("0xb5a2d79e9228f3d278cb36b5b15930f24fe8bae8")
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:      uint64(txs.Len()),
+			types.TxValueKeyTo:         &to,
+			types.TxValueKeyAmount:     big.NewInt(10),
+			types.TxValueKeyGasLimit:   uint64(50000000),
+			types.TxValueKeyData:       common.Hex2Bytes(deployData),
+			types.TxValueKeyGasPrice:   gasPrice,
+			types.TxValueKeyAccessList: accessList,
+			types.TxValueKeyChainID:    chainId,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeEthereumAccessList, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(1), R: big.NewInt(2), S: big.NewInt(3)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+	{
+		// TxTypeEthereumDynamicFee
+		to := common.StringToAddress("0xb5a2d79e9228f3d278cb36b5b15930f24fe8bae8")
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:      uint64(txs.Len()),
+			types.TxValueKeyTo:         &to,
+			types.TxValueKeyAmount:     big.NewInt(3),
+			types.TxValueKeyGasLimit:   uint64(50000000),
+			types.TxValueKeyData:       common.Hex2Bytes(deployData),
+			types.TxValueKeyGasTipCap:  gasPrice,
+			types.TxValueKeyGasFeeCap:  gasPrice,
+			types.TxValueKeyAccessList: accessList,
+			types.TxValueKeyChainID:    chainId,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeEthereumDynamicFee, values)
+		assert.Equal(t, nil, err)
+
+		signatures := types.TxSignatures{
+			&types.TxSignature{V: big.NewInt(2), R: big.NewInt(3), S: big.NewInt(4)},
+		}
+		tx.SetSignature(signatures)
+
+		txs = append(txs, tx)
+		txHashMap[tx.Hash()] = tx
+		// For testing, set GasUsed with tx.Gas()
+		receiptMap[tx.Hash()] = createReceipt(t, tx, tx.Gas())
+		receipts = append(receipts, receiptMap[tx.Hash()])
+	}
+
+	// Create a block which includes all transaction data.
+	var block *types.Block
+	if header != nil {
+		block = types.NewBlock(header, txs, receipts)
+	} else {
+		block = types.NewBlock(&types.Header{Number: big.NewInt(1)}, txs, nil)
+	}
+
+	return block, txs, txHashMap, receiptMap, receipts
+}
+
 func createReceipt(t *testing.T, tx *types.Transaction, gasUsed uint64) *types.Receipt {
 	rct := types.NewReceipt(uint(0), tx.Hash(), gasUsed)
 	rct.Logs = []*types.Log{}
@@ -2264,4 +2352,47 @@ func TestEthTransactionArgs_setDefaults(t *testing.T) {
 			require.Equal(t, test.expectedResult, txArgs)
 		}
 	}
+}
+
+func TestEthereumAPI_GetRawTransactionByHash(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	block, txs, txHashMap, _, _ := createEthereumTypedTestData(t, nil)
+
+	// Define queryFromPool for ReadTxAndLookupInfo function return tx from hash map.
+	// MockDatabaseManager will initiate data with txHashMap, block and queryFromPool.
+	// If queryFromPool is true, MockDatabaseManager will return nil to query transactions from transaction pool,
+	// otherwise return a transaction from txHashMap.
+	mockDBManager := &MockDatabaseManager{txHashMap: txHashMap, blockData: block, queryFromPool: false}
+
+	// Mock Backend functions.
+	mockBackend.EXPECT().ChainDB().Return(mockDBManager).Times(txs.Len())
+
+	for i := 0; i < txs.Len(); i++ {
+		rawTx, err := api.GetRawTransactionByHash(context.Background(), txs[i].Hash())
+		if err != nil {
+			t.Fatal(err)
+		}
+		prefix := types.TxType(rawTx[0])
+		// When get raw transaction by eth namespace API, EthereumTxTypeEnvelope must not be included.
+		require.NotEqual(t, types.EthereumTxTypeEnvelope, prefix)
+	}
+
+	mockCtrl.Finish()
+}
+
+func TestEthereumAPI_GetRawTransactionByBlockNumberAndIndex(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	block, txs, _, _, _ := createEthereumTypedTestData(t, nil)
+
+	// Mock Backend functions.
+	mockBackend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil).Times(txs.Len())
+
+	for i := 0; i < txs.Len(); i++ {
+		rawTx := api.GetRawTransactionByBlockNumberAndIndex(context.Background(), rpc.BlockNumber(block.NumberU64()), hexutil.Uint(i))
+		prefix := types.TxType(rawTx[0])
+		// When get raw transaction by eth namespace API, EthereumTxTypeEnvelope must not be included.
+		require.NotEqual(t, types.EthereumTxTypeEnvelope, prefix)
+	}
+
+	mockCtrl.Finish()
 }


### PR DESCRIPTION
## Proposed changes

`EthereumTxTypeEnvelope`(=0x78) is used for `klay` namespace APIs, not `eth`.

### As-is
* `EthereumTxTypeEnvelope`(=0x78) is appended for raw tx result when fetching Ethereum typed transactions using `eth_getRawTransactionByBlockHashAndIndex` and `eth_getRawTransactionByBlockNumberAndIndex`. 
```shell
# eth_getRawTransactionByBlockHashAndIndex
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockHashAndIndex","params":["0x229ad80da53d0fb4111bf07d6b486d7dc57ee2af8c1e9f0af35dd4e7c0658885", "0x0"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x7802f86e8207e3458505d21dba008505d21dba0082c350943e2ac308cd78ac2fe162f9522deb2b56d9da94998080c001a04fc36a3c56650ffe1da32b5fdb81e3b5dd39c57154dfe721192a0742da91c261a0119b80ec12e1c01faab5673f29bcd3d8a56a4c319426bccf1570c7e13afe1477"}

# eth_getRawTransactionByBlockNumberAndIndex
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockNumberAndIndex","params":["0x174a5", "0x0"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x7802f86e8207e3458505d21dba008505d21dba0082c350943e2ac308cd78ac2fe162f9522deb2b56d9da94998080c001a04fc36a3c56650ffe1da32b5fdb81e3b5dd39c57154dfe721192a0742da91c261a0119b80ec12e1c01faab5673f29bcd3d8a56a4c319426bccf1570c7e13afe1477"}
```

### To-be (If this PR is merged)
* `EthereumTxTypeEnvelope`(=0x78) is appended for raw tx result. 
```shell
# eth_getRawTransactionByBlockHashAndIndex
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockHashAndIndex","params":["0x229ad80da53d0fb4111bf07d6b486d7dc57ee2af8c1e9f0af35dd4e7c0658885", "0x0"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x02f86e8207e3458505d21dba008505d21dba0082c350943e2ac308cd78ac2fe162f9522deb2b56d9da94998080c001a04fc36a3c56650ffe1da32b5fdb81e3b5dd39c57154dfe721192a0742da91c261a0119b80ec12e1c01faab5673f29bcd3d8a56a4c319426bccf1570c7e13afe1477"}

# eth_getRawTransactionByBlockNumberAndIndex
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockNumberAndIndex","params":["0x174a5", "0x0"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x02f86e8207e3458505d21dba008505d21dba0082c350943e2ac308cd78ac2fe162f9522deb2b56d9da94998080c001a04fc36a3c56650ffe1da32b5fdb81e3b5dd39c57154dfe721192a0742da91c261a0119b80ec12e1c01faab5673f29bcd3d8a56a4c319426bccf1570c7e13afe1477"}
```
* Of course raw tx of other tx types returned as it is. 
```shell
# eth_getRawTransactionByBlockNumberAndIndex for LegacyTransaction
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockNumberAndIndex","params":["0x17d63", "0x0"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0xf866468505d21dba0082c350943e2ac308cd78ac2fe162f9522deb2b56d9da94998080820fe9a0ee8406f2a554e781b07f0a66889a4c697ca58348345d303923f59f87bae204a7a06165806b67122f0e1309b673835cfe2e7ec0a14ecc7d11249ee21b520a351d21"

# eth_getRawTransactionByBlockNumberAndIndex for ValueTransfer
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockHashAndIndex","params":["0x226f0e25cda2732dda1f74ec47d9a5a32e64566325987c3eed1690c3c12eab63", "0x0"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x08f880498505d21dba0082c350943e2ac308cd78ac2fe162f9522deb2b56d9da94998201f494ca7a99380131e6c76cfa622396347107aeedca2df847f845820feaa0cfe0a5fae76def5ae00ab0c77416d6056f408c25fb1c58ae06898ed284b69762a0691b9ef65784125bb85b5a97c569c65ea168517d26219114b596465ba22bf8d5"}
``` 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...