### PR TITLE
[API] Added new subbridge API for listing bridge and contract addresses together.

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -1472,6 +1472,10 @@ web3._extend({
 			getter: 'subbridge_listBridge'
 		}),
 		new web3._extend.Property({
+			name: 'listBridgeWithToken',
+			getter: 'subbridge_listBridgeWithToken'
+		}),
+		new web3._extend.Property({
 			name: 'txPendingCount',
 			getter: 'subbridge_txPendingCount'
 		}),

--- a/node/sc/api_bridge.go
+++ b/node/sc/api_bridge.go
@@ -213,8 +213,8 @@ func (sb *SubBridgeAPI) ListBridge() []*BridgeJournal {
 
 func (sb *SubBridgeAPI) ListBridgeWithToken() ([]map[string]interface{}, error) {
 	// TODO: Add mutex guard for `counterpartToken`
-	var bridgeWithTokens []map[string]interface{}
 	bridgeJournals := sb.subBridge.bridgeManager.GetAllBridge()
+	bridgeWithTokens := make([]map[string]interface{}, 0, len(bridgeJournals))
 	for _, bridgeJournal := range bridgeJournals {
 		cbi, ok := sb.subBridge.bridgeManager.GetBridgeInfo(bridgeJournal.ChildAddress)
 		if !ok {


### PR DESCRIPTION
## Proposed changes

The current `subbridge_listBridge` API lists only bridge address pairs as well as the status of the bridge subscription. The newly added API lists bridge addresses and registered contract addresses together.
 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
