### PR TITLE
[SC] Fixed misleading value transfer log

### DIFF
--- a/node/sc/bridge_manager.go
+++ b/node/sc/bridge_manager.go
@@ -156,8 +156,8 @@ func NewBridgeInfo(sb *SubBridge, addr common.Address, bridge *bridgecontract.Br
 	return bi, nil
 }
 
-// handleValueTrnsferLog pushes value transfer transaction's log
-func handleValueTrnsferLog(isChild bool, funcName, txHash string, reqNonce uint64) {
+// handleValueTransferLog pushes value transfer transaction's log
+func handleValueTransferLog(isChild bool, funcName, txHash string, reqNonce uint64) {
 	// Note the `isChild` should be interpreted as reverse. Refer `ProcessRequestEvent()` in sub_event_handler.go
 	var vtDir string
 	if isChild {
@@ -321,13 +321,13 @@ func (bi *BridgeInfo) handleRequestValueTransferEvent(ev *RequestValueTransferEv
 		if err != nil {
 			return err
 		}
-		handleValueTrnsferLog(bi.onChildChain, "handleKLAYTransfer", handleTx.Hash().String(), ev.RequestNonce)
+		handleValueTransferLog(bi.onChildChain, "handleKLAYTransfer", handleTx.Hash().String(), ev.RequestNonce)
 	case ERC20:
 		handleTx, err = bi.bridge.HandleERC20Transfer(auth, ev.Raw.TxHash, ev.From, ev.To, tokenAddr, ev.ValueOrTokenId, ev.RequestNonce, ev.Raw.BlockNumber, ev.ExtraData)
 		if err != nil {
 			return err
 		}
-		handleValueTrnsferLog(bi.onChildChain, "handleERC20Transfer", handleTx.Hash().String(), ev.RequestNonce)
+		handleValueTransferLog(bi.onChildChain, "handleERC20Transfer", handleTx.Hash().String(), ev.RequestNonce)
 	case ERC721:
 		// get URI of the ERC721
 		var uri string
@@ -349,7 +349,7 @@ func (bi *BridgeInfo) handleRequestValueTransferEvent(ev *RequestValueTransferEv
 		if err != nil {
 			return err
 		}
-		handleValueTrnsferLog(bi.onChildChain, "handleERC721Transfer", handleTx.Hash().String(), ev.RequestNonce)
+		handleValueTransferLog(bi.onChildChain, "handleERC721Transfer", handleTx.Hash().String(), ev.RequestNonce)
 	default:
 		logger.Error("Got Unknown Token Type ReceivedEvent", "bridge", ev.Raw.Address, "nonce", ev.RequestNonce, "from", ev.From)
 		return nil

--- a/node/sc/bridge_manager.go
+++ b/node/sc/bridge_manager.go
@@ -156,11 +156,11 @@ func NewBridgeInfo(sb *SubBridge, addr common.Address, bridge *bridgecontract.Br
 	return bi, nil
 }
 
-// handleValueTransferLog pushes value transfer transaction's log
-func handleValueTransferLog(isChild bool, funcName, txHash string, reqNonce uint64) {
-	// Note the `isChild` should be interpreted as reverse. Refer `ProcessRequestEvent()` in sub_event_handler.go
+// handleValueTransferLog records value transfer transaction's log
+func handleValueTransferLog(onChild bool, funcName, txHash string, reqNonce uint64) {
+	// Note the `onChild` should be interpreted as reverse. Refer `ProcessRequestEvent()` in sub_event_handler.go
 	var vtDir string
-	if isChild {
+	if onChild {
 		vtDir = "parent--->child"
 	} else {
 		vtDir = "child--->parent"

--- a/node/sc/bridge_manager.go
+++ b/node/sc/bridge_manager.go
@@ -159,13 +159,14 @@ func NewBridgeInfo(sb *SubBridge, addr common.Address, bridge *bridgecontract.Br
 // handleValueTrnsferLog pushes value transfer transaction's log
 func handleValueTrnsferLog(isChild bool, funcName, txHash string, reqNonce uint64) {
 	// Note the `isChild` should be interpreted as reverse. Refer `ProcessRequestEvent()` in sub_event_handler.go
+	var vtDir string
 	if isChild {
-		logger.Trace("Bridge contract transaction is created", "VTDirection", "parent--->child",
-			"contractCall", funcName, "nonce", reqNonce, "tx", txHash)
+		vtDir = "parent--->child"
 	} else {
-		logger.Trace("Bridge contract transaction is created", "VTDirection", "child--->parent",
-			"contractCall", funcName, "nonce", reqNonce, "tx", txHash)
+		vtDir = "child--->parent"
 	}
+	logger.Trace("Bridge contract transaction is created", "VTDirection", vtDir,
+		"contractCall", funcName, "nonce", reqNonce, "tx", txHash)
 }
 
 func (bi *BridgeInfo) loop() {

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -344,6 +344,10 @@ func (sbh *SubBridgeHandler) writeServiceChainTxReceipts(bc *blockchain.BlockCha
 	for _, receipt := range receipts {
 		txHash := receipt.TxHash
 		if tx := sbh.subbridge.GetBridgeTxPool().Get(txHash); tx != nil {
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				logger.Error("Transaction's receipt sent from child chain is invalid",
+					"status", receipt.Status, "txHash", txHash.String())
+			}
 			if tx.Type().IsChainDataAnchoring() {
 				data, err := tx.AnchoredData()
 				if err != nil {

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -345,7 +345,7 @@ func (sbh *SubBridgeHandler) writeServiceChainTxReceipts(bc *blockchain.BlockCha
 		txHash := receipt.TxHash
 		if tx := sbh.subbridge.GetBridgeTxPool().Get(txHash); tx != nil {
 			if receipt.Status != types.ReceiptStatusSuccessful {
-				logger.Error("Transaction's receipt sent from child chain is invalid",
+				logger.Error("A transaction sent from the child chain is failed",
 					"status", receipt.Status, "txHash", txHash.String())
 			}
 			if tx.Type().IsChainDataAnchoring() {

--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -345,7 +345,7 @@ func (sbh *SubBridgeHandler) writeServiceChainTxReceipts(bc *blockchain.BlockCha
 		txHash := receipt.TxHash
 		if tx := sbh.subbridge.GetBridgeTxPool().Get(txHash); tx != nil {
 			if receipt.Status != types.ReceiptStatusSuccessful {
-				logger.Error("A transaction sent from the child chain is failed",
+				logger.Error("A transaction sent from the child chain failed",
 					"status", receipt.Status, "txHash", txHash.String())
 			}
 			if tx.Type().IsChainDataAnchoring() {


### PR DESCRIPTION
## Proposed changes

The message had misleading log information in the previous value transfer logs (i.e., removed logs in this PR). The message `Bridge succeeded to ...` is incorrect because the right above function calls `bi.bridge.HandleERC20Transfer`, `bi.bridge.HandleKLAYTransfer`, and `bi.bridge.HandleERC721Transfer` just makes a transaction, not the transaction invokes. This PR considers receipt status received from the counterpart chain too. If the receipt is invalid, a status and transaction hash are pushed to logs.

This PR makes an observable value transfer path. The end-developer can find where the value transfer failed with the added and fixed log. Let me describe two examples.
1. Failed value transfer request from _child_ to _parent_
- The end-developer can figure out where the transaction is failed by tracking this log `logger.Error("Transaction's receipt sent from child chain is invalid", "status", receipt.Status, "txHash", txHash.String())`. This log says the failure happened from the parent chain and the transaction hash now can be searched on the parent chain.
2. Failed value transfer request from _parent_ to _child_
- The developer should search this log `logger.Trace("Bridge contract transaction is created", "VTDirection", "parent--->child", "contractCall", funcName, "nonce", reqNonce, "tx", txHash)` and it says the value transfer handle was failed from the child chain. Now what the developer should do is search the transaction hash on the child chain.
## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
