### PR TITLE
Add Naive Params() and ParamsAt()

### DIFF
--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -668,6 +668,13 @@ func makeExpectedResult(indices []int, candidate []common.Address) []common.Addr
 	return copyAndSortAddrs(expected)
 }
 
+// Asserts taht if all (key,value) pairs of `subset` exists in `set`
+func assertMapSubset(t *testing.T, subset, set map[string]interface{}) {
+	for k, v := range subset {
+		assert.Equal(t, set[k], v)
+	}
+}
+
 func TestSnapshot_Validators_AfterMinimumStakingVotes(t *testing.T) {
 	type vote struct {
 		key   string
@@ -1324,6 +1331,98 @@ func TestGovernance_Votes(t *testing.T) {
 			assert.Equal(t, item.value, items[item.key])
 		}
 
+		engine.Stop()
+	}
+}
+
+func TestGovernance_ReaderEngine(t *testing.T) {
+	// Test that ReaderEngine (Params(), ParamsAt(), UpdateParams()) works.
+	type vote = map[string]interface{}
+	type expected = map[string]interface{} // expected (subset of) governance items
+	type testcase struct {
+		length   int // total number of blocks to simulate
+		votes    map[int]vote
+		expected map[int]expected
+	}
+
+	testcases := []testcase{
+		{
+			8,
+			map[int]vote{
+				1: {"governance.unitprice": uint64(17)},
+			},
+			map[int]expected{
+				0: {"governance.unitprice": uint64(1)},
+				1: {"governance.unitprice": uint64(1)},
+				2: {"governance.unitprice": uint64(1)},
+				3: {"governance.unitprice": uint64(1)},
+				4: {"governance.unitprice": uint64(1)},
+				5: {"governance.unitprice": uint64(1)},
+				6: {"governance.unitprice": uint64(17)},
+				7: {"governance.unitprice": uint64(17)},
+				8: {"governance.unitprice": uint64(17)},
+			},
+		},
+	}
+
+	var configItems []interface{}
+	configItems = append(configItems, proposerPolicy(params.WeightedRandom))
+	configItems = append(configItems, proposerUpdateInterval(1))
+	configItems = append(configItems, epoch(3))
+	configItems = append(configItems, governanceMode("single"))
+	configItems = append(configItems, minimumStake(new(big.Int).SetUint64(4000000)))
+	configItems = append(configItems, istanbulCompatibleBlock(new(big.Int).SetUint64(0)))
+	configItems = append(configItems, blockPeriod(0)) // set block period to 0 to prevent creating future block
+	stakes := []uint64{4000000, 4000000, 4000000, 4000000}
+
+	for _, tc := range testcases {
+		// Create test blockchain
+		chain, engine := newBlockChain(4, configItems...)
+
+		oldStakingManager := reward.GetStakingManager()
+		stakingInfo := makeFakeStakingInfo(0, nodeKeys, stakes)
+		reward.SetTestStakingManagerWithStakingInfoCache(stakingInfo)
+
+		var previousBlock, currentBlock *types.Block = nil, chain.Genesis()
+
+		// Create blocks with votes
+		for num := 0; num <= tc.length; num++ {
+			// Validate current params with Params() and CurrentSetCopy().
+			// Check that both returns the expected result.
+			assertMapSubset(t, tc.expected[num], engine.governance.Params().StrMap())
+			assertMapSubset(t, tc.expected[num], engine.governance.CurrentSetCopy())
+
+			// Place a vote if a vote is scheduled in upcoming block
+			// Note that we're building (head+1)'th block here.
+			for k, v := range tc.votes[num+1] {
+				ok := engine.governance.AddVote(k, v)
+				assert.True(t, ok)
+			}
+
+			// Create a block
+			previousBlock = currentBlock
+			currentBlock = makeBlockWithSeal(chain, engine, previousBlock)
+			_, err := chain.InsertChain(types.Blocks{currentBlock})
+			assert.NoError(t, err)
+
+			// Load parameters for the next block
+			err = engine.governance.UpdateParams()
+			assert.NoError(t, err)
+		}
+
+		// Validate historic parameters with ParamsAt() and ReadGovernance().
+		// Check that both returns the expected result.
+		for num := 0; num <= tc.length; num++ {
+			pset, err := engine.governance.ParamsAt(uint64(num))
+			assert.NoError(t, err)
+			assertMapSubset(t, tc.expected[num], pset.StrMap())
+
+			_, items, err := engine.governance.ReadGovernance(uint64(num))
+			assert.NoError(t, err)
+			assertMapSubset(t, tc.expected[num], items)
+		}
+
+		reward.SetTestStakingManager(oldStakingManager)
 		engine.Stop()
 	}
 }

--- a/governance/default.go
+++ b/governance/default.go
@@ -1089,7 +1089,7 @@ func writeFailLog(key int, err error) {
 	logger.Crit(msg, "err", err)
 }
 
-func AddGovernanceCacheForTest(e Engine, num uint64, config *params.ChainConfig) {
+func AddGovernanceCacheForTest(e HeaderEngine, num uint64, config *params.ChainConfig) {
 	// addGovernanceCache only exists and relevant in *Governance.
 	if g, ok := e.(*Governance); ok {
 		data := GetGovernanceItemsFromChainConfig(config)
@@ -1167,6 +1167,10 @@ func (g *Governance) GetVoteMapCopy() map[string]VoteStatus {
 
 func (g *Governance) GetGovernanceTalliesCopy() []GovernanceTallyItem {
 	return g.GovernanceTallies.Copy()
+}
+
+func (gov *Governance) CurrentSetCopy() map[string]interface{} {
+	return gov.currentSet.Items()
 }
 
 func (gov *Governance) PendingChanges() map[string]interface{} {

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -26,6 +26,25 @@ import (
 
 type Engine interface {
 	HeaderEngine
+	ReaderEngine
+}
+
+type ReaderEngine interface {
+	// Returns the current params. Which are the values that shall be
+	// used to build the upcoming (head+1) block. Block processing codes
+	// should be using this method.
+	Params() *params.GovParamSet
+
+	// Returns the params at given block number. The returned params
+	// were used to build the block at given number.
+	// The number must be equal or less than current block height (head).
+	ParamsAt(num uint64) (*params.GovParamSet, error)
+
+	// Update the current params (the ones returned by Params()).
+	// by reaading the latest blockchain states.
+	// This function must be called after every block is mined to
+	// guarantee that Params() works correctly.
+	UpdateParams() error
 }
 
 type HeaderEngine interface {
@@ -60,6 +79,7 @@ type HeaderEngine interface {
 	InitialChainConfig() *params.ChainConfig
 	GetVoteMapCopy() map[string]VoteStatus
 	GetGovernanceTalliesCopy() []GovernanceTallyItem
+	CurrentSetCopy() map[string]interface{}
 	PendingChanges() map[string]interface{}
 	Votes() []GovernanceVote
 	IdxCache() []uint64

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -30,9 +30,9 @@ type Engine interface {
 }
 
 type ReaderEngine interface {
-	// Returns the current params. Which are the values that shall be
+	// Returns the params at the current block. The returned params shall be
 	// used to build the upcoming (head+1) block. Block processing codes
-	// should be using this method.
+	// should use this method.
 	Params() *params.GovParamSet
 
 	// Returns the params at given block number. The returned params
@@ -41,7 +41,7 @@ type ReaderEngine interface {
 	ParamsAt(num uint64) (*params.GovParamSet, error)
 
 	// Update the current params (the ones returned by Params()).
-	// by reaading the latest blockchain states.
+	// by reading the latest blockchain states.
 	// This function must be called after every block is mined to
 	// guarantee that Params() works correctly.
 	UpdateParams() error

--- a/governance/mixed_test.go
+++ b/governance/mixed_test.go
@@ -1,0 +1,113 @@
+package governance
+
+import (
+	"testing"
+
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/storage/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMixedEngine(t *testing.T, config *params.ChainConfig) (*MixedEngine, database.DBManager, *Governance) {
+	config.Istanbul.Epoch = 30
+	// TODO: if ContractEngine is added, make sure to disable it in this test.
+
+	db := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
+
+	e := NewMixedEngine(config, db)
+	defaultGov := e.defaultGov.(*Governance) // to manipulate internal fields
+
+	require.NotNil(t, e)
+	require.NotNil(t, defaultGov)
+
+	return e, db, defaultGov
+}
+
+// Under Header era,
+// Check that
+// - From a fresh MixedEngine instance, Params() and ParamsAt(0) returns the
+//   initial config value.
+func TestMixedEngine_Header_New(t *testing.T) {
+	valueA := uint64(0x11)
+
+	config := getTestConfig()
+	config.Istanbul.SubGroupSize = valueA
+	e, _, _ := newTestMixedEngine(t, config)
+
+	// Params() should work even before explicitly calling UpdateParams().
+	// For instance in cn.New().
+	pset := e.Params()
+	assert.Equal(t, valueA, pset.CommitteeSize())
+
+	pset, err := e.ParamsAt(0)
+	assert.Nil(t, err)
+	assert.Equal(t, valueA, pset.CommitteeSize())
+}
+
+// Under Header era,
+// Check that
+// - after UpdateParams(), Params() returns the new value
+func TestMixedEngine_Header_Params(t *testing.T) {
+	valueA := uint64(0x11)
+	valueB := uint64(0x22)
+
+	config := getTestConfig()
+	config.Istanbul.SubGroupSize = valueA
+	e, _, defaultGov := newTestMixedEngine(t, config)
+
+	defaultGov.currentSet.SetValue(params.CommitteeSize, valueB)
+	err := e.UpdateParams()
+	assert.Nil(t, err)
+
+	pset := e.Params()
+	assert.Equal(t, valueB, pset.CommitteeSize())
+}
+
+// Under Header era,
+// Check that
+// - after DB is written at [n - epoch], ParamsAt(n) returns the new value
+// - ParamsAt(n) == ReadGovernance(n)
+func TestMixedEngine_Header_ParamsAt(t *testing.T) {
+	valueA := uint64(0x11)
+	valueB := uint64(0x22)
+
+	config := getTestConfig()
+	config.Istanbul.SubGroupSize = valueA
+	e, _, defaultGov := newTestMixedEngine(t, config)
+
+	// Write to database. Note that we must use gov.WriteGovernance(), not db.WriteGovernance().
+	// The reason is that gov.ReadGovernance() depends on the caches, and that
+	// gov.WriteGovernance() sets idxCache accordingly, whereas db.WriteGovernance don't,
+	items := e.Params().StrMap()
+	items["istanbul.committeesize"] = valueB
+	gset := NewGovernanceSet()
+	gset.Import(items)
+	defaultGov.WriteGovernance(30, NewGovernanceSet(), gset)
+
+	testcases := []struct {
+		num   uint64
+		value uint64
+	}{
+		{0, valueA},
+		{30, valueA},
+		{31, valueA},
+		{59, valueA},
+		{60, valueB},
+		{61, valueB},
+	}
+	for _, tc := range testcases {
+		// Check that e.ParamsAt() == tc
+		pset, err := e.ParamsAt(tc.num)
+		assert.Nil(t, err)
+		assert.Equal(t, tc.value, pset.CommitteeSize())
+
+		// Check that defaultGov.ReadGovernance() == tc
+		// and by extension defaultGov.ReadGovernance() == e.ParamsAt().
+		_, strMap, err := defaultGov.ReadGovernance(tc.num)
+		assert.Nil(t, err)
+		pset, err = params.NewGovParamSetStrMap(strMap)
+		assert.Nil(t, err)
+		assert.Equal(t, tc.value, pset.CommitteeSize())
+	}
+}

--- a/governance/mixed_test.go
+++ b/governance/mixed_test.go
@@ -24,8 +24,7 @@ func newTestMixedEngine(t *testing.T, config *params.ChainConfig) (*MixedEngine,
 	return e, db, defaultGov
 }
 
-// Under Header era,
-// Check that
+// Without ContractGov, Check that
 // - From a fresh MixedEngine instance, Params() and ParamsAt(0) returns the
 //   initial config value.
 func TestMixedEngine_Header_New(t *testing.T) {
@@ -45,8 +44,7 @@ func TestMixedEngine_Header_New(t *testing.T) {
 	assert.Equal(t, valueA, pset.CommitteeSize())
 }
 
-// Under Header era,
-// Check that
+// Without ContractGov, Check that
 // - after UpdateParams(), Params() returns the new value
 func TestMixedEngine_Header_Params(t *testing.T) {
 	valueA := uint64(0x11)
@@ -64,8 +62,7 @@ func TestMixedEngine_Header_Params(t *testing.T) {
 	assert.Equal(t, valueB, pset.CommitteeSize())
 }
 
-// Under Header era,
-// Check that
+// Without ContractGov, Check that
 // - after DB is written at [n - epoch], ParamsAt(n) returns the new value
 // - ParamsAt(n) == ReadGovernance(n)
 func TestMixedEngine_Header_ParamsAt(t *testing.T) {
@@ -76,9 +73,9 @@ func TestMixedEngine_Header_ParamsAt(t *testing.T) {
 	config.Istanbul.SubGroupSize = valueA
 	e, _, defaultGov := newTestMixedEngine(t, config)
 
-	// Write to database. Note that we must use gov.WriteGovernance(), not db.WriteGovernance().
+	// Write to database. Note that we must use gov.WriteGovernance(), not db.WriteGovernance()
 	// The reason is that gov.ReadGovernance() depends on the caches, and that
-	// gov.WriteGovernance() sets idxCache accordingly, whereas db.WriteGovernance don't,
+	// gov.WriteGovernance() sets idxCache accordingly, whereas db.WriteGovernance don't
 	items := e.Params().StrMap()
 	items["istanbul.committeesize"] = valueB
 	gset := NewGovernanceSet()


### PR DESCRIPTION
## Proposed changes

- Add `MixedEngine.Params()` that returns the params out of `Governance.currentSet`.
  - This can replace `GetGovernanceValue(key)` and all nominal getters.
- Add `MixedEngine.ParamsAt(0)` that returns the params out of `db.ReadGovernanceAtNumber()`
  - This can replace `GetGovernanceItemAtNumber(num, key)`.

Intended use:

```diff
  // governance/api.go
- if GovernanceModeMap[api.governance.GovernanceMode()] == params.GovernanceMode_Ballot {
-     return true
- }
- return false
+ return api.governance.Params().GovernanceModeInt() == params.GovernanceMode_Ballot
```

```diff
  // consensus/istanbul/backend/snapshot.go
- if r, err := gov.GetGovernanceItemAtNumber(number, governance.GovernanceKeyMapReverse[params.Epoch]); err == nil && r != nil {
-     epoch = r.(uint64)
- } else {
-     logger.Error("Couldn't get governance value istanbul.epoch", "err", err, "received", r)
-     epoch = params.DefaultEpoch
- }
+ pset, err := gov.ParamsAt(number)
+ if err != nil {
+     logger.Error("Couldn't get governance value", "err", err)
+ }
+ epoch := pset.Epoch()
```

Actual replacement will happen in another PR, as it involves a lot of changes.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

https://github.com/klaytn/klaytn/issues/1375

## Further comments
