### PR TITLE
state: make GetCodeSize mirror GetCode implementation wise

### DIFF
--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -328,17 +328,10 @@ func (self *StateDB) IsContractAccount(addr common.Address) bool {
 
 func (self *StateDB) GetCodeSize(addr common.Address) int {
 	stateObject := self.getStateObject(addr)
-	if stateObject == nil {
-		return 0
+	if stateObject != nil {
+		return stateObject.CodeSize(self.db)
 	}
-	if stateObject.code != nil {
-		return len(stateObject.code)
-	}
-	size, err := self.db.ContractCodeSize(common.BytesToHash(stateObject.CodeHash()))
-	if err != nil {
-		self.setError(err)
-	}
-	return size
+	return 0
 }
 
 func (self *StateDB) GetCodeHash(addr common.Address) common.Hash {


### PR DESCRIPTION
## Proposed changes
- From https://github.com/ethereum/go-ethereum/pull/21056
- Now GetCodeSize does not set error for emptyCodeHash
- Before this, it set error for emptyCodeHash due to missing value
- This change is introduced to apply https://github.com/klaytn/klaytn/pull/766

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
