### PR TITLE
Add more methods to GovParamSet

### DIFF
--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -3,13 +3,18 @@ package params
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"math/big"
 	"reflect"
 	"strconv"
 	"strings"
 
 	"github.com/klaytn/klaytn/common"
+)
+
+var (
+	errUnknownGovParamKey  = errors.New("Unknown governance param key")
+	errUnknownGovParamName = errors.New("Unknown governance param name")
+	errBadGovParamValue    = errors.New("Malformed governance param value")
 )
 
 type govParamType struct {
@@ -267,7 +272,7 @@ func NewGovParamSetStrMap(items map[string]interface{}) (*GovParamSet, error) {
 	for name, value := range items {
 		key, ok := govParamNames[name]
 		if !ok {
-			return nil, fmt.Errorf("Unknown governance param '%s'", name)
+			return nil, errUnknownGovParamName
 		}
 		err := p.set(key, value)
 		if err != nil {
@@ -297,7 +302,7 @@ func NewGovParamSetBytesMap(items map[string][]byte) (*GovParamSet, error) {
 	for name, value := range items {
 		key, ok := govParamNames[name]
 		if !ok {
-			return nil, fmt.Errorf("Unknown governance param '%s'", name)
+			return nil, errUnknownGovParamName
 		}
 		err := p.setBytes(key, value)
 		if err != nil {
@@ -339,11 +344,11 @@ func NewGovParamSetChainConfig(config *ChainConfig) (*GovParamSet, error) {
 func (p *GovParamSet) set(key int, value interface{}) error {
 	ty, ok := govParamTypes[key]
 	if !ok {
-		return errors.New("Unknown governance param key")
+		return errUnknownGovParamKey
 	}
 	parsed, ok := ty.ParseValue(value)
 	if !ok {
-		return errors.New("Malformed governance param value")
+		return errBadGovParamValue
 	}
 	p.items[key] = parsed
 	return nil
@@ -352,11 +357,11 @@ func (p *GovParamSet) set(key int, value interface{}) error {
 func (p *GovParamSet) setBytes(key int, bytes []byte) error {
 	ty, ok := govParamTypes[key]
 	if !ok {
-		return errors.New("Unknown governance param key")
+		return errUnknownGovParamKey
 	}
 	parsed, ok := ty.ParseBytes(bytes)
 	if !ok {
-		return errors.New("Malformed governance param value")
+		return errBadGovParamValue
 	}
 	p.items[key] = parsed
 	return nil

--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -291,6 +291,22 @@ func NewGovParamSetIntMap(items map[int]interface{}) (*GovParamSet, error) {
 	return p, nil
 }
 
+func NewGovParamSetBytesMap(items map[string][]byte) (*GovParamSet, error) {
+	p := NewGovParamSet()
+
+	for name, value := range items {
+		key, ok := govParamNames[name]
+		if !ok {
+			return nil, fmt.Errorf("Unknown governance param '%s'", name)
+		}
+		err := p.setBytes(key, value)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
 func NewGovParamSetChainConfig(config *ChainConfig) (*GovParamSet, error) {
 	items := make(map[int]interface{})
 	if config.Istanbul != nil {
@@ -326,6 +342,19 @@ func (p *GovParamSet) set(key int, value interface{}) error {
 		return errors.New("Unknown governance param key")
 	}
 	parsed, ok := ty.ParseValue(value)
+	if !ok {
+		return errors.New("Malformed governance param value")
+	}
+	p.items[key] = parsed
+	return nil
+}
+
+func (p *GovParamSet) setBytes(key int, bytes []byte) error {
+	ty, ok := govParamTypes[key]
+	if !ok {
+		return errors.New("Unknown governance param key")
+	}
+	parsed, ok := ty.ParseBytes(bytes)
 	if !ok {
 		return errors.New("Malformed governance param value")
 	}

--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -248,6 +248,19 @@ func NewGovParamSet() *GovParamSet {
 	}
 }
 
+// Return a new GovParamSet that contains keys from both input sets.
+// If a key belongs to both sets, the value from `update` is used.
+func NewGovParamSetMerged(base *GovParamSet, update *GovParamSet) *GovParamSet {
+	p := NewGovParamSet()
+	for key, value := range base.items {
+		p.items[key] = value
+	}
+	for key, value := range update.items {
+		p.items[key] = value
+	}
+	return p
+}
+
 func NewGovParamSetStrMap(items map[string]interface{}) (*GovParamSet, error) {
 	p := NewGovParamSet()
 

--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/log"
 )
 
 var (
@@ -387,4 +388,87 @@ func (p *GovParamSet) IntMap() map[int]interface{} {
 func (p *GovParamSet) Get(key int) (interface{}, bool) {
 	v, ok := p.items[key]
 	return v, ok
+}
+
+// Return a parameter value or return a nil if the key does not exist.
+func (p *GovParamSet) MustGet(key int) interface{} {
+	if v, ok := p.Get(key); ok {
+		return v
+	} else {
+		logger := log.NewModuleLogger(log.Governance)
+		logger.Crit("Attempted to get missing GovParam item", "key", key, "name", govParamNamesReverse[key])
+		return nil
+	}
+}
+
+// Nominal getters. Shortcut for MustGet() + type assertion.
+
+func (p *GovParamSet) GovernanceModeStr() string {
+	return p.MustGet(GovernanceMode).(string)
+}
+
+func (p *GovParamSet) GovernanceModeInt() int {
+	return govModeNames[p.GovernanceModeStr()]
+}
+
+func (p *GovParamSet) GoverningNode() common.Address {
+	return p.MustGet(GoverningNode).(common.Address)
+}
+
+func (p *GovParamSet) Epoch() uint64 {
+	return p.MustGet(Epoch).(uint64)
+}
+
+func (p *GovParamSet) Policy() uint64 {
+	return p.MustGet(Policy).(uint64)
+}
+
+func (p *GovParamSet) CommitteeSize() uint64 {
+	return p.MustGet(CommitteeSize).(uint64)
+}
+
+func (p *GovParamSet) UnitPrice() uint64 {
+	return p.MustGet(UnitPrice).(uint64)
+}
+
+func (p *GovParamSet) MintingAmountStr() string {
+	return p.MustGet(MintingAmount).(string)
+}
+
+func (p *GovParamSet) MintingAmountBig() *big.Int {
+	n, _ := new(big.Int).SetString(p.MintingAmountStr(), 10)
+	return n
+}
+
+func (p *GovParamSet) Ratio() string {
+	return p.MustGet(Ratio).(string)
+}
+
+func (p *GovParamSet) UseGiniCoeff() bool {
+	return p.MustGet(UseGiniCoeff).(bool)
+}
+
+func (p *GovParamSet) DeferredTxFee() bool {
+	return p.MustGet(DeferredTxFee).(bool)
+}
+
+func (p *GovParamSet) MinimumStakeStr() string {
+	return p.MustGet(MinimumStake).(string)
+}
+
+func (p *GovParamSet) MinimumStakeBig() *big.Int {
+	n, _ := new(big.Int).SetString(p.MinimumStakeStr(), 10)
+	return n
+}
+
+func (p *GovParamSet) StakeUpdateInterval() uint64 {
+	return p.MustGet(StakeUpdateInterval).(uint64)
+}
+
+func (p *GovParamSet) ProposerRefreshInterval() uint64 {
+	return p.MustGet(ProposerRefreshInterval).(uint64)
+}
+
+func (p *GovParamSet) Timeout() uint64 {
+	return p.MustGet(Timeout).(uint64)
 }

--- a/params/governance_paramset_test.go
+++ b/params/governance_paramset_test.go
@@ -132,11 +132,34 @@ func TestGovParamSet_Get(t *testing.T) {
 	v, ok := p.Get(Epoch)
 	assert.True(t, ok)
 	assert.Equal(t, num, v)
+	assert.Equal(t, num, p.MustGet(Epoch))
 
 	// Not exists
 	v, ok = p.Get(CommitteeSize)
 	assert.False(t, ok)
 	assert.Nil(t, v)
+}
+
+func TestGovParamSet_Nominal(t *testing.T) {
+	c := CypressChainConfig
+	p, err := NewGovParamSetChainConfig(c)
+	assert.Nil(t, err)
+
+	assert.Equal(t, c.Istanbul.Epoch, p.Epoch())
+	assert.Equal(t, c.Istanbul.ProposerPolicy, p.Policy())
+	assert.Equal(t, c.Istanbul.SubGroupSize, p.CommitteeSize())
+	assert.Equal(t, c.UnitPrice, p.UnitPrice())
+	assert.Equal(t, c.Governance.GovernanceMode, p.GovernanceModeStr())
+	assert.Equal(t, c.Governance.GoverningNode, p.GoverningNode())
+	assert.Equal(t, c.Governance.Reward.MintingAmount.String(), p.MintingAmountStr())
+	assert.Equal(t, c.Governance.Reward.MintingAmount, p.MintingAmountBig())
+	assert.Equal(t, c.Governance.Reward.Ratio, p.Ratio())
+	assert.Equal(t, c.Governance.Reward.UseGiniCoeff, p.UseGiniCoeff())
+	assert.Equal(t, c.Governance.Reward.DeferredTxFee, p.DeferredTxFee())
+	assert.Equal(t, c.Governance.Reward.MinimumStake.String(), p.MinimumStakeStr())
+	assert.Equal(t, c.Governance.Reward.MinimumStake, p.MinimumStakeBig())
+	assert.Equal(t, c.Governance.Reward.StakingUpdateInterval, p.StakeUpdateInterval())
+	assert.Equal(t, c.Governance.Reward.ProposerUpdateInterval, p.ProposerRefreshInterval())
 }
 
 func TestGovParamSet_New(t *testing.T) {

--- a/params/governance_paramset_test.go
+++ b/params/governance_paramset_test.go
@@ -164,6 +164,37 @@ func TestGovParamSet_New(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestGovParamSet_Merged(t *testing.T) {
+	base, err := NewGovParamSetStrMap(map[string]interface{}{
+		"istanbul.epoch":         123456,
+		"istanbul.committeesize": 77,
+	})
+	assert.Nil(t, err)
+
+	update, err := NewGovParamSetStrMap(map[string]interface{}{
+		"istanbul.committeesize": 99,
+		"istanbul.policy":        2,
+	})
+	assert.Nil(t, err)
+
+	p := NewGovParamSetMerged(base, update)
+
+	// Was only in base
+	v, ok := p.Get(Epoch)
+	assert.Equal(t, uint64(123456), v)
+	assert.True(t, ok)
+
+	// Was only in update
+	v, ok = p.Get(Policy)
+	assert.Equal(t, uint64(2), v)
+	assert.True(t, ok)
+
+	// Was in both - prefers the value in update
+	v, ok = p.Get(CommitteeSize)
+	assert.Equal(t, uint64(99), v)
+	assert.True(t, ok)
+}
+
 func TestGovParamSet_RegressDb(t *testing.T) {
 	// MiscDB stores governance data as JSON strings. The value types can be
 	// slightly wrong during unmarshal because we unmarshal into interface{}.

--- a/params/governance_paramset_test.go
+++ b/params/governance_paramset_test.go
@@ -156,6 +156,14 @@ func TestGovParamSet_New(t *testing.T) {
 	assert.Equal(t, uint64(604800), v)
 	assert.True(t, ok)
 
+	p, err = NewGovParamSetBytesMap(map[string][]byte{
+		"istanbul.epoch": {0x12, 0x34},
+	})
+	assert.Nil(t, err)
+	v, ok = p.Get(Epoch)
+	assert.Equal(t, uint64(0x1234), v)
+	assert.True(t, ok)
+
 	c := CypressChainConfig
 	p, err = NewGovParamSetChainConfig(c)
 	assert.Nil(t, err)


### PR DESCRIPTION
## Proposed changes

#### GovParamSet with defaults

- Add `NewGovParamSetMerged(base, update)`.
- Add `MustGet(key int) interface{}`
- Add nominal getters (`Epoch()`, `UnitPrice()`, ..)
- Note that `MustGet(key)` exit with `logger.Crit` when the `key` does not exist.
  - When creating a new GovParamSet, make sure to set proper defaults or fallback values.

Intended use (resembles the current `governance.Governance` behavior):

```go
// When creating a param set
func (e *ContractEngine) Params() *GovParamSet {
    currSet := e.readParamsFromContract(num)
    initSet := params.NewGovParamSetChainConfig(e.initialConfig)
    return params.NewGovParamSetMerged(initSet, currSet)
}
```

```go
// When querying a param
// - If contract stores 'istanbul.epoch' param, return the value.
// - If contract doesn't have the param, return genesis config value.
// - If both don't have the param, logger.Crit() and exit.
gov.Params().Epoch()
```

#### Parse bytes data

- Add `NewGovParamSetBytesMap(map[string][]byte)`.
  - Create a GovParamSet out of a bytes map. Will be used to parse a contract call's output.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

https://github.com/klaytn/klaytn/issues/1375

## Further comments

Refer to https://github.com/klaytn/klaytn/pull/1303#discussion_r864451927 for the reasoning behind the `MustGet()`. This PR implements the 'choice4' in the comment.