### PR TITLE
Use go install if golang version is v1.18

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build none
 // +build none
 
 package main
@@ -1008,8 +1009,13 @@ func doXgo(cmdline []string) {
 	flag.CommandLine.Parse(cmdline)
 	env := build.Env()
 
+	subCmd := "get"
+	if strings.HasPrefix(runtime.Version(), "go1.18") {
+		subCmd = "install"
+	}
+
 	// Make sure xgo is available for cross compilation
-	gogetxgo := goTool("get", "github.com/klaytn/xgo")
+	gogetxgo := goTool(subCmd, "github.com/klaytn/xgo")
 	build.MustRun(gogetxgo)
 
 	// If all tools building is requested, build everything the builder wants


### PR DESCRIPTION
## Proposed changes

In Go 1.18, `go get` will no longer build packages; it will only be used to add, update, or remove dependencies in `go.mod`. 
Reference: https://go.dev/doc/go-get-install-deprecation

Currently, `go get` is used to install `xgo` used for cross-compile and mobile framework not used in Klaytn now. 
Therefore, we only need to change this for `xgo` and the code using `xgo` will be deprecated soon.
In the future, we should update cross-compile script not to use `xgo` as go-Ethereum did. 



## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
