### PR TITLE
update console for external services

### DIFF
--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -269,6 +269,7 @@ var FlagGroups = []FlagGroup{
 			JSpathFlag,
 			ExecFlag,
 			PreloadJSFlag,
+			HeaderFlag,
 			MaxRequestContentLengthFlag,
 			APIFilterGetLogsDeadlineFlag,
 			APIFilterGetLogsMaxItemsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -674,6 +674,10 @@ var (
 		Usage:  "Comma separated list of JavaScript files to preload into the console",
 		EnvVar: "KLAYTN_PRELOAD",
 	}
+	HeaderFlag = cli.StringSliceFlag{
+		Name:  "header",
+		Usage: "Set an HTTP header. <header:value>",
+	}
 	APIFilterGetLogsDeadlineFlag = cli.DurationFlag{
 		Name:   "api.filter.getLogs.deadline",
 		Usage:  "Execution deadline for log collecting filter APIs",


### PR DESCRIPTION
## Proposed changes

- use all api modules if "rpc_module" not found in the console
- add header flags for console

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

Although console is the useful interactive cli tools, we could not request to external api services such as KAS.
Now we can use console cli for external apis like below

```
$ ./ken attach https://node-api.klaytnapi.com/v1/klaytn --header 'x-chain-id:8217' --header 'Authorization:Basic S0...'
Welcome to the Klaytn JavaScript console!

instance: Klaytn/v1.8.3/linux-amd64/go1.18
use all modules because "rpc_modules" does not supported

> klay.blockNumber
94325753

> admin.peers
Error: 400 Bad Request: {"code":1034210,"message":"Unsupported method - admin_peers","requestId":"ac28ef9a-9dd7-9793-83c1-49ec16b6d214"}
    at web3.js:3278:20
....
```