### PR TITLE
[EVM] Returning a specific error through a new error stack 

### DIFF
--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -60,7 +60,7 @@ func enable1884(jt *JumpTable) {
 	}
 }
 
-func opSelfBalance(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+func opSelfBalance(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack, errStack *ErrStack) ([]byte, error) {
 	balance := evm.interpreter.intPool.get().Set(evm.StateDB.GetBalance(contract.Address()))
 	stack.push(balance)
 	return nil, nil
@@ -80,7 +80,7 @@ func enable1344(jt *JumpTable) {
 }
 
 // opChainID implements CHAINID opcode
-func opChainID(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+func opChainID(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack, errStack *ErrStack) ([]byte, error) {
 	chainId := evm.interpreter.intPool.get().Set(evm.chainConfig.ChainID)
 	stack.push(chainId)
 	return nil, nil
@@ -118,7 +118,7 @@ func enable3198(jt *JumpTable) {
 }
 
 // opBaseFee implements BASEFEE opcode
-func opBaseFee(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+func opBaseFee(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack, errStack *ErrStack) ([]byte, error) {
 	baseFee := evm.interpreter.intPool.get().Set(evm.Context.BaseFee)
 	stack.push(baseFee)
 	return nil, nil

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -27,7 +27,7 @@ import (
 )
 
 type (
-	executionFunc func(pc *uint64, env *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error)
+	executionFunc func(pc *uint64, env *EVM, contract *Contract, memory *Memory, stack *Stack, errStack *ErrStack) ([]byte, error)
 	gasFunc       func(*EVM, *Contract, *Stack, *Memory, uint64) (uint64, error) // last parameter is the requested memory size as a uint64
 	// memorySizeFunc returns the required size, and whether the operation overflowed a uint64
 	memorySizeFunc func(*Stack) (size uint64, overflow bool)

--- a/blockchain/vm/stack.go
+++ b/blockchain/vm/stack.go
@@ -97,3 +97,32 @@ func (st *Stack) Print() {
 	}
 	fmt.Println("#############")
 }
+
+type ErrStack struct {
+	errs []error
+}
+
+func newErrStack() *ErrStack {
+	return &ErrStack{}
+}
+
+func (st *ErrStack) push(e error) {
+	st.errs = append(st.errs, e)
+}
+
+func (st *ErrStack) pushToLog(txHash string) {
+	for i := 0; i < st.len(); i++ {
+		logger.Debug("EVM errors:", "idx", i+1, "txHash", txHash, "err", st.errs[i].Error())
+	}
+}
+
+func (st *ErrStack) len() int {
+	return len(st.errs)
+}
+
+func (st *ErrStack) getFirstErr() error {
+	if st.len() != 0 {
+		return st.errs[0]
+	}
+	return nil
+}


### PR DESCRIPTION
## Proposed changes
The current EVM implementation does not have the correct reasoning for a failed execution. The example below shows the motivation of this PR.

- Case1. A deployed contract does not have function calls, which means the function only executes the code implemented in the target function.
- Case2. A deployed contract has function calls.

Say an input gas is not enough to execute a transaction (contract call). Ideally, then, both cases must return Out-of-gas (OOG) that indicates it to receipt as well. The case2, however, returns `ErrExecutionReverted`, which does not explain why the transaction failed. This is because of the lack of error tracking in the current EVM implementation. 

Now, let me describe when an error was discovered and how it is returned.
There's no `call` opcode in the case1 scenario, which can directly determine the required gas (`constant gas` + `dynamic gas`) to execute the target opcode to be executed. The case2 makes another execution context for the `call` opcode and the OOG error is returned from that context, but the call opcode unconditionally returns `nil`. Finally returns `ErrExecutionReverted` by revert instruction, not the OOG error. 

This change records found errors in the error stack during the EVM execution and replaces the error with a first error in the error stack if the EVM returns `ErrExecutionReverted`. The residual errors without the first error are just logged and gown away. The residual errors can be delivered to receipt linearly again if the first error is resolved.

This PR considered only the errors from the `call` opcode. I commented on the other opcodes and did not make a change for them for now. 


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
