### PR TITLE
Replace t.Fatal in goroutines to t.Error and return

### DIFF
--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -404,7 +404,8 @@ func TestBasePeer_SendTransactionWithSortedByTime(t *testing.T) {
 
 	go func(t *testing.T) {
 		if err := basePeer.SendTransactions(txs); err != nil {
-			t.Fatal(t)
+			t.Error(t)
+			return
 		}
 	}(t)
 
@@ -459,7 +460,8 @@ func TestBasePeer_ReSendTransactionWithSortedByTime(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 	go func(t *testing.T) {
 		if err := basePeer.ReSendTransactions(txs); err != nil {
-			t.Fatal(t)
+			t.Error(t)
+			return
 		}
 	}(t)
 
@@ -519,7 +521,8 @@ func TestMultiChannelPeer_SendTransactionWithSortedByTime(t *testing.T) {
 
 	go func(t *testing.T) {
 		if err := multiPeer.SendTransactions(txs); err != nil {
-			t.Fatal(t)
+			t.Error(t)
+			return
 		}
 	}(t)
 
@@ -580,7 +583,8 @@ func TestMultiChannelPeer_ReSendTransactionWithSortedByTime(t *testing.T) {
 
 	go func(t *testing.T) {
 		if err := multiPeer.ReSendTransactions(txs); err != nil {
-			t.Fatal(t)
+			t.Error(t)
+			return
 		}
 	}(t)
 


### PR DESCRIPTION
## Proposed changes

From go1.16, Vet warns the use of t.Fatal in goroutines during the test.
So, all t.Fatal in goroutines in test files are converted to t.Error and return as golang release note suggested.

Reference: Vet section in [go1.16 Release note](https://go.dev/doc/go1.16)

The same as #1312

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
