### PR TITLE
Moved verify header to insert receipt chain

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1208,6 +1208,11 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 			stats.ignored++
 			continue
 		}
+		if !bc.engine.CanVerifyHeadersConcurrently() {
+			if err := bc.engine.VerifyHeader(bc, block.Header(), true); err != nil {
+				return i, err
+			}
+		}
 		// Compute all the non-consensus fields of the receipts
 		if err := SetReceiptsData(bc.chainConfig, block, receipts); err != nil {
 			return i, fmt.Errorf("failed to set receipts data: %v", err)

--- a/blockchain/headerchain.go
+++ b/blockchain/headerchain.go
@@ -255,11 +255,6 @@ func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, writeHeader WhCa
 			stats.ignored++
 			continue
 		}
-		if !hc.engine.CanVerifyHeadersConcurrently() {
-			if err := hc.engine.VerifyHeader(hc, header, true); err != nil {
-				return i, err
-			}
-		}
 		if err := writeHeader(header); err != nil {
 			return i, err
 		}


### PR DESCRIPTION
## Proposed changes

While snap syncing it is not possible to verify headers without staking information. This PR moves `VerifyHeaders` in `InsertReceiptChain` which is after appropriate staking information download.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
