### PR TITLE
Remove vote when checkVote() fails in HandleGovernanceVote

### DIFF
--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -1086,6 +1086,21 @@ func TestSnapshot_Validators_AddRemove(t *testing.T) {
 				9: {[]int{0, 1, 2}},
 			},
 		},
+		{ // multiple removevalidator & addvalidator
+			10,
+			map[int]vote{
+				0: {"governance.removevalidator", 3},
+				2: {"governance.removevalidator", 3},
+				4: {"governance.addvalidator", 3},
+				6: {"governance.addvalidator", 3},
+			},
+			map[int]expected{
+				1: {[]int{0, 1, 2}},
+				3: {[]int{0, 1, 2}},
+				5: {[]int{0, 1, 2, 3}},
+				7: {[]int{0, 1, 2, 3}},
+			},
+		},
 		{ // multiple addvalidators & removevalidators
 			10,
 			map[int]vote{
@@ -1101,6 +1116,21 @@ func TestSnapshot_Validators_AddRemove(t *testing.T) {
 				5: {[]int{0, 1, 2, 3}},
 				7: {[]int{0, 1}},
 				9: {[]int{0, 1}},
+			},
+		},
+		{ // multiple removevalidators & addvalidators
+			10,
+			map[int]vote{
+				0: {"governance.removevalidator", []int{2, 3}},
+				2: {"governance.removevalidator", []int{2, 3}},
+				4: {"governance.addvalidator", []int{2, 3}},
+				6: {"governance.addvalidator", []int{2, 3}},
+			},
+			map[int]expected{
+				1: {[]int{0, 1}},
+				3: {[]int{0, 1}},
+				5: {[]int{0, 1, 2, 3}},
+				7: {[]int{0, 1, 2, 3}},
 			},
 		},
 	}

--- a/governance/api.go
+++ b/governance/api.go
@@ -97,7 +97,7 @@ func (api *PublicGovernanceAPI) Vote(key string, val interface{}) (string, error
 		}
 	}
 	if api.governance.AddVote(key, val) {
-		return "Your vote is prepared. It will be put into the block header or applied when your node generates a block as a proposer.", nil
+		return "Your vote is prepared. It will be put into the block header or applied when your node generates a block as a proposer. Note that your vote may be duplicate.", nil
 	}
 	return "", errInvalidKeyValue
 }

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -809,7 +809,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.AddVote("governance.addvalidator", validators[1].String())
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
-	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, proposer) // self = proposer
 	// check if casted
 	if !gov.voteMap.items["governance.addvalidator"].Casted {
 		t.Errorf("Adding an existing validator failed")
@@ -970,7 +970,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], validators[0])
 	// check if casted
 	if !gov.voteMap.items["governance.addvalidator"].Casted {
 		t.Errorf("Adding an existing validator failed")
@@ -978,7 +978,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], validators[2])
 	// check if casted
 	if !gov.voteMap.items["governance.addvalidator"].Casted {
 		t.Errorf("Adding an existing validator failed")

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -965,6 +965,29 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Test adding an existing validator, because there are 3 nodes 2 plus votes are required to add a new validator
+	gov.AddVote("governance.addvalidator", validators[1].String())
+
+	header.Number = blockCounter.Add(blockCounter, common.Big1)
+	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self)
+	// check if casted
+	if !gov.voteMap.items["governance.addvalidator"].Casted {
+		t.Errorf("Adding an existing validator failed")
+	}
+
+	header.Number = blockCounter.Add(blockCounter, common.Big1)
+	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self)
+	// check if casted
+	if !gov.voteMap.items["governance.addvalidator"].Casted {
+		t.Errorf("Adding an existing validator failed")
+	}
+
+	gov.RemoveVote("governance.addvalidator", validators[1], blockCounter.Uint64())
+	gov.voteMap.Clear()
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Test removing a demoted validator, because there are 4 nodes 3 votes are required to remove a demoted validator
 	gov.AddVote("governance.removevalidator", demotedValidators[1].String())
 

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -804,6 +804,23 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.voteMap.Clear()
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Test adding an existing validator
+	header.Number = blockCounter.Add(blockCounter, common.Big1)
+	gov.AddVote("governance.addvalidator", validators[1].String())
+	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
+
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	// check if casted
+	if !gov.voteMap.items["governance.addvalidator"].Casted {
+		t.Errorf("Adding an existing validator failed")
+	}
+	gov.RemoveVote("governance.addvalidator", validators[1], 0)
+	if i, _ := valSet.GetByAddress(validators[1]); i == -1 {
+		t.Errorf("Validator addition failed, %d validators remains", valSet.Size())
+	}
+	gov.voteMap.Clear()
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Test removing a demoted validator
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	gov.AddVote("governance.removevalidator", demotedValidators[1].String())

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -363,6 +363,7 @@ func (gov *Governance) HandleGovernanceVote(valset istanbul.ValidatorSet, votes 
 			if addr, ok := gVote.Value.(common.Address); ok {
 				if !gov.checkVote(addr, authorize, valset) {
 					if proposer == self {
+						logger.Warn("A meaningless vote has been proposed. It is being removed without further handling", "key", gVote.Key, "value", gVote.Value)
 						gov.removeDuplicatedVote(gVote, header.Number.Uint64())
 					}
 					return valset, votes, tally
@@ -371,6 +372,7 @@ func (gov *Governance) HandleGovernanceVote(valset istanbul.ValidatorSet, votes 
 				for _, address := range addresses {
 					if !gov.checkVote(address, authorize, valset) {
 						if proposer == self {
+							logger.Warn("A meaningless vote has been proposed. It is being removed without further handling", "key", gVote.Key, "value", gVote.Value)
 							gov.removeDuplicatedVote(gVote, header.Number.Uint64())
 						}
 						return valset, votes, tally

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -381,6 +381,8 @@ func (gov *Governance) HandleGovernanceVote(valset istanbul.ValidatorSet, votes 
 			}
 
 			if checkVotePass, typeAssertPass := checkValidator(); !checkVotePass {
+				// this vote is adding existing validator or removing nonexistent validator
+				gov.removeDuplicatedVote(gVote, header.Number.Uint64())
 				return valset, votes, tally
 			} else if !typeAssertPass {
 				logger.Warn("Invalid value Type", "number", header.Number, "Validator", gVote.Validator, "key", gVote.Key, "value", gVote.Value)

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -382,7 +382,9 @@ func (gov *Governance) HandleGovernanceVote(valset istanbul.ValidatorSet, votes 
 
 			if checkVotePass, typeAssertPass := checkValidator(); !checkVotePass {
 				// this vote is adding existing validator or removing nonexistent validator
-				gov.removeDuplicatedVote(gVote, header.Number.Uint64())
+				if self == proposer {
+					gov.removeDuplicatedVote(gVote, header.Number.Uint64())
+				}
 				return valset, votes, tally
 			} else if !typeAssertPass {
 				logger.Warn("Invalid value Type", "number", header.Number, "Validator", gVote.Validator, "key", gVote.Key, "value", gVote.Value)


### PR DESCRIPTION
## Proposed changes

- Adding an existing validator via `governance.vote("governance.addvalidator", existing_val_addr)` has a bug. Refer to the log below.
- This is caused by https://github.com/klaytn/klaytn/blob/dev/governance/handler.go#L365 where `checkVote()` checks if the address to be added already exists in the validator set, in which case it returns WITHOUT REMOVING THE VOTE.
- This fix removes the vote when `checkVote()` fails. (remove in this context means setting Casted to true)

### Bug log
- Initial setting
For an initial council, we remove one validator so that we can add it back.

```
> klay.getCouncil()
["0x19c032589b76ac395d3a713088e67f9ce9edf1c6", "0x353a5fd7cd9b8d0fe3e7c65d6c3d229cd0f14533", "0xd4ca4f3f2d80fb5b2f569df45d4c28a98f48a289", "0xe0c91bc72396b6c1e937ef717bf59a90c558f285"]
> addr = klay.getCouncil()[0]
"0x19c032589b76ac395d3a713088e67f9ce9edf1c6"
> governance.vote("governance.removevalidator", addr)
"Your vote is prepared. It will be put into the block header or applied when your node generates a block as a proposer."
> governance.myVotes
[{
    BlockNum: 6,
    Casted: true,
    Key: "governance.removevalidator",
    Value: "0x19c032589b76ac395d3a713088e67f9ce9edf1c6"
}]
```

- add validator (1)

```
> governance.vote("governance.addvalidator", addr)
"Your vote is prepared. It will be put into the block header or applied when your node generates a block as a proposer."
> governance.myVotes
[{
    BlockNum: 6,
    Casted: true,
    Key: "governance.removevalidator",
    Value: "0x19c032589b76ac395d3a713088e67f9ce9edf1c6"
}, {
    BlockNum: 16,
    Casted: true,
    Key: "governance.addvalidator",
    Value: "0x19c032589b76ac395d3a713088e67f9ce9edf1c6"
}]
```

- add validator (2) with an existing address

```
> governance.vote("governance.addvalidator", addr)
"Your vote is prepared. It will be put into the block header or applied when your node generates a block as a proposer."
> governance.myVotes
[{
    BlockNum: 0,
    Casted: false,
    Key: "governance.addvalidator",
    Value: "0x19c032589b76ac395d3a713088e67f9ce9edf1c6"
}, {
    BlockNum: 6,
    Casted: true,
    Key: "governance.removevalidator",
    Value: "0x19c032589b76ac395d3a713088e67f9ce9edf1c6"
}]
```

We can see that the second vote is not cast and it keeps appearing in every block the voter becomes the proposer.

```
> klay.getBlock(16).voteData
"0xf84294353a5fd7cd9b8d0fe3e7c65d6c3d229cd0f1453397676f7665726e616e63652e61646476616c696461746f729419c032589b76ac395d3a713088e67f9ce9edf1c6"
> klay.getBlock(22).voteData
"0xf84294353a5fd7cd9b8d0fe3e7c65d6c3d229cd0f1453397676f7665726e616e63652e61646476616c696461746f729419c032589b76ac395d3a713088e67f9ce9edf1c6"
> klay.getBlock(25).voteData
"0xf84294353a5fd7cd9b8d0fe3e7c65d6c3d229cd0f1453397676f7665726e616e63652e61646476616c696461746f729419c032589b76ac395d3a713088e67f9ce9edf1c6"
> klay.getBlock(28).voteData
"0xf84294353a5fd7cd9b8d0fe3e7c65d6c3d229cd0f1453397676f7665726e616e63652e61646476616c696461746f729419c032589b76ac395d3a713088e67f9ce9edf1c6"
```



## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
