### PR TITLE
Fix KafkaSuite.TearDownTest to not crash

### DIFF
--- a/datasync/chaindatafetcher/kafka/kafka_test.go
+++ b/datasync/chaindatafetcher/kafka/kafka_test.go
@@ -65,7 +65,9 @@ func (s *KafkaSuite) SetupTest() {
 }
 
 func (s *KafkaSuite) TearDownTest() {
-	s.kfk.Close()
+	if s.kfk != nil {
+		s.kfk.Close()
+	}
 }
 
 func (s *KafkaSuite) TestKafka_split() {


### PR DESCRIPTION
## Proposed changes

- Fixes the bug that fails `make test`.
- `KafkaSuite.TearDownTest()` crashes in local environment (no kafka connection) because `s.kfk` is nil

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
