### PR TITLE
Add MixedEngine as pass-through to governance.Governance

### DIFF
--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -52,7 +52,7 @@ func TestEthereumAPI_Coinbase(t *testing.T) {
 
 // testNodeAddress generates nodeAddress and tests Etherbase and Coinbase.
 func testNodeAddress(t *testing.T, testAPIName string) {
-	gov := governance.NewGovernance(
+	gov := governance.NewMixedEngineNoInit(
 		dummyChainConfigForEthereumAPITest,
 		database.NewMemoryDBManager(),
 	)

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -167,8 +167,8 @@ func initGenesis(ctx *cli.Context) error {
 
 		// Write governance items to database
 		// If governance data already exist, it'll be skipped with an error log and will not return an error
-		if err := governance.NewGovernance(genesis.Config, chainDB).WriteGovernance(0, govSet,
-			governance.NewGovernanceSet()); err != nil {
+		gov := governance.NewMixedEngineNoInit(genesis.Config, chainDB)
+		if err := gov.WriteGovernance(0, govSet, governance.NewGovernanceSet()); err != nil {
 			logger.Crit("Failed to write governance items", "err", err)
 		}
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -50,7 +50,7 @@ const (
 
 var logger = log.NewModuleLogger(log.ConsensusIstanbulBackend)
 
-func New(rewardbase common.Address, config *istanbul.Config, privateKey *ecdsa.PrivateKey, db database.DBManager, governance *governance.Governance, nodetype common.ConnType) consensus.Istanbul {
+func New(rewardbase common.Address, config *istanbul.Config, privateKey *ecdsa.PrivateKey, db database.DBManager, governance governance.Engine, nodetype common.ConnType) consensus.Istanbul {
 
 	recents, _ := lru.NewARC(inmemorySnapshots)
 	recentMessages, _ := lru.NewARC(inmemoryPeers)
@@ -115,8 +115,8 @@ type backend struct {
 	rewardbase  common.Address
 	currentView atomic.Value //*istanbul.View
 
-	// Reference to the governance.Governance
-	governance *governance.Governance
+	// Reference to the governance.Engine
+	governance governance.Engine
 	// Last Block Number which has current Governance Config
 	lastGovernanceBlock uint64
 

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -816,7 +816,7 @@ func newTestBackendWithConfig(chainConfig *params.ChainConfig, blockPeriod uint6
 		// if governance mode is single, set the node key to the governing node.
 		chainConfig.Governance.GoverningNode = crypto.PubkeyToAddress(key.PublicKey)
 	}
-	gov := governance.NewGovernanceInitialize(chainConfig, dbm)
+	gov := governance.NewMixedEngine(chainConfig, dbm)
 	istanbulConfig := istanbul.DefaultConfig
 	istanbulConfig.BlockPeriod = blockPeriod
 	istanbulConfig.ProposerPolicy = istanbul.ProposerPolicy(chainConfig.Istanbul.ProposerPolicy)

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -674,11 +674,6 @@ func getTestConfig() *params.ChainConfig {
 	return config
 }
 
-func getGovernance(dbm database.DBManager) *governance.Governance {
-	config := getTestConfig()
-	return governance.NewGovernanceInitialize(config, dbm)
-}
-
 func Benchmark_getTargetReceivers(b *testing.B) {
 	_, backend := newBlockChain(1)
 	defer backend.Stop()

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -51,7 +51,7 @@ type Snapshot struct {
 	Tally         []governance.GovernanceTallyItem // Current vote tally to avoid recalculating
 }
 
-func getGovernanceValue(gov *governance.Governance, number uint64) (epoch uint64, policy uint64, committeeSize uint64) {
+func getGovernanceValue(gov governance.Engine, number uint64) (epoch uint64, policy uint64, committeeSize uint64) {
 	if r, err := gov.GetGovernanceItemAtNumber(number, governance.GovernanceKeyMapReverse[params.Epoch]); err == nil && r != nil {
 		epoch = r.(uint64)
 	} else {
@@ -78,7 +78,7 @@ func getGovernanceValue(gov *governance.Governance, number uint64) (epoch uint64
 // newSnapshot create a new snapshot with the specified startup parameters. This
 // method does not initialize the set of recent validators, so only ever use if for
 // the genesis block.
-func newSnapshot(gov *governance.Governance, number uint64, hash common.Hash, valSet istanbul.ValidatorSet, chainConfig *params.ChainConfig) *Snapshot {
+func newSnapshot(gov governance.Engine, number uint64, hash common.Hash, valSet istanbul.ValidatorSet, chainConfig *params.ChainConfig) *Snapshot {
 	epoch, policy, committeeSize := getGovernanceValue(gov, number)
 
 	snap := &Snapshot{
@@ -144,7 +144,7 @@ func (s *Snapshot) checkVote(address common.Address, authorize bool) bool {
 
 // apply creates a new authorization snapshot by applying the given headers to
 // the original one.
-func (s *Snapshot) apply(headers []*types.Header, gov *governance.Governance, addr common.Address, policy uint64, chain consensus.ChainReader) (*Snapshot, error) {
+func (s *Snapshot) apply(headers []*types.Header, gov governance.Engine, addr common.Address, policy uint64, chain consensus.ChainReader) (*Snapshot, error) {
 	// Allow passing in no headers for cleaner code
 	if len(headers) == 0 {
 		return s, nil

--- a/governance/api.go
+++ b/governance/api.go
@@ -30,7 +30,7 @@ import (
 )
 
 type PublicGovernanceAPI struct {
-	governance *Governance // Node interfaced by this API
+	governance Engine // Node interfaced by this API
 }
 
 type returnTally struct {
@@ -39,16 +39,16 @@ type returnTally struct {
 	ApprovalPercentage float64
 }
 
-func NewGovernanceAPI(gov *Governance) *PublicGovernanceAPI {
+func NewGovernanceAPI(gov Engine) *PublicGovernanceAPI {
 	return &PublicGovernanceAPI{governance: gov}
 }
 
 type GovernanceKlayAPI struct {
-	governance *Governance
+	governance Engine
 	chain      blockChain
 }
 
-func NewGovernanceKlayAPI(gov *Governance, chain blockChain) *GovernanceKlayAPI {
+func NewGovernanceKlayAPI(gov Engine, chain blockChain) *GovernanceKlayAPI {
 	return &GovernanceKlayAPI{governance: gov, chain: chain}
 }
 

--- a/governance/api.go
+++ b/governance/api.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"math/big"
 	"strings"
-	"sync/atomic"
 
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
@@ -31,12 +30,6 @@ import (
 
 type PublicGovernanceAPI struct {
 	governance Engine // Node interfaced by this API
-}
-
-type returnTally struct {
-	Key                string
-	Value              interface{}
-	ApprovalPercentage float64
 }
 
 func NewGovernanceAPI(gov Engine) *PublicGovernanceAPI {
@@ -86,7 +79,7 @@ func (api *PublicGovernanceAPI) Vote(key string, val interface{}) (string, error
 	gMode := api.governance.GovernanceMode()
 	gNode := api.governance.GoverningNode()
 
-	if GovernanceModeMap[gMode] == params.GovernanceMode_Single && gNode != api.governance.nodeAddress.Load().(common.Address) {
+	if GovernanceModeMap[gMode] == params.GovernanceMode_Single && gNode != api.governance.NodeAddress() {
 		return "", errPermissionDenied
 	}
 	if strings.ToLower(key) == "governance.removevalidator" {
@@ -106,21 +99,27 @@ func (api *PublicGovernanceAPI) Vote(key string, val interface{}) (string, error
 func (api *PublicGovernanceAPI) isRemovingSelf(val string) bool {
 	for _, str := range strings.Split(val, ",") {
 		str = strings.Trim(str, " ")
-		if common.HexToAddress(str) == api.governance.nodeAddress.Load().(common.Address) {
+		if common.HexToAddress(str) == api.governance.NodeAddress() {
 			return true
 		}
 	}
 	return false
 }
 
+type returnTally struct {
+	Key                string
+	Value              interface{}
+	ApprovalPercentage float64
+}
+
 func (api *PublicGovernanceAPI) ShowTally() []*returnTally {
 	ret := []*returnTally{}
 
-	for _, val := range api.governance.GovernanceTallies.Copy() {
+	for _, val := range api.governance.GetGovernanceTallies() {
 		item := &returnTally{
 			Key:                val.Key,
 			Value:              val.Value,
-			ApprovalPercentage: float64(val.Votes) / float64(atomic.LoadUint64(&api.governance.totalVotingPower)) * 100,
+			ApprovalPercentage: float64(val.Votes) / float64(api.governance.TotalVotingPower()) * 100,
 		}
 		ret = append(ret, item)
 	}
@@ -132,13 +131,13 @@ func (api *PublicGovernanceAPI) TotalVotingPower() (float64, error) {
 	if !api.isGovernanceModeBallot() {
 		return 0, errNotAvailableInThisMode
 	}
-	return float64(atomic.LoadUint64(&api.governance.totalVotingPower)) / 1000.0, nil
+	return float64(api.governance.TotalVotingPower()) / 1000.0, nil
 }
 
 func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interface{}, error) {
 	blockNumber := uint64(0)
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blockNumber = api.governance.blockChain.CurrentHeader().Number.Uint64()
+		blockNumber = api.governance.BlockChain().CurrentHeader().Number.Uint64()
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
@@ -153,7 +152,7 @@ func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interf
 func (api *PublicGovernanceAPI) GetStakingInfo(num *rpc.BlockNumber) (*reward.StakingInfo, error) {
 	blockNumber := uint64(0)
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blockNumber = api.governance.blockChain.CurrentHeader().Number.Uint64()
+		blockNumber = api.governance.BlockChain().CurrentHeader().Number.Uint64()
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
@@ -180,28 +179,26 @@ func (api *PublicGovernanceAPI) IdxCacheFromDb() []uint64 {
 func (api *PublicGovernanceAPI) ItemCacheFromDb(num *rpc.BlockNumber) map[string]interface{} {
 	blockNumber := uint64(0)
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blockNumber = api.governance.blockChain.CurrentHeader().Number.Uint64()
+		blockNumber = api.governance.BlockChain().CurrentHeader().Number.Uint64()
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
-	ret, _ := api.governance.db.ReadGovernance(blockNumber)
+	ret, _ := api.governance.DB().ReadGovernance(blockNumber)
 	return ret
 }
 
-type VoteList struct {
+type returnVote struct {
 	Key      string
 	Value    interface{}
 	Casted   bool
 	BlockNum uint64
 }
 
-func (api *PublicGovernanceAPI) MyVotes() []*VoteList {
+func (api *PublicGovernanceAPI) MyVotes() []*returnVote {
+	ret := []*returnVote{}
 
-	ret := make([]*VoteList, 0, api.governance.voteMap.Size())
-	//ret := []*VoteList{}
-
-	for k, v := range api.governance.voteMap.Copy() {
-		item := &VoteList{
+	for k, v := range api.governance.GetVoteMap() {
+		item := &returnVote{
 			Key:      k,
 			Value:    v.Value,
 			Casted:   v.Casted,
@@ -217,15 +214,15 @@ func (api *PublicGovernanceAPI) MyVotingPower() (float64, error) {
 	if !api.isGovernanceModeBallot() {
 		return 0, errNotAvailableInThisMode
 	}
-	return float64(atomic.LoadUint64(&api.governance.votingPower)) / 1000.0, nil
+	return float64(api.governance.MyVotingPower()) / 1000.0, nil
 }
 
 func (api *PublicGovernanceAPI) ChainConfig() *params.ChainConfig {
-	return api.governance.ChainConfig
+	return api.governance.InitialChainConfig()
 }
 
 func (api *PublicGovernanceAPI) NodeAddress() common.Address {
-	return api.governance.nodeAddress.Load().(common.Address)
+	return api.governance.NodeAddress()
 }
 
 func (api *PublicGovernanceAPI) isGovernanceModeBallot() bool {

--- a/governance/default.go
+++ b/governance/default.go
@@ -751,6 +751,11 @@ func (g *Governance) addGovernanceCache(num uint64, data GovernanceSet) {
 	}
 }
 
+func (gov *Governance) AddGovernanceCacheForTest(num uint64, config *params.ChainConfig) {
+	data := GetGovernanceItemsFromChainConfig(config)
+	gov.addGovernanceCache(num, data)
+}
+
 // getGovernanceCacheKey returns cache key of the given block number
 func getGovernanceCacheKey(num uint64) common.GovernanceCacheKey {
 	v := fmt.Sprintf("%v", num)
@@ -1091,13 +1096,6 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 func writeFailLog(key int, err error) {
 	msg := "Failed to set " + GovernanceKeyMapReverse[key]
 	logger.Crit(msg, "err", err)
-}
-
-func AddGovernanceCacheForTest(g *Governance, num uint64, config *params.ChainConfig) {
-	// Don't update cache if num (block number) is smaller than the biggest number of cached block number
-
-	data := GetGovernanceItemsFromChainConfig(config)
-	g.addGovernanceCache(num, data)
 }
 
 func (gov *Governance) GovernanceMode() string {

--- a/governance/default.go
+++ b/governance/default.go
@@ -471,6 +471,26 @@ func (g *Governance) SetMyVotingPower(t uint64) {
 	atomic.StoreUint64(&g.votingPower, t)
 }
 
+func (g *Governance) NodeAddress() common.Address {
+	return g.nodeAddress.Load().(common.Address)
+}
+
+func (g *Governance) TotalVotingPower() uint64 {
+	return atomic.LoadUint64(&g.totalVotingPower)
+}
+
+func (g *Governance) MyVotingPower() uint64 {
+	return atomic.LoadUint64(&g.votingPower)
+}
+
+func (gov *Governance) BlockChain() blockChain {
+	return gov.blockChain
+}
+
+func (gov *Governance) DB() database.DBManager {
+	return gov.db
+}
+
 func (g *Governance) GetEncodedVote(addr common.Address, number uint64) []byte {
 	// TODO-Klaytn-Governance Change this part to add all votes to the header at once
 	for key, val := range g.voteMap.Copy() {
@@ -1138,6 +1158,18 @@ func (gov *Governance) UseGiniCoeff() bool {
 
 func (gov *Governance) ChainId() uint64 {
 	return gov.ChainConfig.ChainID.Uint64()
+}
+
+func (gov *Governance) InitialChainConfig() *params.ChainConfig {
+	return gov.ChainConfig
+}
+
+func (g *Governance) GetVoteMap() map[string]VoteStatus {
+	return g.voteMap.Copy()
+}
+
+func (g *Governance) GetGovernanceTallies() []GovernanceTallyItem {
+	return g.GovernanceTallies.Copy()
 }
 
 func (gov *Governance) PendingChanges() map[string]interface{} {

--- a/governance/doc.go
+++ b/governance/doc.go
@@ -61,6 +61,7 @@ Governance related functions and variables are defined in the files listed below
   - default.go    : the governance struct, cache and persistence
   - handler.go    : functions to handle votes and its application
   - api.go        : console APIs to get governance information and to cast a vote
+  - interface.go  : Abstract interfaces to various underlying implementations
 
 */
 package governance

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -1,0 +1,89 @@
+// Copyright 2022 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package governance
+
+import (
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
+)
+
+type Engine interface {
+	HeaderEngine
+}
+
+type HeaderEngine interface {
+	// Cast votes from API
+	AddVote(key string, val interface{}) bool
+	ValidateVote(vote *GovernanceVote) (*GovernanceVote, bool)
+
+	// Access database for voting states
+	CanWriteGovernanceState(num uint64) bool
+	WriteGovernanceState(num uint64, isCheckpoint bool) error
+
+	// Access database for network params
+	ReadGovernance(num uint64) (uint64, map[string]interface{}, error)
+	WriteGovernance(num uint64, data GovernanceSet, delta GovernanceSet) error
+
+	// Compose header.Vote and header.Governance
+	GetEncodedVote(addr common.Address, number uint64) []byte
+	GetGovernanceChange() map[string]interface{}
+
+	// Intake header.Vote and header.Governance
+	VerifyGovernance(received []byte) error
+	ClearVotes(num uint64)
+	WriteGovernanceForNextEpoch(number uint64, governance []byte)
+	UpdateCurrentSet(num uint64)
+	HandleGovernanceVote(
+		valset istanbul.ValidatorSet, votes []GovernanceVote, tally []GovernanceTallyItem,
+		header *types.Header, proposer common.Address, self common.Address) (
+		istanbul.ValidatorSet, []GovernanceVote, []GovernanceTallyItem)
+
+	// Get internal fields
+	ChainId() uint64
+	PendingChanges() map[string]interface{}
+	Votes() []GovernanceVote
+	IdxCache() []uint64
+	IdxCacheFromDb() []uint64
+
+	// Set internal fields
+	SetNodeAddress(addr common.Address)
+	SetTotalVotingPower(t uint64)
+	SetMyVotingPower(t uint64)
+	SetBlockchain(chain blockChain)
+	SetTxPool(txpool txPool)
+
+	// Get network params
+	GovernanceMode() string
+	GoverningNode() common.Address
+	UnitPrice() uint64
+	CommitteeSize() uint64
+	Epoch() uint64
+	ProposerPolicy() uint64
+	DeferredTxFee() bool
+	MinimumStake() string
+	MintingAmount() string
+	ProposerUpdateInterval() uint64
+	Ratio() string
+	StakingUpdateInterval() uint64
+	UseGiniCoeff() bool
+	GetGovernanceValue(key int) interface{}
+	GetGovernanceItemAtNumber(num uint64, key string) (interface{}, error)
+	GetItemAtNumberByIntKey(num uint64, key int) (interface{}, error)
+	GetGoverningInfoAtNumber(num uint64) (bool, common.Address, error)
+	GetMinimumStakingAtNumber(num uint64) (uint64, error)
+}

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -20,6 +20,8 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/istanbul"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/storage/database"
 )
 
 type Engine interface {
@@ -55,10 +57,19 @@ type HeaderEngine interface {
 
 	// Get internal fields
 	ChainId() uint64
+	InitialChainConfig() *params.ChainConfig
+	GetVoteMap() map[string]VoteStatus
+	GetGovernanceTallies() []GovernanceTallyItem
 	PendingChanges() map[string]interface{}
 	Votes() []GovernanceVote
 	IdxCache() []uint64
 	IdxCacheFromDb() []uint64
+
+	NodeAddress() common.Address
+	TotalVotingPower() uint64
+	MyVotingPower() uint64
+	BlockChain() blockChain
+	DB() database.DBManager
 
 	// Set internal fields
 	SetNodeAddress(addr common.Address)

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -97,4 +97,7 @@ type HeaderEngine interface {
 	GetItemAtNumberByIntKey(num uint64, key int) (interface{}, error)
 	GetGoverningInfoAtNumber(num uint64) (bool, common.Address, error)
 	GetMinimumStakingAtNumber(num uint64) (uint64, error)
+
+	// Test harness
+	AddGovernanceCacheForTest(num uint64, config *params.ChainConfig)
 }

--- a/governance/interface_test.go
+++ b/governance/interface_test.go
@@ -2,3 +2,4 @@ package governance
 
 // Compile-time type implementation check
 var _ Engine = (*Governance)(nil)
+var _ Engine = (*MixedEngine)(nil)

--- a/governance/interface_test.go
+++ b/governance/interface_test.go
@@ -1,0 +1,4 @@
+package governance
+
+// Compile-time type implementation check
+var _ Engine = (*Governance)(nil)

--- a/governance/mixed.go
+++ b/governance/mixed.go
@@ -1,0 +1,198 @@
+package governance
+
+import (
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/storage/database"
+)
+
+type MixedEngine struct {
+	initialConfig *params.ChainConfig
+
+	// Data sources
+	db database.DBManager
+
+	// Subordinate engines
+	defaultGov *Governance
+}
+
+func newMixedEngine(config *params.ChainConfig, db database.DBManager, doInit bool) *MixedEngine {
+	e := &MixedEngine{
+		initialConfig: config,
+		db:            db,
+	}
+
+	if doInit {
+		e.defaultGov = NewGovernanceInitialize(config, db)
+	} else {
+		e.defaultGov = NewGovernance(config, db)
+	}
+	return e
+}
+
+// Most users are encouraged to call this constructor
+func NewMixedEngine(config *params.ChainConfig, db database.DBManager) *MixedEngine {
+	return newMixedEngine(config, db, true)
+}
+
+// For test purposes
+func NewMixedEngineNoInit(config *params.ChainConfig, db database.DBManager) *MixedEngine {
+	return newMixedEngine(config, db, false)
+}
+
+// Pass-through to HeaderEngine
+func (e *MixedEngine) AddVote(key string, val interface{}) bool {
+	return e.defaultGov.AddVote(key, val)
+}
+func (e *MixedEngine) ValidateVote(vote *GovernanceVote) (*GovernanceVote, bool) {
+	return e.defaultGov.ValidateVote(vote)
+}
+func (e *MixedEngine) CanWriteGovernanceState(num uint64) bool {
+	return e.defaultGov.CanWriteGovernanceState(num)
+}
+func (e *MixedEngine) WriteGovernanceState(num uint64, isCheckpoint bool) error {
+	return e.defaultGov.WriteGovernanceState(num, isCheckpoint)
+}
+func (e *MixedEngine) ReadGovernance(num uint64) (uint64, map[string]interface{}, error) {
+	return e.defaultGov.ReadGovernance(num)
+}
+func (e *MixedEngine) WriteGovernance(num uint64, data GovernanceSet, delta GovernanceSet) error {
+	return e.defaultGov.WriteGovernance(num, data, delta)
+}
+func (e *MixedEngine) GetEncodedVote(addr common.Address, number uint64) []byte {
+	return e.defaultGov.GetEncodedVote(addr, number)
+}
+func (e *MixedEngine) GetGovernanceChange() map[string]interface{} {
+	return e.defaultGov.GetGovernanceChange()
+}
+func (e *MixedEngine) VerifyGovernance(received []byte) error {
+	return e.defaultGov.VerifyGovernance(received)
+}
+func (e *MixedEngine) ClearVotes(num uint64) {
+	e.defaultGov.ClearVotes(num)
+}
+func (e *MixedEngine) WriteGovernanceForNextEpoch(number uint64, governance []byte) {
+	e.defaultGov.WriteGovernanceForNextEpoch(number, governance)
+}
+func (e *MixedEngine) UpdateCurrentSet(num uint64) {
+	e.defaultGov.UpdateCurrentSet(num)
+}
+func (e *MixedEngine) HandleGovernanceVote(
+	valset istanbul.ValidatorSet, votes []GovernanceVote, tally []GovernanceTallyItem,
+	header *types.Header, proposer common.Address, self common.Address) (
+	istanbul.ValidatorSet, []GovernanceVote, []GovernanceTallyItem) {
+	return e.defaultGov.HandleGovernanceVote(valset, votes, tally, header, proposer, self)
+}
+func (e *MixedEngine) ChainId() uint64 {
+	return e.defaultGov.ChainId()
+}
+func (e *MixedEngine) InitialChainConfig() *params.ChainConfig {
+	return e.defaultGov.InitialChainConfig()
+}
+func (e *MixedEngine) GetVoteMap() map[string]VoteStatus {
+	return e.defaultGov.GetVoteMap()
+}
+func (e *MixedEngine) GetGovernanceTallies() []GovernanceTallyItem {
+	return e.defaultGov.GetGovernanceTallies()
+}
+func (e *MixedEngine) PendingChanges() map[string]interface{} {
+	return e.defaultGov.PendingChanges()
+}
+func (e *MixedEngine) Votes() []GovernanceVote {
+	return e.defaultGov.Votes()
+}
+func (e *MixedEngine) IdxCache() []uint64 {
+	return e.defaultGov.IdxCache()
+}
+func (e *MixedEngine) IdxCacheFromDb() []uint64 {
+	return e.defaultGov.IdxCacheFromDb()
+}
+func (e *MixedEngine) NodeAddress() common.Address {
+	return e.defaultGov.NodeAddress()
+}
+func (e *MixedEngine) TotalVotingPower() uint64 {
+	return e.defaultGov.TotalVotingPower()
+}
+func (e *MixedEngine) MyVotingPower() uint64 {
+	return e.defaultGov.MyVotingPower()
+}
+func (e *MixedEngine) BlockChain() blockChain {
+	return e.defaultGov.BlockChain()
+}
+func (e *MixedEngine) DB() database.DBManager {
+	return e.defaultGov.DB()
+}
+func (e *MixedEngine) SetNodeAddress(addr common.Address) {
+	e.defaultGov.SetNodeAddress(addr)
+}
+func (e *MixedEngine) SetTotalVotingPower(t uint64) {
+	e.defaultGov.SetTotalVotingPower(t)
+}
+func (e *MixedEngine) SetMyVotingPower(t uint64) {
+	e.defaultGov.SetMyVotingPower(t)
+}
+func (e *MixedEngine) SetBlockchain(chain blockChain) {
+	e.defaultGov.SetBlockchain(chain)
+}
+func (e *MixedEngine) SetTxPool(txpool txPool) {
+	e.defaultGov.SetTxPool(txpool)
+}
+func (e *MixedEngine) GovernanceMode() string {
+	return e.defaultGov.GovernanceMode()
+}
+func (e *MixedEngine) GoverningNode() common.Address {
+	return e.defaultGov.GoverningNode()
+}
+func (e *MixedEngine) UnitPrice() uint64 {
+	return e.defaultGov.UnitPrice()
+}
+func (e *MixedEngine) CommitteeSize() uint64 {
+	return e.defaultGov.CommitteeSize()
+}
+func (e *MixedEngine) Epoch() uint64 {
+	return e.defaultGov.Epoch()
+}
+func (e *MixedEngine) ProposerPolicy() uint64 {
+	return e.defaultGov.ProposerPolicy()
+}
+func (e *MixedEngine) DeferredTxFee() bool {
+	return e.defaultGov.DeferredTxFee()
+}
+func (e *MixedEngine) MinimumStake() string {
+	return e.defaultGov.MinimumStake()
+}
+func (e *MixedEngine) MintingAmount() string {
+	return e.defaultGov.MintingAmount()
+}
+func (e *MixedEngine) ProposerUpdateInterval() uint64 {
+	return e.defaultGov.ProposerUpdateInterval()
+}
+func (e *MixedEngine) Ratio() string {
+	return e.defaultGov.Ratio()
+}
+func (e *MixedEngine) StakingUpdateInterval() uint64 {
+	return e.defaultGov.StakingUpdateInterval()
+}
+func (e *MixedEngine) UseGiniCoeff() bool {
+	return e.defaultGov.UseGiniCoeff()
+}
+func (e *MixedEngine) GetGovernanceValue(key int) interface{} {
+	return e.defaultGov.GetGovernanceValue(key)
+}
+func (e *MixedEngine) GetGovernanceItemAtNumber(num uint64, key string) (interface{}, error) {
+	return e.defaultGov.GetGovernanceItemAtNumber(num, key)
+}
+func (e *MixedEngine) GetItemAtNumberByIntKey(num uint64, key int) (interface{}, error) {
+	return e.defaultGov.GetItemAtNumberByIntKey(num, key)
+}
+func (e *MixedEngine) GetGoverningInfoAtNumber(num uint64) (bool, common.Address, error) {
+	return e.defaultGov.GetGoverningInfoAtNumber(num)
+}
+func (e *MixedEngine) GetMinimumStakingAtNumber(num uint64) (uint64, error) {
+	return e.defaultGov.GetMinimumStakingAtNumber(num)
+}
+func (e *MixedEngine) AddGovernanceCacheForTest(num uint64, config *params.ChainConfig) {
+	e.defaultGov.AddGovernanceCacheForTest(num, config)
+}

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -133,7 +133,7 @@ type CN struct {
 
 	components []interface{}
 
-	governance *governance.Governance
+	governance governance.Engine
 }
 
 func (s *CN) AddLesServer(ls LesServer) {
@@ -454,7 +454,7 @@ func CreateDB(ctx *node.ServiceContext, config *Config, name string) database.DB
 }
 
 // CreateConsensusEngine creates the required type of consensus engine instance for a Klaytn service
-func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig *params.ChainConfig, db database.DBManager, gov *governance.Governance, nodetype common.ConnType) consensus.Engine {
+func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig *params.ChainConfig, db database.DBManager, gov governance.Engine, nodetype common.ConnType) consensus.Engine {
 	// Only istanbul  BFT is allowed in the main net. PoA is supported by service chain
 	if chainConfig.Governance == nil {
 		chainConfig.Governance = params.GetDefaultGovernanceConfig(params.UseIstanbul)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -214,7 +214,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	setEngineType(chainConfig)
 
 	// load governance state
-	governance := governance.NewGovernanceInitialize(chainConfig, chainDB)
+	governance := governance.NewMixedEngine(chainConfig, chainDB)
 
 	// Set latest unitPrice/gasPrice
 	chainConfig.UnitPrice = governance.UnitPrice()

--- a/node/sc/mainbridge_test.go
+++ b/node/sc/mainbridge_test.go
@@ -65,7 +65,7 @@ func testNewMainBridge(t *testing.T) *MainBridge {
 func testBlockChain(t *testing.T) *blockchain.BlockChain {
 	db := database.NewMemoryDBManager()
 
-	gov := governance.NewGovernanceInitialize(&params.ChainConfig{
+	gov := governance.NewMixedEngine(&params.ChainConfig{
 		ChainID:       big.NewInt(2018),
 		UnitPrice:     25000000000,
 		DeriveShaImpl: 0,

--- a/tests/hard_fork_test.go
+++ b/tests/hard_fork_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/klaytn/klaytn/common/profile"
 	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/crypto"
-	"github.com/klaytn/klaytn/governance"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 	"github.com/klaytn/klaytn/storage/database"
@@ -91,9 +90,9 @@ func TestHardForkBlock(t *testing.T) {
 		os.RemoveAll(dir)
 	}()
 
-	gov := generateGovernaceDataForTest()
 	chainConfig, _, err := blockchain.SetupGenesisBlock(chainDb, &genesis, params.UnusedNetworkId, false, false)
-	governance.AddGovernanceCacheForTest(gov, 0, genesis.Config)
+	gov := generateGovernaceDataForTest()
+	gov.AddGovernanceCacheForTest(0, genesis.Config)
 	engine := istanbulBackend.New(genesisAddr, istanbul.DefaultConfig, genesisKey, chainDb, gov, common.CONSENSUSNODE)
 	chain, err := blockchain.NewBlockChain(chainDb, nil, chainConfig, engine, vm.Config{})
 

--- a/tests/klay_test_blockchain_test.go
+++ b/tests/klay_test_blockchain_test.go
@@ -65,7 +65,7 @@ type BCData struct {
 	validatorPrivKeys  []*ecdsa.PrivateKey
 	engine             consensus.Istanbul
 	genesis            *blockchain.Genesis
-	governance         *governance.Governance
+	governance         governance.Engine
 	rewardDistributor  *reward.RewardDistributor
 }
 

--- a/tests/klay_test_blockchain_test.go
+++ b/tests/klay_test_blockchain_test.go
@@ -123,7 +123,7 @@ func NewBCData(maxAccounts, numValidators int) (*BCData, error) {
 
 	engine.Start(bc, bc.CurrentBlock, bc.HasBadBlock)
 
-	governance.AddGovernanceCacheForTest(gov, 0, genesis.Config)
+	gov.AddGovernanceCacheForTest(0, genesis.Config)
 	rewardDistributor := reward.NewRewardDistributor(gov)
 
 	return &BCData{bc, addrs, privKeys, chainDb,

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -490,7 +490,7 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 func generateGovernaceDataForTest() governance.Engine {
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
 
-	return governance.NewGovernanceInitialize(&params.ChainConfig{
+	return governance.NewMixedEngine(&params.ChainConfig{
 		ChainID:       big.NewInt(2018),
 		UnitPrice:     25000000000,
 		DeriveShaImpl: 0,

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -486,8 +486,8 @@ func defaultCacheConfig() *blockchain.CacheConfig {
 	}
 }
 
-// generateGovernaceDataForTest returns *governance.Governance for test.
-func generateGovernaceDataForTest() *governance.Governance {
+// generateGovernaceDataForTest returns governance.Engine for test.
+func generateGovernaceDataForTest() governance.Engine {
 	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
 
 	return governance.NewGovernanceInitialize(&params.ChainConfig{


### PR DESCRIPTION
## Proposed changes

- This is follow-up of https://github.com/klaytn/klaytn/pull/1297
- Introduce `MixedEngine` which is a a new implementation of `governance.Engine`
- For now, MixedEngine is simply a wrapper to `governance.Governance`. All function calls pass-through to underlying Governance instance.
- In the future, MixedEngine will contain multiple engines in it and redirect function calls to them depending on configuration and block number.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
