### PR TITLE
database: refactor database package unittest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ executors:
     working_directory: /go/src/github.com/klaytn/klaytn
     docker:
       - image: klaytn/build_base:1.2-go.1.18-solc0.8.13
-      - image: localstack/localstack:0.11.5
+      - image: localstack/localstack:0.13.0
       - image: circleci/redis:6.0.8-alpine
       - name: zookeeper
         image: wurstmeister/zookeeper

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -99,21 +99,17 @@ func newTestDynamoS3DB() (Database, func()) {
 	}
 }
 
-var testValues = []string{"a", "1251", "\x00123\x00"}
-
-// var testValues = []string{"", "a", "1251", "\x00123\x00"} original test_values; modified since badgerDB can't store empty key
-
-// TODO-Klaytn-Database Need to add DynamoDB to the below list.
-var testDatabases = []func() (Database, func()){newTestLDB, newTestBadgerDB, newTestMemDB}
-
-// var testDatabases = []func() (Database, func()){newTestLDB, newTestBadgerDB, newTestMemDB, newTestDynamoS3DB} if want to include the dynamo test, use this line
-
 type commonDatabaseTestSuite struct {
 	suite.Suite
 	database Database
 }
 
 func TestDatabaseTestSuite(t *testing.T) {
+	// If you want to include dynamo test, use below line
+	// var testDatabases = []func() (Database, func()){newTestLDB, newTestBadgerDB, newTestMemDB, newTestDynamoS3DB}
+
+	// TODO-Klaytn-Database Need to add DynamoDB to the below list.
+	testDatabases := []func() (Database, func()){newTestLDB, newTestBadgerDB, newTestMemDB}
 	for _, newFn := range testDatabases {
 		db, remove := newFn()
 		suite.Run(t, &commonDatabaseTestSuite{database: db})
@@ -186,6 +182,10 @@ func (ts *commonDatabaseTestSuite) TestNotFoundErr() {
 // TestPutGet tests the basic put and get operations.
 func (ts *commonDatabaseTestSuite) TestPutGet() {
 	db, t := ts.database, ts.T()
+
+	// Since badgerDB can't store empty key, testValues is modified. Below line is the original testValues.
+	// var testValues = []string{"", "a", "1251", "\x00123\x00"}
+	testValues := []string{"a", "1251", "\x00123\x00"}
 
 	// put
 	for _, v := range testValues {

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/klaytn/klaytn/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 func newTestLDB() (Database, func()) {
@@ -87,7 +88,9 @@ func newTestDynamoS3DB() (Database, func()) {
 		panic("failed to create test DynamoS3 database: " + err.Error())
 	}
 	return db, func() {
-		db.deleteDB()
+		db.Close()
+		db.deleteTable()
+		db.fdb.deleteBucket()
 
 		// to finish test with DynamoDB singletons
 		dynamoDBClient = oldDynamoDBClient
@@ -96,39 +99,73 @@ func newTestDynamoS3DB() (Database, func()) {
 	}
 }
 
-var test_values = []string{"a", "1251", "\x00123\x00"}
+var testValues = []string{"a", "1251", "\x00123\x00"}
 
-// var test_values = []string{"", "a", "1251", "\x00123\x00"} original test_values; modified since badgerDB can't store empty key
+// var testValues = []string{"", "a", "1251", "\x00123\x00"} original test_values; modified since badgerDB can't store empty key
 
 // TODO-Klaytn-Database Need to add DynamoDB to the below list.
 var testDatabases = []func() (Database, func()){newTestLDB, newTestBadgerDB, newTestMemDB}
 
 // var testDatabases = []func() (Database, func()){newTestLDB, newTestBadgerDB, newTestMemDB, newTestDynamoS3DB} if want to include the dynamo test, use this line
 
-// TestDatabase_PutGet tests the basic put and get operations.
-func TestDatabase_PutGet(t *testing.T) {
-	for _, dbCreateFn := range testDatabases {
-		db, remove := dbCreateFn()
-		defer remove()
-		testPutGet(db, t)
+type commonDatabaseTestSuite struct {
+	suite.Suite
+	database Database
+}
+
+func TestDatabaseTestSuite(t *testing.T) {
+	for _, newFn := range testDatabases {
+		db, remove := newFn()
+		suite.Run(t, &commonDatabaseTestSuite{database: db})
+		remove()
 	}
 }
 
-// TestDatabase_ParallelPutGet tests the parallel put and get operations.
-func TestDatabase_ParallelPutGet(t *testing.T) {
-	for _, dbCreateFn := range testDatabases {
-		db, remove := dbCreateFn()
-		defer remove()
-		testParallelPutGet(db, t)
-	}
-}
+// TestNilValue checks if all database write/read nil value in the same way.
+func (ts *commonDatabaseTestSuite) TestNilValue() {
+	db, t := ts.database, ts.T()
 
-// TestDatabase_NotFoundErr checks if an empty database returns
-// dataNotFoundErr for the given  random key.
-func TestDatabase_NotFoundErr(t *testing.T) {
-	for _, dbCreateFn := range testDatabases {
-		db, remove := dbCreateFn()
-		defer remove()
+	// non-batch
+	{
+		// write nil value
+		key := common.MakeRandomBytes(32)
+		assert.Nil(t, db.Put(key, nil))
+
+		// get nil value
+		ret, err := db.Get(key)
+		assert.Equal(t, []byte{}, ret)
+		assert.Nil(t, err)
+
+		// check existence
+		exist, err := db.Has(key)
+		assert.Equal(t, true, exist)
+		assert.Nil(t, err)
+
+		val, err := db.Get(randStrBytes(100))
+		assert.Nil(t, val)
+		assert.Error(t, err)
+		assert.Equal(t, dataNotFoundErr, err)
+	}
+
+	// batch
+	{
+		batch := db.NewBatch()
+
+		// write nil value
+		key := common.MakeRandomBytes(32)
+		assert.Nil(t, batch.Put(key, nil))
+		assert.NoError(t, batch.Write())
+
+		// get nil value
+		ret, err := db.Get(key)
+		assert.Equal(t, []byte{}, ret)
+		assert.Nil(t, err)
+
+		// check existence
+		exist, err := db.Has(key)
+		assert.Equal(t, true, exist)
+		assert.Nil(t, err)
+
 		val, err := db.Get(randStrBytes(100))
 		assert.Nil(t, val)
 		assert.Error(t, err)
@@ -136,63 +173,22 @@ func TestDatabase_NotFoundErr(t *testing.T) {
 	}
 }
 
-// TestDatabase_NilValue checks if all database write/read nil value in the same way.
-func TestDatabase_NilValue(t *testing.T) {
-	for _, dbCreateFn := range testDatabases {
-		db, remove := dbCreateFn()
-		defer remove()
+// TestNotFoundErr checks if an empty database returns DataNotFoundErr for the given random key.
+func (ts *commonDatabaseTestSuite) TestNotFoundErr() {
+	db, t := ts.database, ts.T()
 
-		{
-			// write nil value
-			key := common.MakeRandomBytes(32)
-			assert.Nil(t, db.Put(key, nil))
-
-			// get nil value
-			ret, err := db.Get(key)
-			assert.Equal(t, []byte{}, ret)
-			assert.Nil(t, err)
-
-			// check existence
-			exist, err := db.Has(key)
-			assert.Equal(t, true, exist)
-			assert.Nil(t, err)
-
-			val, err := db.Get(randStrBytes(100))
-			assert.Nil(t, val)
-			assert.Error(t, err)
-			assert.Equal(t, dataNotFoundErr, err)
-		}
-
-		// batch
-		{
-			batch := db.NewBatch()
-
-			// write nil value
-			key := common.MakeRandomBytes(32)
-			assert.Nil(t, batch.Put(key, nil))
-			assert.NoError(t, batch.Write())
-
-			// get nil value
-			ret, err := db.Get(key)
-			assert.Equal(t, []byte{}, ret)
-			assert.Nil(t, err)
-
-			// check existence
-			exist, err := db.Has(key)
-			assert.Equal(t, true, exist)
-			assert.Nil(t, err)
-
-			val, err := db.Get(randStrBytes(100))
-			assert.Nil(t, val)
-			assert.Error(t, err)
-			assert.Equal(t, dataNotFoundErr, err)
-		}
-	}
+	val, err := db.Get(randStrBytes(100))
+	assert.Nil(t, val)
+	assert.Error(t, err)
+	assert.Equal(t, dataNotFoundErr, err)
 }
 
-func testPutGet(db Database, t *testing.T) {
+// TestPutGet tests the basic put and get operations.
+func (ts *commonDatabaseTestSuite) TestPutGet() {
+	db, t := ts.database, ts.T()
+
 	// put
-	for _, v := range test_values {
+	for _, v := range testValues {
 		err := db.Put([]byte(v), []byte(v))
 		if err != nil {
 			t.Fatalf("put failed: %v", err)
@@ -200,7 +196,7 @@ func testPutGet(db Database, t *testing.T) {
 	}
 
 	// get
-	for _, v := range test_values {
+	for _, v := range testValues {
 		data, err := db.Get([]byte(v))
 		if err != nil {
 			t.Fatalf("get failed: %v", err)
@@ -211,7 +207,7 @@ func testPutGet(db Database, t *testing.T) {
 	}
 
 	// override with "?"
-	for _, v := range test_values {
+	for _, v := range testValues {
 		err := db.Put([]byte(v), []byte("?"))
 		if err != nil {
 			t.Fatalf("put override failed: %v", err)
@@ -219,7 +215,7 @@ func testPutGet(db Database, t *testing.T) {
 	}
 
 	// get "?" by key
-	for _, v := range test_values {
+	for _, v := range testValues {
 		data, err := db.Get([]byte(v))
 		if err != nil {
 			t.Fatalf("get failed: %v", err)
@@ -230,7 +226,7 @@ func testPutGet(db Database, t *testing.T) {
 	}
 
 	// override returned value
-	for _, v := range test_values {
+	for _, v := range testValues {
 		orig, err := db.Get([]byte(v))
 		if err != nil {
 			t.Fatalf("get failed: %v", err)
@@ -246,7 +242,7 @@ func testPutGet(db Database, t *testing.T) {
 	}
 
 	// delete
-	for _, v := range test_values {
+	for _, v := range testValues {
 		err := db.Delete([]byte(v))
 		if err != nil {
 			t.Fatalf("delete %q failed: %v", v, err)
@@ -254,7 +250,7 @@ func testPutGet(db Database, t *testing.T) {
 	}
 
 	// try to get deleted values
-	for _, v := range test_values {
+	for _, v := range testValues {
 		_, err := db.Get([]byte(v))
 		if err == nil {
 			t.Fatalf("got deleted value %q", v)
@@ -278,7 +274,9 @@ func TestShardDB(t *testing.T) {
 	fmt.Printf("idx %d   %d   %d\n", idx, shard, seed)
 }
 
-func testParallelPutGet(db Database, t *testing.T) {
+// TestParallelPutGet tests the parallel put and get operations.
+func (ts *commonDatabaseTestSuite) TestParallelPutGet() {
+	db := ts.database
 	const n = 8
 	var pending sync.WaitGroup
 


### PR DESCRIPTION
## Proposed changes
- Change1. upgrade localstack to reduce localstack memory consuming so it avoids intermittent memory or time limit exceed.
  - we use localstack docker container to run a local dynamodb, and dynamodb unittest uses this docker image. we use localstack:0.11.5, but, sometimes the dynamodb test fails. By upgrading localstack version, the problem seems disappear. I hope this upgrade can reduce memory consuming and 30m exceed error in circle ci.
  - dev - localstack:0.11.5. this PR - localstack:0.13.0
- Change2. reduce running time of some database unittest by refactoring database_test.go and dynamodb_test.go

closes https://github.com/klaytn/klaytn/issues/1400

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
