### PR TITLE
Remove unused global minimumStakingAmount

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -253,10 +253,6 @@ func SetupGenesisBlock(db database.DBManager, genesis *Genesis, networkId uint64
 		if storedcfg.Governance.Reward.ProposerUpdateInterval != 0 {
 			params.SetProposerUpdateInterval(storedcfg.Governance.Reward.ProposerUpdateInterval)
 		}
-		if storedcfg.Governance.Reward.MinimumStake != nil &&
-			storedcfg.Governance.Reward.MinimumStake.Cmp(common.Big0) > 0 {
-			params.SetMinimumStakingAmount(storedcfg.Governance.Reward.MinimumStake)
-		}
 	}
 	// Special case: don't change the existing config of a non-mainnet chain if no new
 	// config is supplied. These chains would get AllProtocolChanges (and a compat error)

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -125,7 +125,6 @@ func initGenesis(ctx *cli.Context) error {
 	}
 	params.SetStakingUpdateInterval(genesis.Config.Governance.Reward.StakingUpdateInterval)
 	params.SetProposerUpdateInterval(genesis.Config.Governance.Reward.ProposerUpdateInterval)
-	params.SetMinimumStakingAmount(genesis.Config.Governance.Reward.MinimumStake)
 
 	// Open an initialise both full and light databases
 	stack := MakeFullNode(ctx)

--- a/governance/default.go
+++ b/governance/default.go
@@ -449,10 +449,6 @@ func (g *Governance) updateGovernanceParams() {
 	params.SetStakingUpdateInterval(g.StakingUpdateInterval())
 	params.SetProposerUpdateInterval(g.ProposerUpdateInterval())
 
-	if minimumStakingAmount, ok := new(big.Int).SetString(g.MinimumStake(), 10); ok {
-		params.SetMinimumStakingAmount(minimumStakingAmount)
-	}
-
 	// NOTE: HumanReadable related functions are inactivated now
 	if txGasHumanReadable, ok := g.currentSet.GetValue(params.ConstTxGasHumanReadable); ok {
 		params.TxGasHumanReadable = txGasHumanReadable.(uint64)

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -91,12 +91,6 @@ func updateProposerUpdateInterval(g *Governance, k string, v interface{}) {
 	params.SetProposerUpdateInterval(g.ProposerUpdateInterval())
 }
 
-func updateMinimumStakingAmount(g *Governance, k string, v interface{}) {
-	if val, ok := new(big.Int).SetString(g.MinimumStake(), 10); ok {
-		params.SetMinimumStakingAmount(val)
-	}
-}
-
 func updateProposerPolicy(g *Governance, k string, v interface{}) {
 	if g.blockChain != nil {
 		g.blockChain.SetProposerPolicy(g.ProposerPolicy())

--- a/params/governance_params.go
+++ b/params/governance_params.go
@@ -31,8 +31,7 @@ const (
 	kirContractIncentiveInSton    int64 = 3200000000 // 3.2 KLAY for KIR contract (Unit: ston)
 	pocContractIncentiveInSton    int64 = 3200000000 // 3.2 KLAY for PoC contract (Unit: ston)
 
-	defaultMintedKLAYInSton           int64 = 9600000000 // Default amount of minted KLAY. 9.6 KLAY for block reward (Unit: ston)
-	defaultMinimumStakingAmountInKlay int64 = 5000000    // Default amount of minimum staking (Unit: KLAY)
+	defaultMintedKLAYInSton int64 = 9600000000 // Default amount of minted KLAY. 9.6 KLAY for block reward (Unit: ston)
 
 	DefaultCNRewardRatio  = 34 // Default CN reward ratio 34%
 	DefaultPoCRewardRatio = 54 // Default PoC ratio 54%
@@ -46,10 +45,6 @@ var (
 	PoCContractIncentive    = big.NewInt(0).Mul(big.NewInt(pocContractIncentiveInSton), big.NewInt(Ston))
 
 	DefaultMintedKLAY = big.NewInt(0).Mul(big.NewInt(defaultMintedKLAYInSton), big.NewInt(Ston))
-
-	// TODO-Governance remove below minimum staking amount parameter
-	defaultMinimumStakingAmount = big.NewInt(0).Mul(big.NewInt(defaultMinimumStakingAmountInKlay), big.NewInt(KLAY))
-	minimumStakingAmount        atomic.Value
 
 	stakingUpdateInterval  uint64 = 86400 // About 1 day. 86400 blocks = (24 hrs) * (3600 secs/hr) * (1 block/sec)
 	proposerUpdateInterval uint64 = 3600  // About 1 hour. 3600 blocks = (1 hr) * (3600 secs/hr) * (1 block/sec)
@@ -180,15 +175,4 @@ func SetProposerUpdateInterval(num uint64) {
 func ProposerUpdateInterval() uint64 {
 	ret := atomic.LoadUint64(&proposerUpdateInterval)
 	return ret
-}
-
-func SetMinimumStakingAmount(val *big.Int) {
-	minimumStakingAmount.Store(val)
-}
-
-func MinimumStakingAmount() *big.Int {
-	if m, ok := minimumStakingAmount.Load().(*big.Int); ok {
-		return m
-	}
-	return defaultMinimumStakingAmount
 }

--- a/params/governance_params_test.go
+++ b/params/governance_params_test.go
@@ -17,23 +17,8 @@
 package params
 
 import (
-	"math/big"
 	"testing"
-
-	"github.com/klaytn/klaytn/common"
 )
-
-func TestSetMinimumStakingAmount(t *testing.T) {
-	testData := []*big.Int{common.Big1, common.Big100, common.Big32, common.Big256, common.Big257}
-
-	for i := 0; i < len(testData); i++ {
-		SetMinimumStakingAmount(testData[i])
-
-		if MinimumStakingAmount().Cmp(testData[i]) != 0 {
-			t.Errorf("MinimumStakingAmount is different from the given testData. Result : %v, Expected : %v", MinimumStakingAmount(), testData[i])
-		}
-	}
-}
 
 func TestSetProposerUpdateInterval(t *testing.T) {
 	testData := []uint64{3600, 100, 500, 7200, 10}


### PR DESCRIPTION
## Proposed changes

- The global variable `minimumStakingAmount` in params/governance_params.go is set in many places, but never used.
- A code wants minimum staking amount, but uses governance.Governance instead. (https://github.com/klaytn/klaytn/blob/v1.8.3/consensus/istanbul/backend/snapshot.go#L207) 
- Completes a TODO (https://github.com/klaytn/klaytn/blob/v1.8.3/params/governance_params.go#L50)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
