### PR TITLE
sort transactions at the same gas price by received time

### DIFF
--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -849,7 +849,6 @@ func (s TxByPriceAndTime) Less(i, j int) bool {
 	}
 	return cmp > 0
 
-	//return s[i].data.GetPrice().Cmp(s[j].data.GetPrice()) > 0
 }
 func (s TxByPriceAndTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -563,8 +563,8 @@ func (tx *Transaction) WithSignature(signer Signer, sig []byte) (*Transaction, e
 	if err != nil {
 		return nil, err
 	}
-	cpy := NewTx(tx.data)
 
+	cpy := &Transaction{data: tx.data, time: tx.time}
 	if tx.Type().IsEthTypedTransaction() {
 		te, ok := cpy.data.(TxInternalDataEthTyped)
 		if ok {
@@ -585,7 +585,7 @@ func (tx *Transaction) WithFeePayerSignature(signer Signer, sig []byte) (*Transa
 		return nil, err
 	}
 
-	cpy := NewTx(tx.data)
+	cpy := &Transaction{data: tx.data, time: tx.time}
 
 	feePayerSig := TxSignatures{&TxSignature{v, r, s}}
 	if err := cpy.SetFeePayerSignatures(feePayerSig); err != nil {

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -895,7 +895,7 @@ func (t *TransactionsByPriceAndNonce) Txs() map[common.Address]Transactions {
 // Note, the input map is reowned so the caller should not interact any more with
 // if after providing it to the constructor.
 func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions) *TransactionsByPriceAndNonce {
-	// Initialize a price based heap with the head transactions
+	// Initialize a price and received time based heap with the head transactions
 	heads := make(TxByPriceAndTime, 0, len(txs))
 	for _, accTxs := range txs {
 		heads = append(heads, accTxs[0])

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -835,7 +835,7 @@ func (s TxByNonce) Less(i, j int) bool {
 }
 func (s TxByNonce) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
-// TxByPrice implements both the sort and the heap interface, making it useful
+// TxByPriceAndTime implements both the sort and the heap interface, making it useful
 // for all at once sorting as well as individually adding and removing elements.
 type TxByPriceAndTime Transactions
 

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -20,9 +20,10 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"errors"
-	"github.com/klaytn/klaytn/rlp"
 	"math"
 	"math/big"
+
+	"github.com/klaytn/klaytn/rlp"
 
 	"github.com/klaytn/klaytn/blockchain/types/accountkey"
 	"github.com/klaytn/klaytn/common"

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"errors"
+	"github.com/klaytn/klaytn/rlp"
 	"math"
 	"math/big"
 
@@ -631,9 +632,16 @@ func equalRecipient(a, b *common.Address) bool {
 // NewAccountCreationTransactionWithMap is a test only function since the accountCreation tx is disabled.
 // The function generates an accountCreation function like 'NewTxInternalDataWithMap()'.
 func NewAccountCreationTransactionWithMap(values map[TxValueKeyType]interface{}) (*Transaction, error) {
-	txdata, err := newTxInternalDataAccountCreationWithMap(values)
+	txData, err := newTxInternalDataAccountCreationWithMap(values)
 	if err != nil {
 		return nil, err
 	}
-	return &Transaction{data: txdata}, nil
+
+	return NewTx(txData), nil
+}
+
+func calculateTxSize(data TxInternalData) common.StorageSize {
+	c := writeCounter(0)
+	rlp.Encode(&c, data)
+	return common.StorageSize(c)
 }

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -260,9 +260,13 @@ func TestHandleTxMsg(t *testing.T) {
 	}
 	// If pm.acceptTxs == 1, TxPool.HandleTxMsg is called.
 	{
+
 		atomic.StoreUint32(&pm.acceptTxs, 1)
 		mockTxPool := mocks.NewMockTxPool(mockCtrl)
-		mockTxPool.EXPECT().HandleTxMsg(gomock.Eq(txs)).AnyTimes()
+
+		//The time field in received transaction through pm.handleMsg() has different value from generated transaction(`tx1`).
+		//It can check whether the transaction created `HandleTxMsg()` is the same as `tx1` through `AddToKnownTxs(txs[0].Hash())`.
+		mockTxPool.EXPECT().HandleTxMsg(gomock.Any()).AnyTimes()
 		pm.txpool = mockTxPool
 
 		mockPeer.EXPECT().AddToKnownTxs(txs[0].Hash()).Times(1)

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -260,7 +260,6 @@ func TestHandleTxMsg(t *testing.T) {
 	}
 	// If pm.acceptTxs == 1, TxPool.HandleTxMsg is called.
 	{
-
 		atomic.StoreUint32(&pm.acceptTxs, 1)
 		mockTxPool := mocks.NewMockTxPool(mockCtrl)
 

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -123,8 +123,12 @@ func TestBasePeer_ReSendTransactions(t *testing.T) {
 
 	assert.False(t, basePeer.KnowsTx(tx1.Hash()))
 	assert.Equal(t, len(sentTxs), len(receivedTxs))
-	receivedTxs[0].Hash()
-	assert.Equal(t, sentTxs[0], receivedTxs[0])
+	assert.Equal(t, sentTxs[0].Hash(), receivedTxs[0].Hash())
+
+	sendTxBinary, _ := sentTxs[0].MarshalBinary()
+	receivedTxBinary, _ := receivedTxs[0].MarshalBinary()
+	assert.Equal(t, sendTxBinary, receivedTxBinary)
+
 }
 
 func TestBasePeer_AsyncSendTransactions(t *testing.T) {

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -94,8 +94,11 @@ func TestBasePeer_SendTransactions(t *testing.T) {
 
 	assert.True(t, basePeer.KnowsTx(tx1.Hash()))
 	assert.Equal(t, len(sentTxs), len(receivedTxs))
-	receivedTxs[0].Hash()
-	assert.Equal(t, sentTxs[0], receivedTxs[0])
+	assert.Equal(t, sentTxs[0].Hash(), receivedTxs[0].Hash())
+
+	sendTxBinary, _ := sentTxs[0].MarshalBinary()
+	receivedTxBinary, _ := receivedTxs[0].MarshalBinary()
+	assert.Equal(t, sendTxBinary, receivedTxBinary)
 }
 
 func TestBasePeer_ReSendTransactions(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

This PR changes the sorting of pool transactions with the same gas price.

Previously transactions were sorted randomly (due to the way go maps work).
Now they are sorted by the time that they were added to the mempool in ascending order.

I ported code from https://github.com/ethereum/go-ethereum/pull/21358

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

Related #1274 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
