### PR TITLE
peer: fix multiChannelPeer ReadMsg loop to read closed ch immediately

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -33,13 +33,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/klaytn/klaytn/consensus/istanbul"
-
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus"
+	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/datasync/downloader"
 	"github.com/klaytn/klaytn/datasync/fetcher"

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -531,13 +531,12 @@ func (pm *ProtocolManager) processMsg(msgCh <-chan p2p.Msg, p Peer, addr common.
 func (pm *ProtocolManager) processConsensusMsg(msgCh <-chan p2p.Msg, p Peer, addr common.Address, errCh chan<- error) {
 	for msg := range msgCh {
 		if handler, ok := pm.engine.(consensus.Handler); ok {
+			_, err := handler.HandleMsg(addr, msg)
 			// if msg is istanbul msg, handled is true and err is nil if handle msg is successful.
-			if _, err := handler.HandleMsg(addr, msg); err != nil {
+			if err != nil {
 				p.GetP2PPeer().Log().Warn("ProtocolManager failed to handle consensus message. This can happen during block synchronization.", "msg", msg, "err", err)
-				if err != istanbul.ErrStoppedEngine {
-					errCh <- err
-					return
-				}
+				errCh <- err
+				return
 			}
 		}
 		msg.Discard()

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -533,8 +533,9 @@ func (pm *ProtocolManager) processConsensusMsg(msgCh <-chan p2p.Msg, p Peer, add
 		if handler, ok := pm.engine.(consensus.Handler); ok {
 			_, err := handler.HandleMsg(addr, msg)
 			// if msg is istanbul msg, handled is true and err is nil if handle msg is successful.
-			if err != nil {
+			if err == istanbul.ErrStoppedEngine {
 				p.GetP2PPeer().Log().Warn("ProtocolManager failed to handle consensus message. This can happen during block synchronization.", "msg", msg, "err", err)
+			} else if err != nil {
 				errCh <- err
 				return
 			}

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -1000,6 +1000,7 @@ func (p *multiChannelPeer) ReadMsg(rw p2p.MsgReadWriter, connectionOrder int, er
 	}, channelSizePerPeer)
 	go func() {
 		for {
+			// TODO-klaytn: check 30-second timeout works
 			msg, err := rw.ReadMsg()
 			readMsgCh <- struct {
 				p2p.Msg

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -1002,10 +1002,14 @@ func (p *multiChannelPeer) ReadMsg(rw p2p.MsgReadWriter, connectionOrder int, er
 		for {
 			// TODO-klaytn: check 30-second timeout works
 			msg, err := rw.ReadMsg()
-			readMsgCh <- struct {
+			select {
+			case <-closed:
+				return
+			case readMsgCh <- struct {
 				p2p.Msg
 				error
-			}{msg, err}
+			}{msg, err}:
+			}
 		}
 	}()
 

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -1014,10 +1014,14 @@ func (p *multiChannelPeer) ReadMsg(rw p2p.MsgReadWriter, connectionOrder int, er
 			if err != nil {
 				p.GetP2PPeer().Log().Warn("ProtocolManager failed to get msg channel", "err", err)
 				errCh <- err
-			} else if msg.Size > ProtocolMaxMsgSize {
-				err := errResp(ErrMsgTooLarge, "%v > %v", msg.Size, ProtocolMaxMsgSize)
+				return
+			}
+
+			if msg.Size > ProtocolMaxMsgSize {
+				err = errResp(ErrMsgTooLarge, "%v > %v", msg.Size, ProtocolMaxMsgSize)
 				p.GetP2PPeer().Log().Warn("ProtocolManager over max msg size", "err", err)
 				errCh <- err
+				return
 			}
 			msgCh <- msg
 		case <-closed:


### PR DESCRIPTION
## Proposed changes
- In the case of a CN, since the node can mine a block, when it is determined that the sync is complete, it switches to the mining mode. However, if it is a multichannel<->multichannel connection, and if the sync is completed before reaching the latest block, the CN should be converted to the sync mode in a few seconds. However, it did not converted to the sync mode immediately. It seems solve next issue, but actually it is not. https://github.com/klaytn/klaytn/issues/1200.
- It seems next causes are the reason of this issue, and i think (2) cause is direct.
  - (1) A message is read from the p2p connection, and if it is determined that there is an error, the p2p connection is disconnected. Becuase istanbul engine is shutdown due to the syncing, the istanbul consensus msg can be received. However, it is considered an error, so p2p connection is disconnected.
  - (2) But, in the case of multichannel, the p2p connection is not properly disconnected, so the corrupted connection is lasts more than 30 seconds.
- Therefore, in this PR, I tried to solve the above two problems. I thought a lot about whether it is correct to solve (1) as well. While reviewing, I would like you to look on this part.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
