### PR TITLE
Restrict staking information downloader to fetch data only on weighted random policy

### DIFF
--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -205,7 +205,7 @@ type BlockChain interface {
 }
 
 // New creates a new downloader to fetch hashes and blocks from remote peers.
-func New(mode SyncMode, stateDB database.DBManager, stateBloom *statedb.SyncBloom, mux *event.TypeMux, chain BlockChain, lightchain LightChain, dropPeer peerDropFn) *Downloader {
+func New(mode SyncMode, stateDB database.DBManager, stateBloom *statedb.SyncBloom, mux *event.TypeMux, chain BlockChain, lightchain LightChain, dropPeer peerDropFn, proposerPolicy uint64) *Downloader {
 	if lightchain == nil {
 		lightchain = chain
 	}
@@ -215,7 +215,7 @@ func New(mode SyncMode, stateDB database.DBManager, stateBloom *statedb.SyncBloo
 		stateDB:           stateDB,
 		stateBloom:        stateBloom,
 		mux:               mux,
-		queue:             newQueue(blockCacheMaxItems, blockCacheInitialItems),
+		queue:             newQueue(blockCacheMaxItems, blockCacheInitialItems, proposerPolicy),
 		peers:             newPeerSet(),
 		rttEstimate:       uint64(rttMaxEstimate),
 		rttConfidence:     uint64(1000000),

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -30,6 +30,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klaytn/klaytn/consensus/istanbul"
+
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -145,7 +147,7 @@ func newTester() *downloadTester {
 	tester.stateDb = database.NewMemoryDBManager()
 	tester.stateDb.GetMemDB().Put(genesis.Root().Bytes(), []byte{0x00})
 
-	tester.downloader = New(FullSync, tester.stateDb, statedb.NewSyncBloom(1, tester.stateDb.GetMemDB()), new(event.TypeMux), tester, nil, tester.dropPeer)
+	tester.downloader = New(FullSync, tester.stateDb, statedb.NewSyncBloom(1, tester.stateDb.GetMemDB()), new(event.TypeMux), tester, nil, tester.dropPeer, uint64(istanbul.WeightedRandom))
 
 	return tester
 }

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -30,12 +30,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/klaytn/klaytn/consensus/istanbul"
-
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/gxhash"
+	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/event"
 	"github.com/klaytn/klaytn/params"

--- a/datasync/downloader/queue.go
+++ b/datasync/downloader/queue.go
@@ -27,11 +27,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/klaytn/klaytn/consensus/istanbul"
-
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/prque"
+	"github.com/klaytn/klaytn/consensus/istanbul"
 	klaytnmetrics "github.com/klaytn/klaytn/metrics"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/reward"

--- a/datasync/downloader/queue_test.go
+++ b/datasync/downloader/queue_test.go
@@ -28,16 +28,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/klaytn/klaytn/reward"
-
-	"github.com/klaytn/klaytn/consensus/istanbul"
-
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/gxhash"
+	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/storage/database"
 )
 

--- a/datasync/downloader/resultstore.go
+++ b/datasync/downloader/resultstore.go
@@ -79,7 +79,7 @@ func (r *resultStore) SetThrottleThreshold(threshold uint64) uint64 {
 //   throttled - if true, the store is at capacity, this particular header is not prior now
 //   item      - the result to store data into
 //   err       - any error that occurred
-func (r *resultStore) AddFetch(header *types.Header, fastSync bool) (stale, throttled bool, item *fetchResult, err error) {
+func (r *resultStore) AddFetch(header *types.Header, fastSync bool, proposerPolicy uint64) (stale, throttled bool, item *fetchResult, err error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -89,7 +89,7 @@ func (r *resultStore) AddFetch(header *types.Header, fastSync bool) (stale, thro
 		return stale, throttled, item, err
 	}
 	if item == nil {
-		item = newFetchResult(header, fastSync)
+		item = newFetchResult(header, fastSync, proposerPolicy)
 		r.items[index] = item
 	}
 	return stale, throttled, item, err

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -33,6 +33,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/klaytn/klaytn/consensus/istanbul"
+
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -76,7 +78,11 @@ const (
 // errIncompatibleConfig is returned if the requested protocols and configs are
 // not compatible (low protocol version restrictions and high requirements).
 var errIncompatibleConfig = errors.New("incompatible configuration")
-var errUnknownProcessingError = errors.New("unknown error during the msg processing")
+
+var (
+	errUnknownProcessingError  = errors.New("unknown error during the msg processing")
+	errUnsupportedEnginePolicy = errors.New("unsupported engine or policy")
+)
 
 func errResp(code errCode, format string, v ...interface{}) error {
 	return fmt.Errorf("%v - %v", code, fmt.Sprintf(format, v...))
@@ -254,7 +260,11 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		if atomic.LoadUint32(&manager.fastSync) == 1 {
 			stateBloom = statedb.NewSyncBloom(uint64(cacheLimit), chainDB.GetStateTrieDB())
 		}
-		manager.downloader = downloader.New(mode, chainDB, stateBloom, manager.eventMux, blockchain, nil, manager.removePeer)
+		var proposerPolicy uint64
+		if config.Istanbul != nil {
+			proposerPolicy = config.Istanbul.ProposerPolicy
+		}
+		manager.downloader = downloader.New(mode, chainDB, stateBloom, manager.eventMux, blockchain, nil, manager.removePeer, proposerPolicy)
 	}
 
 	// Create and set fetcher
@@ -920,6 +930,10 @@ func handleReceiptsMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 
 // handleStakingInfoRequestMsg handles staking information request message.
 func handleStakingInfoRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
+	if pm.chainconfig.Istanbul == nil || pm.chainconfig.Istanbul.ProposerPolicy != uint64(istanbul.WeightedRandom) {
+		return errResp(ErrUnsupportedEnginePolicy, "the engine is not istanbul or the policy is not weighted random")
+	}
+
 	// Decode the retrieval message
 	msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 	if _, err := msgStream.List(); err != nil {
@@ -959,6 +973,10 @@ func handleStakingInfoRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error
 
 // handleStakingInfoMsg handles staking information response message.
 func handleStakingInfoMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
+	if pm.chainconfig.Istanbul == nil || pm.chainconfig.Istanbul.ProposerPolicy != uint64(istanbul.WeightedRandom) {
+		return errResp(ErrUnsupportedEnginePolicy, "the engine is not istanbul or the policy is not weighted random")
+	}
+
 	// A batch of stakingInfos arrived to one of our previous requests
 	var stakingInfos []*reward.StakingInfo
 	if err := msg.Decode(&stakingInfos); err != nil {

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -33,13 +33,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/klaytn/klaytn/consensus/istanbul"
-
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus"
+	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/datasync/downloader"
 	"github.com/klaytn/klaytn/datasync/fetcher"

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -23,16 +23,14 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/klaytn/klaytn/reward"
-
-	"github.com/klaytn/klaytn/consensus/istanbul"
-	"github.com/klaytn/klaytn/params"
-
 	"github.com/golang/mock/gomock"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/networks/p2p"
 	mocks2 "github.com/klaytn/klaytn/node/cn/mocks"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/rlp"
 	"github.com/klaytn/klaytn/work/mocks"
 	"github.com/stretchr/testify/assert"

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/klaytn/klaytn/reward"
-
 	"github.com/golang/mock/gomock"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -40,6 +38,7 @@ import (
 	"github.com/klaytn/klaytn/networks/p2p/discover"
 	"github.com/klaytn/klaytn/node/cn/mocks"
 	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/reward"
 	workmocks "github.com/klaytn/klaytn/work/mocks"
 	"github.com/stretchr/testify/assert"
 )

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klaytn/klaytn/reward"
+
 	"github.com/golang/mock/gomock"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -142,6 +144,16 @@ func newReceipt(gasUsed int) *types.Receipt {
 	rct.Logs = []*types.Log{}
 	rct.Bloom = types.Bloom{}
 	return rct
+}
+
+func newStakingInfo(blockNumber uint64) *reward.StakingInfo {
+	return &reward.StakingInfo{
+		BlockNum:              blockNumber,
+		CouncilNodeAddrs:      []common.Address{{0x1}, {0x1}},
+		CouncilStakingAddrs:   []common.Address{{0x2}, {0x2}},
+		CouncilRewardAddrs:    []common.Address{{0x3}, {0x3}},
+		CouncilStakingAmounts: []uint64{2, 5, 6},
+	}
 }
 
 func TestNewProtocolManager(t *testing.T) {

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -103,6 +103,7 @@ const (
 	ErrSuspendedPeer
 	ErrUnexpectedTxType
 	ErrFailedToGetStateDB
+	ErrUnsupportedEnginePolicy
 )
 
 func (e errCode) String() string {
@@ -123,6 +124,7 @@ var errorToString = map[int]string{
 	ErrSuspendedPeer:           "Suspended peer",
 	ErrUnexpectedTxType:        "Unexpected tx type",
 	ErrFailedToGetStateDB:      "Failed to get stateDB",
+	ErrUnsupportedEnginePolicy: "Unsupported engine or policy",
 }
 
 //go:generate mockgen -destination=node/cn/mocks/downloader_mock.go -package=mocks github.com/klaytn/klaytn/node/cn ProtocolManagerDownloader


### PR DESCRIPTION
## Proposed changes

Downloader tries to fetch staking information regardless of engine or proposer policy. This PR restricts staking information task not to reserve to downloader queue. If a peer sends staking info message, it returns an error message to the requested peer.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

