### PR TITLE
fix use of *reflect.SliceHeader

### DIFF
--- a/consensus/gxhash/algorithm.go
+++ b/consensus/gxhash/algorithm.go
@@ -143,10 +143,12 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 		logFn("Generated gxhash verification cache", "elapsed", common.PrettyDuration(elapsed))
 	}()
 	// Convert our destination slice to a byte buffer
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&dest))
-	header.Len *= 4
-	header.Cap *= 4
-	cache := *(*[]byte)(unsafe.Pointer(&header))
+	var cache []byte
+	cacheHdr := (*reflect.SliceHeader)(unsafe.Pointer(&cache))
+	dstHdr := (*reflect.SliceHeader)(unsafe.Pointer(&dest))
+	cacheHdr.Data = dstHdr.Data
+	cacheHdr.Len = dstHdr.Len * 4
+	cacheHdr.Cap = dstHdr.Cap * 4
 
 	// Calculate the number of theoretical rows (we'll store in one buffer nonetheless)
 	size := uint64(len(cache))
@@ -284,11 +286,12 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 	swapped := !isLittleEndian()
 
 	// Convert our destination slice to a byte buffer
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&dest))
-	header.Len *= 4
-	header.Cap *= 4
-	dataset := *(*[]byte)(unsafe.Pointer(&header))
-
+	var dataset []byte
+	datasetHdr := (*reflect.SliceHeader)(unsafe.Pointer(&dataset))
+	destHdr := (*reflect.SliceHeader)(unsafe.Pointer(&dest))
+	datasetHdr.Data = destHdr.Data
+	datasetHdr.Len = destHdr.Len * 4
+	datasetHdr.Cap = destHdr.Cap * 4
 	// Generate the dataset on many goroutines since it takes a while
 	threads := runtime.NumCPU()
 	size := uint64(len(dataset))

--- a/consensus/gxhash/gxhash.go
+++ b/consensus/gxhash/gxhash.go
@@ -103,11 +103,12 @@ func memoryMapFile(file *os.File, write bool) (mmap.MMap, []uint32, error) {
 		return nil, nil, err
 	}
 	// Yay, we managed to memory map the file, here be dragons
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&mem))
-	header.Len /= 4
-	header.Cap /= 4
-
-	return mem, *(*[]uint32)(unsafe.Pointer(&header)), nil
+	var view []uint32
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&view))
+	header.Data = (*reflect.SliceHeader)(unsafe.Pointer(&mem)).Data
+	header.Cap = len(mem) / 4
+	header.Len = header.Cap
+	return mem, view, nil
 }
 
 // memoryMapAndGenerate tries to memory map a temporary file of uint32s for write


### PR DESCRIPTION
## Proposed changes

`go vet` warns the current use of *reflect.SliceHeader.
The code is changed in more recommended way.

```
consensus/gxhash/algorithm.go:146:12: possible misuse of reflect.SliceHeader
consensus/gxhash/algorithm.go:149:37: possible misuse of reflect.SliceHeader
consensus/gxhash/algorithm.go:287:12: possible misuse of reflect.SliceHeader
consensus/gxhash/algorithm.go:290:39: possible misuse of reflect.SliceHeader
consensus/gxhash/gxhash.go:106:12: possible misuse of reflect.SliceHeader
consensus/gxhash/gxhash.go:110:42: possible misuse of reflect.SliceHeader
```

The rationale of this change: https://github.com/golang/go/issues/40701

All changes in this PR are imported from https://github.com/ethereum/go-ethereum/pull/21372 https://github.com/ethereum/go-ethereum/pull/22696



## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
