### PR TITLE
stabilize memory use, fix memory leak

### DIFF
--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -1029,7 +1029,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) 
 	if EnabledExpensive {
 		defer func(start time.Time) { s.AccountCommits += time.Since(start) }(time.Now())
 	}
-	root, err = s.trie.Commit(func(leaf []byte, parent common.Hash, parentDepth int) error {
+	root, err = s.trie.Commit(func(path []byte, leaf []byte, parent common.Hash, parentDepth int) error {
 		serializer := account.NewAccountSerializer()
 		if err := rlp.DecodeBytes(leaf, serializer); err != nil {
 			logger.Warn("RLP decode failed", "err", err, "leaf", string(leaf))

--- a/blockchain/state/sync.go
+++ b/blockchain/state/sync.go
@@ -34,15 +34,15 @@ import (
 // LRU cache is mendatory when state syncing and block processing are executed simultaneously
 func NewStateSync(root common.Hash, database statedb.StateTrieReadDB, bloom *statedb.SyncBloom, lruCache *lru.Cache) *statedb.TrieSync {
 	var syncer *statedb.TrieSync
-	callback := func(leaf []byte, parent common.Hash, parentDepth int) error {
+	callback := func(path []byte, leaf []byte, parent common.Hash, parentDepth int) error {
 		serializer := account.NewAccountSerializer()
 		if err := rlp.Decode(bytes.NewReader(leaf), serializer); err != nil {
 			return err
 		}
 		obj := serializer.GetAccount()
 		if pa := account.GetProgramAccount(obj); pa != nil {
-			syncer.AddSubTrie(pa.GetStorageRoot(), parentDepth+1, parent, nil)
-			syncer.AddCodeEntry(common.BytesToHash(pa.GetCodeHash()), parentDepth+1, parent)
+			syncer.AddSubTrie(pa.GetStorageRoot(), path, parentDepth+1, parent, nil)
+			syncer.AddCodeEntry(common.BytesToHash(pa.GetCodeHash()), path, parentDepth+1, parent)
 		}
 		return nil
 	}

--- a/storage/statedb/hasher.go
+++ b/storage/statedb/hasher.go
@@ -278,12 +278,12 @@ func (h *hasher) store(n node, db *Database, force bool) (node, uint16) {
 			switch n := n.(type) {
 			case *shortNode:
 				if child, ok := n.Val.(valueNode); ok {
-					h.onleaf(child, hash, 0)
+					h.onleaf(nil, child, hash, 0)
 				}
 			case *fullNode:
 				for i := 0; i < 16; i++ {
 					if child, ok := n.Children[i].(valueNode); ok {
-						h.onleaf(child, hash, 0)
+						h.onleaf(nil, child, hash, 0)
 					}
 				}
 			}

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -39,8 +39,14 @@ var ErrNotRequested = errors.New("not requested")
 // node it already processed previously.
 var ErrAlreadyProcessed = errors.New("already processed")
 
+// maxFetchesPerDepth is the maximum number of pending trie nodes per depth. The
+// role of this value is to limit the number of trie nodes that get expanded in
+// memory if the node was configured with a significant number of peers.
+const maxFetchesPerDepth = 16384
+
 // request represents a scheduled or already in-flight state retrieval request.
 type request struct {
+	path []byte      // Merkle path leading to this node for prioritization
 	hash common.Hash // Hash of the node data content to retrieve
 	data []byte      // Data content of the node, cached until all subtrees complete
 	code bool        // Whether this is a code entry
@@ -101,6 +107,7 @@ type TrieSync struct {
 	nodeReqs         map[common.Hash]*request // Pending requests pertaining to a trie node hash
 	codeReqs         map[common.Hash]*request // Pending requests pertaining to a code hash
 	queue            *prque.Prque             // Priority queue with the pending requests
+	fetches          map[int]int              // Number of active fetches per trie node depth
 	retrievedByDepth map[int]int              // Retrieved trie node number counted by depth
 	committedByDepth map[int]int              // Committed trie nodes number counted by depth
 	bloom            *SyncBloom               // Bloom filter for fast state existence checks
@@ -116,17 +123,18 @@ func NewTrieSync(root common.Hash, database StateTrieReadDB, callback LeafCallba
 		nodeReqs:         make(map[common.Hash]*request),
 		codeReqs:         make(map[common.Hash]*request),
 		queue:            prque.New(),
+		fetches:          make(map[int]int),
 		retrievedByDepth: make(map[int]int),
 		committedByDepth: make(map[int]int),
 		bloom:            bloom,
 		exist:            lruCache,
 	}
-	ts.AddSubTrie(root, 0, common.Hash{}, callback)
+	ts.AddSubTrie(root, nil, 0, common.Hash{}, callback)
 	return ts
 }
 
 // AddSubTrie registers a new trie to the sync code, rooted at the designated parent.
-func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, callback LeafCallback) {
+func (s *TrieSync) AddSubTrie(root common.Hash, path []byte, depth int, parent common.Hash, callback LeafCallback) {
 	// Short circuit if the trie is empty or already known
 	if root == emptyRoot {
 		return
@@ -152,6 +160,7 @@ func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, c
 	}
 	// Assemble the new sub-trie sync request
 	req := &request{
+		path:     path,
 		hash:     root,
 		depth:    depth,
 		callback: callback,
@@ -171,7 +180,7 @@ func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, c
 // AddCodeEntry schedules the direct retrieval of a contract code that should not
 // be interpreted as a trie node, but rather accepted and stored into the database
 // as is.
-func (s *TrieSync) AddCodeEntry(hash common.Hash, depth int, parent common.Hash) {
+func (s *TrieSync) AddCodeEntry(hash common.Hash, path []byte, depth int, parent common.Hash) {
 	// Short circuit if the entry is empty or already known
 	if hash == emptyState {
 		return
@@ -199,6 +208,7 @@ func (s *TrieSync) AddCodeEntry(hash common.Hash, depth int, parent common.Hash)
 	}
 	// Assemble the new sub-trie sync request
 	req := &request{
+		path:  path,
 		hash:  hash,
 		code:  true,
 		depth: depth,
@@ -219,7 +229,18 @@ func (s *TrieSync) AddCodeEntry(hash common.Hash, depth int, parent common.Hash)
 func (s *TrieSync) Missing(max int) []common.Hash {
 	requests := []common.Hash{}
 	for !s.queue.Empty() && (max == 0 || len(requests) < max) {
-		requests = append(requests, s.queue.PopItem().(common.Hash))
+		// Retrieve th enext item in line
+		item, prio := s.queue.Peek()
+
+		// If we have too many already-pending tasks for this depth, throttle
+		depth := int(prio >> 56)
+		if s.fetches[depth] > maxFetchesPerDepth {
+			break
+		}
+		// Item is allowed to be scheduled, add it to the task list
+		s.queue.Pop()
+		s.fetches[depth]++
+		requests = append(requests, item.(common.Hash))
 	}
 	return requests
 }
@@ -336,7 +357,11 @@ func (s *TrieSync) schedule(req *request) {
 	// is a trie node and code has same hash. In this case two elements
 	// with same hash and same or different depth will be pushed. But it's
 	// ok the worst case is the second response will be treated as duplicated.
-	s.queue.Push(req.hash, int64(req.depth))
+	prio := int64(len(req.path)) << 56 // depth >= 128 will never happen, storage leaves will be included in their parents
+	for i := 0; i < 14 && i < len(req.path); i++ {
+		prio |= int64(15-req.path[i]) << (52 - i*4) // 15-nibble => lexicographic order
+	}
+	s.queue.Push(req.hash, prio)
 }
 
 // children retrieves all the missing children of a state trie entry for future
@@ -344,6 +369,7 @@ func (s *TrieSync) schedule(req *request) {
 func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 	// Gather all the children of the node, irrelevant whether known or not
 	type child struct {
+		path  []byte
 		node  node
 		depth int
 	}
@@ -353,6 +379,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 	case *shortNode:
 		children = []child{{
 			node:  node.Val,
+			path:  append(append([]byte(nil), req.path...), node.Key...),
 			depth: req.depth + len(node.Key),
 		}}
 	case *fullNode:
@@ -360,6 +387,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 			if node.Children[i] != nil {
 				children = append(children, child{
 					node:  node.Children[i],
+					path:  append(append([]byte(nil), req.path...), byte(i)),
 					depth: req.depth + 1,
 				})
 			}
@@ -373,7 +401,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 		// Notify any external watcher of a new key/value node
 		if req.callback != nil {
 			if node, ok := (child.node).(valueNode); ok {
-				if err := req.callback(node, req.hash, child.depth); err != nil {
+				if err := req.callback(req.path, node, req.hash, child.depth); err != nil {
 					return nil, err
 				}
 			}
@@ -403,6 +431,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 
 			// Locally unknown node, schedule for retrieval
 			requests = append(requests, &request{
+				path:     child.path,
 				hash:     hash,
 				parents:  []*request{req},
 				depth:    child.depth,
@@ -424,9 +453,11 @@ func (s *TrieSync) commit(req *request) (err error) {
 	if req.code {
 		s.membatch.codes[req.hash] = req.data
 		delete(s.codeReqs, req.hash)
+		s.fetches[len(req.path)]--
 	} else {
 		s.membatch.nodes[req.hash] = req.data
 		delete(s.nodeReqs, req.hash)
+		s.fetches[len(req.path)]--
 	}
 	// Check all parents for completion
 	for _, parent := range req.parents {

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -39,7 +39,7 @@ var (
 // LeafCallback is a callback type invoked when a trie operation reaches a leaf
 // node. It's used by state sync and commit to allow handling external references
 // between account and database tries.
-type LeafCallback func(leaf []byte, parent common.Hash, parentDepth int) error
+type LeafCallback func(path []byte, leaf []byte, parent common.Hash, parentDepth int) error
 
 // Trie is a Merkle Patricia Trie.
 // The zero value is an empty trie with no database.


### PR DESCRIPTION
## Proposed changes

- This PR is derived from https://github.com/ethereum/go-ethereum/pull/21491
- In summary
  - Restricts trie node expansion max depth
  - Makes state sync deterministic in terms of node expansion (sorted by node path)
  - Fixed memory leak by using 1 lazy defer `Sync.cancel`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

