### PR TITLE
Change signer generation function for woker

### DIFF
--- a/work/worker.go
+++ b/work/worker.go
@@ -466,7 +466,7 @@ func (self *worker) makeCurrent(parent *types.Block, header *types.Header) error
 	if err != nil {
 		return err
 	}
-	work := NewTask(self.config, types.LatestSignerForChainID(self.config.ChainID), stateDB, header)
+	work := NewTask(self.config, types.MakeSigner(self.config, header.Number), stateDB, header)
 	if self.nodetype != common.CONSENSUSNODE {
 		work.Block = parent
 	}


### PR DESCRIPTION
## Proposed changes

Klaytn usually generates signer with functions: `MakeSigner` and `LatestSignerForChainID`. 
- `MakeSigner`: generates a signer based on the given chain config and block number. 
- `LatestSignerForChainID`: is used where the current block number and fork configuration are unknown. 

In most cases, using `LatestSignerForChainID` instead of `MakeSigner` doesn't make any consistency issue because the latest signer can determine which singing mechanism should be applied to make/recover a signature. 

However, using a random signer can make a performance issue because of SenderCacher because its behavior depends on the type of signer. 


**Background**
SenderCacher increases block processing performance by parallelly recovering a sender address during block processing. A transactions stores a pair of the recovered address and the signer used. If the node tries to recover the sender of the transaction with the same signer, it just returns the recovered address it holds without recovering again.

**Problem**
SenderCacher uses worker's signer and it is generated by types.LatestSignerForChainID(self.config.ChainID) [here](https://github.com/klaytn/klaytn/blob/1cef10ac7a2dd958324f92ea5460926b92bd0df8/work/worker.go#L469).
However, a node uses another signer generated by types.MakeSigner(chainConfig, header.Number) [here](https://github.com/klaytn/klaytn/blob/1cef10ac7a2dd958324f92ea5460926b92bd0df8/blockchain/blockchain.go#L2568) when it processes blocks. types.LatestSignerForChainID(self.config.ChainID) always return London signer, but types.MakeSigner(chainConfig, header.Number) returns London signer after EthTxType Hardfork enabled. The mismatch of the signer type prohibits the use of SenderCacher. So, Klaytn nodes having v1.8.0 or higher version has performance degrade before the hardfork.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

Resolves #1288