### PR TITLE
setup: set hardfork block number to 0 for --baobab-test

### DIFF
--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -427,6 +427,12 @@ func genBaobabTestGenesis(nodeAddrs, testAddrs []common.Address) *blockchain.Gen
 	testGenesis.Config.Governance.Reward.StakingUpdateInterval = 60
 	testGenesis.Config.Governance.Reward.ProposerUpdateInterval = 30
 	testGenesis.Config.Governance.Reward.MinimumStake = new(big.Int).SetUint64(5000000)
+
+	// To enable all the features in the test, set hardfork block number to 0
+	testGenesis.Config.IstanbulCompatibleBlock = big.NewInt(0)
+	testGenesis.Config.LondonCompatibleBlock = big.NewInt(0)
+	testGenesis.Config.EthTxTypeCompatibleBlock = big.NewInt(0)
+
 	allocationFunction := genesis.AllocWithPrebaobabContract(append(nodeAddrs, testAddrs...), new(big.Int).Exp(big.NewInt(10), big.NewInt(50), nil))
 	allocationFunction(testGenesis)
 	WriteFile([]byte(baobabOperatorAddress), "baobab_operator", "address")


### PR DESCRIPTION
## Proposed changes

- To enable all the features in the test, set hardfork block number to 0
- If the genesis.json for the test is generated with `--baobab-test` flag, it will enable all the features after the hardfork

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
