### PR TITLE
Deep copy ChainConfig in tests

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -93,11 +93,9 @@ func NewSimulatedBackendWithDatabase(database database.DBManager, alloc blockcha
 // NewSimulatedBackendWithGasPrice creates a new binding backend using a simulated blockchain with a given unitPrice.
 // for testing purposes.
 func NewSimulatedBackendWithGasPrice(alloc blockchain.GenesisAlloc, unitPrice uint64) *SimulatedBackend {
-	// Without changing `params.AllGxhashProtocolChanges`,
-	// the copied config is used for no side effect of other tests
-	cfg := *params.AllGxhashProtocolChanges
+	cfg := params.AllGxhashProtocolChanges.Copy()
 	cfg.UnitPrice = unitPrice
-	return NewSimulatedBackendWithDatabase(database.NewMemoryDBManager(), alloc, &cfg)
+	return NewSimulatedBackendWithDatabase(database.NewMemoryDBManager(), alloc, cfg)
 }
 
 // NewSimulatedBackend creates a new binding backend using a simulated blockchain

--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -348,18 +348,16 @@ func TestSetupGenesis(t *testing.T) {
 }
 
 func genCypressGenesisBlock() *Genesis {
-	copyOfCypressChainConfig := *params.CypressChainConfig
 	genesis := DefaultGenesisBlock()
-	genesis.Config = &copyOfCypressChainConfig
+	genesis.Config = params.CypressChainConfig.Copy()
 	genesis.Governance = SetGenesisGovernance(genesis)
 	InitDeriveSha(genesis.Config.DeriveShaImpl)
 	return genesis
 }
 
 func genBaobabGenesisBlock() *Genesis {
-	copyOfBaobabChainConfig := *params.BaobabChainConfig
 	genesis := DefaultBaobabGenesisBlock()
-	genesis.Config = &copyOfBaobabChainConfig
+	genesis.Config = params.BaobabChainConfig.Copy()
 	genesis.Governance = SetGenesisGovernance(genesis)
 	InitDeriveSha(genesis.Config.DeriveShaImpl)
 	return genesis

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -58,8 +58,7 @@ func init() {
 	testTxPoolConfig = DefaultTxPoolConfig
 	testTxPoolConfig.Journal = ""
 
-	cpy := *params.TestChainConfig
-	eip1559Config = &cpy
+	eip1559Config = params.TestChainConfig.Copy()
 	eip1559Config.IstanbulCompatibleBlock = common.Big0
 	eip1559Config.LondonCompatibleBlock = common.Big0
 	eip1559Config.EthTxTypeCompatibleBlock = common.Big0

--- a/consensus/clique/snapshot_test.go
+++ b/consensus/clique/snapshot_test.go
@@ -407,7 +407,7 @@ func TestClique(t *testing.T) {
 		genesis.Commit(common.Hash{}, db)
 
 		// Assemble a chain of headers from the cast votes
-		config := *params.TestChainConfig
+		config := params.TestChainConfig.Copy()
 		config.Clique = &params.CliqueConfig{
 			Period: 1,
 			Epoch:  tt.epoch,
@@ -415,7 +415,7 @@ func TestClique(t *testing.T) {
 		engine := New(config.Clique, db)
 		engine.fakeBlockScore = true
 
-		blocks, _ := blockchain.GenerateChain(&config, genesis.ToBlock(common.Hash{}, db), engine, db, len(tt.votes), func(j int, gen *blockchain.BlockGen) {
+		blocks, _ := blockchain.GenerateChain(config, genesis.ToBlock(common.Hash{}, db), engine, db, len(tt.votes), func(j int, gen *blockchain.BlockGen) {
 			vote := new(governance.GovernanceVote)
 			if tt.votes[j].auth {
 				vote.Key = "addvalidator"
@@ -455,7 +455,7 @@ func TestClique(t *testing.T) {
 			batches[len(batches)-1] = append(batches[len(batches)-1], block)
 		}
 		// Pass all the headers through clique and ensure tallying succeeds
-		chain, err := blockchain.NewBlockChain(db, nil, &config, engine, vm.Config{})
+		chain, err := blockchain.NewBlockChain(db, nil, config, engine, vm.Config{})
 		if err != nil {
 			t.Errorf("test %d: failed to create test chain: %v", i, err)
 			continue

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -668,7 +668,7 @@ func getTestVotingPowers(num int) []uint64 {
 }
 
 func getTestConfig() *params.ChainConfig {
-	config := params.TestChainConfig
+	config := params.TestChainConfig.Copy()
 	config.Governance = params.GetDefaultGovernanceConfig()
 	config.Istanbul = params.GetDefaultIstanbulConfig()
 	return config

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -107,8 +107,7 @@ func excludeNodeByAddr(target common.Address) {
 func newBlockChain(n int, items ...interface{}) (*blockchain.BlockChain, *backend) {
 	// generate a genesis block
 	genesis := blockchain.DefaultGenesisBlock()
-	config := *params.TestChainConfig // copy test chain config which may be modified
-	genesis.Config = &config
+	genesis.Config = params.TestChainConfig.Copy()
 	genesis.Timestamp = uint64(time.Now().Unix())
 
 	var (

--- a/node/sc/mainbridge_test.go
+++ b/node/sc/mainbridge_test.go
@@ -83,6 +83,7 @@ func testBlockChain(t *testing.T) *blockchain.BlockChain {
 	var genesis *blockchain.Genesis
 	genesis = blockchain.DefaultGenesisBlock()
 	genesis.BlockScore = big.NewInt(1)
+	genesis.Config = params.CypressChainConfig.Copy()
 	genesis.Config.Governance = params.GetDefaultGovernanceConfig()
 	genesis.Config.Istanbul = params.GetDefaultIstanbulConfig()
 	genesis.Config.UnitPrice = 25 * params.Ston

--- a/params/config.go
+++ b/params/config.go
@@ -21,6 +21,7 @@
 package params
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -268,6 +269,13 @@ func (c *ChainConfig) String() string {
 			engine,
 		)
 	}
+}
+
+func (c *ChainConfig) Copy() *ChainConfig {
+	r := &ChainConfig{}
+	j, _ := json.Marshal(c)
+	json.Unmarshal(j, r)
+	return r
 }
 
 // IsIstanbulForkEnabled returns whether num is either equal to the istanbul block or greater.

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -26,3 +26,24 @@ func TestChainConfig_CheckConfigForkOrder(t *testing.T) {
 	assert.Nil(t, BaobabChainConfig.CheckConfigForkOrder())
 	assert.Nil(t, CypressChainConfig.CheckConfigForkOrder())
 }
+
+func TestChainConfig_Copy(t *testing.T) {
+	a := CypressChainConfig
+	b := a.Copy()
+
+	b.UnitPrice = 0x1111
+	assert.NotEqual(t, a.UnitPrice, b.UnitPrice)
+
+	b.Istanbul.Epoch = 0x2222
+	assert.NotEqual(t, a.Istanbul.Epoch, b.Istanbul.Epoch)
+
+	b.Governance.Reward = &RewardConfig{Ratio: "11/22/33"}
+	assert.NotEqual(t, a.Governance.Reward.Ratio, b.Governance.Reward.Ratio)
+}
+
+func BenchmarkChainConfig_Copy(b *testing.B) {
+	a := CypressChainConfig
+	for i := 0; i < b.N; i++ {
+		a.Copy()
+	}
+}

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -17,6 +17,7 @@
 package params
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,15 +29,43 @@ func TestChainConfig_CheckConfigForkOrder(t *testing.T) {
 }
 
 func TestChainConfig_Copy(t *testing.T) {
+	// Temporarily modify CypressChainConfig to simulate copying `nil` field.
+	savedBlock := CypressChainConfig.LondonCompatibleBlock
+	CypressChainConfig.LondonCompatibleBlock = nil
+	defer func() { CypressChainConfig.LondonCompatibleBlock = savedBlock }()
+
 	a := CypressChainConfig
 	b := a.Copy()
 
+	// simple field
+	assert.Equal(t, a.UnitPrice, b.UnitPrice)
 	b.UnitPrice = 0x1111
 	assert.NotEqual(t, a.UnitPrice, b.UnitPrice)
 
+	// nested field
+	assert.Equal(t, a.Istanbul.Epoch, b.Istanbul.Epoch)
 	b.Istanbul.Epoch = 0x2222
 	assert.NotEqual(t, a.Istanbul.Epoch, b.Istanbul.Epoch)
 
+	// non-nil pointer field with omitempty
+	assert.NotNil(t, a.IstanbulCompatibleBlock)
+	assert.Equal(t, a.IstanbulCompatibleBlock, b.IstanbulCompatibleBlock)
+	b.IstanbulCompatibleBlock = big.NewInt(111111)
+	assert.NotEqual(t, a.IstanbulCompatibleBlock, b.IstanbulCompatibleBlock)
+
+	// nil pointer field with omitempty
+	assert.Nil(t, a.LondonCompatibleBlock)
+	assert.Equal(t, a.LondonCompatibleBlock, b.LondonCompatibleBlock)
+	b.LondonCompatibleBlock = big.NewInt(222222)
+	assert.NotEqual(t, a.LondonCompatibleBlock, b.LondonCompatibleBlock)
+
+	// non-nil pointer field without omitempty
+	assert.Equal(t, a.Governance.Reward.MintingAmount, b.Governance.Reward.MintingAmount)
+	b.Governance.Reward.MintingAmount = big.NewInt(3333333)
+	assert.NotEqual(t, a.Governance.Reward.MintingAmount, b.Governance.Reward.MintingAmount)
+
+	// nested field of *struct type
+	assert.Equal(t, a.Governance.Reward.Ratio, b.Governance.Reward.Ratio)
 	b.Governance.Reward = &RewardConfig{Ratio: "11/22/33"}
 	assert.NotEqual(t, a.Governance.Reward.Ratio, b.Governance.Reward.Ratio)
 }

--- a/tests/klay_blockchain_test.go
+++ b/tests/klay_blockchain_test.go
@@ -165,6 +165,7 @@ func newKlaytnNode(t *testing.T, dir string, validator *TestAccountType) (*node.
 	genesis := blockchain.DefaultGenesisBlock()
 	genesis.ExtraData = genesis.ExtraData[:types.IstanbulExtraVanity]
 	genesis.ExtraData = append(genesis.ExtraData, istanbulConfData...)
+	genesis.Config = params.CypressChainConfig.Copy()
 	genesis.Config.Istanbul.SubGroupSize = 1
 	genesis.Config.Istanbul.ProposerPolicy = uint64(istanbul.RoundRobin)
 	genesis.Config.Governance.Reward.MintingAmount = new(big.Int).Mul(big.NewInt(9000000000000000000), big.NewInt(params.KLAY))


### PR DESCRIPTION
## Proposed changes

- Add `ChainConfig.Copy()` method.
- In tests, copy the global ChainConfig before modifying its fields. (e.g. params.CypressChainConfig)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments


- Wait, didn't you remove `Copy()` in a previous PR?
  - Yes in [PR #1401](https://github.com/klaytn/klaytn/pull/1401) I removed `GovernanceConfig.Copy()` and `IstanbulConfig.Copy()`.
  - In this PR I am adding `ChainConfig.Copy()`.

- Why `ChainConfig.Copy()` is necessary?
  - Some tests have been modifying the globals, affecting other test cases ([code](https://github.com/klaytn/klaytn/blob/v1.8.4/tests/klay_blockchain_test.go#L166)).
  - Some tests tried to fix the problem, but only shallow copy. ([code](https://github.com/klaytn/klaytn/blob/v1.8.4/blockchain/tx_pool_test.go#L61))
    ```go
    cpy := *param.ChainConfig
    ```

- Why use `json`?
  - Less error-prone. You don't have to manually write Copy() function.
  - Efficient. I tried a deepcopy library [jinzhu/copier](https://github.com/jinzhu/copier) and was slower than json.
    - Using json
      ```go
      r := &ChainConfig{}
      j, _ := json.Marshal(c)
      json.Unmarshal(j, r)
      // BenchmarkChainConfig_Copy-10              184416              6518 ns/op
      ```
    - Using jinzhu/copier
      ```go
      r := &ChainConfig{}
      copier.CopyWithOption(r, c, copier.Option{DeepCopy: true})
      // BenchmarkChainConfig_Copy-10               59310             19769 ns/op
      ```