### PR TITLE
Convert t.Fatal to t.Error and return to follow vet recommendation

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1039,14 +1039,17 @@ func TestCanonicalBlockRetrieval(t *testing.T) {
 					continue // busy wait for canonical hash to be written
 				}
 				if ch != block.Hash() {
-					t.Fatalf("unknown canonical hash, want %s, got %s", block.Hash().Hex(), ch.Hex())
+					t.Errorf("unknown canonical hash, want %s, got %s", block.Hash().Hex(), ch.Hex())
+					return
 				}
 				fb := blockchain.db.ReadBlock(ch, block.NumberU64())
 				if fb == nil {
-					t.Fatalf("unable to retrieve block %d for canonical hash: %s", block.NumberU64(), ch.Hex())
+					t.Errorf("unable to retrieve block %d for canonical hash: %s", block.NumberU64(), ch.Hex())
+					return
 				}
 				if fb.Hash() != block.Hash() {
-					t.Fatalf("invalid block hash for block %d, want %s, got %s", block.NumberU64(), block.Hash().Hex(), fb.Hash().Hex())
+					t.Errorf("invalid block hash for block %d, want %s, got %s", block.NumberU64(), block.Hash().Hex(), fb.Hash().Hex())
+					return
 				}
 				return
 			}

--- a/networks/p2p/simulations/adapters/inproc_test.go
+++ b/networks/p2p/simulations/adapters/inproc_test.go
@@ -43,7 +43,8 @@ func TestTCPPipe(t *testing.T) {
 
 			_, err := c1.Write(msg)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 		}
 
@@ -54,11 +55,13 @@ func TestTCPPipe(t *testing.T) {
 			out := make([]byte, size)
 			_, err := c2.Read(out)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 
 			if !bytes.Equal(msg, out) {
-				t.Fatalf("expected %#v, got %#v", msg, out)
+				t.Errorf("expected %#v, got %#v", msg, out)
+				return
 			}
 		}
 		done <- struct{}{}
@@ -87,7 +90,8 @@ func TestTCPPipeBidirections(t *testing.T) {
 
 			_, err := c1.Write(msg)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 		}
 
@@ -97,16 +101,19 @@ func TestTCPPipeBidirections(t *testing.T) {
 			out := make([]byte, size)
 			_, err := c2.Read(out)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 
 			if !bytes.Equal(expected, out) {
-				t.Fatalf("expected %#v, got %#v", out, expected)
+				t.Errorf("expected %#v, got %#v", out, expected)
+				return
 			} else {
 				msg := []byte(fmt.Sprintf("pong %02d", i))
 				_, err := c2.Write(msg)
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
 			}
 		}
@@ -117,11 +124,13 @@ func TestTCPPipeBidirections(t *testing.T) {
 			out := make([]byte, size)
 			_, err := c1.Read(out)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 
 			if !bytes.Equal(expected, out) {
-				t.Fatalf("expected %#v, got %#v", out, expected)
+				t.Errorf("expected %#v, got %#v", out, expected)
+				return
 			}
 		}
 		done <- struct{}{}
@@ -153,7 +162,8 @@ func TestNetPipe(t *testing.T) {
 
 				_, err := c1.Write(msg)
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
 			}
 		}()
@@ -165,11 +175,13 @@ func TestNetPipe(t *testing.T) {
 			out := make([]byte, size)
 			_, err := c2.Read(out)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 
 			if !bytes.Equal(msg, out) {
-				t.Fatalf("expected %#v, got %#v", msg, out)
+				t.Errorf("expected %#v, got %#v", msg, out)
+				return
 			}
 		}
 
@@ -204,7 +216,8 @@ func TestNetPipeBidirections(t *testing.T) {
 
 				_, err := c1.Write(msg)
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
 			}
 		}()
@@ -217,11 +230,13 @@ func TestNetPipeBidirections(t *testing.T) {
 				out := make([]byte, size)
 				_, err := c1.Read(out)
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
 
 				if !bytes.Equal(expected, out) {
-					t.Fatalf("expected %#v, got %#v", expected, out)
+					t.Errorf("expected %#v, got %#v", expected, out)
+					return
 				}
 			}
 
@@ -235,17 +250,20 @@ func TestNetPipeBidirections(t *testing.T) {
 			out := make([]byte, size)
 			_, err := c2.Read(out)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 
 			if !bytes.Equal(expected, out) {
-				t.Fatalf("expected %#v, got %#v", expected, out)
+				t.Errorf("expected %#v, got %#v", expected, out)
+				return
 			} else {
 				msg := []byte(fmt.Sprintf(pongTemplate, i))
 
 				_, err := c2.Write(msg)
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
 			}
 		}

--- a/networks/p2p/simulations/mocker_test.go
+++ b/networks/p2p/simulations/mocker_test.go
@@ -113,7 +113,8 @@ func TestMocker(t *testing.T) {
 				}
 			case <-time.After(30 * time.Second):
 				wg.Done()
-				t.Fatalf("Timeout waiting for nodes being started up!")
+				t.Errorf("Timeout waiting for nodes being started up!")
+				return
 			}
 		}
 	}()

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -55,7 +55,8 @@ func TestBasePeer_Send(t *testing.T) {
 	expectedMsg := generateMsg(t, NewBlockHashesMsg, data)
 	go func(t *testing.T) {
 		if err := basePeer.Send(NewBlockHashesMsg, data); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -79,7 +80,8 @@ func TestBasePeer_SendTransactions(t *testing.T) {
 	assert.False(t, basePeer.KnowsTx(sentTxs[0].Hash()))
 	go func(t *testing.T) {
 		if err := basePeer.SendTransactions(sentTxs); err != nil {
-			t.Fatal(t)
+			t.Error(t)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -108,7 +110,8 @@ func TestBasePeer_ReSendTransactions(t *testing.T) {
 	assert.False(t, basePeer.KnowsTx(sentTxs[0].Hash()))
 	go func(t *testing.T) {
 		if err := basePeer.ReSendTransactions(sentTxs); err != nil {
-			t.Fatal(t)
+			t.Error(t)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -186,7 +189,8 @@ func TestBasePeer_SendBlockHeaders(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 	go func(t *testing.T) {
 		if err := basePeer.SendBlockHeaders(sentHeaders); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -208,7 +212,8 @@ func TestBasePeer_SendFetchedBlockHeader(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 	go func(t *testing.T) {
 		if err := basePeer.SendFetchedBlockHeader(sentHeader); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -230,7 +235,8 @@ func TestBasePeer_SendNodeData(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 	go func(t *testing.T) {
 		if err := basePeer.SendNodeData(sentData); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -252,7 +258,8 @@ func TestBasePeer_FetchBlockHeader(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 	go func(t *testing.T) {
 		if err := basePeer.FetchBlockHeader(sentHash); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -273,7 +280,8 @@ func TestBasePeer_RequestBodies(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 	go func(t *testing.T) {
 		if err := basePeer.RequestBodies(sentHashes); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -294,7 +302,8 @@ func TestBasePeer_FetchBlockBodies(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 	go func(t *testing.T) {
 		if err := basePeer.FetchBlockBodies(sentHashes); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -315,7 +324,8 @@ func TestBasePeer_RequestNodeData(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 	go func(t *testing.T) {
 		if err := basePeer.RequestNodeData(sentHashes); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()
@@ -336,7 +346,8 @@ func TestBasePeer_RequestReceipts(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 	go func(t *testing.T) {
 		if err := basePeer.RequestReceipts(sentHashes); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}(t)
 	receivedMsg, err := oppositePipe.ReadMsg()

--- a/node/sc/mainbridge_test.go
+++ b/node/sc/mainbridge_test.go
@@ -219,7 +219,8 @@ func TestMainBridge_handleMsg(t *testing.T) {
 		data := "valid message"
 		go func() {
 			if err := p2p.Send(pipe2, StatusMsg, data); err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 		}()
 
@@ -233,7 +234,8 @@ func TestMainBridge_handleMsg(t *testing.T) {
 		data := strings.Repeat("a", ProtocolMaxMsgSize+1)
 		go func() {
 			if err := p2p.Send(pipe2, StatusMsg, data); err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 		}()
 

--- a/node/sc/subbridge_test.go
+++ b/node/sc/subbridge_test.go
@@ -176,7 +176,8 @@ func TestSubBridge_handleMsg(t *testing.T) {
 		data := "valid message"
 		go func() {
 			if err := p2p.Send(pipe2, StatusMsg, data); err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 		}()
 
@@ -190,7 +191,8 @@ func TestSubBridge_handleMsg(t *testing.T) {
 		data := strings.Repeat("a", ProtocolMaxMsgSize+1)
 		go func() {
 			if err := p2p.Send(pipe2, StatusMsg, data); err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 		}()
 

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -812,7 +812,8 @@ func prepare(t *testing.T, vtcallback func(*testInfo)) *testInfo {
 					case KLAY, ERC20, ERC721:
 						break
 					default:
-						t.Fatalf("received ev.TokenType is unknown: %v", ev.TokenType)
+						t.Errorf("received ev.TokenType is unknown: %v", ev.TokenType)
+						return
 					}
 
 					if ev.Raw.Address == info.localInfo.address {

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -294,12 +294,14 @@ func TestDynamoDB_Retry(t *testing.T) {
 	go func() {
 		tcpAddr, err := net.ResolveTCPAddr("tcp", fakeEndpoint)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 
 		listen, err := net.ListenTCP("tcp", tcpAddr)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 		defer listen.Close()
 
@@ -310,7 +312,8 @@ func TestDynamoDB_Retry(t *testing.T) {
 			// Deadline prevents infinite waiting of the fake server
 			// Wait longer than (maxRetries+1) * timeout
 			if err := listen.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 			conn, err := listen.AcceptTCP()
 			if err != nil {

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -212,25 +212,29 @@ func TestRedisCache_Timeout(t *testing.T) {
 	go func() {
 		tcpAddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:11234")
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 
 		listen, err := net.ListenTCP("tcp", tcpAddr)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 		defer listen.Close()
 
 		for {
 			if err := listen.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 			_, err := listen.AcceptTCP()
 			if err != nil {
 				if strings.Contains(err.Error(), "timeout") {
 					return
 				}
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 		}
 	}()

--- a/tests/resend_nil_test.go
+++ b/tests/resend_nil_test.go
@@ -101,7 +101,8 @@ func BenchmarkResendNilDereference(t *testing.B) {
 			})
 			if err != nil {
 				fmt.Println("tx gen err", err)
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 
 			signedTx, err := types.SignTx(tx, signer, bcdata.privKeys[0])


### PR DESCRIPTION
## Proposed changes

`make test` fails with the following errors when the machine use golang v1.16 or higher. 
```
blockchain/blockchain_test.go:1042:6: call to (*T).Fatalf from a non-test goroutine
```

From go1.16, `Vet` warns the use of `t.Fatal` in goroutines during the test. 
And, the warning stops the further process of `make test`. 
So, all `t.Fatal` in goroutines in test files are converted to `t.Error` and `return` as golang release note suggested.

Reference: `Vet` section in [go1.16 Release note](https://go.dev/doc/go1.16)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
