### PR TITLE
Fix docker pipeline to add dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,6 +551,7 @@ workflows:
               only: dev
           requires:
             - pass-tests
+          extra_build_args: '--platform=linux/amd64'
           image: klaytn/klaytn
           tag: dev
           executor: docker/docker
@@ -616,6 +617,7 @@ workflows:
               ignore: /.*/
           requires:
             - pass-tests
+          extra_build_args: '--platform=linux/amd64'
           image: klaytn/klaytn
           tag: latest,$CIRCLE_TAG
           executor: docker/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ FROM --platform=linux/amd64 ubuntu:20.04
 ARG SRC_DIR
 ARG PKG_DIR
 
+RUN apt update
+RUN apt install -yq musl-dev
 RUN mkdir -p $PKG_DIR/conf $PKG_DIR/bin
 
 # Startup scripts and binaries must be in the same location

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ADD . $SRC_DIR
 RUN git init
 RUN cd $SRC_DIR && make all
 
-FROM --platform=linux/amd64 ubuntu:20.04
+FROM ubuntu:20.04
 ARG SRC_DIR
 ARG PKG_DIR
 


### PR DESCRIPTION
## Proposed changes

- Update klaytn docker image to install libc(musl-dev) library while build image
- Add '--platform=linux/amd64' args on docker build pipeline to fix issues on Apple M1 chips

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues



## Further comments


