### PR TITLE
Change consensus quorumsize

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -46,10 +46,10 @@ import (
 )
 
 const (
-	//checkpointInterval = 1024 // Number of blocks after which to save the vote snapshot to the database
-	//inmemorySnapshots  = 128  // Number of recent vote snapshots to keep in memory
-	//inmemoryPeers      = 40
-	//inmemoryMessages   = 1024
+	// checkpointInterval = 1024 // Number of blocks after which to save the vote snapshot to the database
+	// inmemorySnapshots  = 128  // Number of recent vote snapshots to keep in memory
+	// inmemoryPeers      = 40
+	// inmemoryMessages   = 1024
 
 	checkpointInterval = 1024 // Number of blocks after which to save the vote snapshot to the database
 	inmemorySnapshots  = 496  // Number of recent vote snapshots to keep in memory
@@ -89,6 +89,7 @@ var (
 	// errMismatchTxhashes is returned if the TxHash in header is mismatch.
 	errMismatchTxhashes = errors.New("mismatch transactions hashes")
 )
+
 var (
 	defaultBlockScore = big.NewInt(1)
 	now               = time.Now
@@ -324,8 +325,8 @@ func (sb *backend) verifyCommittedSeals(chain consensus.ChainReader, header *typ
 		}
 	}
 
-	// The length of validSeal should be larger than number of faulty node + 1
-	if validSeal <= 2*snap.ValSet.F() {
+	// The length of validSeal should be larger than the quorum size of consensus
+	if validSeal < snap.ValSet.QuorumSize() {
 		return errInvalidCommittedSeals
 	}
 
@@ -409,8 +410,8 @@ func (sb *backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 // Note, the block header and state database might be updated to reflect any
 // consensus rules that happen at finalization (e.g. block rewards).
 func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
-	receipts []*types.Receipt) (*types.Block, error) {
-
+	receipts []*types.Receipt,
+) (*types.Block, error) {
 	// If sb.chain is nil, it means backend is not initialized yet.
 	if sb.chain != nil && sb.governance.ProposerPolicy() == uint64(istanbul.WeightedRandom) {
 		// TODO-Klaytn Let's redesign below logic and remove dependency between block reward and istanbul consensus.

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -79,9 +79,9 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 		return errFailedDecodeCommit
 	}
 
-	//logger.Error("receive handle commit","num", commit.View.Sequence)
+	// logger.Error("receive handle commit","num", commit.View.Sequence)
 	if err := c.checkMessage(msgCommit, commit.View); err != nil {
-		//logger.Error("### istanbul/commit.go checkMessage","num",commit.View.Sequence,"err",err)
+		// logger.Error("### istanbul/commit.go checkMessage","num",commit.View.Sequence,"err",err)
 		return err
 	}
 
@@ -106,7 +106,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 			logger.Warn("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() {
+		} else if c.current.GetPrepareOrCommitSize() >= c.QuorumSize() {
 			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgCommit)
 			c.current.LockHash()
 			c.setState(StatePrepared)
@@ -119,7 +119,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 	// If we already have a proposal, we may have chance to speed up the consensus process
 	// by committing the proposal without PREPARE messages.
 	//logger.Error("### consensus check","len(commits)",c.current.Commits.Size(),"f(2/3)",2*c.valSet.F(),"state",c.state.Cmp(StateCommitted))
-	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() > 2*c.valSet.F() {
+	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() >= c.QuorumSize() {
 		// Still need to call LockHash here since state can skip Prepared state and jump directly to the Committed state.
 		c.current.LockHash()
 		c.commit()

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -106,7 +106,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 			logger.Warn("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() >= c.QuorumSize() {
+		} else if c.current.GetPrepareOrCommitSize() >= c.valSet.QuorumSize() {
 			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgCommit)
 			c.current.LockHash()
 			c.setState(StatePrepared)
@@ -119,7 +119,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 	// If we already have a proposal, we may have chance to speed up the consensus process
 	// by committing the proposal without PREPARE messages.
 	//logger.Error("### consensus check","len(commits)",c.current.Commits.Size(),"f(2/3)",2*c.valSet.F(),"state",c.state.Cmp(StateCommitted))
-	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() >= c.QuorumSize() {
+	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() >= c.valSet.QuorumSize() {
 		// Still need to call LockHash here since state can skip Prepared state and jump directly to the Committed state.
 		c.current.LockHash()
 		c.commit()

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -44,21 +44,23 @@ func TestCore_sendCommit(t *testing.T) {
 	// invalid case - not committee
 	{
 		// Increase round number until the owner of istanbul.core is not a member of the committee
-		for istCore.valSet.CheckInSubList(lastProposal.Hash(), istCore.currentView(), istCore.Address()) {
-			istCore.current.round.Add(istCore.current.round, common.Big1)
-			istCore.valSet.CalcProposer(lastProposer, istCore.current.round.Uint64())
+		if istCore.valSet.Size() > istCore.valSet.SubGroupSize() {
+			for istCore.valSet.CheckInSubList(lastProposal.Hash(), istCore.currentView(), istCore.Address()) {
+				istCore.current.round.Add(istCore.current.round, common.Big1)
+				istCore.valSet.CalcProposer(lastProposer, istCore.current.round.Uint64())
+			}
+
+			mockCtrl := gomock.NewController(t)
+			mockBackend := mock_istanbul.NewMockBackend(mockCtrl)
+			mockBackend.EXPECT().Sign(gomock.Any()).Return(nil, nil).Times(0)
+			mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
+
+			istCore.backend = mockBackend
+			istCore.sendCommit()
+
+			// methods of mockBackend should be executed given times
+			mockCtrl.Finish()
 		}
-
-		mockCtrl := gomock.NewController(t)
-		mockBackend := mock_istanbul.NewMockBackend(mockCtrl)
-		mockBackend.EXPECT().Sign(gomock.Any()).Return(nil, nil).Times(0)
-		mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
-
-		istCore.backend = mockBackend
-		istCore.sendCommit()
-
-		// methods of mockBackend should be executed given times
-		mockCtrl.Finish()
 	}
 
 	// valid case

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -37,10 +37,6 @@ import (
 	"github.com/rcrowley/go-metrics"
 )
 
-const (
-	consensusMinValSet = 4
-)
-
 var logger = log.NewModuleLogger(log.ConsensusIstanbulCore)
 
 // New creates an Istanbul consensus core
@@ -417,14 +413,6 @@ func (c *core) newRoundChangeTimer() {
 
 func (c *core) checkValidatorSignature(data []byte, sig []byte) (common.Address, error) {
 	return istanbul.CheckValidatorSignature(c.valSet, data, sig)
-}
-
-func (c *core) QuorumSize() int {
-	if c.valSet.Size() < consensusMinValSet {
-		return int(c.valSet.Size())
-	}
-
-	return int(math.Ceil(float64(2*c.valSet.Size()) / 3))
 }
 
 // PrepareCommittedSeal returns a committed seal for the given hash

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -37,6 +37,10 @@ import (
 	"github.com/rcrowley/go-metrics"
 )
 
+const (
+	consensusMinValSet = 4
+)
+
 var logger = log.NewModuleLogger(log.ConsensusIstanbulCore)
 
 // New creates an Istanbul consensus core
@@ -189,14 +193,14 @@ func (c *core) commit() {
 		}
 
 		if err := c.backend.Commit(proposal, committedSeals); err != nil {
-			c.current.UnlockHash() //Unlock block when insertion fails
+			c.current.UnlockHash() // Unlock block when insertion fails
 			c.sendNextRoundChange("commit failure")
 			return
 		}
 	} else {
 		// TODO-Klaytn never happen, but if proposal is nil, mining is not working.
 		logger.Error("istanbul.core current.Proposal is NULL")
-		c.current.UnlockHash() //Unlock block when insertion fails
+		c.current.UnlockHash() // Unlock block when insertion fails
 		c.sendNextRoundChange("commit failure. proposal is nil")
 		return
 	}
@@ -281,7 +285,7 @@ func (c *core) startNewRound(round *big.Int) {
 		// If we have pending request, propose pending request
 		if c.current.IsHashLocked() {
 			r := &istanbul.Request{
-				Proposal: c.current.Proposal(), //c.current.Proposal would be the locked proposal by previous proposer, see updateRoundState
+				Proposal: c.current.Proposal(), // c.current.Proposal would be the locked proposal by previous proposer, see updateRoundState
 			}
 			c.sendPreprepare(r)
 		} else if c.current.pendingRequest != nil {
@@ -413,6 +417,14 @@ func (c *core) newRoundChangeTimer() {
 
 func (c *core) checkValidatorSignature(data []byte, sig []byte) (common.Address, error) {
 	return istanbul.CheckValidatorSignature(c.valSet, data, sig)
+}
+
+func (c *core) QuorumSize() int {
+	if c.valSet.Size() < consensusMinValSet {
+		return int(c.valSet.Size())
+	}
+
+	return int(math.Ceil(float64(2*c.valSet.Size()) / 3))
 }
 
 // PrepareCommittedSeal returns a committed seal for the given hash

--- a/consensus/istanbul/core/core_test.go
+++ b/consensus/istanbul/core/core_test.go
@@ -1,0 +1,61 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from quorum/consensus/istanbul/core/core_test.go (2019/09/30).
+// Modified and improved for the klaytn development.
+
+package core
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
+)
+
+// What quorum size Q do we need in Byzantine setting?
+//  * Liveness: Q <= N - f
+//      As in non-Byzantine case, failed nodes might not reply
+//  * Safety: Quorum intersection must contain one non-faulty node
+//      Idea: out of f+1 nodes, at most one can be faulty
+//      Hence:  2Q - N > f    (since f could be malicious)
+//  So: N + f < 2Q <= 2(N - f)
+
+func TestCore_QuorumSize(t *testing.T) {
+	validatorAddrs, _ := genValidators(4)
+	mockBackend, mockCtrl := newMockBackend(t, validatorAddrs)
+	defer mockCtrl.Finish()
+
+	istConfig := istanbul.DefaultConfig
+	istConfig.ProposerPolicy = istanbul.WeightedRandom
+
+	istCore := New(mockBackend, istConfig).(*core)
+	if err := istCore.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer istCore.Stop()
+
+	valSet := istCore.valSet
+	for i := 1; i <= 100; i++ {
+		valSet.AddValidator(common.StringToAddress(fmt.Sprint(i)))
+		valSet.SetSubGroupSize(valSet.Size())
+		if 2*valSet.QuorumSize() <= int(valSet.Size())+valSet.F() || 2*valSet.QuorumSize() > 2*(int(valSet.Size())-valSet.F()) {
+			t.Errorf("quorumSize constraint failed, expected value (2*QuorumSize > Size+F && 2*QuorumSize > 2*(Size-F)) to qs:%v, f: %v, size+f:%v, be:%v, got: %v, for size: %v", valSet.QuorumSize(), valSet.F(), int(valSet.Size())+valSet.F(), true, false, valSet.Size())
+		}
+	}
+}

--- a/consensus/istanbul/core/core_test.go
+++ b/consensus/istanbul/core/core_test.go
@@ -37,7 +37,7 @@ import (
 //  So: N + f < 2Q <= 2(N - f)
 
 func TestCore_QuorumSize(t *testing.T) {
-	validatorAddrs, _ := genValidators(4)
+	validatorAddrs, _ := genValidators(1)
 	mockBackend, mockCtrl := newMockBackend(t, validatorAddrs)
 	defer mockCtrl.Finish()
 
@@ -51,7 +51,7 @@ func TestCore_QuorumSize(t *testing.T) {
 	defer istCore.Stop()
 
 	valSet := istCore.valSet
-	for i := 1; i <= 100; i++ {
+	for i := 0; i <= 100; i++ {
 		valSet.AddValidator(common.StringToAddress(fmt.Sprint(i)))
 		valSet.SetSubGroupSize(valSet.Size())
 		if 2*valSet.QuorumSize() <= int(valSet.Size())+valSet.F() || 2*valSet.QuorumSize() > 2*(int(valSet.Size())-valSet.F()) {

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -523,8 +523,6 @@ func simulateMaliciousCN(t *testing.T, numValidators int, numMalicious int) Stat
 	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
 	defer fork.ClearHardForkBlockNumberConfig()
 
-	// Note that genValidators(n) will generate n/3 validators.
-	// We want n validators, thus calling genValidators(3n).
 	validatorAddrs, validatorKeyMap := genValidators(numValidators)
 
 	// Add more EXPECT()s to remove unexpected call error
@@ -619,8 +617,6 @@ func simulateChainSplit(t *testing.T, numValidators int) (State, State) {
 	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
 	defer fork.ClearHardForkBlockNumberConfig()
 
-	// Note that genValidators(n) will generate n/3 validators.
-	// We want n validators, thus calling genValidators(3n).
 	validatorAddrs, validatorKeyMap := genValidators(numValidators)
 
 	// Add more EXPECT()s to remove unexpected call error

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -643,7 +643,6 @@ func simulateChainSplit(t *testing.T, numValidators int) (State, State) {
 	coreProposer := New(mockBackend, istConfig).(*core)
 	coreA := New(mockBackend, istConfig).(*core)
 	coreB := New(mockBackend, istConfig).(*core)
-
 	require.Nil(t,
 		coreProposer.Start(),
 		coreA.Start(),

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -98,27 +98,10 @@ func genValidators(n int) ([]common.Address, map[common.Address]*ecdsa.PrivateKe
 
 // getRandomValidator selects a validator in the given validator set.
 // `isCommittee` determines whether it returns a committee or a non-committee.
-func getRandomValidator(isCommittee bool, valSet istanbul.ValidatorSet, prevHash common.Hash, view *istanbul.View) istanbul.Validator {
+func getRandomValidator(valSet istanbul.ValidatorSet, prevHash common.Hash, view *istanbul.View) istanbul.Validator {
 	committee := valSet.SubList(prevHash, view)
 
-	if isCommittee {
-		return committee[rand.Int()%(len(committee)-1)]
-	}
-
-	for _, val := range valSet.List() {
-		for _, com := range committee {
-			if val.Address() == com.Address() {
-				isCommittee = true
-			}
-		}
-		if !isCommittee {
-			return val
-		}
-		isCommittee = false
-	}
-
-	// it should not be happened
-	return nil
+	return committee[rand.Int()%(len(committee)-1)]
 }
 
 // signBlock signs the given block with the given private key
@@ -263,7 +246,7 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 
 	// Preprepare message originated from invalid sender
 	{
-		msgSender := getRandomValidator(false, validators, lastBlock.Hash(), istCore.currentView())
+		msgSender := getRandomValidator(validators, lastBlock.Hash(), istCore.currentView())
 		msgSenderKey := validatorKeyMap[msgSender.Address()]
 
 		newProposal, err := genBlock(lastBlock, msgSenderKey)
@@ -271,7 +254,11 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		istanbulMsg, err := genIstanbulMsg(msgPreprepare, lastProposal.Hash(), newProposal, msgSender.Address(), msgSenderKey)
+		// generate invalidAddress
+		var invalidAddress common.Address
+		invalidAddress = common.Address{}
+
+		istanbulMsg, err := genIstanbulMsg(msgPreprepare, lastProposal.Hash(), newProposal, invalidAddress, msgSenderKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -309,10 +296,14 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 
 	// Prepare message originated from invalid sender
 	{
-		msgSender := getRandomValidator(false, validators, lastBlock.Hash(), istCore.currentView())
+		msgSender := getRandomValidator(validators, lastBlock.Hash(), istCore.currentView())
 		msgSenderKey := validatorKeyMap[msgSender.Address()]
 
-		istanbulMsg, err := genIstanbulMsg(msgPrepare, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), msgSender.Address(), msgSenderKey)
+		// generate invalidAddress
+		var invalidAddress common.Address
+		invalidAddress = common.Address{}
+
+		istanbulMsg, err := genIstanbulMsg(msgPrepare, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), invalidAddress, msgSenderKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -327,7 +318,7 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 
 	// Prepare message originated from valid sender
 	{
-		msgSender := getRandomValidator(true, validators, lastBlock.Hash(), istCore.currentView())
+		msgSender := getRandomValidator(validators, lastBlock.Hash(), istCore.currentView())
 		msgSenderKey := validatorKeyMap[msgSender.Address()]
 
 		istanbulMsg, err := genIstanbulMsg(msgPrepare, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), msgSender.Address(), msgSenderKey)
@@ -345,10 +336,14 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 
 	// Commit message originated from invalid sender
 	{
-		msgSender := getRandomValidator(false, validators, lastBlock.Hash(), istCore.currentView())
+		msgSender := getRandomValidator(validators, lastBlock.Hash(), istCore.currentView())
 		msgSenderKey := validatorKeyMap[msgSender.Address()]
 
-		istanbulMsg, err := genIstanbulMsg(msgCommit, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), msgSender.Address(), msgSenderKey)
+		// generate invalidAddress
+		var invalidAddress common.Address
+		invalidAddress = common.Address{}
+
+		istanbulMsg, err := genIstanbulMsg(msgCommit, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), invalidAddress, msgSenderKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -363,7 +358,7 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 
 	// Commit message originated from valid sender
 	{
-		msgSender := getRandomValidator(true, validators, lastBlock.Hash(), istCore.currentView())
+		msgSender := getRandomValidator(validators, lastBlock.Hash(), istCore.currentView())
 		msgSenderKey := validatorKeyMap[msgSender.Address()]
 
 		istanbulMsg, err := genIstanbulMsg(msgCommit, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), msgSender.Address(), msgSenderKey)
@@ -399,7 +394,7 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 
 	// RoundChange message originated from valid sender
 	{
-		msgSender := getRandomValidator(true, validators, lastBlock.Hash(), istCore.currentView())
+		msgSender := getRandomValidator(validators, lastBlock.Hash(), istCore.currentView())
 		msgSenderKey := validatorKeyMap[msgSender.Address()]
 
 		istanbulMsg, err := genIstanbulMsg(msgRoundChange, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), msgSender.Address(), msgSenderKey)

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -792,7 +792,7 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 
 			for idx, valAdd := range validatorAddrs {
 				// the number of round change messages greater than the quorum have to be collected
-				if idx == istCore.QuorumSize() {
+				if idx == istCore.valSet.QuorumSize() {
 					break
 				}
 

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -86,7 +86,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			logger.Warn("received prepare of the hash locked proposal and change state to prepared", "msgType", msgPrepare)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() >= c.QuorumSize() {
+		} else if c.current.GetPrepareOrCommitSize() >= c.valSet.QuorumSize() {
 			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -58,7 +58,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 		return errFailedDecodePrepare
 	}
 
-	//logger.Error("call receive prepare","num",prepare.View.Sequence)
+	// logger.Error("call receive prepare","num",prepare.View.Sequence)
 	if err := c.checkMessage(msgPrepare, prepare.View); err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			logger.Warn("received prepare of the hash locked proposal and change state to prepared", "msgType", msgPrepare)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() {
+		} else if c.current.GetPrepareOrCommitSize() >= c.QuorumSize() {
 			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -44,21 +44,23 @@ func TestCore_sendPrepare(t *testing.T) {
 	// invalid case - not committee
 	{
 		// Increase round number until the owner of istanbul.core is not a member of the committee
-		for istCore.valSet.CheckInSubList(lastProposal.Hash(), istCore.currentView(), istCore.Address()) {
-			istCore.current.round.Add(istCore.current.round, common.Big1)
-			istCore.valSet.CalcProposer(lastProposer, istCore.current.round.Uint64())
+		if istCore.valSet.Size() > istCore.valSet.SubGroupSize() {
+			for istCore.valSet.CheckInSubList(lastProposal.Hash(), istCore.currentView(), istCore.Address()) {
+				istCore.current.round.Add(istCore.current.round, common.Big1)
+				istCore.valSet.CalcProposer(lastProposer, istCore.current.round.Uint64())
+			}
+
+			mockCtrl := gomock.NewController(t)
+			mockBackend := mock_istanbul.NewMockBackend(mockCtrl)
+			mockBackend.EXPECT().Sign(gomock.Any()).Return(nil, nil).Times(0)
+			mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
+
+			istCore.backend = mockBackend
+			istCore.sendPrepare()
+
+			// methods of mockBackend should be executed given times
+			mockCtrl.Finish()
 		}
-
-		mockCtrl := gomock.NewController(t)
-		mockBackend := mock_istanbul.NewMockBackend(mockCtrl)
-		mockBackend.EXPECT().Sign(gomock.Any()).Return(nil, nil).Times(0)
-		mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
-
-		istCore.backend = mockBackend
-		istCore.sendPrepare()
-
-		// methods of mockBackend should be executed given times
-		mockCtrl.Finish()
 	}
 
 	// valid case

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -113,7 +113,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 	}
 
 	var numCatchUp, numStartNewRound int
-	if c.valSet.Size() < 4 {
+	if c.valSet.Size() < consensusMinValSet {
 		n := int(c.valSet.Size())
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n
@@ -121,8 +121,8 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 		numCatchUp = n - 1
 	} else {
 		f := int(c.valSet.F())
-		// 2*F + 1 ROUND CHANGE messages can start new round.
-		numStartNewRound = 2*f + 1
+		// QuorumSize ROUND CHANGE messages can start new round.
+		numStartNewRound = c.QuorumSize()
 		// F + 1 ROUND CHANGE messages can start catch up the round.
 		numCatchUp = f + 1
 	}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -113,7 +113,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 	}
 
 	var numCatchUp, numStartNewRound int
-	if c.valSet.Size() < consensusMinValSet {
+	if c.valSet.Size() < 4 {
 		n := int(c.valSet.Size())
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n
@@ -122,7 +122,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 	} else {
 		f := int(c.valSet.F())
 		// QuorumSize ROUND CHANGE messages can start new round.
-		numStartNewRound = c.QuorumSize()
+		numStartNewRound = c.valSet.QuorumSize()
 		// F + 1 ROUND CHANGE messages can start catch up the round.
 		numCatchUp = f + 1
 	}

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -103,6 +103,8 @@ type ValidatorSet interface {
 	Copy() ValidatorSet
 	// Get the maximum number of faulty nodes
 	F() int
+	// Get the quorum number of consensus
+	QuorumSize() int
 	// Get proposer policy
 	Policy() ProposerPolicy
 

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -364,11 +364,7 @@ func (valSet *defaultSet) Copy() istanbul.ValidatorSet {
 }
 
 func (valSet *defaultSet) F() int {
-	if valSet.Size() > valSet.subSize {
-		return int(math.Ceil(float64(valSet.subSize)/3)) - 1
-	} else {
-		return int(math.Ceil(float64(valSet.Size())/3)) - 1
-	}
+	return int(math.Ceil(float64(valSet.Size())/3)) - 1 // It's the same as int(math.Floor(float64((valSet.Size()-1)/3)))
 }
 
 func (valSet *defaultSet) Policy() istanbul.ProposerPolicy { return valSet.policy }

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -367,6 +367,24 @@ func (valSet *defaultSet) F() int {
 	return int(math.Ceil(float64(valSet.Size())/3)) - 1 // It's the same as int(math.Floor(float64((valSet.Size()-1)/3)))
 }
 
+func (valSet *defaultSet) QuorumSize() int {
+	valSet.validatorMu.RLock()
+	defer valSet.validatorMu.RUnlock()
+
+	n := valSet.Size()
+	// the minimum number of byzantine fault tolerance is 4, if n < 4, every node has to participate in the consensus for safety
+	if n < 4 {
+		return int(n)
+	}
+
+	// It's going to be removed. Because klaytn should set the valSet.subSize equal to valSet.Size() for safety
+	if n > valSet.subSize {
+		n = valSet.subSize
+	}
+
+	return int(math.Ceil(float64(2*n) / 3))
+}
+
 func (valSet *defaultSet) Policy() istanbul.ProposerPolicy { return valSet.policy }
 
 func (valSet *defaultSet) Refresh(hash common.Hash, blockNum uint64, config *params.ChainConfig, isSingle bool, governingNode common.Address, minStaking uint64) error {

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -604,6 +604,24 @@ func (valSet *weightedCouncil) F() int {
 	return int(math.Ceil(float64(valSet.Size())/3)) - 1 // It's the same as int(math.Floor(float64((valSet.Size()-1)/3)))
 }
 
+func (valSet *weightedCouncil) QuorumSize() int {
+	valSet.validatorMu.RLock()
+	defer valSet.validatorMu.RUnlock()
+
+	n := valSet.Size()
+	// the minimum number of byzantine fault tolerance is 4, if n < 4, every node has to participate in the consensus for safety
+	if n < 4 {
+		return int(n)
+	}
+
+	// It's going to be removed. Because klaytn should set the valSet.subSize() equal to valSet.Size() for safety
+	if n > valSet.subSize {
+		n = valSet.subSize
+	}
+
+	return int(math.Ceil(float64(2*n) / 3))
+}
+
 func (valSet *weightedCouncil) Policy() istanbul.ProposerPolicy { return valSet.policy }
 
 // Refresh recalculates up-to-date proposers only when blockNum is the proposer update interval.

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -138,7 +138,6 @@ func RecoverWeightedCouncilProposer(valSet istanbul.ValidatorSet, proposerAddrs 
 }
 
 func NewWeightedCouncil(addrs []common.Address, demotedAddrs []common.Address, rewards []common.Address, votingPowers []uint64, weights []uint64, policy istanbul.ProposerPolicy, committeeSize uint64, blockNum uint64, proposersBlockNum uint64, chain consensus.ChainReader) *weightedCouncil {
-
 	if policy != istanbul.WeightedRandom {
 		logger.Error("unsupported proposer policy for weighted council", "policy", policy)
 		return nil
@@ -228,7 +227,6 @@ func NewWeightedCouncil(addrs []common.Address, demotedAddrs []common.Address, r
 }
 
 func GetWeightedCouncilData(valSet istanbul.ValidatorSet) (validators []common.Address, demotedValidators []common.Address, rewardAddrs []common.Address, votingPowers []uint64, weights []uint64, proposers []common.Address, proposersBlockNum uint64) {
-
 	weightedCouncil, ok := valSet.(*weightedCouncil)
 	if !ok {
 		logger.Error("not weightedCouncil type.")
@@ -464,7 +462,7 @@ func (valSet *weightedCouncil) GetDemotedByAddress(addr common.Address) (int, is
 
 func (valSet *weightedCouncil) GetProposer() istanbul.Validator {
 	// TODO-Klaytn-Istanbul: nil check for valSet.proposer is needed
-	//logger.Trace("GetProposer()", "proposer", valSet.proposer)
+	// logger.Trace("GetProposer()", "proposer", valSet.proposer)
 	return valSet.proposer.Load().(istanbul.Validator)
 }
 
@@ -581,7 +579,7 @@ func (valSet *weightedCouncil) Copy() istanbul.ValidatorSet {
 	valSet.validatorMu.RLock()
 	defer valSet.validatorMu.RUnlock()
 
-	var newWeightedCouncil = weightedCouncil{
+	newWeightedCouncil := weightedCouncil{
 		subSize:           valSet.subSize,
 		policy:            valSet.policy,
 		proposer:          valSet.proposer,
@@ -603,11 +601,7 @@ func (valSet *weightedCouncil) Copy() istanbul.ValidatorSet {
 }
 
 func (valSet *weightedCouncil) F() int {
-	if valSet.Size() > valSet.subSize {
-		return int(math.Ceil(float64(valSet.subSize)/3)) - 1
-	} else {
-		return int(math.Ceil(float64(valSet.Size())/3)) - 1
-	}
+	return int(math.Ceil(float64(valSet.Size())/3)) - 1 // It's the same as int(math.Floor(float64((valSet.Size()-1)/3)))
 }
 
 func (valSet *weightedCouncil) Policy() istanbul.ProposerPolicy { return valSet.policy }


### PR DESCRIPTION
## Proposed changes

The detailed explanation of changing consensus quorum size is written in issues https://github.com/klaytn/klaytn/issues/1403

### Before
```
N = the number of total nodes participating in the consensus
F = Ceiling(N/3) - 1
Quorum = 2F + 1
```
### Proposed
```
N = the number of total nodes participating in the consensus
F = Ceiling(N/3) - 1   //It's the same as Floor((N-1)/3) 
Quorum = Ceiling((N*2/3))
```

There is another change about test of consensus. 
Some tests assume the number of committee(subGroupSize) is less than the total validator's number.
But it could be the same. And the committee size could be changed to be the same as the number of validators.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

Closes #1403 

## Further comments

Before the code is applied to the cypress, committee size should be equal to the total number of validators.
