### PR TITLE
Add new GovParamSet type as governance parameter model

### DIFF
--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/log"
 )
 
 type govParamType struct {
@@ -221,22 +220,6 @@ var govParamNames = map[string]int{
 	"reward.proposerupdateinterval": ProposerRefreshInterval,
 }
 
-var govParamDefaults = map[int]interface{}{
-	GovernanceMode:          DefaultGovernanceMode,
-	GoverningNode:           DefaultGoverningNode,
-	Epoch:                   DefaultEpoch,
-	Policy:                  DefaultProposerPolicy,
-	CommitteeSize:           DefaultSubGroupSize,
-	UnitPrice:               DefaultUnitPrice,
-	MintingAmount:           DefaultMintingAmount,
-	Ratio:                   DefaultRatio,
-	UseGiniCoeff:            DefaultUseGiniCoeff,
-	DeferredTxFee:           DefaultDefferedTxFee,
-	MinimumStake:            DefaultMinimumStake,
-	StakeUpdateInterval:     DefaultStakeUpdateInterval,
-	ProposerRefreshInterval: DefaultProposerRefreshInterval,
-}
-
 var govParamNamesReverse = map[int]string{}
 
 func init() {
@@ -348,91 +331,7 @@ func (p *GovParamSet) IntMap() map[int]interface{} {
 }
 
 // Returns a parameter value and a boolean indicating success.
-// Use Get() to be careful about existence of a parameter.
 func (p *GovParamSet) Get(key int) (interface{}, bool) {
 	v, ok := p.items[key]
 	return v, ok
-}
-
-// Returns a parameter value or default value for the key if the value is not set.
-// Use MustGet() if you are confident that the value is set.
-// To simply quote a parameter in an expression, MustGet() can come in handy.
-func (p *GovParamSet) MustGet(key int) interface{} {
-	if v, ok := p.items[key]; ok {
-		return v
-	}
-	if d, ok := govParamDefaults[key]; ok {
-		// If key is a known parameter, fallback to default
-		return d
-	}
-	// This path is very unlikely.
-	logger := log.NewModuleLogger(log.Governance)
-	logger.Crit("Unknown governance param key")
-	return nil
-}
-
-func (p *GovParamSet) GovernanceMode() string {
-	return p.MustGet(GovernanceMode).(string)
-}
-
-func (p *GovParamSet) GoverningNode() common.Address {
-	return p.MustGet(GoverningNode).(common.Address)
-}
-
-func (p *GovParamSet) Epoch() uint64 {
-	return p.MustGet(Epoch).(uint64)
-}
-
-func (p *GovParamSet) Policy() uint64 {
-	return p.MustGet(Policy).(uint64)
-}
-
-func (p *GovParamSet) CommitteeSize() uint64 {
-	return p.MustGet(CommitteeSize).(uint64)
-}
-
-func (p *GovParamSet) UnitPrice() uint64 {
-	return p.MustGet(UnitPrice).(uint64)
-}
-
-func (p *GovParamSet) MintingAmountStr() string {
-	return p.MustGet(MintingAmount).(string)
-}
-
-func (p *GovParamSet) MintingAmountBig() *big.Int {
-	n, _ := new(big.Int).SetString(p.MintingAmountStr(), 10)
-	return n
-}
-
-func (p *GovParamSet) Ratio() string {
-	return p.MustGet(Ratio).(string)
-}
-
-func (p *GovParamSet) UseGiniCoeff() bool {
-	return p.MustGet(UseGiniCoeff).(bool)
-}
-
-func (p *GovParamSet) DeferredTxFee() bool {
-	return p.MustGet(DeferredTxFee).(bool)
-}
-
-func (p *GovParamSet) MinimumStakeStr() string {
-	return p.MustGet(MinimumStake).(string)
-}
-
-func (p *GovParamSet) MinimumStakeBig() *big.Int {
-	n, _ := new(big.Int).SetString(p.MinimumStakeStr(), 10)
-	return n
-}
-
-func (p *GovParamSet) StakeUpdateInterval() uint64 {
-	return p.MustGet(StakeUpdateInterval).(uint64)
-}
-
-func (p *GovParamSet) ProposerRefreshInterval() uint64 {
-	return p.MustGet(ProposerRefreshInterval).(uint64)
-}
-
-func (p *GovParamSet) Timeout() uint64 {
-	return p.MustGet(Timeout).(uint64)
 }

--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -1,0 +1,438 @@
+package params
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/log"
+)
+
+type govParamType struct {
+	// The canonical type
+	canonicalType reflect.Type
+
+	// Parse arbitrary typed value into canonical type
+	// Return false if not possible
+	parseValue func(v interface{}) (interface{}, bool)
+
+	// Parse byte array into canonical type
+	// Return false if not possible
+	parseBytes func(b []byte) (interface{}, bool)
+
+	// Application-specific checks.
+	// It is safe to assume that type of 'v' is canonicalType
+	validate func(v interface{}) bool
+}
+
+func (ty *govParamType) ParseValue(v interface{}) (interface{}, bool) {
+	if x, ok := ty.parseValue(v); ok {
+		return x, ty.Validate(x)
+	} else {
+		return nil, false
+	}
+}
+
+func (ty *govParamType) ParseBytes(b []byte) (interface{}, bool) {
+	if x, ok := ty.parseBytes(b); ok {
+		return x, ty.Validate(x)
+	} else {
+		return nil, false
+	}
+}
+
+func (ty *govParamType) Validate(v interface{}) bool {
+	// return ty.canonicalType == reflect.TypeOf(v) && ty.validate(v)
+	if ty.canonicalType != reflect.TypeOf(v) {
+		return false
+	}
+	if ty.validate != nil && !ty.validate(v) {
+		return false
+	}
+	return true
+}
+
+var (
+	govModeNames = map[string]int{
+		"none":   GovernanceMode_None,
+		"single": GovernanceMode_Single,
+		"ballot": GovernanceMode_Ballot,
+	}
+
+	parseValueString = func(v interface{}) (interface{}, bool) {
+		s, ok := v.(string)
+		return s, ok
+	}
+	parseBytesString = func(b []byte) (interface{}, bool) {
+		return string(b), true
+	}
+	validatePass = func(v interface{}) bool {
+		return true
+	}
+
+	govParamTypeGovMode = &govParamType{
+		canonicalType: reflect.TypeOf("single"),
+		parseValue:    parseValueString,
+		parseBytes:    parseBytesString,
+		validate: func(v interface{}) bool {
+			_, ok := govModeNames[v.(string)]
+			return ok
+		},
+	}
+
+	govParamTypeAddress = &govParamType{
+		canonicalType: reflect.TypeOf(common.Address{}),
+		parseValue: func(v interface{}) (interface{}, bool) {
+			switch v.(type) {
+			case string:
+				s := v.(string)
+				return common.HexToAddress(s), common.IsHexAddress(s)
+			case common.Address:
+				return v, true
+			default:
+				return nil, false
+			}
+		},
+		parseBytes: func(b []byte) (interface{}, bool) {
+			return common.BytesToAddress(b), len(b) == common.AddressLength
+		},
+		validate: validatePass,
+	}
+
+	govParamTypeUint64 = &govParamType{
+		canonicalType: reflect.TypeOf(uint64(0)),
+		parseValue: func(v interface{}) (interface{}, bool) {
+			switch v.(type) {
+			case int:
+				return uint64(v.(int)), v.(int) >= 0
+			case uint:
+				return uint64(v.(uint)), true
+			case uint64:
+				return v.(uint64), true
+			case float64:
+				return uint64(v.(float64)), v.(float64) >= 0
+			default:
+				return nil, false
+			}
+		},
+		parseBytes: func(b []byte) (interface{}, bool) {
+			// Must not exceed uint64 range
+			return new(big.Int).SetBytes(b).Uint64(), len(b) <= 8
+		},
+		validate: validatePass,
+	}
+
+	govParamTypeBigInt = &govParamType{
+		canonicalType: reflect.TypeOf(""),
+		parseValue: func(v interface{}) (interface{}, bool) {
+			switch v.(type) {
+			case string:
+				_, ok := new(big.Int).SetString(v.(string), 10)
+				return v.(string), ok
+			case *big.Int:
+				return v.(*big.Int).String(), true
+			default:
+				return nil, false
+			}
+		},
+		parseBytes: func(b []byte) (interface{}, bool) {
+			return new(big.Int).SetBytes(b).String(), true
+		},
+		validate: func(v interface{}) bool {
+			if n, ok := new(big.Int).SetString(v.(string), 10); ok {
+				return n.Sign() >= 0 // must be non-negative.
+			}
+			return false
+		},
+	}
+
+	govParamTypeRatio = &govParamType{
+		canonicalType: reflect.TypeOf("12/34/54"),
+		parseValue:    parseValueString,
+		parseBytes:    parseBytesString,
+		validate: func(v interface{}) bool {
+			strs := strings.Split(v.(string), "/")
+			if len(strs) != 3 {
+				return false
+			}
+			for _, s := range strs {
+				n, err := strconv.Atoi(s)
+				if err != nil || n < 0 {
+					return false
+				}
+			}
+			return true
+		},
+	}
+
+	govParamTypeBool = &govParamType{
+		canonicalType: reflect.TypeOf(true),
+		parseValue: func(v interface{}) (interface{}, bool) {
+			b, ok := v.(bool)
+			return b, ok
+		},
+		parseBytes: func(b []byte) (interface{}, bool) {
+			if bytes.Compare(b, []byte{0x01}) == 0 {
+				return true, true
+			} else if bytes.Compare(b, []byte{0x00}) == 0 {
+				return false, true
+			} else {
+				return nil, false
+			}
+		},
+		validate: validatePass,
+	}
+)
+
+var govParamTypes = map[int]*govParamType{
+	GovernanceMode:          govParamTypeGovMode,
+	GoverningNode:           govParamTypeAddress,
+	Epoch:                   govParamTypeUint64,
+	Policy:                  govParamTypeUint64,
+	CommitteeSize:           govParamTypeUint64,
+	UnitPrice:               govParamTypeUint64,
+	MintingAmount:           govParamTypeBigInt,
+	Ratio:                   govParamTypeRatio,
+	UseGiniCoeff:            govParamTypeBool,
+	DeferredTxFee:           govParamTypeBool,
+	MinimumStake:            govParamTypeBigInt,
+	StakeUpdateInterval:     govParamTypeUint64,
+	ProposerRefreshInterval: govParamTypeUint64,
+}
+
+var govParamNames = map[string]int{
+	"governance.governancemode":     GovernanceMode,
+	"governance.governingnode":      GoverningNode,
+	"istanbul.epoch":                Epoch,
+	"istanbul.policy":               Policy,
+	"istanbul.committeesize":        CommitteeSize,
+	"governance.unitprice":          UnitPrice,
+	"reward.mintingamount":          MintingAmount,
+	"reward.ratio":                  Ratio,
+	"reward.useginicoeff":           UseGiniCoeff,
+	"reward.deferredtxfee":          DeferredTxFee,
+	"reward.minimumstake":           MinimumStake,
+	"reward.stakingupdateinterval":  StakeUpdateInterval,
+	"reward.proposerupdateinterval": ProposerRefreshInterval,
+}
+
+var govParamDefaults = map[int]interface{}{
+	GovernanceMode:          DefaultGovernanceMode,
+	GoverningNode:           DefaultGoverningNode,
+	Epoch:                   DefaultEpoch,
+	Policy:                  DefaultProposerPolicy,
+	CommitteeSize:           DefaultSubGroupSize,
+	UnitPrice:               DefaultUnitPrice,
+	MintingAmount:           DefaultMintingAmount,
+	Ratio:                   DefaultRatio,
+	UseGiniCoeff:            DefaultUseGiniCoeff,
+	DeferredTxFee:           DefaultDefferedTxFee,
+	MinimumStake:            DefaultMinimumStake,
+	StakeUpdateInterval:     DefaultStakeUpdateInterval,
+	ProposerRefreshInterval: DefaultProposerRefreshInterval,
+}
+
+var govParamNamesReverse = map[int]string{}
+
+func init() {
+	for name, key := range govParamNames {
+		govParamNamesReverse[key] = name
+	}
+}
+
+// GovParamSet is an immutable set of governance parameters
+// with various convenience getters.
+type GovParamSet struct {
+	// Items in canonical type.
+	// Only type checked and validated values will be stored.
+	items map[int]interface{}
+}
+
+func NewGovParamSet() *GovParamSet {
+	return &GovParamSet{
+		items: make(map[int]interface{}),
+	}
+}
+
+func NewGovParamSetStrMap(items map[string]interface{}) (*GovParamSet, error) {
+	p := NewGovParamSet()
+
+	for name, value := range items {
+		key, ok := govParamNames[name]
+		if !ok {
+			return nil, fmt.Errorf("Unknown governance param '%s'", name)
+		}
+		err := p.set(key, value)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return p, nil
+}
+
+func NewGovParamSetIntMap(items map[int]interface{}) (*GovParamSet, error) {
+	p := NewGovParamSet()
+
+	for key, value := range items {
+		err := p.set(key, value)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return p, nil
+}
+
+func NewGovParamSetChainConfig(config *ChainConfig) (*GovParamSet, error) {
+	items := make(map[int]interface{})
+	if config.Istanbul != nil {
+		items[Epoch] = config.Istanbul.Epoch
+		items[Policy] = config.Istanbul.ProposerPolicy
+		items[CommitteeSize] = config.Istanbul.SubGroupSize
+	}
+	items[UnitPrice] = config.UnitPrice
+	if config.Governance != nil {
+		items[GoverningNode] = config.Governance.GoverningNode
+		items[GovernanceMode] = config.Governance.GovernanceMode
+		if config.Governance.Reward != nil {
+			if config.Governance.Reward.MintingAmount != nil {
+				items[MintingAmount] = config.Governance.Reward.MintingAmount.String()
+			}
+			items[Ratio] = config.Governance.Reward.Ratio
+			items[UseGiniCoeff] = config.Governance.Reward.UseGiniCoeff
+			items[DeferredTxFee] = config.Governance.Reward.DeferredTxFee
+			items[StakeUpdateInterval] = config.Governance.Reward.StakingUpdateInterval
+			items[ProposerRefreshInterval] = config.Governance.Reward.ProposerUpdateInterval
+			if config.Governance.Reward.MinimumStake != nil {
+				items[MinimumStake] = config.Governance.Reward.MinimumStake.String()
+			}
+		}
+	}
+
+	return NewGovParamSetIntMap(items)
+}
+
+func (p *GovParamSet) set(key int, value interface{}) error {
+	ty, ok := govParamTypes[key]
+	if !ok {
+		return errors.New("Unknown governance param key")
+	}
+	parsed, ok := ty.ParseValue(value)
+	if !ok {
+		return errors.New("Malformed governance param value")
+	}
+	p.items[key] = parsed
+	return nil
+}
+
+func (p *GovParamSet) StrMap() map[string]interface{} {
+	m := map[string]interface{}{}
+	for key, value := range p.items {
+		m[govParamNamesReverse[key]] = value
+	}
+	return m
+}
+
+func (p *GovParamSet) IntMap() map[int]interface{} {
+	m := map[int]interface{}{}
+	for key, value := range p.items {
+		m[key] = value
+	}
+	return m
+}
+
+// Returns a parameter value and a boolean indicating success.
+// Use Get() to be careful about existence of a parameter.
+func (p *GovParamSet) Get(key int) (interface{}, bool) {
+	v, ok := p.items[key]
+	return v, ok
+}
+
+// Returns a parameter value or default value for the key if the value is not set.
+// Use MustGet() if you are confident that the value is set.
+// To simply quote a parameter in an expression, MustGet() can come in handy.
+func (p *GovParamSet) MustGet(key int) interface{} {
+	if v, ok := p.items[key]; ok {
+		return v
+	}
+	if d, ok := govParamDefaults[key]; ok {
+		// If key is a known parameter, fallback to default
+		return d
+	}
+	// This path is very unlikely.
+	logger := log.NewModuleLogger(log.Governance)
+	logger.Crit("Unknown governance param key")
+	return nil
+}
+
+func (p *GovParamSet) GovernanceMode() string {
+	return p.MustGet(GovernanceMode).(string)
+}
+
+func (p *GovParamSet) GoverningNode() common.Address {
+	return p.MustGet(GoverningNode).(common.Address)
+}
+
+func (p *GovParamSet) Epoch() uint64 {
+	return p.MustGet(Epoch).(uint64)
+}
+
+func (p *GovParamSet) Policy() uint64 {
+	return p.MustGet(Policy).(uint64)
+}
+
+func (p *GovParamSet) CommitteeSize() uint64 {
+	return p.MustGet(CommitteeSize).(uint64)
+}
+
+func (p *GovParamSet) UnitPrice() uint64 {
+	return p.MustGet(UnitPrice).(uint64)
+}
+
+func (p *GovParamSet) MintingAmountStr() string {
+	return p.MustGet(MintingAmount).(string)
+}
+
+func (p *GovParamSet) MintingAmountBig() *big.Int {
+	n, _ := new(big.Int).SetString(p.MintingAmountStr(), 10)
+	return n
+}
+
+func (p *GovParamSet) Ratio() string {
+	return p.MustGet(Ratio).(string)
+}
+
+func (p *GovParamSet) UseGiniCoeff() bool {
+	return p.MustGet(UseGiniCoeff).(bool)
+}
+
+func (p *GovParamSet) DeferredTxFee() bool {
+	return p.MustGet(DeferredTxFee).(bool)
+}
+
+func (p *GovParamSet) MinimumStakeStr() string {
+	return p.MustGet(MinimumStake).(string)
+}
+
+func (p *GovParamSet) MinimumStakeBig() *big.Int {
+	n, _ := new(big.Int).SetString(p.MinimumStakeStr(), 10)
+	return n
+}
+
+func (p *GovParamSet) StakeUpdateInterval() uint64 {
+	return p.MustGet(StakeUpdateInterval).(uint64)
+}
+
+func (p *GovParamSet) ProposerRefreshInterval() uint64 {
+	return p.MustGet(ProposerRefreshInterval).(uint64)
+}
+
+func (p *GovParamSet) Timeout() uint64 {
+	return p.MustGet(Timeout).(uint64)
+}

--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -18,10 +18,12 @@ type govParamType struct {
 
 	// Parse arbitrary typed value into canonical type
 	// Return false if not possible
+	// Used to parse or normalize database content.
 	parseValue func(v interface{}) (interface{}, bool)
 
 	// Parse byte array into canonical type
 	// Return false if not possible
+	// Used to parse solidity contract content.
 	parseBytes func(b []byte) (interface{}, bool)
 
 	// Application-specific checks.
@@ -74,6 +76,8 @@ var (
 		return true
 	}
 
+	uint64ByteLen = int(reflect.TypeOf(uint64(0)).Size())
+
 	govParamTypeGovMode = &govParamType{
 		canonicalType: reflect.TypeOf("single"),
 		parseValue:    parseValueString,
@@ -121,7 +125,7 @@ var (
 		},
 		parseBytes: func(b []byte) (interface{}, bool) {
 			// Must not exceed uint64 range
-			return new(big.Int).SetBytes(b).Uint64(), len(b) <= 8
+			return new(big.Int).SetBytes(b).Uint64(), len(b) <= uint64ByteLen
 		},
 		validate: validatePass,
 	}
@@ -159,13 +163,15 @@ var (
 			if len(strs) != 3 {
 				return false
 			}
+			sum := 0
 			for _, s := range strs {
 				n, err := strconv.Atoi(s)
 				if err != nil || n < 0 {
 					return false
 				}
+				sum += n
 			}
-			return true
+			return sum == 100
 		},
 	}
 

--- a/params/governance_paramset_test.go
+++ b/params/governance_paramset_test.go
@@ -117,11 +117,6 @@ func TestGovParamSet_GlobalMaps(t *testing.T) {
 	for _, key := range govParamNames {
 		assert.NotNil(t, govParamTypes[key])
 	}
-
-	assert.Equal(t, len(govParamTypes), len(govParamDefaults))
-	for key := range govParamTypes {
-		assert.NotNil(t, govParamDefaults[key])
-	}
 }
 
 func TestGovParamSet_Get(t *testing.T) {
@@ -134,15 +129,11 @@ func TestGovParamSet_Get(t *testing.T) {
 	v, ok := p.Get(Epoch)
 	assert.True(t, ok)
 	assert.Equal(t, num, v)
-	assert.Equal(t, num, p.MustGet(Epoch))
-	assert.Equal(t, num, p.Epoch())
 
-	// Even when param does not exist, MustGet() must return something.
+	// Not exists
 	v, ok = p.Get(CommitteeSize)
 	assert.False(t, ok)
 	assert.Nil(t, v)
-	assert.Equal(t, DefaultSubGroupSize, p.MustGet(CommitteeSize))
-	assert.Equal(t, DefaultSubGroupSize, p.CommitteeSize())
 }
 
 func TestGovParamSet_New(t *testing.T) {
@@ -150,32 +141,24 @@ func TestGovParamSet_New(t *testing.T) {
 		"istanbul.epoch": 604800,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(604800), p.Epoch())
+	v, ok := p.Get(Epoch)
+	assert.Equal(t, uint64(604800), v)
+	assert.True(t, ok)
 
 	p, err = NewGovParamSetIntMap(map[int]interface{}{
 		Epoch: 604800,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(604800), p.Epoch())
+	v, ok = p.Get(Epoch)
+	assert.Equal(t, uint64(604800), v)
+	assert.True(t, ok)
 
 	c := CypressChainConfig
 	p, err = NewGovParamSetChainConfig(c)
 	assert.Nil(t, err)
-	assert.Equal(t, c.Istanbul.Epoch, p.Epoch())
-	assert.Equal(t, c.Istanbul.ProposerPolicy, p.Policy())
-	assert.Equal(t, c.Istanbul.SubGroupSize, p.CommitteeSize())
-	assert.Equal(t, c.UnitPrice, p.UnitPrice())
-	assert.Equal(t, c.Governance.GovernanceMode, p.GovernanceMode())
-	assert.Equal(t, c.Governance.GoverningNode, p.GoverningNode())
-	assert.Equal(t, c.Governance.Reward.MintingAmount.String(), p.MintingAmountStr())
-	assert.Equal(t, c.Governance.Reward.MintingAmount, p.MintingAmountBig())
-	assert.Equal(t, c.Governance.Reward.Ratio, p.Ratio())
-	assert.Equal(t, c.Governance.Reward.UseGiniCoeff, p.UseGiniCoeff())
-	assert.Equal(t, c.Governance.Reward.DeferredTxFee, p.DeferredTxFee())
-	assert.Equal(t, c.Governance.Reward.MinimumStake.String(), p.MinimumStakeStr())
-	assert.Equal(t, c.Governance.Reward.MinimumStake, p.MinimumStakeBig())
-	assert.Equal(t, c.Governance.Reward.StakingUpdateInterval, p.StakeUpdateInterval())
-	assert.Equal(t, c.Governance.Reward.ProposerUpdateInterval, p.ProposerRefreshInterval())
+	v, ok = p.Get(Epoch)
+	assert.Equal(t, c.Istanbul.Epoch, v)
+	assert.True(t, ok)
 }
 
 func TestGovParamSet_RegressDb(t *testing.T) {

--- a/params/governance_paramset_test.go
+++ b/params/governance_paramset_test.go
@@ -1,0 +1,214 @@
+package params
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGovParamSet_ParseValue(t *testing.T) {
+	zeroAddr := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	mintingAmount := "9600000000000000000"
+	mintingAmountBig, _ := new(big.Int).SetString(mintingAmount, 10)
+
+	testcases := []struct {
+		ty     *govParamType
+		value  interface{}
+		parsed interface{} // If ok, expected value. Ignored if not ok.
+		ok     bool        // Expected 'ok'
+	}{
+		{govParamTypeGovMode, "none", "none", true},
+		{govParamTypeGovMode, "single", "single", true},
+		{govParamTypeGovMode, "ballot", "ballot", true},
+		{govParamTypeGovMode, "asdf", nil, false},
+		{govParamTypeGovMode, "", nil, false},
+		{govParamTypeGovMode, 1, nil, false},
+
+		{govParamTypeAddress, zeroAddr.Hex(), zeroAddr, true},
+		{govParamTypeAddress, zeroAddr, zeroAddr, true},
+		{govParamTypeAddress, 1, nil, false},
+
+		{govParamTypeUint64, int(7), uint64(7), true},
+		{govParamTypeUint64, uint(7), uint64(7), true},
+		{govParamTypeUint64, uint64(7), uint64(7), true},
+		{govParamTypeUint64, float64(1e9), uint64(1e9), true},
+		{govParamTypeUint64, "123", nil, false},
+		{govParamTypeUint64, -1, nil, false},
+		{govParamTypeUint64, -12.0, nil, false},
+
+		{govParamTypeBigInt, mintingAmount, mintingAmount, true},
+		{govParamTypeBigInt, mintingAmountBig, mintingAmount, true},
+		{govParamTypeBigInt, "123", "123", true},
+		{govParamTypeBigInt, "-123", nil, false},
+		{govParamTypeBigInt, "abc", nil, false},
+		{govParamTypeBigInt, "", nil, false},
+
+		{govParamTypeRatio, "100/0/0", "100/0/0", true},
+		{govParamTypeRatio, "10/20/30/40", nil, false},
+		{govParamTypeRatio, "", nil, false},
+
+		{govParamTypeBool, true, true, true},
+		{govParamTypeBool, 0, nil, false},
+		{govParamTypeBool, "", nil, false},
+	}
+
+	for _, tc := range testcases {
+		parsed, ok := tc.ty.ParseValue(tc.value)
+		assert.Equal(t, tc.ok, ok)
+		if ok {
+			assert.Equal(t, tc.parsed, parsed)
+		}
+	}
+}
+
+func TestGovParamSet_ParseBytes(t *testing.T) {
+	zeroAddrHex := "0x0000000000000000000000000000000000000000"
+	zeroAddr := common.HexToAddress(zeroAddrHex)
+	mintingAmount := "9600000000000000000"
+	mintingAmountBig, _ := new(big.Int).SetString(mintingAmount, 10)
+
+	testcases := []struct {
+		ty     *govParamType
+		bytes  []byte
+		parsed interface{} // If ok, expected value. Ignored if not ok.
+		ok     bool        // Expected 'ok'
+	}{
+		{govParamTypeGovMode, []byte("single"), "single", true},
+		{govParamTypeGovMode, []byte(""), nil, false},
+
+		{govParamTypeAddress, zeroAddr.Bytes(), zeroAddr, true},
+		{govParamTypeAddress, []byte(zeroAddr.Hex()), nil, false},
+		{govParamTypeAddress, []byte(""), nil, false},
+
+		{govParamTypeUint64, []byte{0x12, 0x34}, uint64(0x1234), true},
+		{govParamTypeUint64, []byte{}, uint64(0), true},
+		{govParamTypeUint64, []byte{1, 2, 3, 4, 5, 6, 7, 8}, uint64(0x0102030405060708), true},
+		{govParamTypeUint64, []byte{1, 1, 2, 3, 4, 5, 6, 7, 8}, nil, false},
+
+		{govParamTypeBigInt, mintingAmountBig.Bytes(), mintingAmount, true},
+		{govParamTypeBigInt, []byte{0x12, 0x34}, "4660", true},
+
+		{govParamTypeRatio, []byte("100/0/0"), "100/0/0", true},
+		{govParamTypeRatio, []byte("10/20/30/40"), nil, false},
+		{govParamTypeRatio, []byte(""), nil, false},
+
+		{govParamTypeBool, []byte{0x01}, true, true},
+		{govParamTypeBool, []byte{0x00}, false, true},
+		{govParamTypeBool, []byte{0x99}, nil, false},
+		{govParamTypeBool, []byte{}, nil, false},
+	}
+
+	for _, tc := range testcases {
+		parsed, ok := tc.ty.ParseBytes(tc.bytes)
+		assert.Equal(t, tc.ok, ok)
+		if ok {
+			assert.Equal(t, tc.parsed, parsed)
+		}
+	}
+}
+
+func TestGovParamSet_GlobalMaps(t *testing.T) {
+	// Check that govParam* maps hold the same set of parameters.
+
+	assert.Equal(t, len(govParamTypes), len(govParamNames))
+	for _, key := range govParamNames {
+		assert.NotNil(t, govParamTypes[key])
+	}
+
+	assert.Equal(t, len(govParamTypes), len(govParamDefaults))
+	for key := range govParamTypes {
+		assert.NotNil(t, govParamDefaults[key])
+	}
+}
+
+func TestGovParamSet_Get(t *testing.T) {
+	num := uint64(123456)
+	p, _ := NewGovParamSetStrMap(map[string]interface{}{
+		"istanbul.epoch": num,
+	})
+
+	// Exists
+	v, ok := p.Get(Epoch)
+	assert.True(t, ok)
+	assert.Equal(t, num, v)
+	assert.Equal(t, num, p.MustGet(Epoch))
+	assert.Equal(t, num, p.Epoch())
+
+	// Even when param does not exist, MustGet() must return something.
+	v, ok = p.Get(CommitteeSize)
+	assert.False(t, ok)
+	assert.Nil(t, v)
+	assert.Equal(t, DefaultSubGroupSize, p.MustGet(CommitteeSize))
+	assert.Equal(t, DefaultSubGroupSize, p.CommitteeSize())
+}
+
+func TestGovParamSet_New(t *testing.T) {
+	p, err := NewGovParamSetStrMap(map[string]interface{}{
+		"istanbul.epoch": 604800,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(604800), p.Epoch())
+
+	p, err = NewGovParamSetIntMap(map[int]interface{}{
+		Epoch: 604800,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(604800), p.Epoch())
+
+	c := CypressChainConfig
+	p, err = NewGovParamSetChainConfig(c)
+	assert.Nil(t, err)
+	assert.Equal(t, c.Istanbul.Epoch, p.Epoch())
+	assert.Equal(t, c.Istanbul.ProposerPolicy, p.Policy())
+	assert.Equal(t, c.Istanbul.SubGroupSize, p.CommitteeSize())
+	assert.Equal(t, c.UnitPrice, p.UnitPrice())
+	assert.Equal(t, c.Governance.GovernanceMode, p.GovernanceMode())
+	assert.Equal(t, c.Governance.GoverningNode, p.GoverningNode())
+	assert.Equal(t, c.Governance.Reward.MintingAmount.String(), p.MintingAmountStr())
+	assert.Equal(t, c.Governance.Reward.MintingAmount, p.MintingAmountBig())
+	assert.Equal(t, c.Governance.Reward.Ratio, p.Ratio())
+	assert.Equal(t, c.Governance.Reward.UseGiniCoeff, p.UseGiniCoeff())
+	assert.Equal(t, c.Governance.Reward.DeferredTxFee, p.DeferredTxFee())
+	assert.Equal(t, c.Governance.Reward.MinimumStake.String(), p.MinimumStakeStr())
+	assert.Equal(t, c.Governance.Reward.MinimumStake, p.MinimumStakeBig())
+	assert.Equal(t, c.Governance.Reward.StakingUpdateInterval, p.StakeUpdateInterval())
+	assert.Equal(t, c.Governance.Reward.ProposerUpdateInterval, p.ProposerRefreshInterval())
+}
+
+func TestGovParamSet_RegressDb(t *testing.T) {
+	// MiscDB stores governance data as JSON strings. The value types can be
+	// slightly wrong during unmarshal because we unmarshal into interface{}.
+	// Namely, JSON integers can be converted to float64.
+
+	c := CypressChainConfig
+	p, err := NewGovParamSetChainConfig(c)
+	assert.Nil(t, err)
+
+	// Simulate database write then read
+	j, _ := json.Marshal(p.StrMap())
+	var data map[string]interface{}
+	json.Unmarshal(j, &data)
+
+	pp, err := NewGovParamSetStrMap(data)
+	assert.Nil(t, err)
+	assert.Equal(t, p.items, pp.items)
+}
+
+func TestGovParamSet_GetMap(t *testing.T) {
+	c := CypressChainConfig
+	p, err := NewGovParamSetChainConfig(c)
+	assert.Nil(t, err)
+
+	sm := p.StrMap()
+	psm, err := NewGovParamSetStrMap(sm)
+	assert.Nil(t, err)
+	assert.Equal(t, p.items, psm.items)
+
+	im := p.IntMap()
+	pim, err := NewGovParamSetIntMap(im)
+	assert.Nil(t, err)
+	assert.Equal(t, p.items, pim.items)
+}

--- a/params/governance_paramset_test.go
+++ b/params/governance_paramset_test.go
@@ -47,7 +47,10 @@ func TestGovParamSet_ParseValue(t *testing.T) {
 		{govParamTypeBigInt, "", nil, false},
 
 		{govParamTypeRatio, "100/0/0", "100/0/0", true},
+		{govParamTypeRatio, "30/30/40", "30/30/40", true},
 		{govParamTypeRatio, "10/20/30/40", nil, false},
+		{govParamTypeRatio, "0/0/0", nil, false},
+		{govParamTypeRatio, "1/2/3", nil, false},
 		{govParamTypeRatio, "", nil, false},
 
 		{govParamTypeBool, true, true, true},


### PR DESCRIPTION
## Proposed changes

- Introduce new struct `params.GovParamSet`
- It is an immutable set of governance parameters.
- It unifies tedious and error-prone governance data processing
  - Adjust json.Unmarshal'd data (formerly at `adjustDecodedSet()`)
  - Parse []byte encoded data (to read contract output)
  - Nominal getters (like `Governance.Epoch()`)
  - General purpose getters (like `Governance.GetGovernanceValue(key int)`)
- A crucial role of new governance engine will be serving GovParamSet at different block numbers.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
