### PR TITLE
[SC] Try to retrieve handle token address from child chain

### DIFF
--- a/node/sc/api_bridge.go
+++ b/node/sc/api_bridge.go
@@ -331,8 +331,16 @@ func (sb *SubBridgeAPI) RegisterToken(cBridgeAddr, pBridgeAddr, cTokenAddr, pTok
 	if err != nil {
 		return err
 	}
+	err = cBi.RegisterToken(pTokenAddr, cTokenAddr)
+	if err != nil {
+		return err
+	}
 
 	err = pBi.RegisterToken(pTokenAddr, cTokenAddr)
+	if err != nil {
+		return err
+	}
+	err = pBi.RegisterToken(cTokenAddr, pTokenAddr)
 	if err != nil {
 		return err
 	}
@@ -396,13 +404,6 @@ func (sb *SubBridgeAPI) DeregisterToken(cBridgeAddr, pBridgeAddr, cTokenAddr, pT
 
 	if !cExist || !pExist {
 		return ErrNoBridgeInfo
-	}
-
-	pTokenAddrCheck := cBi.GetCounterPartToken(cTokenAddr)
-	cTokenAddrCheck := pBi.GetCounterPartToken(pTokenAddr)
-
-	if pTokenAddr != pTokenAddrCheck || cTokenAddr != cTokenAddrCheck {
-		return errors.New("invalid toke pair")
 	}
 
 	cBi.DeregisterToken(cTokenAddr, pTokenAddr)


### PR DESCRIPTION
## Proposed changes

- Moved runtime token register to the time when an initial token register is called via bridge setup phase.
- Removed invalid bridge pair comparison. This comparison becomes invalid when a node is rebooted.
- The current handle retrieve logic asks to parent chain to retrieve the corresponding handle token address. This PR changes to try to retrieve the handle token address from its own subbridge chain.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
