### PR TITLE
add checking z sign in affineFromJacobian

### DIFF
--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -139,7 +139,18 @@ func (BitCurve *BitCurve) affineFromJacobian(x, y, z *big.Int) (xOut, yOut *big.
 
 // Add returns the sum of (x1,y1) and (x2,y2)
 func (BitCurve *BitCurve) Add(x1, y1, x2, y2 *big.Int) (*big.Int, *big.Int) {
+	// If one point is at infinity, return the other point.
+	// Adding the point at infinity to any point will preserve the other point.
+	if x1.Sign() == 0 && y1.Sign() == 0 {
+		return x2, y2
+	}
+	if x2.Sign() == 0 && y2.Sign() == 0 {
+		return x1, y1
+	}
 	z := new(big.Int).SetInt64(1)
+	if x1.Cmp(x2) == 0 && y1.Cmp(y2) == 0 {
+		return BitCurve.affineFromJacobian(BitCurve.doubleJacobian(x1, y1, z))
+	}
 	return BitCurve.affineFromJacobian(BitCurve.addJacobian(x1, y1, z, x2, y2, z))
 }
 

--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -122,24 +122,11 @@ func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
 // affineFromJacobian reverses the Jacobian transform. See the comment at the
 // top of the file.
 func (BitCurve *BitCurve) affineFromJacobian(x, y, z *big.Int) (xOut, yOut *big.Int) {
-	zinv := new(big.Int).ModInverse(z, BitCurve.P)
-	//GX-TODO:	Introduce a permanent fix
-	//	When passed with x==y==z==0, ModInverse(z, BitCurve.P) results `nil` which leads to new(big.Int).Mul(nil, nil).
-	//	The above parameter condition can be easily met in cases such as adding the same elliptic curve points.
-	//
-	//	Problem:
-	// 		big.Int.Mul(nil, nil) causes SIGSEGV
-	//	Analysis:
-	// 		In Go 1.10.3, ModInverse(0, any) returns 0 (not by design though). The implementation has changed in Go 1.11
-	// 		and ModInverse explicitly returns nil. As zinv := new(big.Int).ModInverse(z, BitCurve.P) stores nil in zinv,
-	// 		zinvsq := new(big.Int).Mul(zinv, zinv) fails with SIGSEGV as it invokes new(big.Int).Mul(nil, nil).
-	//	Fix:
-	//		The following if-block is added to fix the problem temporarily. This is okay since the inverse of 0
-	//		resides in ring R = {0}.
-	if zinv == nil {
-		zinv = new(big.Int)
+	if z.Sign() == 0 {
+		return new(big.Int), new(big.Int)
 	}
 
+	zinv := new(big.Int).ModInverse(z, BitCurve.P)
 	zinvsq := new(big.Int).Mul(zinv, zinv)
 
 	xOut = new(big.Int).Mul(x, zinvsq)


### PR DESCRIPTION
## Proposed changes

When the value of `ModInverse(z, BitCurve.P)` which is `zinv`  is 0, Regardless of the arguments ​​of `x` and `y`, the return values ​​of `xOut` and `yOut` are both 0. Therefore, when `zinv == nil`, there is no need to reset `zinv = 0` and calculate any more, just return `0, 0`. When the argument `z` is 0. `zinv`, which is the value of `ModInverse(z, BitCurve.P)` is `nil`.

When the argument `z` is 0,  just return  `0, 0`. [go-ethereum](https://github.com/ethereum/go-ethereum/blob/master/crypto/secp256k1/curve.go#L108-L115) and [golang](https://github.com/golang/go/blob/master/src/crypto/elliptic/params.go#L76-L82) are already doing that.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
