### PR TITLE
consensus: add writable flag to the snapshot function

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -54,7 +54,7 @@ func (api *API) GetSnapshot(number *rpc.BlockNumber) (*Snapshot, error) {
 	if header == nil {
 		return nil, errUnknownBlock
 	}
-	return api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	return api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil, false)
 }
 
 // GetSnapshotAtHash retrieves the state snapshot at a given block.
@@ -63,7 +63,7 @@ func (api *API) GetSnapshotAtHash(hash common.Hash) (*Snapshot, error) {
 	if header == nil {
 		return nil, errUnknownBlock
 	}
-	return api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	return api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil, false)
 }
 
 // GetValidators retrieves the list of authorized validators with the given block number.
@@ -178,7 +178,7 @@ func (api *APIExtension) GetCouncil(number *rpc.BlockNumber) ([]common.Address, 
 	//}
 
 	// Calculate council list from snapshot
-	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil, false)
 	if err != nil {
 		logger.Error("Failed to get snapshot.", "hash", header.Hash(), "err", err)
 		return nil, errInternalError
@@ -236,7 +236,7 @@ func (api *APIExtension) GetCommittee(number *rpc.BlockNumber) ([]common.Address
 
 	// get the snapshot of the previous block.
 	parentHash := header.ParentHash
-	snap, err := api.istanbul.snapshot(api.chain, blockNumber-1, parentHash, nil)
+	snap, err := api.istanbul.snapshot(api.chain, blockNumber-1, parentHash, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func (api *APIExtension) getConsensusInfo(block *types.Block) (ConsensusInfo, er
 
 	// get the snapshot of the previous block.
 	parentHash := block.ParentHash()
-	snap, err := api.istanbul.snapshot(api.chain, blockNumber-1, parentHash, nil)
+	snap, err := api.istanbul.snapshot(api.chain, blockNumber-1, parentHash, nil, false)
 	if err != nil {
 		return ConsensusInfo{}, err
 	}

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -392,7 +392,7 @@ func (sb *backend) ParentValidators(proposal istanbul.Proposal) istanbul.Validat
 }
 
 func (sb *backend) getValidators(number uint64, hash common.Hash) istanbul.ValidatorSet {
-	snap, err := sb.snapshot(sb.chain, number, hash, nil)
+	snap, err := sb.snapshot(sb.chain, number, hash, nil, true)
 	if err != nil {
 		logger.Error("Snapshot not found.", "err", err)
 		// TODO-Klaytn-Governance The following return case should not be called. Refactor it to error handling.

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -1229,6 +1229,51 @@ func TestSnapshot_Validators_AddRemove(t *testing.T) {
 	}
 }
 
+func TestSnapshot_Writable(t *testing.T) {
+	var configItems []interface{}
+	configItems = append(configItems, proposerPolicy(params.WeightedRandom))
+	configItems = append(configItems, epoch(3))
+	configItems = append(configItems, governanceMode("single"))
+	configItems = append(configItems, blockPeriod(0)) // set block period to 0 to prevent creating future block
+	chain, engine := newBlockChain(1, configItems...)
+
+	// add votes and insert voted blocks
+	var (
+		previousBlock, currentBlock *types.Block = nil, chain.Genesis()
+		err                         error
+	)
+
+	// voteData is inserted at block 4, and current block is block 5.
+	for i := 0; i < 5; i++ {
+		if i == 4 {
+			engine.governance.AddVote("governance.unitprice", uint64(2000000))
+		}
+		previousBlock = currentBlock
+		currentBlock = makeBlockWithSeal(chain, engine, previousBlock)
+		_, err = chain.InsertChain(types.Blocks{currentBlock})
+		assert.NoError(t, err)
+	}
+
+	// save current gov.changeSet's length for the expected value.
+	currentChangeSetLength := len(engine.governance.GetGovernanceChange())
+
+	// block 3 is the start block of an epoch. In this test, the cache of this block's snapshot is cleared.
+	// If cache is not removed, it will just read the cache rather than making the snapshot itself.
+	block := chain.GetBlockByNumber(uint64(3))
+
+	// case [writable == false]
+	// expected result: gov.changeSet should not be modified.
+	engine.recents.Remove(block.Hash()) // assume node is restarted
+	_, err = engine.snapshot(chain, block.NumberU64(), block.Hash(), nil, false)
+	assert.Equal(t, currentChangeSetLength, len(engine.governance.GetGovernanceChange()))
+
+	// case [writable == true]
+	// expected result: gov.changeSet is modified.
+	engine.recents.Remove(block.Hash()) // assume node is restarted
+	_, err = engine.snapshot(chain, block.NumberU64(), block.Hash(), nil, true)
+	assert.Equal(t, 0, len(engine.governance.GetGovernanceChange()))
+}
+
 func TestGovernance_Votes(t *testing.T) {
 	type vote struct {
 		key   string

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -1256,6 +1256,7 @@ func TestSnapshot_Writable(t *testing.T) {
 
 	// save current gov.changeSet's length for the expected value.
 	currentChangeSetLength := len(engine.governance.GetGovernanceChange())
+	assert.Equal(t, 1, currentChangeSetLength)
 
 	// block 3 is the start block of an epoch. In this test, the cache of this block's snapshot is cleared.
 	// If cache is not removed, it will just read the cache rather than making the snapshot itself.

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -823,7 +823,7 @@ func TestSnapshot_Validators_AfterMinimumStakingVotes(t *testing.T) {
 		for _, e := range tc.expected {
 			for _, num := range e.blocks {
 				block := chain.GetBlockByNumber(num)
-				snap, err := engine.snapshot(chain, block.NumberU64(), block.Hash(), nil)
+				snap, err := engine.snapshot(chain, block.NumberU64(), block.Hash(), nil, true)
 				assert.NoError(t, err)
 
 				validators := toAddressList(snap.ValSet.List())
@@ -994,7 +994,7 @@ func TestSnapshot_Validators_BasedOnStaking(t *testing.T) {
 		_, err := chain.InsertChain(types.Blocks{block})
 		assert.NoError(t, err)
 
-		snap, err := engine.snapshot(chain, block.NumberU64(), block.Hash(), nil)
+		snap, err := engine.snapshot(chain, block.NumberU64(), block.Hash(), nil, true)
 		assert.NoError(t, err)
 
 		validators := toAddressList(snap.ValSet.List())
@@ -1215,7 +1215,7 @@ func TestSnapshot_Validators_AddRemove(t *testing.T) {
 				continue
 			}
 			block := chain.GetBlockByNumber(uint64(i))
-			snap, err := engine.snapshot(chain, block.NumberU64(), block.Hash(), nil)
+			snap, err := engine.snapshot(chain, block.NumberU64(), block.Hash(), nil, true)
 			assert.NoError(t, err)
 			validators := copyAndSortAddrs(toAddressList(snap.ValSet.List()))
 

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -144,7 +144,7 @@ func (s *Snapshot) checkVote(address common.Address, authorize bool) bool {
 
 // apply creates a new authorization snapshot by applying the given headers to
 // the original one.
-func (s *Snapshot) apply(headers []*types.Header, gov governance.Engine, addr common.Address, policy uint64, chain consensus.ChainReader) (*Snapshot, error) {
+func (s *Snapshot) apply(headers []*types.Header, gov governance.Engine, addr common.Address, policy uint64, chain consensus.ChainReader, writable bool) (*Snapshot, error) {
 	// Allow passing in no headers for cleaner code
 	if len(headers) == 0 {
 		return s, nil
@@ -179,19 +179,20 @@ func (s *Snapshot) apply(headers []*types.Header, gov governance.Engine, addr co
 		}
 
 		if number%snap.Epoch == 0 {
-			gov.UpdateCurrentSet(number)
-			if len(header.Governance) > 0 {
-				gov.WriteGovernanceForNextEpoch(number, header.Governance)
+			if writable {
+				gov.UpdateCurrentSet(number)
+				if len(header.Governance) > 0 {
+					gov.WriteGovernanceForNextEpoch(number, header.Governance)
+				}
+				gov.ClearVotes(number)
 			}
-			gov.ClearVotes(number)
-
 			// Reload governance values because epoch changed
 			snap.Epoch, snap.Policy, snap.CommitteeSize = getGovernanceValue(gov, number)
 			snap.Votes = make([]governance.GovernanceVote, 0)
 			snap.Tally = make([]governance.GovernanceTallyItem, 0)
 		}
 
-		snap.ValSet, snap.Votes, snap.Tally = gov.HandleGovernanceVote(snap.ValSet, snap.Votes, snap.Tally, header, validator, addr)
+		snap.ValSet, snap.Votes, snap.Tally = gov.HandleGovernanceVote(snap.ValSet, snap.Votes, snap.Tally, header, validator, addr, writable)
 		if policy == uint64(params.WeightedRandom) {
 			// Snapshot of block N (Snapshot_N) should contain proposers for N+1 and following blocks.
 			// Validators for Block N+1 can be calculated based on the staking information from the previous stakingUpdateInterval block.
@@ -232,8 +233,10 @@ func (s *Snapshot) apply(headers []*types.Header, gov governance.Engine, addr co
 	}
 	snap.ValSet.SetSubGroupSize(snap.CommitteeSize)
 
-	gov.SetTotalVotingPower(snap.ValSet.TotalVotingPower())
-	gov.SetMyVotingPower(snap.getMyVotingPower(addr))
+	if writable {
+		gov.SetTotalVotingPower(snap.ValSet.TotalVotingPower())
+		gov.SetMyVotingPower(snap.getMyVotingPower(addr))
+	}
 
 	return snap, nil
 }

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -753,7 +753,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.AddVote("governance.unitprice", uint64(22000))
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
-	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self, true)
 	gov.RemoveVote("governance.unitprice", uint64(22000), 0)
 
 	if _, ok := gov.changeSet.items["governance.unitprice"]; !ok {
@@ -770,7 +770,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.AddVote("istanbul.timeout", newValue)
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
-	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self, true)
 	gov.RemoveVote("istanbul.timeout", newValue, 0)
 	assert.Equal(t, istanbul.DefaultConfig.Timeout, newValue, "Vote had to be applied but it wasn't")
 
@@ -782,7 +782,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.AddVote("governance.removevalidator", validators[1].String())
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
-	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self, true)
 	gov.RemoveVote("governance.removevalidator", validators[1], 0)
 	if i, _ := valSet.GetByAddress(validators[1]); i != -1 {
 		t.Errorf("Validator removal failed, %d validators remains", valSet.Size())
@@ -795,7 +795,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.AddVote("governance.removevalidator", validators[1].String())
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
-	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, proposer) // self = proposer
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, proposer, true) // self = proposer
 	// check if casted
 	if !gov.voteMap.items["governance.removevalidator"].Casted {
 		t.Errorf("Removing a non-existing validator failed")
@@ -812,7 +812,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.AddVote("governance.addvalidator", validators[1].String())
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
-	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self, true)
 	gov.RemoveVote("governance.addvalidator", validators[1], 0)
 	if i, _ := valSet.GetByAddress(validators[1]); i == -1 {
 		t.Errorf("Validator addition failed, %d validators remains", valSet.Size())
@@ -825,7 +825,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.AddVote("governance.addvalidator", validators[1].String())
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
-	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, proposer) // self = proposer
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, proposer, true) // self = proposer
 	// check if casted
 	if !gov.voteMap.items["governance.addvalidator"].Casted {
 		t.Errorf("Adding an existing validator failed")
@@ -842,7 +842,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.AddVote("governance.removevalidator", demotedValidators[1].String())
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
-	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self, true)
 	gov.RemoveVote("governance.removevalidator", demotedValidators[1], 0)
 	if i, _ := valSet.GetDemotedByAddress(demotedValidators[1]); i != -1 {
 		t.Errorf("Demoted validator removal failed, %d demoted validators remains", len(valSet.DemotedList()))
@@ -855,7 +855,7 @@ func TestGovernance_HandleGovernanceVote_None_mode(t *testing.T) {
 	gov.AddVote("governance.addvalidator", demotedValidators[1].String())
 	header.Vote = gov.GetEncodedVote(proposer, blockCounter.Uint64())
 
-	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self)
+	gov.HandleGovernanceVote(valSet, votes, tally, header, proposer, self, true)
 	gov.RemoveVote("governance.addvalidator", demotedValidators[1], 0)
 	// At first, demoted validator is added to the validators, but it will be refreshed right after
 	// So, we here check only if the adding demoted validator to validators
@@ -894,17 +894,17 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	gov.AddVote("governance.unitprice", uint64(22000))
 
 	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self, true)
 
 	header.Vote = gov.GetEncodedVote(validators[1], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[1], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[1], self, true)
 
 	if _, ok := gov.changeSet.items["governance.unitprice"]; ok {
 		t.Errorf("Vote shouldn't be applied yet but it was applied")
 	}
 
 	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self, true)
 	if _, ok := gov.changeSet.items["governance.unitprice"]; !ok {
 		t.Errorf("Vote should be applied but it was not")
 	}
@@ -920,15 +920,15 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 	gov.AddVote("istanbul.timeout", newValue)
 
 	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self, true)
 
 	header.Vote = gov.GetEncodedVote(validators[1], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[1], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[1], self, true)
 
 	assert.NotEqual(t, istanbul.DefaultConfig.Timeout, newValue, "Vote shouldn't be applied yet but it was applied")
 
 	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self, true)
 
 	assert.Equal(t, istanbul.DefaultConfig.Timeout, newValue, "Vote should be applied but it was not")
 	gov.RemoveVote("istanbul.timeout", newValue, blockCounter.Uint64())
@@ -940,18 +940,18 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self, true)
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self, true)
 	if i, _ := valSet.GetByAddress(validators[1]); i == -1 {
 		t.Errorf("Validator removal shouldn't be done yet, %d validators remains", valSet.Size())
 	}
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[3], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[3], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[3], self, true)
 
 	if i, _ := valSet.GetByAddress(validators[1]); i != -1 {
 		t.Errorf("Validator removal failed, %d validators remains", valSet.Size())
@@ -965,7 +965,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], validators[0])
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], validators[0], true)
 	// check if casted
 	if !gov.voteMap.items["governance.removevalidator"].Casted {
 		t.Errorf("Removing a non-existing validator failed")
@@ -973,7 +973,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], validators[2])
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], validators[2], true)
 	// check if casted
 	if !gov.voteMap.items["governance.removevalidator"].Casted {
 		t.Errorf("Removing a non-existing validator failed")
@@ -988,14 +988,14 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self, true)
 	if i, _ := valSet.GetByAddress(validators[1]); i != -1 {
 		t.Errorf("Validator addition shouldn't be done yet, %d validators remains", valSet.Size())
 	}
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self, true)
 
 	if i, _ := valSet.GetByAddress(validators[1]); i == -1 {
 		t.Errorf("Validator addition failed, %d validators remains", valSet.Size())
@@ -1009,7 +1009,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], validators[0])
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], validators[0], true)
 	// check if casted
 	if !gov.voteMap.items["governance.addvalidator"].Casted {
 		t.Errorf("Adding an existing validator failed")
@@ -1017,7 +1017,7 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], validators[2])
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], validators[2], true)
 	// check if casted
 	if !gov.voteMap.items["governance.addvalidator"].Casted {
 		t.Errorf("Adding an existing validator failed")
@@ -1032,18 +1032,18 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self, true)
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self, true)
 	if i, _ := valSet.GetDemotedByAddress(demotedValidators[1]); i == -1 {
 		t.Errorf("Demoted validator removal shouldn't be done yet, %d validators remains", len(valSet.DemotedList()))
 	}
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[3], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[3], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[3], self, true)
 
 	if i, _ := valSet.GetDemotedByAddress(demotedValidators[1]); i != -1 {
 		t.Errorf("Demoted validator removal failed, %d validators remains", len(valSet.DemotedList()))
@@ -1056,18 +1056,18 @@ func TestGovernance_HandleGovernanceVote_Ballot_mode(t *testing.T) {
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[0], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[0], self, true)
 	if i, _ := valSet.GetByAddress(demotedValidators[1]); i != -1 {
 		t.Errorf("Validator addition shouldn't be done yet, %d validators remains", len(valSet.DemotedList()))
 	}
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[2], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[2], self, true)
 
 	header.Number = blockCounter.Add(blockCounter, common.Big1)
 	header.Vote = gov.GetEncodedVote(validators[3], blockCounter.Uint64())
-	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[3], self)
+	valSet, votes, tally = gov.HandleGovernanceVote(valSet, votes, tally, header, validators[3], self, true)
 
 	// At first, demoted validator is added to the validators, but it will be refreshed right after
 	// So, we here check only if the adding demoted validator to validators

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -363,7 +363,9 @@ func (gov *Governance) HandleGovernanceVote(valset istanbul.ValidatorSet, votes 
 
 			if addr, ok := gVote.Value.(common.Address); ok {
 				addresses = append(addresses, addr)
-			} else if addresses, ok = gVote.Value.([]common.Address); !ok {
+			} else if addrs, ok := gVote.Value.([]common.Address); ok {
+				addresses = addrs
+			} else {
 				logger.Warn("Invalid value Type", "number", header.Number, "Validator", gVote.Validator, "key", gVote.Key, "value", gVote.Value)
 			}
 

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -71,7 +71,7 @@ type HeaderEngine interface {
 	UpdateCurrentSet(num uint64)
 	HandleGovernanceVote(
 		valset istanbul.ValidatorSet, votes []GovernanceVote, tally []GovernanceTallyItem,
-		header *types.Header, proposer common.Address, self common.Address) (
+		header *types.Header, proposer common.Address, self common.Address, writable bool) (
 		istanbul.ValidatorSet, []GovernanceVote, []GovernanceTallyItem)
 
 	// Get internal fields

--- a/governance/mixed.go
+++ b/governance/mixed.go
@@ -153,11 +153,11 @@ func (e *MixedEngine) UpdateCurrentSet(num uint64) {
 
 func (e *MixedEngine) HandleGovernanceVote(
 	valset istanbul.ValidatorSet, votes []GovernanceVote, tally []GovernanceTallyItem,
-	header *types.Header, proposer common.Address, self common.Address,
+	header *types.Header, proposer common.Address, self common.Address, writable bool,
 ) (
 	istanbul.ValidatorSet, []GovernanceVote, []GovernanceTallyItem,
 ) {
-	return e.defaultGov.HandleGovernanceVote(valset, votes, tally, header, proposer, self)
+	return e.defaultGov.HandleGovernanceVote(valset, votes, tally, header, proposer, self, writable)
 }
 
 func (e *MixedEngine) ChainId() uint64 {


### PR DESCRIPTION
## Proposed changes

- If cache of the target block's snapshot is not stored, the target block's header need to be processed to make a snapshot. This process can modify `governance struct` or `governance db`, so while serving api call, it should detach the writable process. 
- So, i have made `writable` flag, and it is added not to write `governance struct` and `governance db` while serving api call. 
- For now,  `writable` is false only when snapshot is called during api call. However, we have considered about calling snapshot function with false writable flag when only inquiry is needed during the block creation process. Later PR will include this. 

closes https://github.com/klaytn/klaytn/issues/1399

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
