### PR TITLE
Fill missing Gini field to the GetStakingInfo result

### DIFF
--- a/consensus/istanbul/validator/multi_staking_test.go
+++ b/consensus/istanbul/validator/multi_staking_test.go
@@ -170,7 +170,9 @@ func TestCalcTotalAmount(t *testing.T) {
 		stakingAmounts := testCase.stakingAmounts
 		totalAmount := calcTotalAmount(testCase.weightedValidators, testCase.stakingInfo, stakingAmounts)
 
-		assert.Equal(t, testCase.expectedGini, testCase.stakingInfo.Gini)
+		// Since calcTotalAmount does not update stakingInfo.Gini, we cannot assert expectedGini.
+		// However asserting expectedStakingAmounts proves that calcTotalAmount() used correct Gini.
+		// assert.Equal(t, testCase.expectedGini, testCase.stakingInfo.Gini)
 		assert.Equal(t, testCase.expectedTotalAmount, totalAmount)
 		assert.Equal(t, testCase.expectedStakingAmounts, stakingAmounts)
 	}

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -806,7 +806,7 @@ func calcTotalAmount(weightedValidators []*weightedValidator, stakingInfo *rewar
 				tempStakingAmounts = append(tempStakingAmounts, stakingAmounts[vIdx])
 			}
 		}
-		gini := reward.CalcGiniCoefficient(tempStakingAmounts)
+		gini = reward.CalcGiniCoefficient(tempStakingAmounts)
 
 		for i := range stakingAmounts {
 			stakingAmounts[i] = math.Round(math.Pow(stakingAmounts[i], 1.0/(1+gini)))

--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -793,6 +793,11 @@ func calcTotalAmount(weightedValidators []*weightedValidator, stakingInfo *rewar
 		return 0
 	}
 	totalStaking := float64(0)
+
+	// stakingInfo.Gini is calculated among all CNs (i.e. AddressBook.cnStakingContracts)
+	// But we want the gini calculated among the subset of CNs (i.e. validators)
+	gini := reward.DefaultGiniCoefficient
+
 	if stakingInfo.UseGini {
 		var tempStakingAmounts []float64
 		for vIdx, val := range weightedValidators {
@@ -801,10 +806,10 @@ func calcTotalAmount(weightedValidators []*weightedValidator, stakingInfo *rewar
 				tempStakingAmounts = append(tempStakingAmounts, stakingAmounts[vIdx])
 			}
 		}
-		stakingInfo.Gini = reward.CalcGiniCoefficient(tempStakingAmounts)
+		gini := reward.CalcGiniCoefficient(tempStakingAmounts)
 
 		for i := range stakingAmounts {
-			stakingAmounts[i] = math.Round(math.Pow(stakingAmounts[i], 1.0/(1+stakingInfo.Gini)))
+			stakingAmounts[i] = math.Round(math.Pow(stakingAmounts[i], 1.0/(1+gini)))
 			totalStaking += stakingAmounts[i]
 		}
 	} else {
@@ -813,7 +818,7 @@ func calcTotalAmount(weightedValidators []*weightedValidator, stakingInfo *rewar
 		}
 	}
 
-	logger.Debug("calculate totalStaking", "UseGini", stakingInfo.UseGini, "Gini", stakingInfo.Gini, "totalStaking", totalStaking, "stakingAmounts", stakingAmounts)
+	logger.Debug("calculate totalStaking", "UseGini", stakingInfo.UseGini, "Gini", gini, "totalStaking", totalStaking, "stakingAmounts", stakingAmounts)
 	return totalStaking
 }
 

--- a/reward/reward_config_cache_test.go
+++ b/reward/reward_config_cache_test.go
@@ -92,6 +92,10 @@ func (governance *testGovernance) StakingUpdateInterval() uint64 {
 	return governance.stakingInterval
 }
 
+func (governance *testGovernance) GetMinimumStakingAtNumber(num uint64) (uint64, error) {
+	return 5000000, nil
+}
+
 func (governance *testGovernance) setTestGovernance(epoch uint64, mintingAmount string, ratio string, unitprice uint64, useGiniCoeff bool, deferredTxFee bool) {
 	governance.epoch = epoch
 	governance.mintingAmount = mintingAmount

--- a/reward/reward_config_cache_test.go
+++ b/reward/reward_config_cache_test.go
@@ -93,7 +93,9 @@ func (governance *testGovernance) StakingUpdateInterval() uint64 {
 }
 
 func (governance *testGovernance) GetMinimumStakingAtNumber(num uint64) (uint64, error) {
-	return 5000000, nil
+	// Note: this function will be eventually replaced by ParamsAt().MinimumStake().
+	// Until then we use fixed value.
+	return params.DefaultMinimumStake.Uint64(), nil
 }
 
 func (governance *testGovernance) setTestGovernance(epoch uint64, mintingAmount string, ratio string, unitprice uint64, useGiniCoeff bool, deferredTxFee bool) {

--- a/reward/reward_distributor.go
+++ b/reward/reward_distributor.go
@@ -36,6 +36,7 @@ type governanceHelper interface {
 	DeferredTxFee() bool
 	ProposerPolicy() uint64
 	StakingUpdateInterval() uint64
+	GetMinimumStakingAtNumber(num uint64) (uint64, error)
 }
 
 type RewardDistributor struct {

--- a/reward/staking_info.go
+++ b/reward/staking_info.go
@@ -248,7 +248,7 @@ func (c *ConsolidatedStakingInfo) GetConsolidatedNode(nodeAddr common.Address) *
 // Calculate Gini coefficient of the StakingAmounts.
 // Only amounts greater or equal to `minStake` are included in the calculation.
 // Set `minStake` to 0 to calculate Gini coefficient of all amounts.
-func (c *ConsolidatedStakingInfo) CalcGiniCoefficient(minStake uint64) float64 {
+func (c *ConsolidatedStakingInfo) CalcGiniCoefficientMinStake(minStake uint64) float64 {
 	var amounts []float64
 	for _, node := range c.nodes {
 		if node.StakingAmount >= minStake {

--- a/reward/staking_info.go
+++ b/reward/staking_info.go
@@ -241,9 +241,8 @@ func (c *ConsolidatedStakingInfo) GetAllNodes() []consolidatedNode {
 func (c *ConsolidatedStakingInfo) GetConsolidatedNode(nodeAddr common.Address) *consolidatedNode {
 	if idx, ok := c.nodeIndex[nodeAddr]; ok {
 		return &c.nodes[idx]
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // Calculate Gini coefficient of the StakingAmounts.

--- a/reward/staking_info_test.go
+++ b/reward/staking_info_test.go
@@ -18,14 +18,158 @@ package reward
 
 import (
 	"encoding/json"
-	"errors"
 	"math"
-	"reflect"
 	"testing"
 
 	"github.com/klaytn/klaytn/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type stakingInfoTestCase struct {
+	stakingInfo          *StakingInfo
+	expectedConsolidated *ConsolidatedStakingInfo
+	expectedAmounts      map[common.Address]uint64
+}
+
+var stakingInfoTestCases = generateStakingInfoTestCases()
+
+func generateStakingInfoTestCases() []stakingInfoTestCase {
+	var (
+		n1 = common.HexToAddress("0x8aD8F547fa00f58A8c4fb3B671Ee5f1A75bA028a")
+		n2 = common.HexToAddress("0xB2AAda7943919e82143324296987f6091F3FDC9e")
+		n3 = common.HexToAddress("0xD95c70710f07A3DaF7ae11cFBa10c789da3564D0")
+		n4 = common.HexToAddress("0xC704765db1d21C2Ea6F7359dcB8FD5233DeD16b5")
+
+		s1 = common.HexToAddress("0x4dd324F9821485caE941640B32c3Bcf1fA6E93E6")
+		s2 = common.HexToAddress("0x0d5Df5086B5f86f748dFaed5779c3f862C075B1f")
+		s3 = common.HexToAddress("0xD3Ff05f00491571E86A3cc8b0c320aA76D7413A5")
+		s4 = common.HexToAddress("0x11EF8e61d10365c2ECAe0E95b5fFa9ed4D68d64f")
+
+		r1 = common.HexToAddress("0x241c793A9AD555f52f6C3a83afe6178408796ab2")
+		r2 = common.HexToAddress("0x79b427Fb77077A9716E08D049B0e8f36Abfc8E2E")
+		r3 = common.HexToAddress("0x62E47d858bf8513fc401886B94E33e7DCec2Bfb7")
+		r4 = common.HexToAddress("0xf275f9f4c0d375F9E3E50370f93b504A1e45dB09")
+
+		kir = common.HexToAddress("0x136807B12327a8AfF9831F09617dA1B9D398cda2")
+		poc = common.HexToAddress("0x46bA8F7538CD0749e572b2631F9FB4Ce3653AFB8")
+
+		a0 uint64 = 0
+		aL uint64 = 1000000  // less than minstaking
+		aM uint64 = 5000000  // exactly minstaking
+		a1 uint64 = 10000000 // above minstaking. Using 1,2,4,8 to uniquely spot errors
+		a2 uint64 = 20000000
+		a3 uint64 = 40000000
+		a4 uint64 = 80000000
+	)
+
+	return []stakingInfoTestCase{
+		// Empty
+		{
+			stakingInfo: newEmptyStakingInfo(0),
+			expectedConsolidated: &ConsolidatedStakingInfo{
+				nodes:     make([]consolidatedNode, 0),
+				nodeIndex: make(map[common.Address]int),
+			},
+			expectedAmounts: make(map[common.Address]uint64),
+		},
+
+		// 1 entry
+		{
+			stakingInfo: &StakingInfo{
+				BlockNum:              86400,
+				CouncilNodeAddrs:      []common.Address{n1},
+				CouncilStakingAddrs:   []common.Address{s1},
+				CouncilRewardAddrs:    []common.Address{r1},
+				KIRAddr:               kir,
+				PoCAddr:               poc,
+				UseGini:               true,
+				Gini:                  0.00,
+				CouncilStakingAmounts: []uint64{a1},
+			},
+			expectedConsolidated: &ConsolidatedStakingInfo{
+				nodes: []consolidatedNode{
+					{[]common.Address{n1}, []common.Address{s1}, r1, a1},
+				},
+				nodeIndex: map[common.Address]int{n1: 0},
+			},
+			expectedAmounts: map[common.Address]uint64{n1: a1},
+		},
+
+		// Ordinary 4-entry info
+		{
+			stakingInfo: &StakingInfo{
+				BlockNum:              2 * 86400,
+				CouncilNodeAddrs:      []common.Address{n1, n2, n3, n4},
+				CouncilStakingAddrs:   []common.Address{s1, s2, s3, s4},
+				CouncilRewardAddrs:    []common.Address{r1, r2, r3, r4},
+				KIRAddr:               kir,
+				PoCAddr:               poc,
+				UseGini:               true,
+				Gini:                  0.38, // Gini(10, 20, 40, 80)
+				CouncilStakingAmounts: []uint64{a1, a2, a3, a4},
+			},
+			expectedConsolidated: &ConsolidatedStakingInfo{
+				nodes: []consolidatedNode{
+					{[]common.Address{n1}, []common.Address{s1}, r1, a1},
+					{[]common.Address{n2}, []common.Address{s2}, r2, a2},
+					{[]common.Address{n3}, []common.Address{s3}, r3, a3},
+					{[]common.Address{n4}, []common.Address{s4}, r4, a4},
+				},
+				nodeIndex: map[common.Address]int{n1: 0, n2: 1, n3: 2, n4: 3},
+			},
+			expectedAmounts: map[common.Address]uint64{n1: a1, n2: a2, n3: a3, n4: a4},
+		},
+
+		// 4-entry with common reward addrs
+		{
+			stakingInfo: &StakingInfo{
+				BlockNum:              3 * 86400,
+				CouncilNodeAddrs:      []common.Address{n1, n2, n3, n4},
+				CouncilStakingAddrs:   []common.Address{s1, s2, s3, s4},
+				CouncilRewardAddrs:    []common.Address{r1, r2, r1, r2}, // r1 and r2 used twice each
+				KIRAddr:               kir,
+				PoCAddr:               poc,
+				UseGini:               true,
+				Gini:                  0.17, // Gini(50, 100)
+				CouncilStakingAmounts: []uint64{a1, a2, a3, a4},
+			},
+			expectedConsolidated: &ConsolidatedStakingInfo{
+				nodes: []consolidatedNode{
+					{[]common.Address{n1, n3}, []common.Address{s1, s3}, r1, a1 + a3}, // n1 & n3
+					{[]common.Address{n2, n4}, []common.Address{s2, s4}, r2, a2 + a4}, // n2 & n4
+				},
+				nodeIndex: map[common.Address]int{n1: 0, n2: 1, n3: 0, n4: 1},
+			},
+			expectedAmounts: map[common.Address]uint64{n1: a1 + a3, n2: a2 + a4, n3: a1 + a3, n4: a2 + a4},
+		},
+
+		// 4-entry with less-than-minstaking amounts
+		{
+			stakingInfo: &StakingInfo{
+				BlockNum:              4 * 86400,
+				CouncilNodeAddrs:      []common.Address{n1, n2, n3, n4},
+				CouncilStakingAddrs:   []common.Address{s1, s2, s3, s4},
+				CouncilRewardAddrs:    []common.Address{r1, r2, r3, r4},
+				KIRAddr:               kir,
+				PoCAddr:               poc,
+				UseGini:               true,
+				Gini:                  0.30,                     // Gini(20, 5)
+				CouncilStakingAmounts: []uint64{a2, aM, aL, a0}, // aL and a0 should be ignored in Gini calculation
+			},
+			expectedConsolidated: &ConsolidatedStakingInfo{
+				nodes: []consolidatedNode{
+					{[]common.Address{n1}, []common.Address{s1}, r1, a2},
+					{[]common.Address{n2}, []common.Address{s2}, r2, aM},
+					{[]common.Address{n3}, []common.Address{s3}, r3, aL},
+					{[]common.Address{n4}, []common.Address{s4}, r4, a0},
+				},
+				nodeIndex: map[common.Address]int{n1: 0, n2: 1, n3: 2, n4: 3},
+			},
+			expectedAmounts: map[common.Address]uint64{n1: a2, n2: aM, n3: aL, n4: a0},
+		},
+	}
+}
 
 func TestStakingInfo_GetIndexByNodeAddress(t *testing.T) {
 	testdata := []common.Address{
@@ -95,71 +239,17 @@ func TestStakingInfo_GetStakingAmountByNodeId(t *testing.T) {
 }
 
 func TestStakingInfo_String(t *testing.T) {
-	testCases := []*StakingInfo{
-		newEmptyStakingInfo(0),
-		{
-			1,
-			[]common.Address{
-				common.StringToAddress("node address 1"),
-				common.StringToAddress("node address 2"),
-				common.StringToAddress("node address 3"),
-				common.StringToAddress("node address 4"),
-			},
-			[]common.Address{
-				common.StringToAddress("staking address 1"),
-				common.StringToAddress("staking address 2"),
-				common.StringToAddress("staking address 3"),
-				common.StringToAddress("staking address 4"),
-			},
-			[]common.Address{
-				common.StringToAddress("reward address 1"),
-				common.StringToAddress("reward address 2"),
-				common.StringToAddress("reward address 3"),
-				common.StringToAddress("reward address 4"),
-			},
-			common.StringToAddress("kir address"),
-			common.StringToAddress("poc address"),
-			false,
-			0.0,
-			[]uint64{5000000, 5000000, 5000000, 5000000},
-		},
-		{
-			86400,
-			[]common.Address{
-				common.HexToAddress("0x8aD8F547fa00f58A8c4fb3B671Ee5f1A75bA028a"),
-				common.HexToAddress("0xB2AAda7943919e82143324296987f6091F3FDC9e"),
-				common.HexToAddress("0xD95c70710f07A3DaF7ae11cFBa10c789da3564D0"),
-				common.HexToAddress("0xC704765db1d21C2Ea6F7359dcB8FD5233DeD16b5"),
-			},
-			[]common.Address{
-				common.HexToAddress("0x4dd324F9821485caE941640B32c3Bcf1fA6E93E6"),
-				common.HexToAddress("0x0d5Df5086B5f86f748dFaed5779c3f862C075B1f"),
-				common.HexToAddress("0xD3Ff05f00491571E86A3cc8b0c320aA76D7413A5"),
-				common.HexToAddress("0x11EF8e61d10365c2ECAe0E95b5fFa9ed4D68d64f"),
-			},
-			[]common.Address{
-				common.HexToAddress("0x241c793A9AD555f52f6C3a83afe6178408796ab2"),
-				common.HexToAddress("0x79b427Fb77077A9716E08D049B0e8f36Abfc8E2E"),
-				common.HexToAddress("0x62E47d858bf8513fc401886B94E33e7DCec2Bfb7"),
-				common.HexToAddress("0xf275f9f4c0d375F9E3E50370f93b504A1e45dB09"),
-			},
-			common.HexToAddress("0x136807B12327a8AfF9831F09617dA1B9D398cda2"),
-			common.HexToAddress("0x46bA8F7538CD0749e572b2631F9FB4Ce3653AFB8"),
-			true,
-			0.5,
-			[]uint64{10000000, 20000000, 30000000, 40000000},
-		},
-	}
-
-	for _, testStakingInfo := range testCases {
-		resultStr := testStakingInfo.String()
+	// No information loss in String() -> Unmarshal() round trip
+	for _, testcase := range stakingInfoTestCases {
+		resultStr := testcase.stakingInfo.String()
 		t.Logf("%s", resultStr)
+
 		resultByteArr := []byte(resultStr)
 		resultStakingInfo := &StakingInfo{}
-
 		err := json.Unmarshal(resultByteArr, resultStakingInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, testStakingInfo, resultStakingInfo)
+
+		assert.Equal(t, testcase.stakingInfo, resultStakingInfo)
 	}
 }
 
@@ -259,20 +349,40 @@ func TestGiniReflectToExpectedCCO(t *testing.T) {
 // TestStakingInfoJSON tests marshalling and unmarshalling StakingInfo
 // StakingInfo is marshaled before storing to DB.
 func TestStakingInfoJSON(t *testing.T) {
-	enc := newEmptyStakingInfo(1234)
+	// No information loss in json.Marshal() -> json.Unmarshal() round trip
+	for _, testcase := range stakingInfoTestCases {
+		src := testcase.stakingInfo
 
-	s, err := json.Marshal(enc)
-	if err != nil {
-		t.Fatal(err)
+		s, err := json.Marshal(src)
+		require.Nil(t, err)
+
+		dst := new(StakingInfo)
+		err = json.Unmarshal(s, dst)
+		require.Nil(t, err)
+
+		assert.Equal(t, src, dst)
 	}
+}
 
-	dec := new(StakingInfo)
-	err = json.Unmarshal(s, dec)
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestConsolidatedStakingInfo(t *testing.T) {
+	for _, testcase := range stakingInfoTestCases {
+		expected := testcase.expectedConsolidated
+		c := testcase.stakingInfo.GetConsolidatedStakingInfo()
 
-	if !reflect.DeepEqual(enc, dec) {
-		t.Fatal(errors.New("problem while marshaling or unmarshaling"))
+		// Test ConsolidatedStakingInfo
+		assert.Equal(t, expected.nodes, c.nodes)
+		assert.Equal(t, expected.nodeIndex, c.nodeIndex)
+
+		// Test CalcGiniCoefficient()
+		expectedGini := testcase.stakingInfo.Gini
+		gini := c.CalcGiniCoefficient(5000000)
+		assert.Equal(t, expectedGini, gini)
+
+		// Test GetConsolidatedNode()
+		for addr, expectedAmount := range testcase.expectedAmounts {
+			node := c.GetConsolidatedNode(addr)
+			require.NotNil(t, node)
+			assert.Equal(t, expectedAmount, node.StakingAmount)
+		}
 	}
 }

--- a/reward/staking_info_test.go
+++ b/reward/staking_info_test.go
@@ -379,7 +379,7 @@ func TestConsolidatedStakingInfo(t *testing.T) {
 
 		// Test CalcGiniCoefficient()
 		expectedGini := testcase.stakingInfo.Gini
-		gini := c.CalcGiniCoefficient(2000000)
+		gini := c.CalcGiniCoefficientMinStake(2000000)
 		assert.Equal(t, expectedGini, gini)
 
 		// Test GetConsolidatedNode()

--- a/reward/staking_info_test.go
+++ b/reward/staking_info_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -56,12 +57,15 @@ func generateStakingInfoTestCases() []stakingInfoTestCase {
 
 		a0 uint64 = 0
 		aL uint64 = 1000000  // less than minstaking
-		aM uint64 = 5000000  // exactly minstaking
+		aM uint64 = 2000000  // exactly minstaking (params.DefaultMinimumStake)
 		a1 uint64 = 10000000 // above minstaking. Using 1,2,4,8 to uniquely spot errors
 		a2 uint64 = 20000000
 		a3 uint64 = 40000000
 		a4 uint64 = 80000000
 	)
+	if aM != params.DefaultMinimumStake.Uint64() {
+		panic("broken test assumption")
+	}
 
 	return []stakingInfoTestCase{
 		// Empty
@@ -154,7 +158,7 @@ func generateStakingInfoTestCases() []stakingInfoTestCase {
 				KIRAddr:               kir,
 				PoCAddr:               poc,
 				UseGini:               true,
-				Gini:                  0.30,                     // Gini(20, 5)
+				Gini:                  0.41,                     // Gini(20, 2)
 				CouncilStakingAmounts: []uint64{a2, aM, aL, a0}, // aL and a0 should be ignored in Gini calculation
 			},
 			expectedConsolidated: &ConsolidatedStakingInfo{
@@ -375,7 +379,7 @@ func TestConsolidatedStakingInfo(t *testing.T) {
 
 		// Test CalcGiniCoefficient()
 		expectedGini := testcase.stakingInfo.Gini
-		gini := c.CalcGiniCoefficient(5000000)
+		gini := c.CalcGiniCoefficient(2000000)
 		assert.Equal(t, expectedGini, gini)
 
 		// Test GetConsolidatedNode()

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -115,12 +115,11 @@ func GetStakingInfo(blockNum uint64) *StakingInfo {
 // If the given number is not on the staking block, it returns nil.
 //
 // Fixup for Gini coefficients:
-// Klaytn core before fillMissingGiniCoefficient() stores Gini: -1 in its database.
+// Klaytn core stores Gini: -1 in its database.
 // We ensure GetStakingInfoOnStakingBlock() to always return meaningful Gini.
-//   If cache hit -> fillMissingGini -> modifies cached in-memory object
-//   If db hit -> fillMissingGini -> write to cache
-//   If read contract -> fillMissingGini -> write to db -> write to cache
-// The fixup for Gini happens once every staking info block.
+//   If cache hit                               -> fillMissingGini -> modifies cached in-memory object
+//   If db hit                                  -> fillMissingGini -> write to cache
+//   If read contract -> write to db (gini: -1) -> fillMissingGini -> write to cache
 func GetStakingInfoOnStakingBlock(stakingBlockNumber uint64) *StakingInfo {
 	if stakingManager == nil {
 		logger.Error("unable to GetStakingInfo", "err", ErrStakingManagerNotSet)

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -226,7 +226,6 @@ func fillMissingGiniCoefficient(stakingInfo *StakingInfo, number uint64) error {
 	// - Gini was calculated but there was no eligible node, so Gini = -1.
 	// For the second case, in theory we won't have to recalculalte Gini,
 	// but there is no way to distinguish both. So we just recalculate.
-
 	minStaking, err := stakingManager.governanceHelper.GetMinimumStakingAtNumber(number)
 	if err != nil {
 		return err
@@ -238,6 +237,7 @@ func fillMissingGiniCoefficient(stakingInfo *StakingInfo, number uint64) error {
 	}
 
 	stakingInfo.Gini = c.CalcGiniCoefficient(minStaking)
+	logger.Debug("Calculated missing Gini for stored StakingInfo", "number", number, "gini", stakingInfo.Gini)
 	return nil
 }
 

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -238,7 +238,7 @@ func fillMissingGiniCoefficient(stakingInfo *StakingInfo, number uint64) error {
 		return errors.New("Cannot create ConsolidatedStakingInfo")
 	}
 
-	stakingInfo.Gini = c.CalcGiniCoefficient(minStaking)
+	stakingInfo.Gini = c.CalcGiniCoefficientMinStake(minStaking)
 	logger.Debug("Calculated missing Gini for stored StakingInfo", "number", number, "gini", stakingInfo.Gini)
 	return nil
 }

--- a/reward/staking_manager_test.go
+++ b/reward/staking_manager_test.go
@@ -17,35 +17,50 @@
 package reward
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/klaytn/klaytn/storage/database"
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	stakingInterval = uint64(86400)
-	testData        = []uint64{
-		0, 1, 2, 3,
+type stakingManagerTestCase struct {
+	blockNum    uint64       // Requested num in GetStakingInfo(num)
+	stakingNum  uint64       // Corresponding staking info block number
+	stakingInfo *StakingInfo // Expected GetStakingInfo() output
+}
+
+// Note that Golang will correctly initialize these globals according to dependency.
+// https://go.dev/ref/spec#Order_of_evaluation
+
+// Note the testdata must not exceed maxStakingCache because otherwise cache test will fail.
+var stakingManagerTestData = []*StakingInfo{
+	stakingInfoTestCases[0].stakingInfo,
+	stakingInfoTestCases[1].stakingInfo,
+	stakingInfoTestCases[2].stakingInfo,
+	stakingInfoTestCases[3].stakingInfo,
+}
+var stakingManagerTestCases = generateStakingManagerTestCases()
+
+func generateStakingManagerTestCases() []stakingManagerTestCase {
+	s := stakingManagerTestData
+
+	return []stakingManagerTestCase{
+		{1, 0, s[0]},
+		{100, 0, s[0]},
+		{86400, 0, s[0]},
+		{86401, 0, s[0]},
+		{172800, 0, s[0]},
+		{172801, 86400, s[1]},
+		{200000, 86400, s[1]},
+		{259200, 86400, s[1]},
+		{259201, 172800, s[2]},
+		{300000, 172800, s[2]},
+		{345600, 172800, s[2]},
+		{345601, 259200, s[3]},
+		{400000, 259200, s[3]},
 	}
-	testCases = []struct {
-		stakingNumber  uint64
-		expectedNumber uint64
-	}{
-		{1, 0},
-		{100, 0},
-		{86400, 0},
-		{86401, 0},
-		{172800, 0},
-		{172801, 86400},
-		{200000, 86400},
-		{259200, 86400},
-		{259201, 172800},
-		{300000, 172800},
-		{345600, 172800},
-		{345601, 259200},
-		{400000, 259200},
-	}
-)
+}
 
 func TestStakingManager_NewStakingManager(t *testing.T) {
 	// test if nil
@@ -65,18 +80,67 @@ func TestStakingManager_NewStakingManager(t *testing.T) {
 	assert.Equal(t, stGet, stNew)
 }
 
-// checking calculate blockNumber of stakingInfo and return the stakingInfo with the blockNumber correct when stakingInfo is stored in cache
-func TestStakingManager_getStakingInfoFromStakingCache(t *testing.T) {
+// Check that appropriate StakingInfo is returned given various blockNum argument.
+func checkGetStakingInfo(t *testing.T) {
+	for _, testcase := range stakingManagerTestCases {
+		expcectedInfo := testcase.stakingInfo
+		actualInfo := GetStakingInfo(testcase.blockNum)
+
+		assert.Equal(t, testcase.stakingNum, actualInfo.BlockNum)
+		assert.Equal(t, expcectedInfo, actualInfo)
+	}
+}
+
+// Check that StakinInfo are loaded from cache
+func TestStakingManager_GetFromCache(t *testing.T) {
 	stakingManager := NewStakingManager(newTestBlockChain(), newDefaultTestGovernance(), nil)
 
-	for i := 0; i < len(testData); i++ {
-		testStakingInfo := newEmptyStakingInfo(testData[i] * stakingInterval)
-		stakingManager.stakingInfoCache.add(testStakingInfo)
+	for _, testdata := range stakingManagerTestData {
+		stakingManager.stakingInfoCache.add(testdata)
 	}
 
-	// should find a correct stakingInfo with a given block number
-	for i := 0; i < len(testCases); i++ {
-		resultStakingInfo := GetStakingInfo(testCases[i].stakingNumber)
-		assert.Equal(t, testCases[i].expectedNumber, resultStakingInfo.BlockNum)
+	checkGetStakingInfo(t)
+}
+
+// Check that StakinInfo are loaded from database
+func TestStakingManager_GetFromDB(t *testing.T) {
+	db := database.NewMemoryDBManager()
+	NewStakingManager(newTestBlockChain(), newDefaultTestGovernance(), db)
+
+	for _, testdata := range stakingManagerTestData {
+		AddStakingInfoToDB(testdata)
 	}
+
+	checkGetStakingInfo(t)
+}
+
+// Even if Gini was -1 in the cache, GetStakingInfo returns valid Gini
+func TestStakingManager_FillGiniFromCache(t *testing.T) {
+	stakingManager := NewStakingManager(newTestBlockChain(), newDefaultTestGovernance(), nil)
+
+	for _, testdata := range stakingManagerTestData {
+		// Insert a modified copy of testdata to cache
+		copydata := &StakingInfo{}
+		json.Unmarshal([]byte(testdata.String()), copydata)
+		copydata.Gini = -1 // Suppose Gini was -1 in the cache
+		stakingManager.stakingInfoCache.add(copydata)
+	}
+
+	checkGetStakingInfo(t)
+}
+
+// Even if Gini was -1 in the DB, GetStakingInfo returns valid Gini
+func TestStakingManager_FillGiniFromDB(t *testing.T) {
+	db := database.NewMemoryDBManager()
+	NewStakingManager(newTestBlockChain(), newDefaultTestGovernance(), db)
+
+	for _, testdata := range stakingManagerTestData {
+		// Insert a modified copy of testdata to cache
+		copydata := &StakingInfo{}
+		json.Unmarshal([]byte(testdata.String()), copydata)
+		copydata.Gini = -1 // Suppose Gini was -1 in the cache
+		AddStakingInfoToDB(testdata)
+	}
+
+	checkGetStakingInfo(t)
 }


### PR DESCRIPTION
## Proposed changes

- The output `*StakingInfo` of `GetStakingInfo(num)` now have valid `Gini` field whenever applicable.
  - Previously the `StakingInfo.Gini` field was sometimes `-1`.
  - Now correct `StakingInfo.Gini` value is stored if `UseGini` is true.

- The proposer selection code does not update the `StakingInfo.Gini` in global cache.
  - Previously `weightedValidator.Refresh()` has updated the `StakingInfo.Gini` field stored in the StakingManager cache, affecting the global function `GetStakingInfo()`.
  - Now proposer selection code calculates its own `gini` value and use it.

- Note that the `StakingInfo.Gini` is different from `gini` used in proposer selection.
  - The `StakingInfo.Gini` is calculated among all CNs in the AddressBook, except the ones staked less than `minStake`.
  - The `gini` in proposer selection is calculated among validators (i.e. `ValSet`), a subset of all CNs.

- Add `ConsolidatedStakingInfo` to simplify gini calculation.
  - `ConsolidatedStakingInfo` is a set of `consolidatedNode`s.
  - A `consolidatedNode` is a collection of AddressBook entries under the same `RewardAddr`. Such entries have different `nodeId`s in AddressBook, but they constitute one effective Consensus Node.
  - This new data structure can aid simplifying weightedValidator.Refresh(). But further refactoring is outside the scope of this PR.

- With this PR, I expect the `governance_getStakingInfo` RPC to return meaningful Gini coefficient values.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

https://github.com/klaytn/klaytn/issues/1448

## Further comments
