### PR TITLE
change circleCI docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -622,7 +622,8 @@ workflows:
           image: klaytn/klaytn
           tag: latest,$CIRCLE_TAG
           executor: docker/docker
-          use-remote-docker: 20.10.14
+          use-remote-docker: true
+          remote-docker-version: 20.10.14
 
       - major-tagging:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ aliases:
 
 orbs:
   codecov: codecov/codecov@1.0.5
-  docker: circleci/docker@1.0.1
+  docker: circleci/docker@2.1.1
 
 executors:
   test-executor:
@@ -556,6 +556,7 @@ workflows:
           tag: dev
           executor: docker/docker
           use-remote-docker: true
+          remote-docker-version: 20.10.14
 
       - tag-verify:
           filters: *filter-only-version-tag
@@ -621,7 +622,7 @@ workflows:
           image: klaytn/klaytn
           tag: latest,$CIRCLE_TAG
           executor: docker/docker
-          use-remote-docker: true
+          use-remote-docker: 20.10.14
 
       - major-tagging:
           filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ADD . $SRC_DIR
 RUN git init
 RUN cd $SRC_DIR && make all
 
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
 ARG SRC_DIR
 ARG PKG_DIR
 


### PR DESCRIPTION

## Proposed changes
- local-klaytn-deploy didn't work on mac M1 even after #1365 merged
- #1362 was caused by circleCI@docker version was low
- added --platform in dockerfile again
- upgrade circleci@docker version
- upgrade remote docker verion
`+ docker build --file=./Dockerfile --tag=docker.io/*******/test:latest --platform=linux/amd64 .
"--platform" requires API version 1.38, but the Docker daemon API version is 1.32`
- checked docker image published by local repo circleCI works well in M1 max, ubuntu 20.04


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #1362
- #1365 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
