### PR TITLE
Return nil for non-existing block when fetching uncle count

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -496,16 +496,22 @@ func (api *EthereumAPI) GetUncleByBlockHashAndIndex(ctx context.Context, blockHa
 	return nil, nil
 }
 
-// GetUncleCountByBlockNumber returns 0 because there is no uncle block in Klaytn.
+// GetUncleCountByBlockNumber returns 0 when given blockNr exists because there is no uncle block in Klaytn.
 func (api *EthereumAPI) GetUncleCountByBlockNumber(ctx context.Context, blockNr rpc.BlockNumber) *hexutil.Uint {
-	uncleCount := hexutil.Uint(ZeroUncleCount)
-	return &uncleCount
+	if block, _ := api.publicBlockChainAPI.b.BlockByNumber(ctx, blockNr); block != nil {
+		n := hexutil.Uint(ZeroUncleCount)
+		return &n
+	}
+	return nil
 }
 
-// GetUncleCountByBlockHash returns 0 because there is no uncle block in Klaytn.
+// GetUncleCountByBlockHash returns 0 when given blockHash exists because there is no uncle block in Klaytn.
 func (api *EthereumAPI) GetUncleCountByBlockHash(ctx context.Context, blockHash common.Hash) *hexutil.Uint {
-	uncleCount := hexutil.Uint(ZeroUncleCount)
-	return &uncleCount
+	if block, _ := api.publicBlockChainAPI.b.BlockByHash(ctx, blockHash); block != nil {
+		n := hexutil.Uint(ZeroUncleCount)
+		return &n
+	}
+	return nil
 }
 
 // GetCode returns the code stored at the given address in the state for the given block number.

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -152,7 +152,7 @@ func TestTestEthereumAPI_GetUncleCountByBlockHash(t *testing.T) {
 	existingHash := block.Hash()
 	assert.Equal(t, hexutil.Uint(ZeroUncleCount), *api.GetUncleCountByBlockHash(context.Background(), existingHash))
 
-	// For existing block hash, it must return 0.
+	// For non-existing block hash, it must return nil.
 	mockBackend.EXPECT().BlockByHash(gomock.Any(), gomock.Any()).Return(nil, nil)
 	nonExistingHash := block.Hash()
 	uncleCount := api.GetUncleCountByBlockHash(context.Background(), nonExistingHash)

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -122,16 +122,46 @@ func TestEthereumAPI_GetUncleByBlockHashAndIndex(t *testing.T) {
 
 // TestTestEthereumAPI_GetUncleCountByBlockNumber tests GetUncleCountByBlockNumber.
 func TestTestEthereumAPI_GetUncleCountByBlockNumber(t *testing.T) {
-	api := &EthereumAPI{}
-	uncleCount := hexutil.Uint(ZeroUncleCount)
-	assert.Equal(t, uncleCount, *api.GetUncleCountByBlockNumber(context.Background(), rpc.BlockNumber(0)))
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	block, _, _, _, _ := createTestData(t, nil)
+
+	// For existing block number, it must return 0.
+	mockBackend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil)
+	existingBlockNumber := rpc.BlockNumber(block.Number().Int64())
+	assert.Equal(t, hexutil.Uint(ZeroUncleCount), *api.GetUncleCountByBlockNumber(context.Background(), existingBlockNumber))
+
+	// For non-existing block number, it must return nil.
+	mockBackend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(nil, nil)
+	nonExistingBlockNumber := rpc.BlockNumber(5)
+	uncleCount := api.GetUncleCountByBlockNumber(context.Background(), nonExistingBlockNumber)
+	uintNil := hexutil.Uint(uint(0))
+	expectedResult := &uintNil
+	expectedResult = nil
+	assert.Equal(t, expectedResult, uncleCount)
+
+	mockCtrl.Finish()
 }
 
 // TestTestEthereumAPI_GetUncleCountByBlockHash tests GetUncleCountByBlockHash.
 func TestTestEthereumAPI_GetUncleCountByBlockHash(t *testing.T) {
-	api := &EthereumAPI{}
-	uncleCount := hexutil.Uint(ZeroUncleCount)
-	assert.Equal(t, uncleCount, *api.GetUncleCountByBlockHash(context.Background(), common.Hash{}))
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	block, _, _, _, _ := createTestData(t, nil)
+
+	// For existing block hash, it must return 0.
+	mockBackend.EXPECT().BlockByHash(gomock.Any(), gomock.Any()).Return(block, nil)
+	existingHash := block.Hash()
+	assert.Equal(t, hexutil.Uint(ZeroUncleCount), *api.GetUncleCountByBlockHash(context.Background(), existingHash))
+
+	// For existing block hash, it must return 0.
+	mockBackend.EXPECT().BlockByHash(gomock.Any(), gomock.Any()).Return(nil, nil)
+	nonExistingHash := block.Hash()
+	uncleCount := api.GetUncleCountByBlockHash(context.Background(), nonExistingHash)
+	uintNil := hexutil.Uint(uint(0))
+	expectedResult := &uintNil
+	expectedResult = nil
+	assert.Equal(t, expectedResult, uncleCount)
+
+	mockCtrl.Finish()
 }
 
 // TestEthereumAPI_GetHeaderByNumber tests GetHeaderByNumber.


### PR DESCRIPTION
## Proposed changes

When fetching uncle count for non-existing block using `eth_getUncleCountByBlockHash` or `eth_getUncleCountByBlockNumber` should returns `null` like Ethereum.

### As-is:
* Always return `0x0` regardless of the presence of the block.
```shell
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockHash","params":["0xd9f66395e093e593f2445983ba359d09a8ed2743fc17da159ed25c5db67c4c58"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x0"}
```

### To-be: (If this PR is merged)
**Geth**
```shell
# Fetch uncle count of non-existing block.
curl http://localhost:8545 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockHash","params":["0x068be39d031c80ae8d743484b1db81d2a448869d27b71d21babf022da5edb3f8"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":null}

# Fetch uncle count of existing block.
curl http://localhost:8545 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockNumber","params":["0x9"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x0"}
```
**Klaytn**
* returns `null` for non-existing block and returns `0x0` for existing block.
```shell
# eth_getUncleCountByBlockHash for existing block
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockHash","params":["0x068be39d031c80ae8d743484b1db81d2a448869d27b71d21babf022da5edb3f8"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x0"}

# eth_getUncleCountByBlockHash for non-existing block
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockHash","params":["0xd9f66395e093e593f2445983ba359d09a8ed2743fc17da159ed25c5db67c4c58"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":null}

# eth_getUncleCountByBlockNumber for existing block
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockNumber","params":["0x174a5"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x0"}

# eth_getUncleCountByBlockNumber for non-existing block
curl http://localhost:8551 \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockNumber","params":["0x174a555"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":null}
```


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
