### PR TITLE
consensus: the certain case with six validators or less

### DIFF
--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -113,7 +113,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 			c.setState(StatePrepared)
 			c.sendCommit()
 		} else if uint64(c.current.GetPrepareOrCommitSize()) == c.valSet.Size() && c.valSet.Size() <= ExceptionalValidatorsNumber {
-			logger.Info("received all of agreements and change state to prepared", "msgType", msgCommit)
+			logger.Info("received all of agreements and change state to prepared", "msgType", msgCommit, "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -107,13 +107,8 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 			logger.Warn("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() && c.valSet.Size() > ExceptionalValidatorsNumber {
-			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgCommit)
-			c.current.LockHash()
-			c.setState(StatePrepared)
-			c.sendCommit()
-		} else if uint64(c.current.GetPrepareOrCommitSize()) == c.valSet.Size() && c.valSet.Size() <= ExceptionalValidatorsNumber {
-			logger.Info("received all of agreements and change state to prepared", "msgType", msgCommit, "valSet", c.valSet.Size())
+		} else if c.current.GetPrepareOrCommitSize() >= requiredMessageCount(c.valSet) {
+			logger.Info("received enough agreements and change state to prepared", "msgType", msgCommit, "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()
@@ -125,11 +120,8 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 	// If we already have a proposal, we may have chance to speed up the consensus process
 	// by committing the proposal without PREPARE messages.
 	//logger.Error("### consensus check","len(commits)",c.current.Commits.Size(),"f(2/3)",2*c.valSet.F(),"state",c.state.Cmp(StateCommitted))
-	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() > 2*c.valSet.F() && c.valSet.Size() > ExceptionalValidatorsNumber {
+	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() >= requiredMessageCount(c.valSet) {
 		// Still need to call LockHash here since state can skip Prepared state and jump directly to the Committed state.
-		c.current.LockHash()
-		c.commit()
-	} else if uint64(c.current.Commits.Size()) == c.valSet.Size() && c.valSet.Size() <= ExceptionalValidatorsNumber {
 		c.current.LockHash()
 		c.commit()
 	}

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -107,8 +107,13 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 			logger.Warn("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() {
+		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() && c.valSet.Size() > ExceptionalValidatorsNumber {
 			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgCommit)
+			c.current.LockHash()
+			c.setState(StatePrepared)
+			c.sendCommit()
+		} else if uint64(c.current.GetPrepareOrCommitSize()) == c.valSet.Size() && c.valSet.Size() <= ExceptionalValidatorsNumber {
+			logger.Info("received all of agreements and change state to prepared", "msgType", msgCommit)
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()
@@ -120,8 +125,11 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 	// If we already have a proposal, we may have chance to speed up the consensus process
 	// by committing the proposal without PREPARE messages.
 	//logger.Error("### consensus check","len(commits)",c.current.Commits.Size(),"f(2/3)",2*c.valSet.F(),"state",c.state.Cmp(StateCommitted))
-	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() > 2*c.valSet.F() {
+	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() > 2*c.valSet.F() && c.valSet.Size() > ExceptionalValidatorsNumber {
 		// Still need to call LockHash here since state can skip Prepared state and jump directly to the Committed state.
+		c.current.LockHash()
+		c.commit()
+	} else if uint64(c.current.Commits.Size()) == c.valSet.Size() && c.valSet.Size() <= ExceptionalValidatorsNumber {
 		c.current.LockHash()
 		c.commit()
 	}

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -108,7 +108,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 			c.setState(StatePrepared)
 			c.sendCommit()
 		} else if c.current.GetPrepareOrCommitSize() >= requiredMessageCount(c.valSet) {
-			logger.Info("received enough agreements and change state to prepared", "msgType", msgCommit, "valSet", c.valSet.Size())
+			logger.Info("received a quorum of the messages and change state to prepared", "msgType", msgCommit, "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	// The number in exceptional case
-	// If the number of validators is lower than 6, the chain could be forked by round change
+	// If the number of validators is 6 or less, the chain could be forked by round change
 	ExceptionalValidatorsNumber = 6
 )
 

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -431,7 +431,7 @@ func requiredMessageCount(valSet istanbul.ValidatorSet) int {
 	case 1, 2, 3:
 		return int(size)
 	case 6:
-		return 2*valSet.F() + 2 // when the number of valSet is 6 and return value is 2*F+1, the return value is not safe. It should return 4 or more.
+		return 5 // when the number of valSet is 6 and return value is 2*F+1, the return value is not safe. It should return 4 or more.
 	default:
 		return 2*valSet.F() + 1
 	}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -38,9 +38,9 @@ import (
 )
 
 const (
-	// The number in exceptional case
-	// If the number of validators is 6 or less, the chain could be forked by round change
-	ExceptionalValidatorsNumber = 6
+	// If the number of validators is 6 or less, the chain could be forked by round change if the required minimum consensus message is "2f+1". 
+	// So, the exceptional case such as number of validator is 6, gather more messages than "2f+1". See requiredMessageCount for more specific information.
+	exceptionalValidatorsNumber = 6
 )
 
 var logger = log.NewModuleLogger(log.ConsensusIstanbulCore)

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -37,12 +37,6 @@ import (
 	"github.com/rcrowley/go-metrics"
 )
 
-const (
-	// If the number of validators is 6 or less, the chain could be forked by round change if the required minimum consensus message is "2f+1". 
-	// So, the exceptional case such as number of validator is 6, gather more messages than "2f+1". See requiredMessageCount for more specific information.
-	exceptionalValidatorsNumber = 6
-)
-
 var logger = log.NewModuleLogger(log.ConsensusIstanbulCore)
 
 // New creates an Istanbul consensus core

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -434,8 +434,10 @@ func requiredMessageCount(valSet istanbul.ValidatorSet) int {
 	size := valSet.Size()
 	switch size {
 	// in the certain cases we must receive the messages from all consensus nodes to ensure finality...
-	case 1, 2, 3, 6:
+	case 1, 2, 3:
 		return int(size)
+	case 6:
+		return 2*valSet.F() + 2 // when the number of valSet is 6 and return value is 2*F+1, the return value is not safe. It should return 4 or more.
 	default:
 		return 2*valSet.F() + 1
 	}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -428,3 +428,15 @@ func PrepareCommittedSeal(hash common.Hash) []byte {
 	buf.Write([]byte{byte(msgCommit)})
 	return buf.Bytes()
 }
+
+// Minimum required number of consensus messages to proceed
+func requiredMessageCount(valSet istanbul.ValidatorSet) int {
+	size := valSet.Size()
+	switch size {
+	// in the certain cases we must receive the messages from all consensus nodes to ensure finality...
+	case 1, 2, 3, 6:
+		return int(size)
+	default:
+		return 2*valSet.F() + 1
+	}
+}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -37,6 +37,12 @@ import (
 	"github.com/rcrowley/go-metrics"
 )
 
+const (
+	// The number in exceptional case
+	// If the number of validators is lower than 6, the chain could be forked by round change
+	ExceptionalValidatorsNumber = 6
+)
+
 var logger = log.NewModuleLogger(log.ConsensusIstanbulCore)
 
 // New creates an Istanbul consensus core

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -431,7 +431,7 @@ func requiredMessageCount(valSet istanbul.ValidatorSet) int {
 	case 1, 2, 3:
 		return int(size)
 	case 6:
-		return 5 // when the number of valSet is 6 and return value is 2*F+1, the return value is not safe. It should return 4 or more.
+		return 4 // when the number of valSet is 6 and return value is 2*F+1, the return value(int 3) is not safe. It should return 4 or more.
 	default:
 		return 2*valSet.F() + 1
 	}

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -87,13 +87,8 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			logger.Warn("received prepare of the hash locked proposal and change state to prepared", "msgType", msgPrepare)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() && c.valSet.Size() > ExceptionalValidatorsNumber {
-			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size())
-			c.current.LockHash()
-			c.setState(StatePrepared)
-			c.sendCommit()
-		} else if uint64(c.current.GetPrepareOrCommitSize()) == c.valSet.Size() && c.valSet.Size() <= ExceptionalValidatorsNumber {
-			logger.Info("received all of agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size(), "valSet", c.valSet.Size())
+		} else if c.current.GetPrepareOrCommitSize() >= requiredMessageCount(c.valSet) {
+			logger.Info("received enough agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size(), "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -87,8 +87,13 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			logger.Warn("received prepare of the hash locked proposal and change state to prepared", "msgType", msgPrepare)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() {
+		} else if c.current.GetPrepareOrCommitSize() > 2*c.valSet.F() && c.valSet.Size() > ExceptionalValidatorsNumber {
 			logger.Info("received more than 2f agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size())
+			c.current.LockHash()
+			c.setState(StatePrepared)
+			c.sendCommit()
+		} else if uint64(c.current.GetPrepareOrCommitSize()) == c.valSet.Size() && c.valSet.Size() <= ExceptionalValidatorsNumber {
+			logger.Info("received all of agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -93,7 +93,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			c.setState(StatePrepared)
 			c.sendCommit()
 		} else if uint64(c.current.GetPrepareOrCommitSize()) == c.valSet.Size() && c.valSet.Size() <= ExceptionalValidatorsNumber {
-			logger.Info("received all of agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size(), "valSetq", c.valSet.Size())
+			logger.Info("received all of agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size(), "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -88,7 +88,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			c.setState(StatePrepared)
 			c.sendCommit()
 		} else if c.current.GetPrepareOrCommitSize() >= requiredMessageCount(c.valSet) {
-			logger.Info("received enough agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size(), "valSet", c.valSet.Size())
+			logger.Info("received a quorum of the messages and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size(), "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -93,7 +93,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			c.setState(StatePrepared)
 			c.sendCommit()
 		} else if uint64(c.current.GetPrepareOrCommitSize()) == c.valSet.Size() && c.valSet.Size() <= ExceptionalValidatorsNumber {
-			logger.Info("received all of agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size())
+			logger.Info("received all of agreements and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size(), "valSetq", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
 			c.sendCommit()

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -114,7 +114,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 
 	var numCatchUp, numStartNewRound int
 	if c.valSet.Size() <= ExceptionalValidatorsNumber {
-		n := int(c.valSet.Size())
+		n := requiredMessageCount(c.valSet)
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n
 		// N - 1 ROUND CHANGE messages can catch up the round.

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -113,7 +113,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 	}
 
 	var numCatchUp, numStartNewRound int
-	if c.valSet.Size() < 4 {
+	if c.valSet.Size() <= ExceptionalValidatorsNumber {
 		n := int(c.valSet.Size())
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -28,6 +28,12 @@ import (
 	"github.com/klaytn/klaytn/consensus/istanbul"
 )
 
+const (
+	// If the number of validators is 6 or less, the chain could be forked by round change if the required minimum consensus message is "2f+1".
+	// So, the exceptional case such as number of validator is 6, gather more messages than "2f+1". See requiredMessageCount for more specific information.
+	exceptionalValidatorsNumber = 6
+)
+
 // sendNextRoundChange sends the ROUND CHANGE message with current round + 1
 func (c *core) sendNextRoundChange(loc string) {
 	if c.backend.NodeType() != common.CONSENSUSNODE {
@@ -113,7 +119,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 	}
 
 	var numCatchUp, numStartNewRound int
-	if c.valSet.Size() <= ExceptionalValidatorsNumber {
+	if c.valSet.Size() <= exceptionalValidatorsNumber {
 		n := requiredMessageCount(c.valSet)
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n


### PR DESCRIPTION
## Proposed changes

If the number of validators is 6 or less, the fork could be occurred by round change and byzantine case.
Becuase there are two quorum in the one block.
The quorum size is 2F+1 at the moment. 
If the number of validators is 2 or 3, there is a possibility of multiple consensus in one block becuase F = 0 and quorum is 1.
Also, if the number of validators is 6, there is a possibility that there will be two consensus in one block becuase F = 1 and the quorum is 3.
In incident situation, the number of validators could be reduced for solving the problem.
These cases are very exceptional, but this PR is needed to completely eliminate the possibility of a fork.
In addition, when configuring the service chain and private network with a small number of nodes, this PR enhances network stability.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

#1403 
