### PR TITLE
Before sending transactions, sort transactions in ascending order by time that were created.

### DIFF
--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -506,6 +506,11 @@ func (tx *Transaction) Size() common.StorageSize {
 	return size
 }
 
+// Time returns the time that transaction was created.
+func (tx *Transaction) Time() time.Time {
+	return tx.time
+}
+
 // FillContractAddress fills contract address to receipt. This only works for types deploying a smart contract.
 func (tx *Transaction) FillContractAddress(from common.Address, r *Receipt) {
 	if filler, ok := tx.data.(TxInternalDataContractAddressFiller); ok {

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -28,6 +28,7 @@ import (
 	"math/big"
 	"math/rand"
 	"runtime/debug"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1113,6 +1114,13 @@ func (pm *ProtocolManager) BroadcastBlockHash(block *types.Block) {
 // BroadcastTxs propagates a batch of transactions to its peers which are not known to
 // already have the given transaction.
 func (pm *ProtocolManager) BroadcastTxs(txs types.Transactions) {
+	// This function sendTransaction() is called for each peer internally.
+	// In that case, transactions are sorted for each peer in sendTransaction().
+	// Therefore, it prevents sorting transactions by each peer.
+	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {
+		sort.Sort(types.TxByPriceAndTime(txs))
+	}
+
 	switch pm.nodetype {
 	case common.CONSENSUSNODE:
 		pm.broadcastTxsFromCN(txs)
@@ -1193,6 +1201,13 @@ func (pm *ProtocolManager) ReBroadcastTxs(txs types.Transactions) {
 	// A consensus node does not rebroadcast transactions, hence return here.
 	if pm.nodetype == common.CONSENSUSNODE {
 		return
+	}
+
+	// This function sendTransaction() is called for each peer internally.
+	// In that case, transactions are sorted for each peer in sendTransaction().
+	// Therefore, it prevents sorting transactions by each peer.
+	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {
+		sort.Sort(types.TxByPriceAndTime(txs))
 	}
 
 	peersWithoutTxs := make(map[Peer]types.Transactions)

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1203,7 +1203,7 @@ func (pm *ProtocolManager) ReBroadcastTxs(txs types.Transactions) {
 		return
 	}
 
-	// This function sendTransaction() is called for each peer internally.
+	// This function calls sendTransaction() to broadcast the transactions for each peer.
 	// In that case, transactions are sorted for each peer in sendTransaction().
 	// Therefore, it prevents sorting transactions by each peer.
 	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1114,7 +1114,7 @@ func (pm *ProtocolManager) BroadcastBlockHash(block *types.Block) {
 // BroadcastTxs propagates a batch of transactions to its peers which are not known to
 // already have the given transaction.
 func (pm *ProtocolManager) BroadcastTxs(txs types.Transactions) {
-	// This function sendTransaction() is called for each peer internally.
+	// This function calls sendTransaction() to broadcast the transactions for each peer.
 	// In that case, transactions are sorted for each peer in sendTransaction().
 	// Therefore, it prevents sorting transactions by each peer.
 	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -445,7 +445,7 @@ func (p *basePeer) SendTransactions(txs types.Transactions) error {
 
 // ReSendTransactions sends txs to a peer in order to prevent the txs from missing.
 func (p *basePeer) ReSendTransactions(txs types.Transactions) error {
-	//Before sending transactions, sort transactions in ascending order by time.
+	// Before sending transactions, sort transactions in ascending order by time.
 	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {
 		sort.Sort(types.TxByPriceAndTime(txs))
 	}

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -432,7 +432,7 @@ func (p *basePeer) Send(msgcode uint64, data interface{}) error {
 // SendTransactions sends transactions to the peer and includes the hashes
 // in its transaction hash set for future reference.
 func (p *basePeer) SendTransactions(txs types.Transactions) error {
-	//Before sending transactions, sort transactions in ascending order by time.
+	// Before sending transactions, sort transactions in ascending order by time.
 	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {
 		sort.Sort(types.TxByPriceAndTime(txs))
 	}

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -433,7 +433,9 @@ func (p *basePeer) Send(msgcode uint64, data interface{}) error {
 // in its transaction hash set for future reference.
 func (p *basePeer) SendTransactions(txs types.Transactions) error {
 	//Before sending transactions, sort transactions in ascending order by time.
-	sort.Sort(types.TxByPriceAndTime(txs))
+	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {
+		sort.Sort(types.TxByPriceAndTime(txs))
+	}
 
 	for _, tx := range txs {
 		p.AddToKnownTxs(tx.Hash())
@@ -444,7 +446,9 @@ func (p *basePeer) SendTransactions(txs types.Transactions) error {
 // ReSendTransactions sends txs to a peer in order to prevent the txs from missing.
 func (p *basePeer) ReSendTransactions(txs types.Transactions) error {
 	//Before sending transactions, sort transactions in ascending order by time.
-	sort.Sort(types.TxByPriceAndTime(txs))
+	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {
+		sort.Sort(types.TxByPriceAndTime(txs))
+	}
 
 	return p2p.Send(p.rw, TxMsg, txs)
 }

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -807,8 +807,10 @@ func (p *multiChannelPeer) Broadcast() {
 // SendTransactions sends transactions to the peer and includes the hashes
 // in its transaction hash set for future reference.
 func (p *multiChannelPeer) SendTransactions(txs types.Transactions) error {
-	//Before sending transactions, sort transactions in ascending order by time.
-	sort.Sort(types.TxByPriceAndTime(txs))
+	// Before sending transactions, sort transactions in ascending order by time.
+	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {
+		sort.Sort(types.TxByPriceAndTime(txs))
+	}
 
 	for _, tx := range txs {
 		p.AddToKnownTxs(tx.Hash())
@@ -818,8 +820,10 @@ func (p *multiChannelPeer) SendTransactions(txs types.Transactions) error {
 
 // ReSendTransactions sends txs to a peer in order to prevent the txs from missing.
 func (p *multiChannelPeer) ReSendTransactions(txs types.Transactions) error {
-	//Before sending transactions, sort transactions in ascending order by time.
-	sort.Sort(types.TxByPriceAndTime(txs))
+	// Before sending transactions, sort transactions in ascending order by time.
+	if !sort.IsSorted(types.TxByPriceAndTime(txs)) {
+		sort.Sort(types.TxByPriceAndTime(txs))
+	}
 
 	return p.msgSender(TxMsg, txs)
 }

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 	"sync"
 	"time"
 
@@ -431,6 +432,9 @@ func (p *basePeer) Send(msgcode uint64, data interface{}) error {
 // SendTransactions sends transactions to the peer and includes the hashes
 // in its transaction hash set for future reference.
 func (p *basePeer) SendTransactions(txs types.Transactions) error {
+	//Before sending transactions, sort transactions in ascending order by time.
+	sort.Sort(types.TxByPriceAndTime(txs))
+
 	for _, tx := range txs {
 		p.AddToKnownTxs(tx.Hash())
 	}
@@ -439,6 +443,9 @@ func (p *basePeer) SendTransactions(txs types.Transactions) error {
 
 // ReSendTransactions sends txs to a peer in order to prevent the txs from missing.
 func (p *basePeer) ReSendTransactions(txs types.Transactions) error {
+	//Before sending transactions, sort transactions in ascending order by time.
+	sort.Sort(types.TxByPriceAndTime(txs))
+
 	return p2p.Send(p.rw, TxMsg, txs)
 }
 
@@ -800,6 +807,9 @@ func (p *multiChannelPeer) Broadcast() {
 // SendTransactions sends transactions to the peer and includes the hashes
 // in its transaction hash set for future reference.
 func (p *multiChannelPeer) SendTransactions(txs types.Transactions) error {
+	//Before sending transactions, sort transactions in ascending order by time.
+	sort.Sort(types.TxByPriceAndTime(txs))
+
 	for _, tx := range txs {
 		p.AddToKnownTxs(tx.Hash())
 	}
@@ -808,6 +818,9 @@ func (p *multiChannelPeer) SendTransactions(txs types.Transactions) error {
 
 // ReSendTransactions sends txs to a peer in order to prevent the txs from missing.
 func (p *multiChannelPeer) ReSendTransactions(txs types.Transactions) error {
+	//Before sending transactions, sort transactions in ascending order by time.
+	sort.Sort(types.TxByPriceAndTime(txs))
+
 	return p.msgSender(TxMsg, txs)
 }
 

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -18,13 +18,14 @@ package cn
 
 import (
 	"crypto/ecdsa"
-	"github.com/klaytn/klaytn/crypto"
 	"math/big"
 	"math/rand"
 	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/klaytn/klaytn/crypto"
 
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -436,7 +437,7 @@ func TestBasePeer_ReSendTransactionWithSortedByTime(t *testing.T) {
 	rand.Shuffle(len(txs), func(i, j int) {
 		txs[i], txs[j] = txs[j], txs[i]
 	})
-	
+
 	sortedTxs := make(types.Transactions, len(txs))
 	copy(sortedTxs, txs)
 

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -413,6 +413,7 @@ func TestBasePeer_SendTransactionWithSortedByTime(t *testing.T) {
 	for i, tx := range receivedTxs {
 		assert.True(t, basePeer.KnowsTx(tx.Hash()))
 		assert.Equal(t, sortedTxs[i].Hash(), tx.Hash())
+		assert.False(t, sortedTxs[i].Time().Equal(tx.Time()))
 	}
 }
 

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -467,5 +467,127 @@ func TestBasePeer_ReSendTransactionWithSortedByTime(t *testing.T) {
 	// It should be received transaction with sorted by times.
 	for i, tx := range receivedTxs {
 		assert.Equal(t, sortedTxs[i].Hash(), tx.Hash())
+		assert.False(t, sortedTxs[i].Time().Equal(tx.Time()))
+	}
+}
+
+func TestMultiChannelPeer_SendTransactionWithSortedByTime(t *testing.T) {
+	// Generate a batch of accounts to start with
+	keys := make([]*ecdsa.PrivateKey, 5)
+	for i := 0; i < len(keys); i++ {
+		keys[i], _ = crypto.GenerateKey()
+	}
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	// Generate a batch of transactions.
+	txs := types.Transactions{}
+	for _, key := range keys {
+		tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(100), 100, big.NewInt(1), nil), signer, key)
+
+		txs = append(txs, tx)
+	}
+
+	// Shuffle transactions.
+	rand.Seed(time.Now().Unix())
+	rand.Shuffle(len(txs), func(i, j int) {
+		txs[i], txs[j] = txs[j], txs[i]
+	})
+
+	sortedTxs := make(types.Transactions, len(txs))
+	copy(sortedTxs, txs)
+
+	// Sort transaction by time.
+	sort.Sort(types.TxByPriceAndTime(sortedTxs))
+
+	_, oppositePipe1, oppositePipe2 := newBasePeer()
+	multiPeer, _ := newPeerWithRWs(version, p2pPeers[0], []p2p.MsgReadWriter{oppositePipe1, oppositePipe2})
+
+	for _, tx := range txs {
+		assert.False(t, multiPeer.KnowsTx(tx.Hash()))
+	}
+
+	go func(t *testing.T) {
+		if err := multiPeer.SendTransactions(txs); err != nil {
+			t.Fatal(t)
+		}
+	}(t)
+
+	receivedMsg, err := oppositePipe1.ReadMsg()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var receivedTxs types.Transactions
+	if err := receivedMsg.Decode(&receivedTxs); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, len(txs), len(receivedTxs))
+
+	// It should be received transaction with sorted by times.
+	for i, tx := range receivedTxs {
+		assert.True(t, multiPeer.KnowsTx(tx.Hash()))
+		assert.Equal(t, sortedTxs[i].Hash(), tx.Hash())
+		assert.False(t, sortedTxs[i].Time().Equal(tx.Time()))
+	}
+}
+
+func TestMultiChannelPeer_ReSendTransactionWithSortedByTime(t *testing.T) {
+	// Generate a batch of accounts to start with
+	keys := make([]*ecdsa.PrivateKey, 5)
+	for i := 0; i < len(keys); i++ {
+		keys[i], _ = crypto.GenerateKey()
+	}
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	// Generate a batch of transactions.
+	txs := types.Transactions{}
+	for _, key := range keys {
+		tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(100), 100, big.NewInt(1), nil), signer, key)
+
+		txs = append(txs, tx)
+	}
+
+	// Shuffle transactions.
+	rand.Seed(time.Now().Unix())
+	rand.Shuffle(len(txs), func(i, j int) {
+		txs[i], txs[j] = txs[j], txs[i]
+	})
+
+	sortedTxs := make(types.Transactions, len(txs))
+	copy(sortedTxs, txs)
+
+	// Sort transaction by time.
+	sort.Sort(types.TxByPriceAndTime(sortedTxs))
+
+	_, oppositePipe1, oppositePipe2 := newBasePeer()
+	multiPeer, _ := newPeerWithRWs(version, p2pPeers[0], []p2p.MsgReadWriter{oppositePipe1, oppositePipe2})
+
+	for _, tx := range txs {
+		assert.False(t, multiPeer.KnowsTx(tx.Hash()))
+	}
+
+	go func(t *testing.T) {
+		if err := multiPeer.ReSendTransactions(txs); err != nil {
+			t.Fatal(t)
+		}
+	}(t)
+
+	receivedMsg, err := oppositePipe1.ReadMsg()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var receivedTxs types.Transactions
+	if err := receivedMsg.Decode(&receivedTxs); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, len(txs), len(receivedTxs))
+
+	// It should be received transaction with sorted by times.
+	for i, tx := range receivedTxs {
+		assert.Equal(t, sortedTxs[i].Hash(), tx.Hash())
+		assert.False(t, sortedTxs[i].Time().Equal(tx.Time()))
 	}
 }


### PR DESCRIPTION
## Proposed changes

This PR implemented that before sending transactions, sorting transactions in ascending order according to the time they were created.
  - For transaction sorting, used `TxByPriceAndTime` which implements the sorting interface to sort by time.
  - I added benchmark test in `transaction_test.go` to estimate performance about sorting transactions by time that transaction were created.
    - sorting 20,000 transactions : 40ms
    - sorting 30,000 transactions : 70ms

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Closes #1275 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
