### PR TITLE
Update CircleCI machine image version and rpmbuild dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,7 +415,8 @@ jobs:
           path: /tmp/linter_reports
 
   packaging-linux:
-    machine: true
+    machine: 
+      image: ubuntu-2004:202201-02
     resource_class: large
     working_directory: ~/go/src/github.com/klaytn/klaytn
     steps:
@@ -426,7 +427,8 @@ jobs:
       - upload-repo
 
   packaging-linux-baobab:
-    machine: true
+    machine: 
+      image: ubuntu-2004:202201-02
     resource_class: large
     working_directory: ~/go/src/github.com/klaytn/klaytn
     steps:
@@ -439,7 +441,8 @@ jobs:
           item: "kcn kpn ken"
 
   packaging-darwin:
-    machine: true
+    machine: 
+      image: ubuntu-2004:202201-02
     resource_class: large
     working_directory: ~/go/src/github.com/klaytn/klaytn
     steps:
@@ -451,7 +454,8 @@ jobs:
       - upload-repo
 
   packaging-darwin-baobab:
-    machine: true
+    machine: 
+      image: ubuntu-2004:202201-02
     resource_class: large
     working_directory: ~/go/src/github.com/klaytn/klaytn
     steps:

--- a/build/Dockerfile-go1.18-rpmbuild
+++ b/build/Dockerfile-go1.18-rpmbuild
@@ -1,7 +1,8 @@
 FROM centos:centos7
 
 RUN curl https://dl.google.com/go/go1.18.linux-amd64.tar.gz | tar xzvf - -C /usr/local
-RUN yum install -y make rpm-build git createrepo awscli gcc
+RUN yum install -y make rpm-build git createrepo python3 gcc
+RUN pip3 install awscli
 ENV PATH=$PATH:/usr/local/go/bin
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
Update deprecated machine version from 14.04 to 20.04

## Proposed changes

- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

CircleCI pipeline at [build_n_packaging workflow](https://app.circleci.com/pipelines/github/klaytn/klaytn/6722/workflows/7c1ae5ee-e4dd-438e-b2fb-a2989d9d9054) has failed, Ubuntu version mismatch might occurs problem

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
