### PR TITLE
Added panic guards for prefetchers

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1753,3 +1753,52 @@ func TestDeleteCreateRevert(t *testing.T) {
 		t.Fatalf("block %d: failed to insert into chain: %v", n, err)
 	}
 }
+
+// TestBlockChain_InsertChain_InsertFuntureBlocks inserts future blocks that have missing ancestor.
+// It should return an expected error, but not panic.
+func TestBlockChain_InsertChain_InsertFutureBlocks(t *testing.T) {
+	// configure and generate a sample blockchain
+	var (
+		db          = database.NewMemoryDBManager()
+		key, _      = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address     = crypto.PubkeyToAddress(key.PublicKey)
+		funds       = big.NewInt(100000000000000000)
+		testGenesis = &Genesis{
+			Config: params.TestChainConfig,
+			Alloc:  GenesisAlloc{address: {Balance: funds}},
+		}
+		genesis = testGenesis.MustCommit(db)
+	)
+
+	// Archive mode is given to avoid mismatching between the given starting block number and
+	// the actual block number where the blockchain has been rolled back to due to 128 blocks interval commit.
+	cacheConfig := &CacheConfig{
+		ArchiveMode:         true,
+		CacheSize:           512,
+		BlockInterval:       DefaultBlockInterval,
+		TriesInMemory:       DefaultTriesInMemory,
+		TrieNodeCacheConfig: statedb.GetEmptyTrieNodeCacheConfig(),
+		SnapshotCacheSize:   512,
+	}
+	cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker = 3
+
+	// create new blockchain with enabled internal tx tracing option
+	blockchain, _ := NewBlockChain(db, cacheConfig, testGenesis.Config, gxhash.NewFaker(), vm.Config{})
+	defer blockchain.Stop()
+
+	// generate blocks
+	blocks, _ := GenerateChain(testGenesis.Config, genesis, gxhash.NewFaker(), db, 10, func(i int, block *BlockGen) {})
+
+	// insert the generated blocks into the test chain
+	if n, err := blockchain.InsertChain(blocks[:2]); err != nil {
+		t.Fatalf("failed to process block %d: %v", n, err)
+	}
+
+	// insert future blocks
+	_, err := blockchain.InsertChain(blocks[4:])
+	if err == nil {
+		t.Fatal("should be failed")
+	}
+
+	assert.Equal(t, consensus.ErrUnknownAncestor, err)
+}

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1754,7 +1754,7 @@ func TestDeleteCreateRevert(t *testing.T) {
 	}
 }
 
-// TestBlockChain_InsertChain_InsertFuntureBlocks inserts future blocks that have missing ancestor.
+// TestBlockChain_InsertChain_InsertFutureBlocks inserts future blocks that have a missing ancestor.
 // It should return an expected error, but not panic.
 func TestBlockChain_InsertChain_InsertFutureBlocks(t *testing.T) {
 	// configure and generate a sample blockchain


### PR DESCRIPTION
## Proposed changes

Klaytn increased sync performance starting prefetching before block body validation in https://github.com/klaytn/klaytn/pull/918.
However, this change can trigger issues because the prefetcher executes blocks having unvalidated headers and bodies. 
For example, `nil` parent because of future block insertion or validation errors causes panic returning `invalid memory address or nil pointer dereference` error. 

So, I adopted two logic to be safe in unexpected cases
1. Add the parent is not `nil` condition for next block prefetcher execution.
2. Recover panic from prefetcher. The invalid execution of the prefetcher doesn't affect to the integrity of Klaytn system, so we can recover the error and keep operating the node. 

I think another option is just reverting https://github.com/klaytn/klaytn/pull/918 to get confidence on the blocks that will be executed in the prefetcher. If you can think like this, please let me know. I can change this PR in that way. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
