### PR TITLE
implemented snapshot synchronization

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -652,6 +652,11 @@ func (bc *BlockChain) FastSyncCommitHead(hash common.Hash) error {
 	bc.lastCommittedBlock = block.NumberU64()
 	bc.mu.Unlock()
 
+	// Destroy any existing state snapshot and regenerate it in the background,
+	// also resuming the normal maintenance of any previously paused snapshot.
+	if bc.snaps != nil {
+		bc.snaps.Rebuild(block.Root())
+	}
 	logger.Info("Committed new head block", "number", block.Number(), "hash", hash)
 	return nil
 }
@@ -1049,7 +1054,7 @@ func (bc *BlockChain) Stop() {
 		for !bc.triegc.Empty() {
 			triedb.Dereference(bc.triegc.PopItem().(common.Hash))
 		}
-		if size, _ := triedb.Size(); size != 0 {
+		if size, _, _ := triedb.Size(); size != 0 {
 			logger.Error("Dangling trie nodes after full cleanup")
 		}
 	}
@@ -1307,8 +1312,8 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 
 		// If we exceeded our memory allowance, flush matured singleton nodes to disk
 		var (
-			nodesSize, preimagesSize = trieDB.Size()
-			nodesSizeLimit           = common.StorageSize(bc.cacheConfig.CacheSize) * 1024 * 1024
+			nodesSize, _, preimagesSize = trieDB.Size()
+			nodesSizeLimit              = common.StorageSize(bc.cacheConfig.CacheSize) * 1024 * 1024
 		)
 
 		trieDBNodesSizeBytesGauge.Update(int64(nodesSize))
@@ -2012,7 +2017,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		stats.processed++
 		stats.usedGas += usedGas
 
-		cache, _ := bc.stateCache.TrieDB().Size()
+		cache, _, _ := bc.stateCache.TrieDB().Size()
 		stats.report(chain, i, cache)
 
 		// update governance CurrentSet if it is at an epoch block
@@ -2495,6 +2500,11 @@ func (bc *BlockChain) Config() *params.ChainConfig { return bc.chainConfig }
 
 // Engine retrieves the blockchain's consensus engine.
 func (bc *BlockChain) Engine() consensus.Engine { return bc.engine }
+
+// Snapshots returns the blockchain snapshot tree.
+func (bc *BlockChain) Snapshots() *snapshot.Tree {
+	return bc.snaps
+}
 
 // SubscribeRemovedLogsEvent registers a subscription of RemovedLogsEvent.
 func (bc *BlockChain) SubscribeRemovedLogsEvent(ch chan<- RemovedLogsEvent) event.Subscription {

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -1029,7 +1029,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) 
 	if EnabledExpensive {
 		defer func(start time.Time) { s.AccountCommits += time.Since(start) }(time.Now())
 	}
-	root, err = s.trie.Commit(func(path []byte, leaf []byte, parent common.Hash, parentDepth int) error {
+	root, err = s.trie.Commit(func(_ [][]byte, _ []byte, leaf []byte, parent common.Hash, parentDepth int) error {
 		serializer := account.NewAccountSerializer()
 		if err := rlp.DecodeBytes(leaf, serializer); err != nil {
 			logger.Warn("RLP decode failed", "err", err, "leaf", string(leaf))

--- a/blockchain/state/sync_test.go
+++ b/blockchain/state/sync_test.go
@@ -183,7 +183,7 @@ func TestEmptyStateSync(t *testing.T) {
 	// only bloom
 	{
 		db := database.NewMemoryDBManager()
-		sync := NewStateSync(empty, db, statedb.NewSyncBloom(1, db.GetMemDB()), nil)
+		sync := NewStateSync(empty, db, statedb.NewSyncBloom(1, db.GetMemDB()), nil, nil)
 		if nodes, paths, codes := sync.Missing(1); len(nodes) != 0 || len(paths) != 0 || len(codes) != 0 {
 			t.Errorf("content requested for empty state: %v", sync)
 		}
@@ -193,7 +193,7 @@ func TestEmptyStateSync(t *testing.T) {
 	{
 		lruCache, _ := lru.New(int(1 * units.MB / common.HashLength))
 		db := database.NewMemoryDBManager()
-		sync := NewStateSync(empty, db, statedb.NewSyncBloom(1, db.GetMemDB()), lruCache)
+		sync := NewStateSync(empty, db, statedb.NewSyncBloom(1, db.GetMemDB()), lruCache, nil)
 		if nodes, paths, codes := sync.Missing(1); len(nodes) != 0 || len(paths) != 0 || len(codes) != 0 {
 			t.Errorf("content requested for empty state: %v", sync)
 		}
@@ -202,7 +202,7 @@ func TestEmptyStateSync(t *testing.T) {
 	// no bloom lru
 	{
 		db := database.NewMemoryDBManager()
-		sync := NewStateSync(empty, db, nil, nil)
+		sync := NewStateSync(empty, db, nil, nil, nil)
 		if nodes, paths, codes := sync.Missing(1); len(nodes) != 0 || len(paths) != 0 || len(codes) != 0 {
 			t.Errorf("content requested for empty state: %v", sync)
 		}
@@ -213,7 +213,7 @@ func TestEmptyStateSync(t *testing.T) {
 		bloom := statedb.NewSyncBloom(1, database.NewMemDB())
 		lruCache, _ := lru.New(int(1 * units.MB / common.HashLength))
 		db := database.NewMemoryDBManager()
-		sync := NewStateSync(empty, db, bloom, lruCache)
+		sync := NewStateSync(empty, db, bloom, lruCache, nil)
 		if nodes, paths, codes := sync.Missing(1); len(nodes) != 0 || len(paths) != 0 || len(codes) != 0 {
 			t.Errorf("content requested for empty state: %v", sync)
 		}
@@ -257,7 +257,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 	// Create a destination state and sync with the scheduler
 	dstDiskDb := database.NewMemoryDBManager()
 	dstState := NewDatabase(dstDiskDb)
-	sched := NewStateSync(srcRoot, dstDiskDb, statedb.NewSyncBloom(1, dstDiskDb.GetMemDB()), nil)
+	sched := NewStateSync(srcRoot, dstDiskDb, statedb.NewSyncBloom(1, dstDiskDb.GetMemDB()), nil, nil)
 
 	nodes, paths, codes := sched.Missing(count)
 	var (
@@ -422,7 +422,7 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 	// Create a destination state and sync with the scheduler
 	dstDiskDB := database.NewMemoryDBManager()
 	dstState := NewDatabase(dstDiskDB)
-	sched := NewStateSync(srcRoot, dstDiskDB, statedb.NewSyncBloom(1, dstDiskDB.GetMemDB()), nil)
+	sched := NewStateSync(srcRoot, dstDiskDB, statedb.NewSyncBloom(1, dstDiskDB.GetMemDB()), nil, nil)
 
 	nodes, _, codes := sched.Missing(0)
 	queue := append(append([]common.Hash{}, nodes...), codes...)
@@ -477,7 +477,7 @@ func testIterativeRandomStateSync(t *testing.T, count int) {
 	// Create a destination state and sync with the scheduler
 	dstDb := database.NewMemoryDBManager()
 	dstState := NewDatabase(dstDb)
-	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()), nil)
+	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()), nil, nil)
 
 	queue := make(map[common.Hash]struct{})
 	nodes, _, codes := sched.Missing(count)
@@ -534,7 +534,7 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 	// Create a destination state and sync with the scheduler
 	dstDb := database.NewMemoryDBManager()
 	dstState := NewDatabase(dstDb)
-	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()), nil)
+	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()), nil, nil)
 
 	queue := make(map[common.Hash]struct{})
 	nodes, _, codes := sched.Missing(0)
@@ -610,7 +610,7 @@ func TestIncompleteStateSync(t *testing.T) {
 	// Create a destination state and sync with the scheduler
 	dstDb := database.NewMemoryDBManager()
 	dstState := NewDatabase(dstDb)
-	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()), nil)
+	sched := NewStateSync(srcRoot, dstDb, statedb.NewSyncBloom(1, dstDb.GetMemDB()), nil, nil)
 
 	var added []common.Hash
 

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -131,7 +131,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 
 	// NOTE: lruCache is mandatory when state migration and block processing are executed simultaneously
 	lruCache, _ := lru.New(int(2 * units.Giga / common.HashLength)) // 2GB for 62,500,000 common.Hash key values
-	trieSync := state.NewStateSync(rootHash, dstState.TrieDB().DiskDB(), nil, lruCache)
+	trieSync := state.NewStateSync(rootHash, dstState.TrieDB().DiskDB(), nil, lruCache, nil)
 	var queue []common.Hash
 
 	quitCh := make(chan struct{})

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -123,7 +123,7 @@ var (
 	defaultSyncMode = cn.GetDefaultConfig().SyncMode
 	SyncModeFlag    = TextMarshalerFlag{
 		Name:  "syncmode",
-		Usage: `Blockchain sync mode (only "full" is supported)`,
+		Usage: `Blockchain sync mode ("full" or "snap")`,
 		Value: &defaultSyncMode,
 	}
 	GCModeFlag = cli.StringFlag{
@@ -1586,8 +1586,11 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
-		if cfg.SyncMode != downloader.FullSync {
-			log.Fatalf("only syncmode=full can be used for syncmode!")
+		if cfg.SyncMode == downloader.SnapSync {
+			logger.Info("Snap sync requested, enabling --snapshot")
+			ctx.Set(SnapshotFlag.Name, "true")
+		} else {
+			cfg.SnapshotCacheSize = 0 // Disabled
 		}
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1586,6 +1586,9 @@ func SetKlayConfig(ctx *cli.Context, stack *node.Node, cfg *cn.Config) {
 
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
+		if cfg.SyncMode != downloader.FullSync && cfg.SyncMode != downloader.SnapSync {
+			log.Fatalf("Full Sync or Snap Sync (prototype) is supported only!")
+		}
 		if cfg.SyncMode == downloader.SnapSync {
 			logger.Info("Snap sync requested, enabling --snapshot")
 			ctx.Set(SnapshotFlag.Name, "true")

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -41,7 +41,7 @@ var (
 	errInvalidPeerAddress = errors.New("invalid address")
 
 	// TODO-Klaytn-Istanbul: define Versions and Lengths with correct values.
-	istanbulProtocol = consensus.Protocol{
+	IstanbulProtocol = consensus.Protocol{
 		Name:     "istanbul",
 		Versions: []uint{65, 64},
 		Lengths:  []uint64{23, 21},
@@ -50,7 +50,7 @@ var (
 
 // Protocol implements consensus.Engine.Protocol
 func (sb *backend) Protocol() consensus.Protocol {
-	return istanbulProtocol
+	return IstanbulProtocol
 }
 
 // HandleMsg implements consensus.Handler.HandleMsg

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -129,7 +129,7 @@ func TestBackend_HandleMsg(t *testing.T) {
 
 func TestBackend_Protocol(t *testing.T) {
 	backend := newTestBackend()
-	assert.Equal(t, istanbulProtocol, backend.Protocol())
+	assert.Equal(t, IstanbulProtocol, backend.Protocol())
 }
 
 func TestBackend_ValidatePeerType(t *testing.T) {

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -1455,6 +1455,7 @@ func (d *Downloader) processHeaders(origin uint64, td *big.Int) error {
 				// Terminate if something failed in between processing chunks
 				select {
 				case <-d.cancelCh:
+					rollbackErr = errCanceled
 					return errCanceled
 				default:
 				}

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -405,8 +405,8 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 			// sync completely heals and finishes. Pause snapshot maintenance in the mean
 			// time to prevent access.
 			if snapshots := d.blockchain.Snapshots(); snapshots != nil { // Only nil in tests
-				logger.Warn("State snapshot is disabled")
 				snapshots.Disable()
+				logger.Warn("State snapshot is disabled")
 			}
 			logger.Warn("Enabling snapshot sync prototype")
 			d.snapSync = true

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -33,8 +33,10 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/event"
 	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/node/cn/snap"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/reward"
+	"github.com/klaytn/klaytn/snapshot"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/klaytn/klaytn/storage/statedb"
 	"github.com/rcrowley/go-metrics"
@@ -135,6 +137,10 @@ type Downloader struct {
 	stakingInfoWakeCh chan bool            // [klay/65] Channel to signal the staking info fetcher of new tasks
 	headerProcCh      chan []*types.Header // [klay/62] Channel to feed the header processor new tasks
 
+	// for snapsyncer
+	snapSync   bool         // Whether to run state sync over the snap protocol
+	SnapSyncer *snap.Syncer // TODO-Klaytn-Snapsyncer make private! hack for now
+
 	// for stateFetcher
 	pivotHeader *types.Header
 	pivotLock   sync.RWMutex
@@ -205,6 +211,9 @@ type BlockChain interface {
 
 	// InsertReceiptChain inserts a batch of receipts into the local chain.
 	InsertReceiptChain(types.Blocks, []types.Receipts) (int, error)
+
+	// Snapshots returns the blockchain snapshot tree.
+	Snapshots() *snapshot.Tree
 }
 
 // New creates a new downloader to fetch hashes and blocks from remote peers.
@@ -235,6 +244,7 @@ func New(mode SyncMode, stateDB database.DBManager, stateBloom *statedb.SyncBloo
 		headerProcCh:      make(chan []*types.Header, 1),
 		quitCh:            make(chan struct{}),
 		stateCh:           make(chan dataPack),
+		SnapSyncer:        snap.NewSyncer(stateDB),
 		stateSyncStart:    make(chan *stateSync),
 		syncStatsState: stateSyncStats{
 			processed: stateDB.ReadFastTrieProgress(),
@@ -263,6 +273,8 @@ func (d *Downloader) Progress() klaytn.SyncProgress {
 	switch mode {
 	case FullSync:
 		current = d.blockchain.CurrentBlock().NumberU64()
+	case SnapSync:
+		current = d.blockchain.CurrentFastBlock().NumberU64()
 	case FastSync:
 		current = d.blockchain.CurrentFastBlock().NumberU64()
 	case LightSync:
@@ -319,6 +331,10 @@ func (d *Downloader) UnregisterPeer(id string) error {
 	d.queue.Revoke(id)
 
 	return nil
+}
+
+func (d *Downloader) GetSnapSyncer() *snap.Syncer {
+	return d.SnapSyncer
 }
 
 // Synchronise tries to sync up our local block chain with a remote peer, both
@@ -381,6 +397,20 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 	// when the user attempts to fast sync a new empty network.
 	if mode == FullSync && d.stateBloom != nil {
 		d.stateBloom.Close()
+	}
+
+	if mode == SnapSync {
+		if !d.snapSync {
+			// Snap sync uses the snapshot namespace to store potentially flakey data until
+			// sync completely heals and finishes. Pause snapshot maintenance in the mean
+			// time to prevent access.
+			if snapshots := d.blockchain.Snapshots(); snapshots != nil { // Only nil in tests
+				logger.Warn("State snapshot is disabled")
+				snapshots.Disable()
+			}
+			logger.Warn("Enabling snapshot sync prototype")
+			d.snapSync = true
+		}
 	}
 	// Reset the queue, peer set and wake channels to clean any internal leftover state
 	d.queue.Reset(blockCacheMaxItems, blockCacheInitialItems)
@@ -454,7 +484,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 	if err != nil {
 		return err
 	}
-	if mode == FastSync && pivot == nil {
+	if (mode == FastSync || mode == SnapSync) && pivot == nil {
 		// If no pivot block was returned, the head is below the min full block
 		// threshold (i.e. new chain). In that case we won't really fast sync
 		// anyway, but still need a valid pivot block to avoid some code hitting
@@ -475,7 +505,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 	d.syncStatsLock.Unlock()
 
 	// Ensure our origin point is below any fast sync pivot point
-	if mode == FastSync {
+	if mode == FastSync || mode == SnapSync {
 		if height <= uint64(fsMinFullBlocks) {
 			origin = 0
 		} else {
@@ -486,7 +516,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 		}
 	}
 	d.committed = 1
-	if mode == FastSync && pivot.Number.Uint64() != 0 {
+	if (mode == FastSync || mode == SnapSync) && pivot.Number.Uint64() != 0 {
 		d.committed = 0
 	}
 	// Initiate the sync using a concurrent header and content retrieval algorithm
@@ -502,7 +532,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 		func() error { return d.fetchStakingInfos(origin + 1) }, // StakingInfos are retrieved during fast sync
 		func() error { return d.processHeaders(origin+1, td) },
 	}
-	if mode == FastSync {
+	if mode == FastSync || mode == SnapSync {
 		d.pivotLock.Lock()
 		d.pivotHeader = pivot
 		d.pivotLock.Unlock()
@@ -596,7 +626,7 @@ func (d *Downloader) fetchHead(p *peerConnection) (head *types.Header, pivot *ty
 	// Request the advertised remote head block and wait for the response
 	latest, _ := p.peer.Head()
 	fetch := 1
-	if mode == FastSync {
+	if mode == FastSync || mode == SnapSync {
 		fetch = 2 // head + pivot headers
 	}
 	go p.peer.RequestHeadersByHash(latest, fetch, fsMinFullBlocks-1, true)
@@ -624,7 +654,7 @@ func (d *Downloader) fetchHead(p *peerConnection) (head *types.Header, pivot *ty
 			// or there was not one requested.
 			head := headers[0]
 			if len(headers) == 1 {
-				if mode == FastSync && head.Number.Uint64() > uint64(fsMinFullBlocks) {
+				if (mode == FastSync || mode == SnapSync) && head.Number.Uint64() > uint64(fsMinFullBlocks) {
 					return nil, nil, fmt.Errorf("%w: no pivot included along head header", errBadPeer)
 				}
 				p.logger.Debug("Remote head identified, no pivot", "number", head.Number, "hash", head.Hash())
@@ -662,7 +692,7 @@ func (d *Downloader) findAncestor(p *peerConnection, height uint64) (uint64, err
 	mode := d.getMode()
 	if mode == FullSync {
 		ceil = d.blockchain.CurrentBlock().NumberU64()
-	} else if mode == FastSync {
+	} else if mode == FastSync || mode == SnapSync {
 		ceil = d.blockchain.CurrentFastBlock().NumberU64()
 	}
 	if ceil >= MaxForkAncestry {
@@ -1408,7 +1438,7 @@ func (d *Downloader) processHeaders(origin uint64, td *big.Int) error {
 				// This check cannot be executed "as is" for full imports, since blocks may still be
 				// queued for processing when the header download completes. However, as long as the
 				// peer gave us something useful, we're already happy/progressed (above check).
-				if mode == FastSync || mode == LightSync {
+				if mode == SnapSync || mode == FastSync || mode == LightSync {
 					head := d.lightchain.CurrentHeader()
 					if td.Cmp(d.lightchain.GetTd(head.Hash(), head.Number.Uint64())) > 0 {
 						return errStallingPeer
@@ -1436,7 +1466,7 @@ func (d *Downloader) processHeaders(origin uint64, td *big.Int) error {
 				chunk := headers[:limit]
 
 				// In case of header only syncing, validate the chunk immediately
-				if mode == FastSync || mode == LightSync {
+				if mode == SnapSync || mode == FastSync || mode == LightSync {
 					// Collect the yet unknown headers to mark them as uncertain
 					unknown := make([]*types.Header, 0, len(headers))
 					for _, header := range chunk {
@@ -1472,7 +1502,7 @@ func (d *Downloader) processHeaders(origin uint64, td *big.Int) error {
 					}
 				}
 				// Unless we're doing light chains, schedule the headers for associated content retrieval
-				if mode == FullSync || mode == FastSync {
+				if mode == FullSync || mode == SnapSync || mode == FastSync {
 					// If we've reached the allowed number of pending headers, stall a bit
 					for d.queue.PendingBlocks() >= maxQueuedHeaders || d.queue.PendingReceipts() >= maxQueuedHeaders {
 						select {
@@ -1577,7 +1607,7 @@ func (d *Downloader) processFastSyncContent() error {
 		sync.Cancel()
 	}()
 	closeOnErr := func(s *stateSync) {
-		if err := s.Wait(); err != nil && err != errCancelStateFetch && err != errCanceled {
+		if err := s.Wait(); err != nil && err != errCancelStateFetch && err != errCanceled && err != snap.ErrCancelled {
 			d.queue.Close() // wake up WaitResults
 		}
 	}
@@ -1785,6 +1815,32 @@ func (d *Downloader) DeliverStakingInfos(id string, stakingInfos []*reward.Staki
 // DeliverNodeData injects a new batch of node state data received from a remote node.
 func (d *Downloader) DeliverNodeData(id string, data [][]byte) (err error) {
 	return d.deliver(id, d.stateCh, &statePack{id, data}, stateInMeter, stateDropMeter)
+}
+
+// DeliverSnapPacket is invoked from a peer's message handler when it transmits a
+// data packet for the local node to consume.
+func (d *Downloader) DeliverSnapPacket(peer *snap.Peer, packet snap.Packet) error {
+	switch packet := packet.(type) {
+	case *snap.AccountRangePacket:
+		hashes, accounts, err := packet.Unpack()
+		if err != nil {
+			return err
+		}
+		return d.SnapSyncer.OnAccounts(peer, packet.ID, hashes, accounts, packet.Proof)
+
+	case *snap.StorageRangesPacket:
+		hashset, slotset := packet.Unpack()
+		return d.SnapSyncer.OnStorage(peer, packet.ID, hashset, slotset, packet.Proof)
+
+	case *snap.ByteCodesPacket:
+		return d.SnapSyncer.OnByteCodes(peer, packet.ID, packet.Codes)
+
+	case *snap.TrieNodesPacket:
+		return d.SnapSyncer.OnTrieNodes(peer, packet.ID, packet.Nodes)
+
+	default:
+		return fmt.Errorf("unexpected snap packet type: %T", packet)
+	}
 }
 
 // deliver injects a new batch of data received from a remote node.

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -1822,10 +1822,7 @@ func (d *Downloader) DeliverNodeData(id string, data [][]byte) (err error) {
 func (d *Downloader) DeliverSnapPacket(peer *snap.Peer, packet snap.Packet) error {
 	switch packet := packet.(type) {
 	case *snap.AccountRangePacket:
-		hashes, accounts, err := packet.Unpack()
-		if err != nil {
-			return err
-		}
+		hashes, accounts := packet.Unpack()
 		return d.SnapSyncer.OnAccounts(peer, packet.ID, hashes, accounts, packet.Proof)
 
 	case *snap.StorageRangesPacket:

--- a/datasync/downloader/downloader_fake.go
+++ b/datasync/downloader/downloader_fake.go
@@ -22,6 +22,7 @@ import (
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/node/cn/snap"
 	"github.com/klaytn/klaytn/reward"
 )
 
@@ -46,9 +47,15 @@ func (*FakeDownloader) DeliverStakingInfos(id string, stakingInfos []*reward.Sta
 	return nil
 }
 
+func (*FakeDownloader) DeliverSnapPacket(peer *snap.Peer, packet snap.Packet) error {
+	return nil
+}
+
 func (*FakeDownloader) Terminate() {}
 func (*FakeDownloader) Synchronise(id string, head common.Hash, td *big.Int, mode SyncMode) error {
 	return nil
 }
 func (*FakeDownloader) Progress() klaytn.SyncProgress { return klaytn.SyncProgress{} }
 func (*FakeDownloader) Cancel()                       {}
+
+func (*FakeDownloader) GetSnapSyncer() *snap.Syncer { return nil }

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/klaytn/klaytn/event"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/reward"
+	"github.com/klaytn/klaytn/snapshot"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/klaytn/klaytn/storage/statedb"
 )
@@ -458,6 +459,11 @@ func (dl *downloadTester) InsertReceiptChain(blocks types.Blocks, receipts []typ
 		}
 	}
 	return len(blocks), nil
+}
+
+// Snapshots returns the blockchain snapshot tree.
+func (dl *downloadTester) Snapshots() *snapshot.Tree {
+	return nil
 }
 
 // Rollback removes some recently added elements from the chain.

--- a/datasync/downloader/modes.go
+++ b/datasync/downloader/modes.go
@@ -25,6 +25,7 @@ type SyncMode uint32
 const (
 	FullSync  SyncMode = iota // Synchronise the entire blockchain history from full blocks
 	FastSync                  // Quickly download the headers, full sync only at the chain head
+	SnapSync                  // Download the chain and the state via compact snashots
 	LightSync                 // Download only the headers and terminate afterwards
 )
 
@@ -39,6 +40,8 @@ func (mode SyncMode) String() string {
 		return "full"
 	case FastSync:
 		return "fast"
+	case SnapSync:
+		return "snap"
 	case LightSync:
 		return "light"
 	default:
@@ -52,6 +55,8 @@ func (mode SyncMode) MarshalText() ([]byte, error) {
 		return []byte("full"), nil
 	case FastSync:
 		return []byte("fast"), nil
+	case SnapSync:
+		return []byte("snap"), nil
 	case LightSync:
 		return []byte("light"), nil
 	default:
@@ -65,6 +70,8 @@ func (mode *SyncMode) UnmarshalText(text []byte) error {
 		*mode = FullSync
 	case "fast":
 		*mode = FastSync
+	case "snap":
+		*mode = SnapSync
 	case "light":
 		*mode = LightSync
 	default:

--- a/datasync/downloader/resultstore.go
+++ b/datasync/downloader/resultstore.go
@@ -79,7 +79,7 @@ func (r *resultStore) SetThrottleThreshold(threshold uint64) uint64 {
 //   throttled - if true, the store is at capacity, this particular header is not prior now
 //   item      - the result to store data into
 //   err       - any error that occurred
-func (r *resultStore) AddFetch(header *types.Header, fastSync bool, proposerPolicy uint64) (stale, throttled bool, item *fetchResult, err error) {
+func (r *resultStore) AddFetch(header *types.Header, mode SyncMode, proposerPolicy uint64) (stale, throttled bool, item *fetchResult, err error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -89,7 +89,7 @@ func (r *resultStore) AddFetch(header *types.Header, fastSync bool, proposerPoli
 		return stale, throttled, item, err
 	}
 	if item == nil {
-		item = newFetchResult(header, fastSync, proposerPolicy)
+		item = newFetchResult(header, mode, proposerPolicy)
 		r.items[index] = item
 	}
 	return stale, throttled, item, err

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
+	github.com/holiman/uint256 v1.2.0
 	github.com/huin/goupnp v1.0.3-0.20220313090229-ca81a64b4204
 	github.com/influxdata/influxdb v1.8.3
 	github.com/jackpal/go-nat-pmp v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
+github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.0.3-0.20220313090229-ca81a64b4204 h1:+EYBkW+dbi3F/atB+LSQZSWh7+HNrV3A/N0y6DSoy9k=
 github.com/huin/goupnp v1.0.3-0.20220313090229-ca81a64b4204/go.mod h1:ZxNlw5WqJj6wSsRK5+YfflQGXYfccj5VgQsMNixHM7Y=

--- a/log/log_modules.go
+++ b/log/log_modules.go
@@ -113,12 +113,13 @@ const (
 	Reward
 	ServiceChain
 	Snapshot
+	SnapshotSync
 	StorageDatabase
 	StorageStateDB
 	VM
-	Work
 
 	// 51~60
+	Work
 	CMDKSPN
 	CMDKSEN
 	ChainDataFetcher
@@ -189,12 +190,13 @@ var moduleNames = [ModuleNameLen]string{
 	"contracts/reward",
 	"servicechain",
 	"snapshot",
+	"node/cn/snap",
 	"storage/database",
 	"storage/statedb",
 	"vm",
-	"work",
 
 	// 51~60
+	"work",
 	"cmd/kspn",
 	"cmd/ksen",
 	"datasync/chaindatafetcher",

--- a/networks/p2p/msgrate/msgrate.go
+++ b/networks/p2p/msgrate/msgrate.go
@@ -1,0 +1,471 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from p2p/msgrate/msgrate.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+// Package msgrate allows estimating the throughput of peers for more balanced syncs.
+
+package msgrate
+
+import (
+	"errors"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/klaytn/klaytn/log"
+)
+
+// measurementImpact is the impact a single measurement has on a peer's final
+// capacity value. A value closer to 0 reacts slower to sudden network changes,
+// but it is also more stable against temporary hiccups. 0.1 worked well for
+// most of Ethereum's existence, so might as well go with it.
+const measurementImpact = 0.1
+
+// capacityOverestimation is the ratio of items to over-estimate when retrieving
+// a peer's capacity to avoid locking into a lower value due to never attempting
+// to fetch more than some local stable value.
+const capacityOverestimation = 1.01
+
+// qosTuningPeers is the number of best peers to tune round trip times based on.
+// An Ethereum node doesn't need hundreds of connections to operate correctly,
+// so instead of lowering our download speed to the median of potentially many
+// bad nodes, we can target a smaller set of vey good nodes. At worse this will
+// result in less nodes to sync from, but that's still better than some hogging
+// the pipeline.
+const qosTuningPeers = 5
+
+// rttMinEstimate is the minimal round trip time to target requests for. Since
+// every request entails a 2 way latency + bandwidth + serving database lookups,
+// it should be generous enough to permit meaningful work to be done on top of
+// the transmission costs.
+const rttMinEstimate = 2 * time.Second
+
+// rttMaxEstimate is the maximal round trip time to target requests for. Although
+// the expectation is that a well connected node will never reach this, certain
+// special connectivity ones might experience significant delays (e.g. satellite
+// uplink with 3s RTT). This value should be low enough to forbid stalling the
+// pipeline too long, but large enough to cover the worst of the worst links.
+const rttMaxEstimate = 20 * time.Second
+
+// rttPushdownFactor is a multiplier to attempt forcing quicker requests than
+// what the message rate tracker estimates. The reason is that message rate
+// tracking adapts queries to the RTT, but multiple RTT values can be perfectly
+// valid, they just result in higher packet sizes. Since smaller packets almost
+// always result in stabler download streams, this factor hones in on the lowest
+// RTT from all the functional ones.
+const rttPushdownFactor = 0.9
+
+// rttMinConfidence is the minimum value the roundtrip confidence factor may drop
+// to. Since the target timeouts are based on how confident the tracker is in the
+// true roundtrip, it's important to not allow too huge fluctuations.
+const rttMinConfidence = 0.1
+
+// ttlScaling is the multiplier that converts the estimated roundtrip time to a
+// timeout cap for network requests. The expectation is that peers' response time
+// will fluctuate around the estimated roundtrip, but depending in their load at
+// request time, it might be higher than anticipated. This scaling factor ensures
+// that we allow remote connections some slack but at the same time do enforce a
+// behavior similar to our median peers.
+const ttlScaling = 3
+
+// ttlLimit is the maximum timeout allowance to prevent reaching crazy numbers
+// if some unforeseen network events shappen. As much as we try to hone in on
+// the most optimal values, it doesn't make any sense to go above a threshold,
+// even if everything is slow and screwy.
+const ttlLimit = time.Minute
+
+// tuningConfidenceCap is the number of active peers above which to stop detuning
+// the confidence number. The idea here is that once we hone in on the capacity
+// of a meaningful number of peers, adding one more should ot have a significant
+// impact on things, so just ron with the originals.
+const tuningConfidenceCap = 10
+
+// tuningImpact is the influence that a new tuning target has on the previously
+// cached value. This number is mostly just an out-of-the-blue heuristic that
+// prevents the estimates from jumping around. There's no particular reason for
+// the current value.
+const tuningImpact = 0.25
+
+// Tracker estimates the throughput capacity of a peer with regard to each data
+// type it can deliver. The goal is to dynamically adjust request sizes to max
+// out network throughput without overloading either the peer or th elocal node.
+//
+// By tracking in real time the latencies and bandiwdths peers exhibit for each
+// packet type, it's possible to prevent overloading by detecting a slowdown on
+// one type when another type is pushed too hard.
+//
+// Similarly, real time measurements also help avoid overloading the local net
+// connection if our peers would otherwise be capable to deliver more, but the
+// local link is saturated. In that case, the live measurements will force us
+// to reduce request sizes until the throughput gets stable.
+//
+// Lastly, message rate measurements allows us to detect if a peer is unsuaully
+// slow compared to other peers, in which case we can decide to keep it around
+// or free up the slot so someone closer.
+//
+// Since throughput tracking and estimation adapts dynamically to live network
+// conditions, it's fine to have multiple trackers locally track the same peer
+// in different subsystem. The throughput will simply be distributed across the
+// two trackers if both are highly active.
+type Tracker struct {
+	// capacity is the number of items retrievable per second of a given type.
+	// It is analogous to bandwidth, but we deliberately avoided using bytes
+	// as the unit, since serving nodes also spend a lot of time loading data
+	// from disk, which is linear in the number of items, but mostly constant
+	// in their sizes.
+	//
+	// Callers of course are free to use the item counter as a byte counter if
+	// or when their protocol of choise if capped by bytes instead of items.
+	// (eg. eth.getHeaders vs snap.getAccountRange).
+	capacity map[uint64]float64
+
+	// roundtrip is the latency a peer in general responds to data requests.
+	// This number is not used inside the tracker, but is exposed to compare
+	// peers to each other and filter out slow ones. Note however, it only
+	// makes sense to compare RTTs if the caller caters request sizes for
+	// each peer to target the same RTT. There's no need to make this number
+	// the real networking RTT, we just need a number to compare peers with.
+	roundtrip time.Duration
+
+	lock sync.RWMutex
+}
+
+// NewTracker creates a new message rate tracker for a specific peer. An initial
+// RTT is needed to avoid a peer getting marked as an outlier compared to others
+// right after joining. It's suggested to use the median rtt across all peers to
+// init a new peer tracker.
+func NewTracker(caps map[uint64]float64, rtt time.Duration) *Tracker {
+	if caps == nil {
+		caps = make(map[uint64]float64)
+	}
+	return &Tracker{
+		capacity:  caps,
+		roundtrip: rtt,
+	}
+}
+
+// Capacity calculates the number of items the peer is estimated to be able to
+// retrieve within the alloted time slot. The method will round up any division
+// errors and will add an additional overestimation ratio on top. The reason for
+// overshooting the capacity is because certain message types might not increase
+// the load proportionally to the requested items, so fetching a bit more might
+// still take the same RTT. By forcefully overshooting by a small amount, we can
+// avoid locking into a lower-that-real capacity.
+func (t *Tracker) Capacity(kind uint64, targetRTT time.Duration) int {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	// Calculate the actual measured throughput
+	throughput := t.capacity[kind] * float64(targetRTT) / float64(time.Second)
+
+	// Return an overestimation to force the peer out of a stuck minima, adding
+	// +1 in case the item count is too low for the overestimator to dent
+	return roundCapacity(1 + capacityOverestimation*throughput)
+}
+
+// roundCapacity gives the integer value of a capacity.
+// The result fits int32, and is guaranteed to be positive.
+func roundCapacity(cap float64) int {
+	const maxInt32 = float64(1<<31 - 1)
+	return int(math.Min(maxInt32, math.Max(1, math.Ceil(cap))))
+}
+
+// Update modifies the peer's capacity values for a specific data type with a new
+// measurement. If the delivery is zero, the peer is assumed to have either timed
+// out or to not have the requested data, resulting in a slash to 0 capacity. This
+// avoids assigning the peer retrievals that it won't be able to honour.
+func (t *Tracker) Update(kind uint64, elapsed time.Duration, items int) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// If nothing was delivered (timeout / unavailable data), reduce throughput
+	// to minimum
+	if items == 0 {
+		t.capacity[kind] = 0
+		return
+	}
+	// Otherwise update the throughput with a new measurement
+	if elapsed <= 0 {
+		elapsed = 1 // +1 (ns) to ensure non-zero divisor
+	}
+	measured := float64(items) / (float64(elapsed) / float64(time.Second))
+
+	t.capacity[kind] = (1-measurementImpact)*(t.capacity[kind]) + measurementImpact*measured
+	t.roundtrip = time.Duration((1-measurementImpact)*float64(t.roundtrip) + measurementImpact*float64(elapsed))
+}
+
+// Trackers is a set of message rate trackers across a number of peers with the
+// goal of aggregating certain measurements across the entire set for outlier
+// filtering and newly joining initialization.
+type Trackers struct {
+	trackers map[string]*Tracker
+
+	// roundtrip is the current best guess as to what is a stable round trip time
+	// across the entire collection of connected peers. This is derived from the
+	// various trackers added, but is used as a cache to avoid recomputing on each
+	// network request. The value is updated once every RTT to avoid fluctuations
+	// caused by hiccups or peer events.
+	roundtrip time.Duration
+
+	// confidence represents the probability that the estimated roundtrip value
+	// is the real one across all our peers. The confidence value is used as an
+	// impact factor of new measurements on old estimates. As our connectivity
+	// stabilizes, this value gravitates towards 1, new measurements havinng
+	// almost no impact. If there's a large peer churn and few peers, then new
+	// measurements will impact it more. The confidence is increased with every
+	// packet and dropped with every new connection.
+	confidence float64
+
+	// tuned is the time instance the tracker recalculated its cached roundtrip
+	// value and confidence values. A cleaner way would be to have a heartbeat
+	// goroutine do it regularly, but that requires a lot of maintenance to just
+	// run every now and again.
+	tuned time.Time
+
+	// The fields below can be used to override certain default values. Their
+	// purpose is to allow quicker tests. Don't use them in production.
+	OverrideTTLLimit time.Duration
+
+	log  log.Logger
+	lock sync.RWMutex
+}
+
+// NewTrackers creates an empty set of trackers to be filled with peers.
+func NewTrackers(log log.Logger) *Trackers {
+	return &Trackers{
+		trackers:         make(map[string]*Tracker),
+		roundtrip:        rttMaxEstimate,
+		confidence:       1,
+		tuned:            time.Now(),
+		OverrideTTLLimit: ttlLimit,
+		log:              log,
+	}
+}
+
+// Track inserts a new tracker into the set.
+func (t *Trackers) Track(id string, tracker *Tracker) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if _, ok := t.trackers[id]; ok {
+		return errors.New("already tracking")
+	}
+	t.trackers[id] = tracker
+	t.detune()
+
+	return nil
+}
+
+// Untrack stops tracking a previously added peer.
+func (t *Trackers) Untrack(id string) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if _, ok := t.trackers[id]; !ok {
+		return errors.New("not tracking")
+	}
+	delete(t.trackers, id)
+	return nil
+}
+
+// MedianRoundTrip returns the median RTT across all known trackers. The purpose
+// of the median RTT is to initialize a new peer with sane statistics that it will
+// hopefully outperform. If it seriously underperforms, there's a risk of dropping
+// the peer, but that is ok as we're aiming for a strong median.
+func (t *Trackers) MedianRoundTrip() time.Duration {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.medianRoundTrip()
+}
+
+// medianRoundTrip is the internal lockless version of MedianRoundTrip to be used
+// by the QoS tuner.
+func (t *Trackers) medianRoundTrip() time.Duration {
+	// Gather all the currently measured round trip times
+	rtts := make([]float64, 0, len(t.trackers))
+	for _, tt := range t.trackers {
+		tt.lock.RLock()
+		rtts = append(rtts, float64(tt.roundtrip))
+		tt.lock.RUnlock()
+	}
+	sort.Float64s(rtts)
+
+	median := rttMaxEstimate
+	if qosTuningPeers <= len(rtts) {
+		median = time.Duration(rtts[qosTuningPeers/2]) // Median of our best few peers
+	} else if len(rtts) > 0 {
+		median = time.Duration(rtts[len(rtts)/2]) // Median of all out connected peers
+	}
+	// Restrict the RTT into some QoS defaults, irrelevant of true RTT
+	if median < rttMinEstimate {
+		median = rttMinEstimate
+	}
+	if median > rttMaxEstimate {
+		median = rttMaxEstimate
+	}
+	return median
+}
+
+// MeanCapacities returns the capacities averaged across all the added trackers.
+// The purpos of the mean capacities are to initialize a new peer with some sane
+// starting values that it will hopefully outperform. If the mean overshoots, the
+// peer will be cut back to minimal capacity and given another chance.
+func (t *Trackers) MeanCapacities() map[uint64]float64 {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.meanCapacities()
+}
+
+// meanCapacities is the internal lockless version of MeanCapacities used for
+// debug logging.
+func (t *Trackers) meanCapacities() map[uint64]float64 {
+	capacities := make(map[uint64]float64)
+	for _, tt := range t.trackers {
+		tt.lock.RLock()
+		for key, val := range tt.capacity {
+			capacities[key] += val
+		}
+		tt.lock.RUnlock()
+	}
+	for key, val := range capacities {
+		capacities[key] = val / float64(len(t.trackers))
+	}
+	return capacities
+}
+
+// TargetRoundTrip returns the current target round trip time for a request to
+// complete in.The returned RTT is slightly under the estimated RTT. The reason
+// is that message rate estimation is a 2 dimensional problem which is solvable
+// for any RTT. The goal is to gravitate towards smaller RTTs instead of large
+// messages, to result in a stabler download stream.
+func (t *Trackers) TargetRoundTrip() time.Duration {
+	// Recalculate the internal caches if it's been a while
+	t.tune()
+
+	// Caches surely recent, return target roundtrip
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return time.Duration(float64(t.roundtrip) * rttPushdownFactor)
+}
+
+// TargetTimeout returns the timeout allowance for a single request to finish
+// under. The timeout is proportional to the roundtrip, but also takes into
+// consideration the tracker's confidence in said roundtrip and scales it
+// accordingly. The final value is capped to avoid runaway requests.
+func (t *Trackers) TargetTimeout() time.Duration {
+	// Recalculate the internal caches if it's been a while
+	t.tune()
+
+	// Caches surely recent, return target timeout
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.targetTimeout()
+}
+
+// targetTimeout is the internal lockless version of TargetTimeout to be used
+// during QoS tuning.
+func (t *Trackers) targetTimeout() time.Duration {
+	timeout := time.Duration(ttlScaling * float64(t.roundtrip) / t.confidence)
+	if timeout > t.OverrideTTLLimit {
+		timeout = t.OverrideTTLLimit
+	}
+	return timeout
+}
+
+// tune gathers the individual tracker statistics and updates the estimated
+// request round trip time.
+func (t *Trackers) tune() {
+	// Tune may be called concurrently all over the place, but we only want to
+	// periodically update and even then only once. First check if it was updated
+	// recently and abort if so.
+	t.lock.RLock()
+	dirty := time.Since(t.tuned) > t.roundtrip
+	t.lock.RUnlock()
+	if !dirty {
+		return
+	}
+	// If an update is needed, obtain a write lock but make sure we don't update
+	// it on all concurrent threads one by one.
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if dirty := time.Since(t.tuned) > t.roundtrip; !dirty {
+		return // A concurrent request beat us to the tuning
+	}
+	// First thread reaching the tuning point, update the estimates and return
+	t.roundtrip = time.Duration((1-tuningImpact)*float64(t.roundtrip) + tuningImpact*float64(t.medianRoundTrip()))
+	t.confidence = t.confidence + (1-t.confidence)/2
+
+	t.tuned = time.Now()
+	t.log.Debug("Recalculated msgrate QoS values", "rtt", t.roundtrip, "confidence", t.confidence, "ttl", t.targetTimeout(), "next", t.tuned.Add(t.roundtrip))
+	t.log.Trace("Debug dump of mean capacities", "caps", log.Lazy{Fn: t.meanCapacities})
+}
+
+// detune reduces the tracker's confidence in order to make fresh measurements
+// have a larger impact on the estimates. It is meant to be used during new peer
+// connections so they can have a proper impact on the estimates.
+func (t *Trackers) detune() {
+	// If we have a single peer, confidence is always 1
+	if len(t.trackers) == 1 {
+		t.confidence = 1
+		return
+	}
+	// If we have a ton of peers, don't drop the confidence since there's enough
+	// remaining to retain the same throughput
+	if len(t.trackers) >= tuningConfidenceCap {
+		return
+	}
+	// Otherwise drop the confidence factor
+	peers := float64(len(t.trackers))
+
+	t.confidence = t.confidence * (peers - 1) / peers
+	if t.confidence < rttMinConfidence {
+		t.confidence = rttMinConfidence
+	}
+	t.log.Debug("Relaxed msgrate QoS values", "rtt", t.roundtrip, "confidence", t.confidence, "ttl", t.targetTimeout())
+}
+
+// Capacity is a helper function to access a specific tracker without having to
+// track it explicitly outside.
+func (t *Trackers) Capacity(id string, kind uint64, targetRTT time.Duration) int {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	tracker := t.trackers[id]
+	if tracker == nil {
+		return 1 // Unregister race, don't return 0, it's a dangerous number
+	}
+	return tracker.Capacity(kind, targetRTT)
+}
+
+// Update is a helper function to access a specific tracker without having to
+// track it explicitly outside.
+func (t *Trackers) Update(id string, kind uint64, elapsed time.Duration, items int) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	if tracker := t.trackers[id]; tracker != nil {
+		tracker.Update(kind, elapsed, items)
+	}
+}

--- a/networks/p2p/peer.go
+++ b/networks/p2p/peer.go
@@ -143,6 +143,20 @@ func (p *Peer) Name() string {
 	return p.rws[ConnDefault].name
 }
 
+// RunningCap returns true if the peer is actively connected using any of the
+// enumerated versions of a specific protocol, meaning that at least one of the
+// versions is supported by both this node and the peer p.
+func (p *Peer) RunningCap(protocol string, versions []uint) bool {
+	if protos, ok := p.running[protocol]; ok {
+		for _, ver := range versions {
+			if protos[ConnDefault].Version == ver {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Caps returns the capabilities (supported subprotocols) of the remote peer.
 func (p *Peer) Caps() []Cap {
 	// TODO: maybe return copy

--- a/networks/p2p/tracker/tracker.go
+++ b/networks/p2p/tracker/tracker.go
@@ -1,0 +1,215 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from p2p/tracker/tracker.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package tracker
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/klaytn/klaytn/log"
+	metricutils "github.com/klaytn/klaytn/metrics/utils"
+	"github.com/rcrowley/go-metrics"
+)
+
+var logger = log.NewModuleLogger(log.SnapshotSync)
+
+const (
+	// trackedGaugeName is the prefix of the per-packet request tracking.
+	trackedGaugeName = "p2p/tracked"
+
+	// lostMeterName is the prefix of the per-packet request expirations.
+	lostMeterName = "p2p/lost"
+
+	// staleMeterName is the prefix of the per-packet stale responses.
+	staleMeterName = "p2p/stale"
+
+	// waitHistName is the prefix of the per-packet (req only) waiting time histograms.
+	waitHistName = "p2p/wait"
+
+	// maxTrackedPackets is a huge number to act as a failsafe on the number of
+	// pending requests the node will track. It should never be hit unless an
+	// attacker figures out a way to spin requests.
+	maxTrackedPackets = 100000
+)
+
+// request tracks sent network requests which have not yet received a response.
+type request struct {
+	peer    string
+	version uint // Protocol version
+
+	reqCode uint64 // Protocol message code of the request
+	resCode uint64 // Protocol message code of the expected response
+
+	time   time.Time     // Timestamp when the request was made
+	expire *list.Element // Expiration marker to untrack it
+}
+
+// Tracker is a pending network request tracker to measure how much time it takes
+// a remote peer to respond.
+type Tracker struct {
+	protocol string        // Protocol capability identifier for the metrics
+	timeout  time.Duration // Global timeout after which to drop a tracked packet
+
+	pending map[uint64]*request // Currently pending requests
+	expire  *list.List          // Linked list tracking the expiration order
+	wake    *time.Timer         // Timer tracking the expiration of the next item
+
+	lock sync.Mutex // Lock protecting from concurrent updates
+}
+
+// New creates a new network request tracker to monitor how much time it takes to
+// fill certain requests and how individual peers perform.
+func New(protocol string, timeout time.Duration) *Tracker {
+	return &Tracker{
+		protocol: protocol,
+		timeout:  timeout,
+		pending:  make(map[uint64]*request),
+		expire:   list.New(),
+	}
+}
+
+// Track adds a network request to the tracker to wait for a response to arrive
+// or until the request it cancelled or times out.
+func (t *Tracker) Track(peer string, version uint, reqCode uint64, resCode uint64, id uint64) {
+	if !metricutils.Enabled {
+		return
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// If there's a duplicate request, we've just random-collided (or more probably,
+	// we have a bug), report it. We could also add a metric, but we're not really
+	// expecting ourselves to be buggy, so a noisy warning should be enough.
+	if _, ok := t.pending[id]; ok {
+		logger.Error("Network request id collision", "protocol", t.protocol, "version", version, "code", reqCode, "id", id)
+		return
+	}
+	// If we have too many pending requests, bail out instead of leaking memory
+	if pending := len(t.pending); pending >= maxTrackedPackets {
+		logger.Error("Request tracker exceeded allowance", "pending", pending, "peer", peer, "protocol", t.protocol, "version", version, "code", reqCode)
+		return
+	}
+	// Id doesn't exist yet, start tracking it
+	t.pending[id] = &request{
+		peer:    peer,
+		version: version,
+		reqCode: reqCode,
+		resCode: resCode,
+		time:    time.Now(),
+		expire:  t.expire.PushBack(id),
+	}
+	g := fmt.Sprintf("%s/%s/%d/%#02x", trackedGaugeName, t.protocol, version, reqCode)
+	gauge := metrics.GetOrRegisterGauge(g, nil)
+	gauge.Update(gauge.Value() + 1)
+
+	// If we've just inserted the first item, start the expiration timer
+	if t.wake == nil {
+		t.wake = time.AfterFunc(t.timeout, t.clean)
+	}
+}
+
+// clean is called automatically when a preset time passes without a response
+// being dleivered for the first network request.
+func (t *Tracker) clean() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// Expire anything within a certain threshold (might be no items at all if
+	// we raced with the delivery)
+	for t.expire.Len() > 0 {
+		// Stop iterating if the next pending request is still alive
+		var (
+			head = t.expire.Front()
+			id   = head.Value.(uint64)
+			req  = t.pending[id]
+		)
+		if time.Since(req.time) < t.timeout+5*time.Millisecond {
+			break
+		}
+		// Nope, dead, drop it
+		t.expire.Remove(head)
+		delete(t.pending, id)
+
+		g := fmt.Sprintf("%s/%s/%d/%#02x", trackedGaugeName, t.protocol, req.version, req.reqCode)
+		gauge := metrics.GetOrRegisterGauge(g, nil)
+		gauge.Update(gauge.Value() - 1)
+
+		m := fmt.Sprintf("%s/%s/%d/%#02x", lostMeterName, t.protocol, req.version, req.reqCode)
+		metrics.GetOrRegisterMeter(m, nil).Mark(1)
+	}
+	t.schedule()
+}
+
+// schedule starts a timer to trigger on the expiration of the first network
+// packet.
+func (t *Tracker) schedule() {
+	if t.expire.Len() == 0 {
+		t.wake = nil
+		return
+	}
+	t.wake = time.AfterFunc(time.Until(t.pending[t.expire.Front().Value.(uint64)].time.Add(t.timeout)), t.clean)
+}
+
+// Fulfil fills a pending request, if any is available, reporting on various metrics.
+func (t *Tracker) Fulfil(peer string, version uint, code uint64, id uint64) {
+	if !metricutils.Enabled {
+		return
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// If it's a non existing request, track as stale response
+	req, ok := t.pending[id]
+	if !ok {
+		m := fmt.Sprintf("%s/%s/%d/%#02x", staleMeterName, t.protocol, version, code)
+		metrics.GetOrRegisterMeter(m, nil).Mark(1)
+		return
+	}
+	// If the response is funky, it might be some active attack
+	if req.peer != peer || req.version != version || req.resCode != code {
+		logger.Warn("Network response id collision",
+			"have", fmt.Sprintf("%s:%s/%d:%d", peer, t.protocol, version, code),
+			"want", fmt.Sprintf("%s:%s/%d:%d", peer, t.protocol, req.version, req.resCode),
+		)
+		return
+	}
+	// Everything matches, mark the request serviced and meter it
+	t.expire.Remove(req.expire)
+	delete(t.pending, id)
+	if req.expire.Prev() == nil {
+		if t.wake.Stop() {
+			t.schedule()
+		}
+	}
+	g := fmt.Sprintf("%s/%s/%d/%#02x", trackedGaugeName, t.protocol, req.version, req.reqCode)
+	gauge := metrics.GetOrRegisterGauge(g, nil)
+	gauge.Update(gauge.Value() - 1)
+
+	//h := fmt.Sprintf("%s/%s/%d/%#02x", waitHistName, t.protocol, req.version, req.reqCode)
+	//sampler := func() metrics.Sample {
+	//	return metrics.ResettingSample(
+	//		metrics.NewExpDecaySample(1028, 0.015),
+	//	)
+	//}
+	//metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(time.Since(req.time).Microseconds())
+}

--- a/networks/p2p/tracker/tracker.go
+++ b/networks/p2p/tracker/tracker.go
@@ -205,6 +205,7 @@ func (t *Tracker) Fulfil(peer string, version uint, code uint64, id uint64) {
 	gauge := metrics.GetOrRegisterGauge(g, nil)
 	gauge.Update(gauge.Value() - 1)
 
+	// TODO-Klaytn-SnapSync update the following metrics if necessary
 	//h := fmt.Sprintf("%s/%s/%d/%#02x", waitHistName, t.protocol, req.version, req.reqCode)
 	//sampler := func() metrics.Sample {
 	//	return metrics.ResettingSample(

--- a/node/cn/api_tracer.go
+++ b/node/cn/api_tracer.go
@@ -277,7 +277,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 			// Print progress logs if long enough time elapsed
 			if time.Since(logged) > log.StatsReportLimit {
 				if number > origin {
-					nodeSize, preimageSize := database.TrieDB().Size()
+					nodeSize, _, preimageSize := database.TrieDB().Size()
 					logger.Info("Tracing chain segment", "start", origin, "end", end.NumberU64(), "current", number, "transactions", traced, "elapsed", time.Since(begin), "nodeSize", nodeSize, "preimageSize", preimageSize)
 				} else {
 					logger.Info("Preparing state for chain trace", "block", number, "start", origin, "elapsed", time.Since(begin))
@@ -727,7 +727,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 		}
 		proot = root
 	}
-	nodeSize, preimageSize := database.TrieDB().Size()
+	nodeSize, _, preimageSize := database.TrieDB().Size()
 	logger.Info("Historical state regenerated", "block", block.NumberU64(), "elapsed", time.Since(start), "nodeSize", nodeSize, "preimageSize", preimageSize)
 	return statedb, nil
 }

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1054,6 +1054,10 @@ func handleStakingInfoRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error
 
 		// Retrieve the requested block's staking information, skipping if unknown to us
 		header := pm.blockchain.GetHeaderByHash(hash)
+		if header == nil {
+			logger.Error("Failed to get header", "hash", hash)
+			continue
+		}
 		result := reward.GetStakingInfoOnStakingBlock(header.Number.Uint64())
 		if result == nil {
 			logger.Error("Failed to get staking information on a specific block", "number", header.Number.Uint64(), "hash", hash)

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -73,6 +73,9 @@ const (
 
 	// DefaultTxResendInterval is the second of resending transactions period.
 	DefaultTxResendInterval = 4
+
+	// ExtraNonSnapPeers is the number of non-snap peers allowed to connect more than snap peers.
+	ExtraNonSnapPeers = 5
 )
 
 // errIncompatibleConfig is returned if the requested protocols and configs are
@@ -511,8 +514,8 @@ func (pm *ProtocolManager) handle(p Peer) error {
 		if snap == nil {
 			// If we are running snap-sync, we want to reserve roughly half the peer
 			// slots for peers supporting the snap protocol.
-			// The logic here is; we only allow up to 5 more non-snap peers than snap-peers.
-			if all, snp := pm.peers.Len(), pm.peers.SnapLen(); all-snp > snp+5 {
+			// The logic here is; we only allow up to ExtraNonSnapPeers more non-snap peers than snap-peers.
+			if all, snp := pm.peers.Len(), pm.peers.SnapLen(); all-snp > snp+ExtraNonSnapPeers {
 				reject = true
 			}
 		}

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -45,6 +45,7 @@ import (
 	"github.com/klaytn/klaytn/event"
 	"github.com/klaytn/klaytn/networks/p2p"
 	"github.com/klaytn/klaytn/networks/p2p/discover"
+	"github.com/klaytn/klaytn/node/cn/snap"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/rlp"
@@ -91,6 +92,7 @@ type ProtocolManager struct {
 	networkId uint64
 
 	fastSync  uint32 // Flag whether fast sync is enabled (gets disabled if we already have blocks)
+	snapSync  uint32 // Flag whether fast sync should operate on top of the snap protocol
 	acceptTxs uint32 // Flag whether we're considered synchronised (enables transaction processing)
 
 	txpool      work.TxPool
@@ -118,7 +120,8 @@ type ProtocolManager struct {
 	quitResendCh chan struct{}
 	// wait group is used for graceful shutdowns during downloading
 	// and processing
-	wg sync.WaitGroup
+	wg     sync.WaitGroup
+	peerWg sync.WaitGroup
 	// istanbul BFT
 	engine consensus.Engine
 
@@ -164,12 +167,17 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 	}
 
 	// Figure out whether to allow fast sync or not
-	if mode == downloader.FastSync && blockchain.CurrentBlock().NumberU64() > 0 {
+	if (mode == downloader.FastSync || mode == downloader.SnapSync) && blockchain.CurrentBlock().NumberU64() > 0 {
 		logger.Error("Blockchain not empty, fast sync disabled")
 		mode = downloader.FullSync
 	}
 	if mode == downloader.FastSync {
 		manager.fastSync = uint32(1)
+		manager.snapSync = uint32(0)
+	}
+	if mode == downloader.SnapSync {
+		manager.fastSync = uint32(0)
+		manager.snapSync = uint32(1)
 	}
 	// istanbul BFT
 	protocol := engine.Protocol()
@@ -178,6 +186,10 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 	for i, version := range protocol.Versions {
 		// Skip protocol version if incompatible with the mode of operation
 		if mode == downloader.FastSync && version < klay63 {
+			continue
+		}
+		// TODO-Klaytn-Snapsync add snapsync and version check here
+		if mode == downloader.SnapSync && version < klay65 {
 			continue
 		}
 		// Compatible; initialise the sub-protocol
@@ -241,6 +253,33 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 				return nil
 			},
 		})
+
+		if cnconfig.SnapshotCacheSize > 0 {
+			for _, version := range snap.ProtocolVersions {
+				manager.SubProtocols = append(manager.SubProtocols, p2p.Protocol{
+					Name:    snap.ProtocolName,
+					Version: version,
+					Length:  snap.ProtocolLengths[version],
+					Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
+						peer := snap.NewPeer(version, p, rw)
+						return manager.handleSnapPeer(peer)
+					},
+					RunWithRWs: func(p *p2p.Peer, rws []p2p.MsgReadWriter) error {
+						peer := snap.NewPeer(version, p, rws[p2p.ConnDefault])
+						return manager.handleSnapPeer(peer)
+					},
+					NodeInfo: func() interface{} {
+						return manager.NodeInfo()
+					},
+					PeerInfo: func(id discover.NodeID) interface{} {
+						if p := manager.peers.Peer(fmt.Sprintf("%x", id[:8])); p != nil {
+							return p.Info()
+						}
+						return nil
+					},
+				})
+			}
+		}
 	}
 
 	if len(manager.SubProtocols) == 0 {
@@ -255,8 +294,12 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		// sync is requested. The downloader is responsible for deallocating the state
 
 		// bloom when it's done.
+		// Note: we don't enable it if snap-sync is performed, since it's very heavy
+		// and the heal-portion of the snap sync is much lighter than fast. What we particularly
+		// want to avoid, is a 90%-finished (but restarted) snap-sync to begin
+		// indexing the entire trie
 		var stateBloom *statedb.SyncBloom
-		if atomic.LoadUint32(&manager.fastSync) == 1 {
+		if atomic.LoadUint32(&manager.fastSync) == 1 && atomic.LoadUint32(&manager.snapSync) == 0 {
 			stateBloom = statedb.NewSyncBloom(uint64(cacheLimit), chainDB.GetStateTrieDB())
 		}
 		var proposerPolicy uint64
@@ -278,7 +321,7 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		}
 		inserter := func(blocks types.Blocks) (int, error) {
 			// If fast sync is running, deny importing weird blocks
-			if atomic.LoadUint32(&manager.fastSync) == 1 {
+			if atomic.LoadUint32(&manager.fastSync) == 1 || atomic.LoadUint32(&manager.snapSync) == 1 {
 				logger.Warn("Discarded bad propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
 				return 0, nil
 			}
@@ -318,6 +361,9 @@ func (pm *ProtocolManager) removePeer(id string) {
 		return
 	}
 	logger.Debug("Removing Klaytn peer", "peer", id)
+	if peer.ExistSnapExtension() {
+		pm.downloader.GetSnapSyncer().Unregister(id)
+	}
 
 	// Unregister the peer from the downloader and peer set
 	pm.downloader.UnregisterPeer(id)
@@ -411,14 +457,37 @@ func (pm *ProtocolManager) newPeerWithRWs(pv int, p *p2p.Peer, rws []p2p.MsgRead
 	return newPeerWithRWs(pv, p, meteredRWs)
 }
 
+func (pm *ProtocolManager) handleSnapPeer(peer *snap.Peer) error {
+	pm.peerWg.Add(1)
+	defer pm.peerWg.Done()
+
+	if err := pm.peers.RegisterSnapExtension(peer); err != nil {
+		peer.Log().Warn("Snapshot extension registration failed", "err", err)
+		return err
+	}
+
+	return snap.Handle(pm.blockchain, pm.downloader, peer)
+}
+
 // handle is the callback invoked to manage the life cycle of a Klaytn peer. When
 // this function terminates, the peer is disconnected.
 func (pm *ProtocolManager) handle(p Peer) error {
+	// If the peer has a `snap` extension, wait for it to connect so we can have
+	// a uniform initialization/teardown mechanism
+	snap, err := pm.peers.WaitSnapExtension(p)
+	if err != nil {
+		p.GetP2PPeer().Log().Error("Snapshot extension barrier failed", "err", err)
+		return err
+	}
+
 	// Ignore maxPeers if this is a trusted peer
 	if pm.peers.Len() >= pm.maxPeers && !p.GetP2PPeer().Info().Networks[p2p.ConnDefault].Trusted {
 		return p2p.DiscTooManyPeers
 	}
 	p.GetP2PPeer().Log().Debug("Klaytn peer connected", "name", p.GetP2PPeer().Name())
+
+	pm.peerWg.Add(1)
+	defer pm.peerWg.Done()
 
 	// Execute the handshake
 	var (
@@ -429,17 +498,34 @@ func (pm *ProtocolManager) handle(p Peer) error {
 		td      = pm.blockchain.GetTd(hash, number)
 	)
 
-	err := p.Handshake(pm.networkId, pm.getChainID(), td, hash, genesis.Hash())
-	if err != nil {
+	if err := p.Handshake(pm.networkId, pm.getChainID(), td, hash, genesis.Hash()); err != nil {
 		p.GetP2PPeer().Log().Debug("Klaytn peer handshake failed", "err", err)
 		return err
 	}
+	reject := false
+	if atomic.LoadUint32(&pm.snapSync) == 1 {
+		if snap == nil {
+			// If we are running snap-sync, we want to reserve roughly half the peer
+			// slots for peers supporting the snap protocol.
+			// The logic here is; we only allow up to 5 more non-snap peers than snap-peers.
+			if all, snp := pm.peers.Len(), pm.peers.SnapLen(); all-snp > snp+5 {
+				reject = true
+			}
+		}
+	}
+	// Ignore maxPeers if this is a trusted peer
+	if p.GetP2PPeer().Info().Networks[p2p.ConnDefault].Trusted {
+		if reject || pm.peers.Len() >= pm.maxPeers {
+			return p2p.DiscTooManyPeers
+		}
+	}
+
 	if rw, ok := p.GetRW().(*meteredMsgReadWriter); ok {
 		rw.Init(p.GetVersion())
 	}
 
 	// Register the peer locally
-	if err := pm.peers.Register(p); err != nil {
+	if err := pm.peers.Register(p, snap); err != nil {
 		// if starting node with unlock account, can't register peer until finish unlock
 		p.GetP2PPeer().Log().Info("Klaytn peer registration failed", "err", err)
 		return err
@@ -450,6 +536,13 @@ func (pm *ProtocolManager) handle(p Peer) error {
 	if err := pm.downloader.RegisterPeer(p.GetID(), p.GetVersion(), p); err != nil {
 		return err
 	}
+	if snap != nil {
+		if err := pm.downloader.GetSnapSyncer().Register(snap); err != nil {
+			p.GetP2PPeer().Log().Info("Failed to register peer in snap syncer", "err", err)
+			return err
+		}
+	}
+
 	// Propagate existing transactions. new transactions appearing
 	// after this will be sent via broadcasts.
 	pm.syncTransactions(p)

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -261,10 +261,14 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 					Version: version,
 					Length:  snap.ProtocolLengths[version],
 					Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
+						manager.wg.Add(1)
+						defer manager.wg.Done()
 						peer := snap.NewPeer(version, p, rw)
 						return manager.handleSnapPeer(peer)
 					},
 					RunWithRWs: func(p *p2p.Peer, rws []p2p.MsgReadWriter) error {
+						manager.wg.Add(1)
+						defer manager.wg.Done()
 						peer := snap.NewPeer(version, p, rws[p2p.ConnDefault])
 						return manager.handleSnapPeer(peer)
 					},

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -247,6 +247,8 @@ func TestProtocolManager_removePeer(t *testing.T) {
 		pm.downloader = mockDownloader
 
 		// Return
+		mockPeer.EXPECT().ExistSnapExtension().Return(false).Times(1)
+
 		mockPeerSet.EXPECT().Unregister(peerID).Return(expectedErr).Times(1)
 
 		mockPeer.EXPECT().GetP2PPeer().Return(p2pPeers[0]).Times(1)
@@ -271,6 +273,8 @@ func TestProtocolManager_removePeer(t *testing.T) {
 		pm.downloader = mockDownloader
 
 		// Return
+		mockPeer.EXPECT().ExistSnapExtension().Return(false).Times(1)
+
 		mockPeerSet.EXPECT().Unregister(peerID).Return(nil).Times(1)
 
 		mockPeer.EXPECT().GetP2PPeer().Return(p2pPeers[0]).Times(1)
@@ -1059,7 +1063,7 @@ func TestBroadcastTxsSortedByTime(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 
 	pm.peers = peers
-	pm.peers.Register(basePeer)
+	pm.peers.Register(basePeer, nil)
 
 	go func(t *testing.T) {
 		pm.BroadcastTxs(txs)
@@ -1120,7 +1124,7 @@ func TestReBroadcastTxsSortedByTime(t *testing.T) {
 	basePeer, _, oppositePipe := newBasePeer()
 
 	pm.peers = peers
-	pm.peers.Register(basePeer)
+	pm.peers.Register(basePeer, nil)
 
 	go func(t *testing.T) {
 		pm.ReBroadcastTxs(txs)

--- a/node/cn/mocks/downloader_mock.go
+++ b/node/cn/mocks/downloader_mock.go
@@ -13,6 +13,7 @@ import (
 	types "github.com/klaytn/klaytn/blockchain/types"
 	common "github.com/klaytn/klaytn/common"
 	downloader "github.com/klaytn/klaytn/datasync/downloader"
+	snap "github.com/klaytn/klaytn/node/cn/snap"
 	reward "github.com/klaytn/klaytn/reward"
 )
 
@@ -107,6 +108,20 @@ func (mr *MockProtocolManagerDownloaderMockRecorder) DeliverReceipts(arg0, arg1 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverReceipts", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).DeliverReceipts), arg0, arg1)
 }
 
+// DeliverSnapPacket mocks base method
+func (m *MockProtocolManagerDownloader) DeliverSnapPacket(arg0 *snap.Peer, arg1 snap.Packet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeliverSnapPacket", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeliverSnapPacket indicates an expected call of DeliverSnapPacket
+func (mr *MockProtocolManagerDownloaderMockRecorder) DeliverSnapPacket(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverSnapPacket", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).DeliverSnapPacket), arg0, arg1)
+}
+
 // DeliverStakingInfos mocks base method
 func (m *MockProtocolManagerDownloader) DeliverStakingInfos(arg0 string, arg1 []*reward.StakingInfo) error {
 	m.ctrl.T.Helper()
@@ -119,6 +134,20 @@ func (m *MockProtocolManagerDownloader) DeliverStakingInfos(arg0 string, arg1 []
 func (mr *MockProtocolManagerDownloaderMockRecorder) DeliverStakingInfos(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverStakingInfos", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).DeliverStakingInfos), arg0, arg1)
+}
+
+// GetSnapSyncer mocks base method
+func (m *MockProtocolManagerDownloader) GetSnapSyncer() *snap.Syncer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSnapSyncer")
+	ret0, _ := ret[0].(*snap.Syncer)
+	return ret0
+}
+
+// GetSnapSyncer indicates an expected call of GetSnapSyncer
+func (mr *MockProtocolManagerDownloaderMockRecorder) GetSnapSyncer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapSyncer", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).GetSnapSyncer))
 }
 
 // Progress mocks base method

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -26,6 +26,7 @@ import (
 	"math/big"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -35,6 +36,7 @@ import (
 	"github.com/klaytn/klaytn/datasync/downloader"
 	"github.com/klaytn/klaytn/networks/p2p"
 	"github.com/klaytn/klaytn/networks/p2p/discover"
+	"github.com/klaytn/klaytn/node/cn/snap"
 	"github.com/klaytn/klaytn/rlp"
 )
 
@@ -228,6 +230,17 @@ type Peer interface {
 
 	// RegisterConsensusMsgCode registers the channel of consensus msg.
 	RegisterConsensusMsgCode(msgCode uint64) error
+
+	// RunningCap returns true if the peer is actively connected using any of the
+	// enumerated versions of a specific protocol, meaning that at least one of the
+	// versions is supported by both this node and the peer p.
+	RunningCap(protocol string, versions []uint) bool
+
+	// AddSnapExtension extends the peer to support snap protocol.
+	AddSnapExtension(peer *snap.Peer)
+
+	// ExistSnapExtension returns true if the peer supports snap protocol.
+	ExistSnapExtension() bool
 }
 
 // basePeer is a common data structure used by implementation of Peer.
@@ -254,6 +267,8 @@ type basePeer struct {
 	term             chan struct{}             // Termination channel to stop the broadcaster
 
 	chainID *big.Int // ChainID to sign a transaction
+
+	snapExt *snap.Peer // Satellite `snap` connection
 }
 
 // newKnownBlockCache returns an empty cache for knownBlocksCache.
@@ -306,6 +321,10 @@ var ChannelOfMessage = map[uint64]int{
 	NodeDataMsg:        p2p.ConnDefault,
 	ReceiptsRequestMsg: p2p.ConnDefault,
 	ReceiptsMsg:        p2p.ConnDefault,
+
+	// Protocol messages belonging to klay/65
+	StakingInfoRequestMsg: p2p.ConnDefault,
+	StakingInfoMsg:        p2p.ConnDefault,
 }
 
 var ConcurrentOfChannel = []int{
@@ -763,6 +782,16 @@ func (p *basePeer) RegisterConsensusMsgCode(msgCode uint64) error {
 	return fmt.Errorf("%v peerID: %v ", errNotSupportedByBasePeer, p.GetID())
 }
 
+// AddSnapExtension extends this peer to support snap protocol.
+func (p *basePeer) AddSnapExtension(peer *snap.Peer) {
+	p.snapExt = peer
+}
+
+// ExistSnapExtension returns true if this peer supports snap protocol.
+func (p *basePeer) ExistSnapExtension() bool {
+	return p.snapExt != nil
+}
+
 // singleChannelPeer is a peer that uses a single channel.
 type singleChannelPeer struct {
 	*basePeer
@@ -1026,11 +1055,22 @@ func (p *multiChannelPeer) ReadMsg(rw p2p.MsgReadWriter, connectionOrder int, er
 // Handle is the callback invoked to manage the life cycle of a Klaytn Peer. When
 // this function terminates, the Peer is disconnected.
 func (p *multiChannelPeer) Handle(pm *ProtocolManager) error {
+	// If the peer has a `snap` extension, wait for it to connect so we can have
+	// a uniform initialization/teardown mechanism
+	snap, err := pm.peers.WaitSnapExtension(p)
+	if err != nil {
+		p.GetP2PPeer().Log().Error("Snapshot extension barrier failed", "err", err)
+		return err
+	}
+
 	// Ignore maxPeers if this is a trusted peer
 	if pm.peers.Len() >= pm.maxPeers && !p.GetP2PPeer().Info().Networks[p2p.ConnDefault].Trusted {
 		return p2p.DiscTooManyPeers
 	}
 	p.GetP2PPeer().Log().Debug("Klaytn peer connected", "name", p.GetP2PPeer().Name())
+
+	pm.peerWg.Add(1)
+	defer pm.peerWg.Done()
 
 	// Execute the handshake
 	var (
@@ -1041,16 +1081,32 @@ func (p *multiChannelPeer) Handle(pm *ProtocolManager) error {
 		td      = pm.blockchain.GetTd(hash, number)
 	)
 
-	err := p.Handshake(pm.networkId, pm.getChainID(), td, hash, genesis.Hash())
-	if err != nil {
+	if err := p.Handshake(pm.networkId, pm.getChainID(), td, hash, genesis.Hash()); err != nil {
 		p.GetP2PPeer().Log().Debug("Klaytn peer handshake failed", "err", err)
 		return err
+	}
+	reject := false
+	if atomic.LoadUint32(&pm.snapSync) == 1 {
+		if snap == nil {
+			// If we are running snap-sync, we want to reserve roughly half the peer
+			// slots for peers supporting the snap protocol.
+			// The logic here is; we only allow up to 5 more non-snap peers than snap-peers.
+			if all, snp := pm.peers.Len(), pm.peers.SnapLen(); all-snp > snp+5 {
+				reject = true
+			}
+		}
+	}
+	// Ignore maxPeers if this is a trusted peer
+	if p.GetP2PPeer().Info().Networks[p2p.ConnDefault].Trusted {
+		if reject || pm.peers.Len() >= pm.maxPeers {
+			return p2p.DiscTooManyPeers
+		}
 	}
 
 	p.UpdateRWImplementationVersion()
 
 	// Register the peer locally
-	if err := pm.peers.Register(p); err != nil {
+	if err := pm.peers.Register(p, snap); err != nil {
 		// if starting node with unlock account, can't register peer until finish unlock
 		p.GetP2PPeer().Log().Info("Klaytn peer registration failed", "err", err)
 		return err
@@ -1061,6 +1117,13 @@ func (p *multiChannelPeer) Handle(pm *ProtocolManager) error {
 	if err := pm.downloader.RegisterPeer(p.GetID(), p.GetVersion(), p); err != nil {
 		return err
 	}
+	if snap != nil {
+		if err := pm.downloader.GetSnapSyncer().Register(snap); err != nil {
+			p.GetP2PPeer().Log().Info("Failed to register peer in snap syncer", "err", err)
+			return err
+		}
+	}
+
 	// Propagate existing transactions. new transactions appearing
 	// after this will be sent via broadcasts.
 	pm.syncTransactions(p)

--- a/node/cn/peer_mock_test.go
+++ b/node/cn/peer_mock_test.go
@@ -13,6 +13,7 @@ import (
 	common "github.com/klaytn/klaytn/common"
 	p2p "github.com/klaytn/klaytn/networks/p2p"
 	discover "github.com/klaytn/klaytn/networks/p2p/discover"
+	snap "github.com/klaytn/klaytn/node/cn/snap"
 	rlp "github.com/klaytn/klaytn/rlp"
 )
 
@@ -37,6 +38,18 @@ func NewMockPeer(ctrl *gomock.Controller) *MockPeer {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockPeer) EXPECT() *MockPeerMockRecorder {
 	return m.recorder
+}
+
+// AddSnapExtension mocks base method
+func (m *MockPeer) AddSnapExtension(arg0 *snap.Peer) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddSnapExtension", arg0)
+}
+
+// AddSnapExtension indicates an expected call of AddSnapExtension
+func (mr *MockPeerMockRecorder) AddSnapExtension(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSnapExtension", reflect.TypeOf((*MockPeer)(nil).AddSnapExtension), arg0)
 }
 
 // AddToKnownBlocks mocks base method
@@ -147,6 +160,20 @@ func (m *MockPeer) DisconnectP2PPeer(arg0 p2p.DiscReason) {
 func (mr *MockPeerMockRecorder) DisconnectP2PPeer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectP2PPeer", reflect.TypeOf((*MockPeer)(nil).DisconnectP2PPeer), arg0)
+}
+
+// ExistSnapExtension mocks base method
+func (m *MockPeer) ExistSnapExtension() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExistSnapExtension")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ExistSnapExtension indicates an expected call of ExistSnapExtension
+func (mr *MockPeerMockRecorder) ExistSnapExtension() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistSnapExtension", reflect.TypeOf((*MockPeer)(nil).ExistSnapExtension))
 }
 
 // FetchBlockBodies mocks base method
@@ -470,6 +497,20 @@ func (m *MockPeer) RequestStakingInfo(arg0 []common.Hash) error {
 func (mr *MockPeerMockRecorder) RequestStakingInfo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestStakingInfo", reflect.TypeOf((*MockPeer)(nil).RequestStakingInfo), arg0)
+}
+
+// RunningCap mocks base method
+func (m *MockPeer) RunningCap(arg0 string, arg1 []uint) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunningCap", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// RunningCap indicates an expected call of RunningCap
+func (mr *MockPeerMockRecorder) RunningCap(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunningCap", reflect.TypeOf((*MockPeer)(nil).RunningCap), arg0, arg1)
 }
 
 // Send mocks base method

--- a/node/cn/peer_set.go
+++ b/node/cn/peer_set.go
@@ -21,6 +21,7 @@
 package cn
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -28,12 +29,24 @@ import (
 
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul/backend"
 	"github.com/klaytn/klaytn/networks/p2p"
+	"github.com/klaytn/klaytn/node/cn/snap"
+)
+
+var (
+	// errPeerAlreadyRegistered is returned if a peer is attempted to be added
+	// to the peer set, but one with the same id already exists.
+	errPeerAlreadyRegistered = errors.New("peer already registered")
+
+	// errSnapWithoutIstanbul is returned if a peer attempts to connect only on the
+	// snap protocol without advertizing the istanbul main protocol.
+	errSnapWithoutIstanbul = errors.New("peer connected on snap without compatible istanbul support")
 )
 
 //go:generate mockgen -destination=node/cn/peer_set_mock_test.go -package=cn github.com/klaytn/klaytn/node/cn PeerSet
 type PeerSet interface {
-	Register(p Peer) error
+	Register(p Peer, ext *snap.Peer) error
 	Unregister(id string) error
 
 	Peers() map[string]Peer
@@ -42,6 +55,7 @@ type PeerSet interface {
 	PNPeers() map[common.Address]Peer
 	Peer(id string) Peer
 	Len() int
+	SnapLen() int
 
 	PeersWithoutBlock(hash common.Hash) []Peer
 
@@ -52,6 +66,9 @@ type PeerSet interface {
 	TypePeersWithoutTx(hash common.Hash, nodetype common.ConnType) []Peer
 	CNWithoutTx(hash common.Hash) []Peer
 	UpdateTypePeersWithoutTxs(tx *types.Transaction, nodeType common.ConnType, peersWithoutTxsMap map[Peer]types.Transactions)
+
+	RegisterSnapExtension(peer *snap.Peer) error
+	WaitSnapExtension(peer Peer) (*snap.Peer, error)
 
 	BestPeer() Peer
 	RegisterValidator(connType common.ConnType, validator p2p.PeerTypeValidator)
@@ -65,8 +82,13 @@ type peerSet struct {
 	cnpeers map[common.Address]Peer
 	pnpeers map[common.Address]Peer
 	enpeers map[common.Address]Peer
-	lock    sync.RWMutex
-	closed  bool
+
+	snapPeers int                        // Number of `snap` compatible peers for connection prioritization
+	snapWait  map[string]chan *snap.Peer // Peers connected on `eth` waiting for their snap extension
+	snapPend  map[string]*snap.Peer      // Peers connected on the `snap` protocol, but not yet on `eth`
+
+	lock   sync.RWMutex
+	closed bool
 
 	validator map[common.ConnType]p2p.PeerTypeValidator
 }
@@ -78,6 +100,8 @@ func newPeerSet() *peerSet {
 		cnpeers:   make(map[common.Address]Peer),
 		pnpeers:   make(map[common.Address]Peer),
 		enpeers:   make(map[common.Address]Peer),
+		snapWait:  make(map[string]chan *snap.Peer),
+		snapPend:  make(map[string]*snap.Peer),
 		validator: make(map[common.ConnType]p2p.PeerTypeValidator),
 	}
 
@@ -90,7 +114,7 @@ func newPeerSet() *peerSet {
 
 // Register injects a new peer into the working set, or returns an error if the
 // peer is already known.
-func (ps *peerSet) Register(p Peer) error {
+func (ps *peerSet) Register(p Peer, ext *snap.Peer) error {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 
@@ -126,6 +150,11 @@ func (ps *peerSet) Register(p Peer) error {
 		return fmt.Errorf("fail to validate peer type: %s", err)
 	}
 
+	if ext != nil {
+		p.AddSnapExtension(ext)
+		ps.snapPeers++
+	}
+
 	peersByNodeType[p.GetAddr()] = p // add peer to its node type peer map.
 	ps.peers[p.GetID()] = p          // add peer to entire peer map.
 
@@ -159,6 +188,10 @@ func (ps *peerSet) Unregister(id string) error {
 		delete(ps.enpeers, p.GetAddr())
 	default:
 		return errUnexpectedNodeType
+	}
+
+	if p.ExistSnapExtension() {
+		ps.snapPeers--
 	}
 
 	cnPeerCountGauge.Update(int64(len(ps.cnpeers)))
@@ -225,6 +258,14 @@ func (ps *peerSet) Len() int {
 	defer ps.lock.RUnlock()
 
 	return len(ps.peers)
+}
+
+// SnapLen returns if the current number of `snap` peers in the set.
+func (ps *peerSet) SnapLen() int {
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+
+	return ps.snapPeers
 }
 
 // PeersWithoutBlock retrieves a list of peers that do not have a given block in
@@ -468,4 +509,68 @@ func (peers *peerSet) UpdateTypePeersWithoutTxs(tx *types.Transaction, nodeType 
 		peersWithoutTxsMap[peer] = append(peersWithoutTxsMap[peer], tx)
 	}
 	logger.Trace("Broadcast transaction", "hash", tx.Hash(), "recipients", len(typePeers))
+}
+
+// RegisterSnapExtension unblocks an already connected `klay` peer waiting for its
+// `snap` extension, or if no such peer exists, tracks the extension for the time
+// being until the `eth` main protocol starts looking for it.
+func (peers *peerSet) RegisterSnapExtension(peer *snap.Peer) error {
+	// Reject the peer if it advertises `snap` without `klay` as `snap` is only a
+	// satellite protocol meaningful with the chain selection of `klay`
+	if !peer.RunningCap(backend.IstanbulProtocol.Name, backend.IstanbulProtocol.Versions) {
+		return errSnapWithoutIstanbul
+	}
+	// Ensure nobody can double connect
+	peers.lock.Lock()
+	defer peers.lock.Unlock()
+
+	id := peer.ID()
+	if _, ok := peers.peers[id]; ok {
+		return errPeerAlreadyRegistered // avoid connections with the same id as existing ones
+	}
+	if _, ok := peers.snapPend[id]; ok {
+		return errPeerAlreadyRegistered // avoid connections with the same id as pending ones
+	}
+	// Inject the peer into an `eth` counterpart is available, otherwise save for later
+	if wait, ok := peers.snapWait[id]; ok {
+		delete(peers.snapWait, id)
+		wait <- peer
+		return nil
+	}
+	peers.snapPend[id] = peer
+	return nil
+}
+
+// WaitSnapExtension blocks until all satellite protocols are connected and tracked
+// by the peerset.
+func (ps *peerSet) WaitSnapExtension(peer Peer) (*snap.Peer, error) {
+	// If the peer does not support a compatible `snap`, don't wait
+	if !peer.RunningCap(snap.ProtocolName, snap.ProtocolVersions) {
+		return nil, nil
+	}
+	// Ensure nobody can double connect
+	ps.lock.Lock()
+
+	id := peer.GetID()
+	if _, ok := ps.peers[id]; ok {
+		ps.lock.Unlock()
+		return nil, errPeerAlreadyRegistered // avoid connections with the same id as existing ones
+	}
+	if _, ok := ps.snapWait[id]; ok {
+		ps.lock.Unlock()
+		return nil, errPeerAlreadyRegistered // avoid connections with the same id as pending ones
+	}
+	// If `snap` already connected, retrieve the peer from the pending set
+	if snap, ok := ps.snapPend[id]; ok {
+		delete(ps.snapPend, id)
+
+		ps.lock.Unlock()
+		return snap, nil
+	}
+	// Otherwise wait for `snap` to connect concurrently
+	wait := make(chan *snap.Peer)
+	ps.snapWait[id] = wait
+	ps.lock.Unlock()
+
+	return <-wait, nil
 }

--- a/node/cn/peer_set_mock_test.go
+++ b/node/cn/peer_set_mock_test.go
@@ -11,6 +11,7 @@ import (
 	types "github.com/klaytn/klaytn/blockchain/types"
 	common "github.com/klaytn/klaytn/common"
 	p2p "github.com/klaytn/klaytn/networks/p2p"
+	snap "github.com/klaytn/klaytn/node/cn/snap"
 )
 
 // MockPeerSet is a mock of PeerSet interface
@@ -189,17 +190,31 @@ func (mr *MockPeerSetMockRecorder) PeersWithoutTx(arg0 interface{}) *gomock.Call
 }
 
 // Register mocks base method
-func (m *MockPeerSet) Register(arg0 Peer) error {
+func (m *MockPeerSet) Register(arg0 Peer, arg1 *snap.Peer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Register", arg0)
+	ret := m.ctrl.Call(m, "Register", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Register indicates an expected call of Register
-func (mr *MockPeerSetMockRecorder) Register(arg0 interface{}) *gomock.Call {
+func (mr *MockPeerSetMockRecorder) Register(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockPeerSet)(nil).Register), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockPeerSet)(nil).Register), arg0, arg1)
+}
+
+// RegisterSnapExtension mocks base method
+func (m *MockPeerSet) RegisterSnapExtension(arg0 *snap.Peer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterSnapExtension", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegisterSnapExtension indicates an expected call of RegisterSnapExtension
+func (mr *MockPeerSetMockRecorder) RegisterSnapExtension(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterSnapExtension", reflect.TypeOf((*MockPeerSet)(nil).RegisterSnapExtension), arg0)
 }
 
 // RegisterValidator mocks base method
@@ -242,6 +257,20 @@ func (mr *MockPeerSetMockRecorder) SampleResendPeersByType(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SampleResendPeersByType", reflect.TypeOf((*MockPeerSet)(nil).SampleResendPeersByType), arg0)
 }
 
+// SnapLen mocks base method
+func (m *MockPeerSet) SnapLen() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SnapLen")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// SnapLen indicates an expected call of SnapLen
+func (mr *MockPeerSetMockRecorder) SnapLen() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SnapLen", reflect.TypeOf((*MockPeerSet)(nil).SnapLen))
+}
+
 // TypePeersWithoutTx mocks base method
 func (m *MockPeerSet) TypePeersWithoutTx(arg0 common.Hash, arg1 common.ConnType) []Peer {
 	m.ctrl.T.Helper()
@@ -280,4 +309,19 @@ func (m *MockPeerSet) UpdateTypePeersWithoutTxs(arg0 *types.Transaction, arg1 co
 func (mr *MockPeerSetMockRecorder) UpdateTypePeersWithoutTxs(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTypePeersWithoutTxs", reflect.TypeOf((*MockPeerSet)(nil).UpdateTypePeersWithoutTxs), arg0, arg1, arg2)
+}
+
+// WaitSnapExtension mocks base method
+func (m *MockPeerSet) WaitSnapExtension(arg0 Peer) (*snap.Peer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitSnapExtension", arg0)
+	ret0, _ := ret[0].(*snap.Peer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitSnapExtension indicates an expected call of WaitSnapExtension
+func (mr *MockPeerSetMockRecorder) WaitSnapExtension(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitSnapExtension", reflect.TypeOf((*MockPeerSet)(nil).WaitSnapExtension), arg0)
 }

--- a/node/cn/peer_set_test.go
+++ b/node/cn/peer_set_test.go
@@ -53,20 +53,20 @@ func TestPeerSet_Register(t *testing.T) {
 	setMockPeersConnType(cnPeer, pnPeer, enPeer)
 	setMockPeers([]*MockPeer{cnPeer, pnPeer, enPeer})
 
-	assert.NoError(t, peerSet.Register(cnPeer))
-	assert.NoError(t, peerSet.Register(pnPeer))
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 	assert.Equal(t, 3, len(peerSet.peers))
 
-	assert.Equal(t, errAlreadyRegistered, peerSet.Register(cnPeer))
-	assert.Equal(t, errAlreadyRegistered, peerSet.Register(pnPeer))
-	assert.Equal(t, errAlreadyRegistered, peerSet.Register(enPeer))
+	assert.Equal(t, errAlreadyRegistered, peerSet.Register(cnPeer, nil))
+	assert.Equal(t, errAlreadyRegistered, peerSet.Register(pnPeer, nil))
+	assert.Equal(t, errAlreadyRegistered, peerSet.Register(enPeer, nil))
 	assert.Equal(t, 3, len(peerSet.peers))
 
 	peerSet.closed = true
-	assert.Equal(t, errClosed, peerSet.Register(cnPeer))
-	assert.Equal(t, errClosed, peerSet.Register(pnPeer))
-	assert.Equal(t, errClosed, peerSet.Register(enPeer))
+	assert.Equal(t, errClosed, peerSet.Register(cnPeer, nil))
+	assert.Equal(t, errClosed, peerSet.Register(pnPeer, nil))
+	assert.Equal(t, errClosed, peerSet.Register(enPeer, nil))
 }
 
 func TestPeerSet_Unregister(t *testing.T) {
@@ -82,16 +82,19 @@ func TestPeerSet_Unregister(t *testing.T) {
 	setMockPeers([]*MockPeer{cnPeer, pnPeer, enPeer})
 
 	cnPeer.EXPECT().Close().Times(1)
+	cnPeer.EXPECT().ExistSnapExtension().Return(false).Times(1)
 	pnPeer.EXPECT().Close().Times(1)
+	pnPeer.EXPECT().ExistSnapExtension().Return(false).Times(1)
 	enPeer.EXPECT().Close().Times(1)
+	enPeer.EXPECT().ExistSnapExtension().Return(false).Times(1)
 
 	assert.Equal(t, errNotRegistered, peerSet.Unregister(nodeids[0].String()))
 	assert.Equal(t, errNotRegistered, peerSet.Unregister(nodeids[1].String()))
 	assert.Equal(t, errNotRegistered, peerSet.Unregister(nodeids[2].String()))
 
-	assert.NoError(t, peerSet.Register(cnPeer))
-	assert.NoError(t, peerSet.Register(pnPeer))
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 	assert.Equal(t, 3, len(peerSet.peers))
 
 	assert.NoError(t, peerSet.Unregister(nodeids[0].String()))
@@ -112,9 +115,9 @@ func TestPeerSet_Peers(t *testing.T) {
 	setMockPeersConnType(cnPeer, pnPeer, enPeer)
 	setMockPeers([]*MockPeer{cnPeer, pnPeer, enPeer})
 
-	assert.NoError(t, peerSet.Register(cnPeer))
-	assert.NoError(t, peerSet.Register(pnPeer))
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 
 	peers := peerSet.Peers()
 	expectedPeers := map[string]Peer{nodeids[0].String(): cnPeer, nodeids[1].String(): pnPeer, nodeids[2].String(): enPeer}
@@ -131,7 +134,7 @@ func TestPeerSet_CNPeers(t *testing.T) {
 	setMockPeers([]*MockPeer{cnPeer})
 
 	assert.EqualValues(t, map[common.Address]Peer{}, peerSet.CNPeers())
-	assert.NoError(t, peerSet.Register(cnPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
 	assert.EqualValues(t, map[common.Address]Peer{addrs[0]: cnPeer}, peerSet.CNPeers())
 }
 
@@ -145,7 +148,7 @@ func TestPeerSet_PNPeers(t *testing.T) {
 	setMockPeers([]*MockPeer{pnPeer})
 
 	assert.EqualValues(t, map[common.Address]Peer{}, peerSet.PNPeers())
-	assert.NoError(t, peerSet.Register(pnPeer))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
 	assert.EqualValues(t, map[common.Address]Peer{addrs[0]: pnPeer}, peerSet.PNPeers())
 }
 
@@ -159,7 +162,7 @@ func TestPeerSet_ENPeers(t *testing.T) {
 	setMockPeers([]*MockPeer{enPeer})
 
 	assert.EqualValues(t, map[common.Address]Peer{}, peerSet.ENPeers())
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 	assert.EqualValues(t, map[common.Address]Peer{addrs[0]: enPeer}, peerSet.ENPeers())
 }
 
@@ -176,11 +179,11 @@ func TestPeerSet_Peer_And_Len(t *testing.T) {
 	setMockPeers([]*MockPeer{cnPeer, pnPeer, enPeer})
 
 	assert.Equal(t, 0, peerSet.Len())
-	assert.NoError(t, peerSet.Register(cnPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
 	assert.Equal(t, 1, peerSet.Len())
-	assert.NoError(t, peerSet.Register(pnPeer))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
 	assert.Equal(t, 2, peerSet.Len())
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 	assert.Equal(t, 3, peerSet.Len())
 
 	assert.Equal(t, cnPeer, peerSet.Peer(nodeids[0].String()))
@@ -206,9 +209,9 @@ func TestPeerSet_PeersWithoutBlock(t *testing.T) {
 	pnPeer.EXPECT().KnowsBlock(block.Hash()).Return(true).AnyTimes()
 	enPeer.EXPECT().KnowsBlock(block.Hash()).Return(false).AnyTimes()
 
-	assert.NoError(t, peerSet.Register(cnPeer))
-	assert.NoError(t, peerSet.Register(pnPeer))
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 
 	peersWithoutBlock := peerSet.PeersWithoutBlock(block.Hash())
 	assert.Equal(t, 2, len(peersWithoutBlock))
@@ -246,9 +249,9 @@ func TestPeerSet_PeersWithoutTx(t *testing.T) {
 
 	assert.EqualValues(t, []Peer{}, peerSet.PeersWithoutTx(tx.Hash()))
 
-	assert.NoError(t, peerSet.Register(cnPeer))
-	assert.NoError(t, peerSet.Register(pnPeer))
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 
 	peersWithoutTx := peerSet.PeersWithoutTx(tx.Hash())
 
@@ -277,9 +280,9 @@ func TestPeerSet_TypePeersWithoutTx(t *testing.T) {
 	assert.EqualValues(t, []Peer{}, peerSet.TypePeersWithoutTx(tx.Hash(), common.PROXYNODE))
 	assert.EqualValues(t, []Peer{}, peerSet.TypePeersWithoutTx(tx.Hash(), common.ENDPOINTNODE))
 
-	assert.NoError(t, peerSet.Register(cnPeer))
-	assert.NoError(t, peerSet.Register(pnPeer))
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 
 	assert.EqualValues(t, []Peer{cnPeer}, peerSet.TypePeersWithoutTx(tx.Hash(), common.CONSENSUSNODE))
 	assert.EqualValues(t, []Peer{}, peerSet.TypePeersWithoutTx(tx.Hash(), common.PROXYNODE))
@@ -298,7 +301,7 @@ func TestPeerSet_CNWithoutTx(t *testing.T) {
 	setMockPeers([]*MockPeer{cnPeer})
 
 	assert.EqualValues(t, []Peer{}, peerSet.CNWithoutTx(tx.Hash()))
-	assert.NoError(t, peerSet.Register(cnPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
 	assert.EqualValues(t, []Peer{cnPeer}, peerSet.CNWithoutTx(tx.Hash()))
 }
 
@@ -317,6 +320,7 @@ func TestPeerSet_BestPeer(t *testing.T) {
 	cnPeer.EXPECT().Head().Return(common.Hash{}, big.NewInt(111)).Times(2)
 	pnPeer.EXPECT().Head().Return(common.Hash{}, big.NewInt(222)).Times(2)
 	enPeer.EXPECT().Head().Return(common.Hash{}, big.NewInt(333)).Times(1)
+	enPeer.EXPECT().ExistSnapExtension().Return(false).Times(1)
 	enPeer.EXPECT().Close().Times(1)
 
 	setMockPeersConnType(cnPeer, pnPeer, enPeer)
@@ -324,9 +328,9 @@ func TestPeerSet_BestPeer(t *testing.T) {
 
 	assert.Nil(t, peerSet.BestPeer())
 
-	assert.NoError(t, peerSet.Register(cnPeer))
-	assert.NoError(t, peerSet.Register(pnPeer))
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 
 	assert.Equal(t, enPeer, peerSet.BestPeer())
 
@@ -351,9 +355,9 @@ func TestPeerSet_Close(t *testing.T) {
 	setMockPeersConnType(cnPeer, pnPeer, enPeer)
 	setMockPeers([]*MockPeer{cnPeer, pnPeer, enPeer})
 
-	assert.NoError(t, peerSet.Register(cnPeer))
-	assert.NoError(t, peerSet.Register(pnPeer))
-	assert.NoError(t, peerSet.Register(enPeer))
+	assert.NoError(t, peerSet.Register(cnPeer, nil))
+	assert.NoError(t, peerSet.Register(pnPeer, nil))
+	assert.NoError(t, peerSet.Register(enPeer, nil))
 
 	assert.False(t, peerSet.closed)
 	peerSet.Close()
@@ -371,7 +375,7 @@ func TestPeerSet_SampleResendPeersByType_PN(t *testing.T) {
 		setMockPeers([]*MockPeer{cnPeer})
 
 		assert.Equal(t, []Peer{}, peerSet.SampleResendPeersByType(common.PROXYNODE))
-		assert.NoError(t, peerSet.Register(cnPeer))
+		assert.NoError(t, peerSet.Register(cnPeer, nil))
 		assert.Equal(t, []Peer{cnPeer}, peerSet.SampleResendPeersByType(common.PROXYNODE))
 
 		mockCtrl.Finish()
@@ -386,7 +390,7 @@ func TestPeerSet_SampleResendPeersByType_PN(t *testing.T) {
 		setMockPeers([]*MockPeer{pnPeer})
 
 		assert.Equal(t, []Peer{}, peerSet.SampleResendPeersByType(common.PROXYNODE))
-		assert.NoError(t, peerSet.Register(pnPeer))
+		assert.NoError(t, peerSet.Register(pnPeer, nil))
 		assert.Equal(t, []Peer{pnPeer}, peerSet.SampleResendPeersByType(common.PROXYNODE))
 
 		mockCtrl.Finish()
@@ -405,8 +409,8 @@ func TestPeerSet_SampleResendPeersByType_PN(t *testing.T) {
 		setMockPeers([]*MockPeer{cnPeer, pnPeer})
 
 		assert.Equal(t, []Peer{}, peerSet.SampleResendPeersByType(common.PROXYNODE))
-		assert.NoError(t, peerSet.Register(cnPeer))
-		assert.NoError(t, peerSet.Register(pnPeer))
+		assert.NoError(t, peerSet.Register(cnPeer, nil))
+		assert.NoError(t, peerSet.Register(pnPeer, nil))
 		assert.Equal(t, []Peer{cnPeer}, peerSet.SampleResendPeersByType(common.PROXYNODE))
 
 		mockCtrl.Finish()
@@ -429,10 +433,10 @@ func TestPeerSet_SampleResendPeersByType_PN(t *testing.T) {
 		setMockPeers([]*MockPeer{cnPeer1, cnPeer2, cnPeer3, pnPeer})
 
 		assert.Equal(t, []Peer{}, peerSet.SampleResendPeersByType(common.PROXYNODE))
-		assert.NoError(t, peerSet.Register(cnPeer1))
-		assert.NoError(t, peerSet.Register(cnPeer2))
-		assert.NoError(t, peerSet.Register(cnPeer3))
-		assert.NoError(t, peerSet.Register(pnPeer))
+		assert.NoError(t, peerSet.Register(cnPeer1, nil))
+		assert.NoError(t, peerSet.Register(cnPeer2, nil))
+		assert.NoError(t, peerSet.Register(cnPeer3, nil))
+		assert.NoError(t, peerSet.Register(pnPeer, nil))
 		resendPeers := peerSet.SampleResendPeersByType(common.PROXYNODE)
 
 		assert.Equal(t, 2, len(resendPeers))
@@ -453,7 +457,7 @@ func TestPeerSet_SampleResendPeersByType_EN(t *testing.T) {
 		setMockPeers([]*MockPeer{pnPeer})
 
 		assert.Equal(t, []Peer{}, peerSet.SampleResendPeersByType(common.ENDPOINTNODE))
-		assert.NoError(t, peerSet.Register(pnPeer))
+		assert.NoError(t, peerSet.Register(pnPeer, nil))
 		assert.Equal(t, []Peer{pnPeer}, peerSet.SampleResendPeersByType(common.ENDPOINTNODE))
 
 		mockCtrl.Finish()
@@ -468,7 +472,7 @@ func TestPeerSet_SampleResendPeersByType_EN(t *testing.T) {
 		setMockPeers([]*MockPeer{enPeer})
 
 		assert.Equal(t, []Peer{}, peerSet.SampleResendPeersByType(common.ENDPOINTNODE))
-		assert.NoError(t, peerSet.Register(enPeer))
+		assert.NoError(t, peerSet.Register(enPeer, nil))
 		assert.Equal(t, []Peer{enPeer}, peerSet.SampleResendPeersByType(common.ENDPOINTNODE))
 
 		mockCtrl.Finish()
@@ -487,8 +491,8 @@ func TestPeerSet_SampleResendPeersByType_EN(t *testing.T) {
 		setMockPeers([]*MockPeer{pnPeer, enPeer})
 
 		assert.Equal(t, []Peer{}, peerSet.SampleResendPeersByType(common.ENDPOINTNODE))
-		assert.NoError(t, peerSet.Register(pnPeer))
-		assert.NoError(t, peerSet.Register(enPeer))
+		assert.NoError(t, peerSet.Register(pnPeer, nil))
+		assert.NoError(t, peerSet.Register(enPeer, nil))
 		assert.Equal(t, []Peer{pnPeer, enPeer}, peerSet.SampleResendPeersByType(common.ENDPOINTNODE))
 
 		mockCtrl.Finish()
@@ -708,7 +712,7 @@ func countPeerType(t common.ConnType, peers []Peer) int {
 
 func registerPeers(t *testing.T, ps *peerSet, peers []Peer) {
 	for i, p := range peers {
-		if err := ps.Register(p); err != nil {
+		if err := ps.Register(p, nil); err != nil {
 			t.Fatalf("Failed to register peer to peerSet. index: %v, peer: %v", i, p)
 		}
 	}

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -31,6 +31,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/datasync/downloader"
 	"github.com/klaytn/klaytn/datasync/fetcher"
+	"github.com/klaytn/klaytn/node/cn/snap"
 	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/rlp"
 )
@@ -138,11 +139,14 @@ type ProtocolManagerDownloader interface {
 	DeliverNodeData(id string, data [][]byte) error
 	DeliverReceipts(id string, receipts [][]*types.Receipt) error
 	DeliverStakingInfos(id string, stakingInfos []*reward.StakingInfo) error
+	DeliverSnapPacket(peer *snap.Peer, packet snap.Packet) error
 
 	Terminate()
 	Synchronise(id string, head common.Hash, td *big.Int, mode downloader.SyncMode) error
 	Progress() klaytn.SyncProgress
 	Cancel()
+
+	GetSnapSyncer() *snap.Syncer
 }
 
 //go:generate mockgen -destination=node/cn/mocks/fetcher_mock.go -package=mocks github.com/klaytn/klaytn/node/cn ProtocolManagerFetcher

--- a/node/cn/snap/handler.go
+++ b/node/cn/snap/handler.go
@@ -1,0 +1,525 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from eth/protocols/snap/handler.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package snap
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/state"
+	"github.com/klaytn/klaytn/blockchain/types/account"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/networks/p2p"
+	"github.com/klaytn/klaytn/rlp"
+	"github.com/klaytn/klaytn/snapshot"
+	"github.com/klaytn/klaytn/storage/statedb"
+)
+
+const (
+	// softResponseLimit is the target maximum size of replies to data retrievals.
+	softResponseLimit = 2 * 1024 * 1024
+
+	// maxCodeLookups is the maximum number of bytecodes to serve. This number is
+	// there to limit the number of disk lookups.
+	maxCodeLookups = 1024
+
+	// stateLookupSlack defines the ratio by how much a state response can exceed
+	// the requested limit in order to try and avoid breaking up contracts into
+	// multiple packages and proving them.
+	stateLookupSlack = 0.1
+
+	// maxTrieNodeLookups is the maximum number of state trie nodes to serve. This
+	// number is there to limit the number of disk lookups.
+	maxTrieNodeLookups = 1024
+
+	// maxTrieNodeTimeSpent is the maximum time we should spend on looking up trie nodes.
+	// If we spend too much time, then it's a fairly high chance of timing out
+	// at the remote side, which means all the work is in vain.
+	maxTrieNodeTimeSpent = 5 * time.Second
+)
+
+// Handler is a callback to invoke from an outside runner after the boilerplate
+// exchanges have passed.
+type Handler func(peer *Peer) error
+
+type SnapshotReader interface {
+	StateCache() state.Database
+	Snapshots() *snapshot.Tree
+	ContractCode(hash common.Hash) ([]byte, error)
+	ContractCodeWithPrefix(hash common.Hash) ([]byte, error)
+}
+
+type SnapshotDownloader interface {
+	// DeliverSnapPacket is invoked from a peer's message handler when it transmits a
+	// data packet for the local node to consume.
+	DeliverSnapPacket(peer *Peer, packet Packet) error
+}
+
+// Handle is the callback invoked to manage the life cycle of a `snap` peer.
+// When this function terminates, the peer is disconnected.
+func Handle(reader SnapshotReader, downloader SnapshotDownloader, peer *Peer) error {
+	for {
+		if err := HandleMessage(reader, downloader, peer); err != nil {
+			peer.Log().Debug("Message handling failed in `snap`", "err", err)
+			return err
+		}
+	}
+}
+
+// HandleMessage is invoked whenever an inbound message is received from a
+// remote peer on the `snap` protocol. The remote connection is torn down upon
+// returning any error.
+func HandleMessage(reader SnapshotReader, downloader SnapshotDownloader, peer *Peer) error {
+	// Read the next message from the remote peer, and ensure it's fully consumed
+	msg, err := peer.rw.ReadMsg()
+	if err != nil {
+		return err
+	}
+	if msg.Size > maxMessageSize {
+		return fmt.Errorf("%w: %v > %v", errMsgTooLarge, msg.Size, maxMessageSize)
+	}
+	defer msg.Discard()
+	start := time.Now()
+	// TODO-Klaytn-SnapSync add metric to track the amount of time it takes to serve the request and run the manager
+	// Handle the message depending on its contents
+	switch {
+	case msg.Code == GetAccountRangeMsg:
+		// Decode the account retrieval request
+		var req GetAccountRangePacket
+		if err := msg.Decode(&req); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		// Service the request, potentially returning nothing in case of errors
+		accounts, proofs := ServiceGetAccountRangeQuery(reader, &req)
+
+		// Send back anything accumulated (or empty in case of errors)
+		return p2p.Send(peer.rw, AccountRangeMsg, &AccountRangePacket{
+			ID:       req.ID,
+			Accounts: accounts,
+			Proof:    proofs,
+		})
+
+	case msg.Code == AccountRangeMsg:
+		// A range of accounts arrived to one of our previous requests
+		res := new(AccountRangePacket)
+		if err := msg.Decode(res); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		// Ensure the range is monotonically increasing
+		for i := 1; i < len(res.Accounts); i++ {
+			if bytes.Compare(res.Accounts[i-1].Hash[:], res.Accounts[i].Hash[:]) >= 0 {
+				return fmt.Errorf("accounts not monotonically increasing: #%d [%x] vs #%d [%x]", i-1, res.Accounts[i-1].Hash[:], i, res.Accounts[i].Hash[:])
+			}
+		}
+		requestTracker.Fulfil(peer.id, peer.version, AccountRangeMsg, res.ID)
+
+		return downloader.DeliverSnapPacket(peer, res)
+
+	case msg.Code == GetStorageRangesMsg:
+		// Decode the storage retrieval request
+		var req GetStorageRangesPacket
+		if err := msg.Decode(&req); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		// Service the request, potentially returning nothing in case of errors
+		slots, proofs := ServiceGetStorageRangesQuery(reader, &req)
+
+		// Send back anything accumulated (or empty in case of errors)
+		return p2p.Send(peer.rw, StorageRangesMsg, &StorageRangesPacket{
+			ID:    req.ID,
+			Slots: slots,
+			Proof: proofs,
+		})
+
+	case msg.Code == StorageRangesMsg:
+		// A range of storage slots arrived to one of our previous requests
+		res := new(StorageRangesPacket)
+		if err := msg.Decode(res); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		// Ensure the ranges are monotonically increasing
+		for i, slots := range res.Slots {
+			for j := 1; j < len(slots); j++ {
+				if bytes.Compare(slots[j-1].Hash[:], slots[j].Hash[:]) >= 0 {
+					return fmt.Errorf("storage slots not monotonically increasing for account #%d: #%d [%x] vs #%d [%x]", i, j-1, slots[j-1].Hash[:], j, slots[j].Hash[:])
+				}
+			}
+		}
+		requestTracker.Fulfil(peer.id, peer.version, StorageRangesMsg, res.ID)
+
+		return downloader.DeliverSnapPacket(peer, res)
+
+	case msg.Code == GetByteCodesMsg:
+		// Decode bytecode retrieval request
+		var req GetByteCodesPacket
+		if err := msg.Decode(&req); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		// Service the request, potentially returning nothing in case of errors
+		codes := ServiceGetByteCodesQuery(reader, &req)
+
+		// Send back anything accumulated (or empty in case of errors)
+		return p2p.Send(peer.rw, ByteCodesMsg, &ByteCodesPacket{
+			ID:    req.ID,
+			Codes: codes,
+		})
+
+	case msg.Code == ByteCodesMsg:
+		// A batch of byte codes arrived to one of our previous requests
+		res := new(ByteCodesPacket)
+		if err := msg.Decode(res); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		requestTracker.Fulfil(peer.id, peer.version, ByteCodesMsg, res.ID)
+
+		return downloader.DeliverSnapPacket(peer, res)
+
+	case msg.Code == GetTrieNodesMsg:
+		// Decode trie node retrieval request
+		var req GetTrieNodesPacket
+		if err := msg.Decode(&req); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		// Service the request, potentially returning nothing in case of errors
+		nodes, err := ServiceGetTrieNodesQuery(reader, &req, start)
+		if err != nil {
+			return err
+		}
+		// Send back anything accumulated (or empty in case of errors)
+		return p2p.Send(peer.rw, TrieNodesMsg, &TrieNodesPacket{
+			ID:    req.ID,
+			Nodes: nodes,
+		})
+
+	case msg.Code == TrieNodesMsg:
+		// A batch of trie nodes arrived to one of our previous requests
+		res := new(TrieNodesPacket)
+		if err := msg.Decode(res); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		requestTracker.Fulfil(peer.id, peer.version, TrieNodesMsg, res.ID)
+
+		return downloader.DeliverSnapPacket(peer, res)
+
+	default:
+		return fmt.Errorf("%w: %v", errInvalidMsgCode, msg.Code)
+	}
+}
+
+// ServiceGetAccountRangeQuery assembles the response to an account range query.
+// It is exposed to allow external packages to test protocol behavior.
+func ServiceGetAccountRangeQuery(chain SnapshotReader, req *GetAccountRangePacket) ([]*AccountData, [][]byte) {
+	if req.Bytes > softResponseLimit {
+		req.Bytes = softResponseLimit
+	}
+	// Retrieve the requested state and bail out if non existent
+	tr, err := statedb.NewTrie(req.Root, chain.StateCache().TrieDB())
+	if err != nil {
+		return nil, nil
+	}
+	it, err := chain.Snapshots().AccountIterator(req.Root, req.Origin)
+	if err != nil {
+		return nil, nil
+	}
+	// Iterate over the requested range and pile accounts up
+	var (
+		accounts []*AccountData
+		size     uint64
+		last     common.Hash
+	)
+	for it.Next() {
+		hash, account := it.Hash(), common.CopyBytes(it.Account())
+
+		// Track the returned interval for the Merkle proofs
+		last = hash
+
+		// Assemble the reply item
+		size += uint64(common.HashLength + len(account))
+		accounts = append(accounts, &AccountData{
+			Hash: hash,
+			Body: account,
+		})
+		// If we've exceeded the request threshold, abort
+		if bytes.Compare(hash[:], req.Limit[:]) >= 0 {
+			break
+		}
+		if size > req.Bytes {
+			break
+		}
+	}
+	it.Release()
+
+	// Generate the Merkle proofs for the first and last account
+	proof := NewNodeSet()
+	if err := tr.Prove(req.Origin[:], 0, proof); err != nil {
+		logger.Warn("Failed to prove account range", "origin", req.Origin, "err", err)
+		return nil, nil
+	}
+	if last != (common.Hash{}) {
+		if err := tr.Prove(last[:], 0, proof); err != nil {
+			logger.Warn("Failed to prove account range", "last", last, "err", err)
+			return nil, nil
+		}
+	}
+	nodeList := proof.NodeList()
+	proofs := make([][]byte, 0, len(nodeList))
+	for _, blob := range nodeList {
+		proofs = append(proofs, blob)
+	}
+	return accounts, proofs
+}
+
+func ServiceGetStorageRangesQuery(chain SnapshotReader, req *GetStorageRangesPacket) ([][]*StorageData, [][]byte) {
+	if req.Bytes > softResponseLimit {
+		req.Bytes = softResponseLimit
+	}
+	// TODO-Klaytn-SnapSync Do we want to enforce > 0 accounts and 1 account if origin is set?
+	// TODO-Klaytn-SnapSync   - Logging locally is not ideal as remote faulst annoy the local user
+	// TODO-Klaytn-SnapSync   - Dropping the remote peer is less flexible wrt client bugs (slow is better than non-functional)
+
+	// Calculate the hard limit at which to abort, even if mid storage trie
+	hardLimit := uint64(float64(req.Bytes) * (1 + stateLookupSlack))
+
+	// Retrieve storage ranges until the packet limit is reached
+	var (
+		slots  = make([][]*StorageData, 0, len(req.Accounts))
+		proofs [][]byte
+		size   uint64
+	)
+	for _, accountHash := range req.Accounts {
+		// If we've exceeded the requested data limit, abort without opening
+		// a new storage range (that we'd need to prove due to exceeded size)
+		if size >= req.Bytes {
+			break
+		}
+		// The first account might start from a different origin and end sooner
+		var origin common.Hash
+		if len(req.Origin) > 0 {
+			origin, req.Origin = common.BytesToHash(req.Origin), nil
+		}
+		limit := common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+		if len(req.Limit) > 0 {
+			limit, req.Limit = common.BytesToHash(req.Limit), nil
+		}
+		// Retrieve the requested state and bail out if non existent
+		it, err := chain.Snapshots().StorageIterator(req.Root, accountHash, origin)
+		if err != nil {
+			return nil, nil
+		}
+		// Iterate over the requested range and pile slots up
+		var (
+			storage []*StorageData
+			last    common.Hash
+			abort   bool
+		)
+		for it.Next() {
+			if size >= hardLimit {
+				abort = true
+				break
+			}
+			hash, slot := it.Hash(), common.CopyBytes(it.Slot())
+
+			// Track the returned interval for the Merkle proofs
+			last = hash
+
+			// Assemble the reply item
+			size += uint64(common.HashLength + len(slot))
+			storage = append(storage, &StorageData{
+				Hash: hash,
+				Body: slot,
+			})
+			// If we've exceeded the request threshold, abort
+			if bytes.Compare(hash[:], limit[:]) >= 0 {
+				break
+			}
+		}
+		slots = append(slots, storage)
+		it.Release()
+
+		// Generate the Merkle proofs for the first and last storage slot, but
+		// only if the response was capped. If the entire storage trie included
+		// in the response, no need for any proofs.
+		if origin != (common.Hash{}) || abort {
+			// Request started at a non-zero hash or was capped prematurely, add
+			// the endpoint Merkle proofs
+			accTrie, err := statedb.NewTrie(req.Root, chain.StateCache().TrieDB())
+			if err != nil {
+				return nil, nil
+			}
+			serializer := account.NewAccountSerializer()
+			if err := rlp.DecodeBytes(accTrie.Get(accountHash[:]), serializer); err != nil {
+				return nil, nil
+			}
+			acc := serializer.GetAccount()
+			pacc := account.GetProgramAccount(acc)
+			if pacc == nil {
+				return nil, nil
+			}
+			stTrie, err := statedb.NewTrie(pacc.GetStorageRoot(), chain.StateCache().TrieDB())
+			if err != nil {
+				return nil, nil
+			}
+			proof := NewNodeSet()
+			if err := stTrie.Prove(origin[:], 0, proof); err != nil {
+				logger.Warn("Failed to prove storage range", "origin", req.Origin, "err", err)
+				return nil, nil
+			}
+			if last != (common.Hash{}) {
+				if err := stTrie.Prove(last[:], 0, proof); err != nil {
+					logger.Warn("Failed to prove storage range", "last", last, "err", err)
+					return nil, nil
+				}
+			}
+			for _, blob := range proof.NodeList() {
+				proofs = append(proofs, blob)
+			}
+			// Proof terminates the reply as proofs are only added if a node
+			// refuses to serve more data (exception when a contract fetch is
+			// finishing, but that's that).
+			break
+		}
+	}
+	return slots, proofs
+}
+
+// ServiceGetByteCodesQuery assembles the response to a byte codes query.
+// It is exposed to allow external packages to test protocol behavior.
+func ServiceGetByteCodesQuery(chain SnapshotReader, req *GetByteCodesPacket) [][]byte {
+	if req.Bytes > softResponseLimit {
+		req.Bytes = softResponseLimit
+	}
+	if len(req.Hashes) > maxCodeLookups {
+		req.Hashes = req.Hashes[:maxCodeLookups]
+	}
+	// Retrieve bytecodes until the packet size limit is reached
+	var (
+		codes [][]byte
+		bytes uint64
+	)
+	for _, hash := range req.Hashes {
+		if hash == emptyCode {
+			// Peers should not request the empty code, but if they do, at
+			// least sent them back a correct response without db lookups
+			codes = append(codes, []byte{})
+		} else if blob, err := chain.ContractCode(hash); err == nil {
+			codes = append(codes, blob)
+			bytes += uint64(len(blob))
+		}
+		if bytes > req.Bytes {
+			break
+		}
+	}
+	return codes
+}
+
+// ServiceGetTrieNodesQuery assembles the response to a trie nodes query.
+// It is exposed to allow external packages to test protocol behavior.
+func ServiceGetTrieNodesQuery(chain SnapshotReader, req *GetTrieNodesPacket, start time.Time) ([][]byte, error) {
+	if req.Bytes > softResponseLimit {
+		req.Bytes = softResponseLimit
+	}
+	// Make sure we have the state associated with the request
+	triedb := chain.StateCache().TrieDB()
+
+	accTrie, err := statedb.NewSecureTrie(req.Root, triedb)
+	if err != nil {
+		// We don't have the requested state available, bail out
+		return nil, nil
+	}
+	snap := chain.Snapshots().Snapshot(req.Root)
+	if snap == nil {
+		// We don't have the requested state snapshotted yet, bail out.
+		// In reality we could still serve using the account and storage
+		// tries only, but let's protect the node a bit while it's doing
+		// snapshot generation.
+		return nil, nil
+	}
+	// Retrieve trie nodes until the packet size limit is reached
+	var (
+		nodes [][]byte
+		bytes uint64
+		loads int // Trie hash expansions to count database reads
+	)
+	for _, pathset := range req.Paths {
+		switch len(pathset) {
+		case 0:
+			// Ensure we penalize invalid requests
+			return nil, fmt.Errorf("%w: zero-item pathset requested", errBadRequest)
+
+		case 1:
+			// If we're only retrieving an account trie node, fetch it directly
+			blob, resolved, err := accTrie.TryGetNode(pathset[0])
+			loads += resolved // always account database reads, even for failures
+			if err != nil {
+				break
+			}
+			nodes = append(nodes, blob)
+			bytes += uint64(len(blob))
+
+		default:
+			// Storage slots requested, open the storage trie and retrieve from there
+			acc, err := snap.Account(common.BytesToHash(pathset[0]))
+			loads++ // always account database reads, even for failures
+			if err != nil || acc == nil {
+				break
+			}
+			pacc := account.GetProgramAccount(acc)
+			if pacc == nil {
+				break
+			}
+			stTrie, err := statedb.NewSecureTrie(pacc.GetStorageRoot(), triedb)
+			loads++ // always account database reads, even for failures
+			if err != nil {
+				break
+			}
+			for _, path := range pathset[1:] {
+				blob, resolved, err := stTrie.TryGetNode(path)
+				loads += resolved // always account database reads, even for failures
+				if err != nil {
+					break
+				}
+				nodes = append(nodes, blob)
+				bytes += uint64(len(blob))
+
+				// Sanity check limits to avoid DoS on the store trie loads
+				if bytes > req.Bytes || loads > maxTrieNodeLookups || time.Since(start) > maxTrieNodeTimeSpent {
+					break
+				}
+			}
+		}
+		// Abort request processing if we've exceeded our limits
+		if bytes > req.Bytes || loads > maxTrieNodeLookups || time.Since(start) > maxTrieNodeTimeSpent {
+			break
+		}
+	}
+	return nodes, nil
+}
+
+// NodeInfo represents a short summary of the `snap` sub-protocol metadata
+// known about the host peer.
+type NodeInfo struct{}
+
+// nodeInfo retrieves some `snap` protocol metadata about the running host node.
+func nodeInfo(chain *blockchain.BlockChain) *NodeInfo {
+	return &NodeInfo{}
+}

--- a/node/cn/snap/handler.go
+++ b/node/cn/snap/handler.go
@@ -232,6 +232,7 @@ func ServiceGetAccountRangeQuery(chain SnapshotReader, req *GetAccountRangePacke
 	if req.Bytes > softResponseLimit {
 		req.Bytes = softResponseLimit
 	}
+	// TODO-Klaytn-SnapSync investigate the cache pollution
 	// Retrieve the requested state and bail out if non existent
 	tr, err := statedb.NewTrie(req.Root, chain.StateCache().TrieDB())
 	if err != nil {
@@ -263,6 +264,7 @@ func ServiceGetAccountRangeQuery(chain SnapshotReader, req *GetAccountRangePacke
 		if bytes.Compare(hash[:], req.Limit[:]) >= 0 {
 			break
 		}
+		// TODO-Klaytn-SnapSync check if the size is much larger than soft response limit
 		if size > req.Bytes {
 			break
 		}
@@ -373,6 +375,7 @@ func ServiceGetStorageRangesQuery(chain SnapshotReader, req *GetStorageRangesPac
 			acc := serializer.GetAccount()
 			pacc := account.GetProgramAccount(acc)
 			if pacc == nil {
+				// TODO-Klaytn-SnapSync it would be better to continue rather than return. Do not waste the completed job until now.
 				return nil, nil
 			}
 			stTrie, err := statedb.NewTrie(pacc.GetStorageRoot(), chain.StateCache().TrieDB())

--- a/node/cn/snap/handler_test.go
+++ b/node/cn/snap/handler_test.go
@@ -1,0 +1,300 @@
+// Copyright 2022 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package snap
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/klaytn/klaytn/blockchain/state"
+	"github.com/klaytn/klaytn/blockchain/types/account"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/networks/p2p"
+	"github.com/klaytn/klaytn/rlp"
+	"github.com/klaytn/klaytn/snapshot"
+	"github.com/klaytn/klaytn/storage/database"
+	"github.com/klaytn/klaytn/storage/statedb"
+	"github.com/stretchr/testify/assert"
+)
+
+type testMsgRW struct {
+	reader func() (p2p.Msg, error)
+	writer func(msg p2p.Msg) error
+}
+
+func (rw *testMsgRW) ReadMsg() (p2p.Msg, error)  { return rw.reader() }
+func (rw *testMsgRW) WriteMsg(msg p2p.Msg) error { return nil }
+
+type testDownloader struct{}
+
+func (d *testDownloader) DeliverSnapPacket(peer *Peer, packet Packet) error { return nil }
+
+type testSnapshotReader struct {
+	db   state.Database
+	snap *snapshot.Tree
+}
+
+type testKV struct {
+	k []byte
+	v []byte
+}
+
+func NewTestSnapshotReader(items []*testKV) (*testSnapshotReader, common.Hash) {
+	memdb := database.NewMemoryDBManager()
+	db := state.NewDatabase(memdb)
+	trie, _ := statedb.NewTrie(common.Hash{}, db.TrieDB())
+	for _, kv := range items {
+		trie.Update(kv.k, kv.v)
+	}
+	root, _ := trie.Commit(nil)
+	db.TrieDB().Commit(root, false, 0)
+
+	snap, _ := snapshot.New(memdb, db.TrieDB(), 256, root, false, true, false)
+
+	return &testSnapshotReader{
+		db,
+		snap,
+	}, root
+}
+
+func (r *testSnapshotReader) StateCache() state.Database {
+	return r.db
+}
+
+func (r *testSnapshotReader) Snapshots() *snapshot.Tree {
+	return r.snap
+}
+
+func (r *testSnapshotReader) ContractCode(hash common.Hash) ([]byte, error) {
+	return r.db.ContractCode(hash)
+}
+
+func (r *testSnapshotReader) ContractCodeWithPrefix(hash common.Hash) ([]byte, error) {
+	return nil, nil
+}
+
+func createMsg(msgcode uint64, data interface{}) (p2p.Msg, error) {
+	size, r, err := rlp.EncodeToReader(data)
+	if err != nil {
+		return p2p.Msg{}, err
+	}
+	return p2p.Msg{Code: msgcode, Size: uint32(size), Payload: r}, nil
+}
+
+func createAccountRangeReqMsg(root common.Hash) p2p.Msg {
+	msg, _ := createMsg(GetAccountRangeMsg, &GetAccountRangePacket{
+		ID:     1,
+		Root:   root,
+		Origin: common.Hash{},
+		Limit:  common.Hash{},
+		Bytes:  softResponseLimit,
+	})
+	return msg
+}
+
+func mockPeer(msg p2p.Msg) *Peer {
+	mockPeer := NewFakePeer(1, common.BytesToHash([]byte{0x1}).String(), &testMsgRW{reader: func() (p2p.Msg, error) {
+		return msg, nil
+	}})
+	return mockPeer
+}
+
+func TestMessageDecoding(t *testing.T) {
+	var (
+		msg p2p.Msg
+		err error
+	)
+	msg, err = createMsg(GetAccountRangeMsg, &GetAccountRangePacket{
+		ID:     0,
+		Root:   common.Hash{},
+		Origin: common.Hash{},
+		Limit:  common.Hash{},
+		Bytes:  0,
+	})
+	assert.NoError(t, err)
+	var req1 GetAccountRangePacket
+	assert.NoError(t, msg.Decode(&req1))
+
+	msg, err = createMsg(AccountRangeMsg, &AccountRangePacket{
+		ID:       0,
+		Accounts: nil,
+		Proof:    nil,
+	})
+	assert.NoError(t, err)
+	var req2 AccountRangePacket
+	assert.NoError(t, msg.Decode(&req2))
+
+	msg, err = createMsg(GetStorageRangesMsg, &GetStorageRangesPacket{
+		ID:       0,
+		Root:     common.Hash{},
+		Accounts: nil,
+		Origin:   nil,
+		Limit:    nil,
+		Bytes:    0,
+	})
+	assert.NoError(t, err)
+	var req3 GetStorageRangesPacket
+	assert.NoError(t, msg.Decode(&req3))
+
+	msg, err = createMsg(StorageRangesMsg, &StorageRangesPacket{
+		ID:    0,
+		Slots: nil,
+		Proof: nil,
+	})
+	assert.NoError(t, err)
+	var req4 StorageRangesPacket
+	assert.NoError(t, msg.Decode(&req4))
+
+	msg, err = createMsg(GetByteCodesMsg, &GetByteCodesPacket{
+		ID:     0,
+		Hashes: nil,
+		Bytes:  0,
+	})
+	assert.NoError(t, err)
+	var req5 GetByteCodesPacket
+	assert.NoError(t, msg.Decode(&req5))
+
+	msg, err = createMsg(ByteCodesMsg, &ByteCodesPacket{
+		ID:    0,
+		Codes: nil,
+	})
+	assert.NoError(t, err)
+	var req6 ByteCodesPacket
+	assert.NoError(t, msg.Decode(&req6))
+
+	msg, err = createMsg(GetTrieNodesMsg, &GetTrieNodesPacket{
+		ID:    0,
+		Root:  common.Hash{},
+		Paths: nil,
+		Bytes: 0,
+	})
+	assert.NoError(t, err)
+	var req7 GetTrieNodesPacket
+	assert.NoError(t, msg.Decode(&req7))
+
+	msg, err = createMsg(TrieNodesMsg, &TrieNodesPacket{
+		ID:    0,
+		Nodes: nil,
+	})
+	assert.NoError(t, err)
+	var req8 TrieNodesPacket
+	assert.NoError(t, msg.Decode(&req8))
+}
+
+func TestHandleMessage_ReadMsgErr(t *testing.T) {
+	reader := &testSnapshotReader{}
+
+	// create test message
+	msg, _ := createMsg(GetAccountRangeMsg, []byte{0x1})
+	msg.Size = maxMessageSize + 1
+	peer := mockPeer(msg)
+	testErr := errors.New("test error")
+	peer.rw = &testMsgRW{reader: func() (p2p.Msg, error) { return p2p.Msg{}, testErr }}
+
+	// failed to handle message due to read msg error
+	err := HandleMessage(reader, &testDownloader{}, peer)
+	assert.Equal(t, err, testErr)
+}
+
+func TestHandleMessage_LargeMessageErr(t *testing.T) {
+	reader := &testSnapshotReader{}
+
+	// create test message
+	msg, _ := createMsg(GetAccountRangeMsg, []byte{0x1})
+	msg.Size = maxMessageSize + 1
+	peer := mockPeer(msg)
+
+	// failed to handle message due to too large message size
+	err := HandleMessage(reader, &testDownloader{}, peer)
+	assert.True(t, strings.Contains(err.Error(), errMsgTooLarge.Error()))
+}
+
+func TestHandleMessage_LargeMessageInvalidMsgErr(t *testing.T) {
+	reader := &testSnapshotReader{}
+
+	// create test message
+	msg, _ := createMsg(0x08, []byte{0x1})
+	peer := mockPeer(msg)
+
+	// failed to handle message due to too large message size
+	err := HandleMessage(reader, &testDownloader{}, peer)
+	assert.True(t, strings.Contains(err.Error(), errInvalidMsgCode.Error()))
+}
+
+func TestHandleMessage_GetAccountRange_EmptyItem(t *testing.T) {
+	items := []*testKV{}
+	reader, root := NewTestSnapshotReader(items)
+
+	err := HandleMessage(reader, &testDownloader{}, mockPeer(createAccountRangeReqMsg(root)))
+	assert.NoError(t, err)
+}
+
+func TestHandleMessage_Success(t *testing.T) {
+	items := []*testKV{}
+	for i := uint64(1); i <= 100; i++ {
+		acc, _ := genExternallyOwnedAccount(1, big.NewInt(1))
+		serializer := account.NewAccountSerializerWithAccount(acc)
+		bytes, _ := rlp.EncodeToBytes(serializer)
+		items = append(items, &testKV{key32(i), bytes})
+	}
+
+	reader, root := NewTestSnapshotReader(items)
+	var (
+		msgs []p2p.Msg
+		msg  p2p.Msg
+		err  error
+	)
+
+	msg, err = createMsg(GetAccountRangeMsg, &GetAccountRangePacket{ID: 1, Root: root})
+	assert.NoError(t, err)
+	msgs = append(msgs, msg)
+
+	msg, err = createMsg(AccountRangeMsg, &AccountRangePacket{})
+	assert.NoError(t, err)
+	msgs = append(msgs, msg)
+
+	msg, err = createMsg(GetStorageRangesMsg, &GetStorageRangesPacket{Root: root})
+	assert.NoError(t, err)
+	msgs = append(msgs, msg)
+
+	msg, err = createMsg(StorageRangesMsg, &StorageRangesPacket{})
+	assert.NoError(t, err)
+	msgs = append(msgs, msg)
+
+	msg, err = createMsg(GetByteCodesMsg, &GetByteCodesPacket{})
+	assert.NoError(t, err)
+	msgs = append(msgs, msg)
+
+	msg, err = createMsg(ByteCodesMsg, &ByteCodesPacket{})
+	assert.NoError(t, err)
+	msgs = append(msgs, msg)
+
+	msg, err = createMsg(GetTrieNodesMsg, &GetTrieNodesPacket{Root: root})
+	assert.NoError(t, err)
+	msgs = append(msgs, msg)
+
+	msg, err = createMsg(TrieNodesMsg, &TrieNodesPacket{})
+	assert.NoError(t, err)
+	msgs = append(msgs, msg)
+
+	for _, msg := range msgs {
+		err := HandleMessage(reader, &testDownloader{}, mockPeer(msg))
+		assert.NoError(t, err)
+	}
+}

--- a/node/cn/snap/nodeset.go
+++ b/node/cn/snap/nodeset.go
@@ -60,10 +60,10 @@ func (db *NodeSet) Put(key []byte, value []byte) error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	if _, ok := db.nodes[string(key)]; ok {
+	keystr := string(key)
+	if _, ok := db.nodes[keystr]; ok {
 		return nil
 	}
-	keystr := string(key)
 
 	db.nodes[keystr] = common.CopyBytes(value)
 	db.order = append(db.order, keystr)

--- a/node/cn/snap/nodeset.go
+++ b/node/cn/snap/nodeset.go
@@ -1,0 +1,174 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from light/nodeset.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package snap
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/rlp"
+	"github.com/klaytn/klaytn/storage/database"
+)
+
+// NodeSet stores a set of trie nodes. It implements trie.Database and can also
+// act as a cache for another trie.Database.
+type NodeSet struct {
+	nodes map[string][]byte
+	order []string
+
+	dataSize int
+	lock     sync.RWMutex
+}
+
+// NewNodeSet creates an empty node set
+func NewNodeSet() *NodeSet {
+	return &NodeSet{
+		nodes: make(map[string][]byte),
+	}
+}
+
+func (db *NodeSet) ReadCachedTrieNode(hash common.Hash) ([]byte, error) {
+	return db.Get(hash.Bytes())
+}
+
+func (db *NodeSet) WriteMerkleProof(key, value []byte) {
+	db.Put(key, value)
+}
+
+// Put stores a new node in the set
+func (db *NodeSet) Put(key []byte, value []byte) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if _, ok := db.nodes[string(key)]; ok {
+		return nil
+	}
+	keystr := string(key)
+
+	db.nodes[keystr] = common.CopyBytes(value)
+	db.order = append(db.order, keystr)
+	db.dataSize += len(value)
+
+	return nil
+}
+
+// Delete removes a node from the set
+func (db *NodeSet) Delete(key []byte) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	delete(db.nodes, string(key))
+	return nil
+}
+
+// Get returns a stored node
+func (db *NodeSet) Get(key []byte) ([]byte, error) {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+
+	if entry, ok := db.nodes[string(key)]; ok {
+		return entry, nil
+	}
+	return nil, errors.New("not found")
+}
+
+// Has returns true if the node set contains the given key
+func (db *NodeSet) Has(key []byte) (bool, error) {
+	_, err := db.Get(key)
+	return err == nil, nil
+}
+
+// KeyCount returns the number of nodes in the set
+func (db *NodeSet) KeyCount() int {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+
+	return len(db.nodes)
+}
+
+// DataSize returns the aggregated data size of nodes in the set
+func (db *NodeSet) DataSize() int {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+
+	return db.dataSize
+}
+
+// NodeList converts the node set to a NodeList
+func (db *NodeSet) NodeList() NodeList {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+
+	var values NodeList
+	for _, key := range db.order {
+		values = append(values, db.nodes[key])
+	}
+	return values
+}
+
+// Store writes the contents of the set to the given database
+func (db *NodeSet) Store(target database.KeyValueWriter) {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+
+	for key, value := range db.nodes {
+		target.Put([]byte(key), value)
+	}
+}
+
+// NodeList stores an ordered list of trie nodes. It implements ethdb.KeyValueWriter.
+type NodeList []rlp.RawValue
+
+// Store writes the contents of the list to the given database
+func (n NodeList) Store(db database.KeyValueWriter) {
+	for _, node := range n {
+		db.Put(crypto.Keccak256(node), node)
+	}
+}
+
+// NodeSet converts the node list to a NodeSet
+func (n NodeList) NodeSet() *NodeSet {
+	db := NewNodeSet()
+	n.Store(db)
+	return db
+}
+
+// Put stores a new node at the end of the list
+func (n *NodeList) Put(key []byte, value []byte) error {
+	*n = append(*n, value)
+	return nil
+}
+
+// Delete panics as there's no reason to remove a node from the list.
+func (n *NodeList) Delete(key []byte) error {
+	panic("not supported")
+}
+
+// DataSize returns the aggregated data size of nodes in the list
+func (n NodeList) DataSize() int {
+	var size int
+	for _, node := range n {
+		size += len(node)
+	}
+	return size
+}

--- a/node/cn/snap/peer.go
+++ b/node/cn/snap/peer.go
@@ -1,0 +1,137 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from eth/protocols/snap/peer.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package snap
+
+import (
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/networks/p2p"
+)
+
+// Peer is a collection of relevant information we have about a `snap` peer.
+type Peer struct {
+	id string // Unique ID for the peer, cached
+
+	*p2p.Peer                   // The embedded P2P package peer
+	rw        p2p.MsgReadWriter // Input/output streams for snap
+	version   uint              // Protocol version negotiated
+
+	logger log.Logger // Contextual logger with the peer id injected
+}
+
+// NewPeer create a wrapper for a network connection and negotiated  protocol
+// version.
+func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) *Peer {
+	id := p.ID().String()
+	return &Peer{
+		id:      id[:16],
+		Peer:    p,
+		rw:      rw,
+		version: version,
+		logger:  logger.NewWith("peer", id[:16]),
+	}
+}
+
+// NewFakePeer create a fake snap peer without a backing p2p peer, for testing purposes.
+func NewFakePeer(version uint, id string, rw p2p.MsgReadWriter) *Peer {
+	return &Peer{
+		id:      id[:16],
+		rw:      rw,
+		version: version,
+		logger:  logger.NewWith("peer", id[:8]),
+	}
+}
+
+// ID retrieves the peer's unique identifier.
+func (p *Peer) ID() string {
+	return p.id
+}
+
+// Version retrieves the peer's negoatiated `snap` protocol version.
+func (p *Peer) Version() uint {
+	return p.version
+}
+
+// Log overrides the P2P logget with the higher level one containing only the id.
+func (p *Peer) Log() log.Logger {
+	return p.logger
+}
+
+// RequestAccountRange fetches a batch of accounts rooted in a specific account
+// trie, starting with the origin.
+func (p *Peer) RequestAccountRange(id uint64, root common.Hash, origin, limit common.Hash, bytes uint64) error {
+	p.logger.Trace("Fetching range of accounts", "reqid", id, "root", root, "origin", origin, "limit", limit, "bytes", common.StorageSize(bytes))
+
+	requestTracker.Track(p.id, p.version, GetAccountRangeMsg, AccountRangeMsg, id)
+	return p2p.Send(p.rw, GetAccountRangeMsg, &GetAccountRangePacket{
+		ID:     id,
+		Root:   root,
+		Origin: origin,
+		Limit:  limit,
+		Bytes:  bytes,
+	})
+}
+
+// RequestStorageRanges fetches a batch of storage slots belonging to one or more
+// accounts. If slots from only one accout is requested, an origin marker may also
+// be used to retrieve from there.
+func (p *Peer) RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, bytes uint64) error {
+	if len(accounts) == 1 && origin != nil {
+		p.logger.Trace("Fetching range of large storage slots", "reqid", id, "root", root, "account", accounts[0], "origin", common.BytesToHash(origin), "limit", common.BytesToHash(limit), "bytes", common.StorageSize(bytes))
+	} else {
+		p.logger.Trace("Fetching ranges of small storage slots", "reqid", id, "root", root, "accounts", len(accounts), "first", accounts[0], "bytes", common.StorageSize(bytes))
+	}
+	requestTracker.Track(p.id, p.version, GetStorageRangesMsg, StorageRangesMsg, id)
+	return p2p.Send(p.rw, GetStorageRangesMsg, &GetStorageRangesPacket{
+		ID:       id,
+		Root:     root,
+		Accounts: accounts,
+		Origin:   origin,
+		Limit:    limit,
+		Bytes:    bytes,
+	})
+}
+
+// RequestByteCodes fetches a batch of bytecodes by hash.
+func (p *Peer) RequestByteCodes(id uint64, hashes []common.Hash, bytes uint64) error {
+	p.logger.Trace("Fetching set of byte codes", "reqid", id, "hashes", len(hashes), "bytes", common.StorageSize(bytes))
+
+	requestTracker.Track(p.id, p.version, GetByteCodesMsg, ByteCodesMsg, id)
+	return p2p.Send(p.rw, GetByteCodesMsg, &GetByteCodesPacket{
+		ID:     id,
+		Hashes: hashes,
+		Bytes:  bytes,
+	})
+}
+
+// RequestTrieNodes fetches a batch of account or storage trie nodes rooted in
+// a specificstate trie.
+func (p *Peer) RequestTrieNodes(id uint64, root common.Hash, paths []TrieNodePathSet, bytes uint64) error {
+	p.logger.Trace("Fetching set of trie nodes", "reqid", id, "root", root, "pathsets", len(paths), "bytes", common.StorageSize(bytes))
+
+	requestTracker.Track(p.id, p.version, GetTrieNodesMsg, TrieNodesMsg, id)
+	return p2p.Send(p.rw, GetTrieNodesMsg, &GetTrieNodesPacket{
+		ID:    id,
+		Root:  root,
+		Paths: paths,
+		Bytes: bytes,
+	})
+}

--- a/node/cn/snap/peer.go
+++ b/node/cn/snap/peer.go
@@ -56,7 +56,7 @@ func NewFakePeer(version uint, id string, rw p2p.MsgReadWriter) *Peer {
 		id:      id[:16],
 		rw:      rw,
 		version: version,
-		logger:  logger.NewWith("peer", id[:8]),
+		logger:  logger.NewWith("peer", id[:16]),
 	}
 }
 

--- a/node/cn/snap/protocol.go
+++ b/node/cn/snap/protocol.go
@@ -1,0 +1,241 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from eth/protocols/snap/protocol.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package snap
+
+import (
+	"errors"
+	"io"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/rlp"
+)
+
+// Constants to match up protocol versions and messages
+const (
+	SNAP1 = 1
+)
+
+// ProtocolName is the official short name of the `snap` protocol used during
+// devp2p capability negotiation.
+const ProtocolName = "snap"
+
+// ProtocolVersions are the supported versions of the `snap` protocol (first
+// is primary).
+var ProtocolVersions = []uint{SNAP1}
+
+// ProtocolLengths are the number of implemented message corresponding to
+// different protocol versions.
+var ProtocolLengths = map[uint]uint64{SNAP1: 8}
+
+// maxMessageSize is the maximum cap on the size of a protocol message.
+const maxMessageSize = 10 * 1024 * 1024
+
+const (
+	GetAccountRangeMsg  = 0x00
+	AccountRangeMsg     = 0x01
+	GetStorageRangesMsg = 0x02
+	StorageRangesMsg    = 0x03
+	GetByteCodesMsg     = 0x04
+	ByteCodesMsg        = 0x05
+	GetTrieNodesMsg     = 0x06
+	TrieNodesMsg        = 0x07
+)
+
+var (
+	errMsgTooLarge    = errors.New("message too long")
+	errDecode         = errors.New("invalid message")
+	errInvalidMsgCode = errors.New("invalid message code")
+	errBadRequest     = errors.New("bad request")
+)
+
+// Packet represents a p2p message in the `snap` protocol.
+type Packet interface {
+	Name() string // Name returns a string corresponding to the message type.
+	Kind() byte   // Kind returns the message type.
+}
+
+// GetAccountRangePacket represents an account query.
+type GetAccountRangePacket struct {
+	ID     uint64      // Request ID to match up responses with
+	Root   common.Hash // Root hash of the account trie to serve
+	Origin common.Hash // Hash of the first account to retrieve
+	Limit  common.Hash // Hash of the last account to retrieve
+	Bytes  uint64      // Soft limit at which to stop returning data
+}
+
+// AccountRangePacket represents an account query response.
+type AccountRangePacket struct {
+	ID       uint64         // ID of the request this is a response for
+	Accounts []*AccountData // List of consecutive accounts from the trie
+	Proof    [][]byte       // List of trie nodes proving the account range
+}
+
+// AccountData represents a single account in a query response.
+type AccountData struct {
+	Hash common.Hash  // Hash of the account
+	Body rlp.RawValue // Account body in slim format
+}
+
+type accountData struct {
+	Hash common.Hash
+	Body []byte
+}
+
+// EncodeRLP serializes the istanbul fields into the Klaytn RLP format.
+func (a *AccountData) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, &accountData{
+		Hash: a.Hash,
+		Body: a.Body[:],
+	})
+}
+
+// DecodeRLP implements rlp.Decoder, and load the istanbul fields from a RLP stream.
+func (a *AccountData) DecodeRLP(s *rlp.Stream) error {
+	var dec accountData
+	if err := s.Decode(&dec); err != nil {
+		return err
+	}
+
+	a.Hash, a.Body = dec.Hash, dec.Body
+	return nil
+}
+
+// Unpack retrieves the accounts from the range packet and converts from slim
+// wire representation to consensus format. The returned data is RLP encoded
+// since it's expected to be serialized to disk without further interpretation.
+//
+// Note, this method does a round of RLP decoding and reencoding, so only use it
+// once and cache the results if need be. Ideally discard the packet afterwards
+// to not double the memory use.
+func (p *AccountRangePacket) Unpack() ([]common.Hash, [][]byte, error) {
+	var (
+		hashes   = make([]common.Hash, len(p.Accounts))
+		accounts = make([][]byte, len(p.Accounts))
+	)
+	for i, acc := range p.Accounts {
+		hashes[i], accounts[i] = acc.Hash, acc.Body
+	}
+	return hashes, accounts, nil
+}
+
+// GetStorageRangesPacket represents an storage slot query.
+type GetStorageRangesPacket struct {
+	ID       uint64        // Request ID to match up responses with
+	Root     common.Hash   // Root hash of the account trie to serve
+	Accounts []common.Hash // Account hashes of the storage tries to serve
+	Origin   []byte        // Hash of the first storage slot to retrieve (large contract mode)
+	Limit    []byte        // Hash of the last storage slot to retrieve (large contract mode)
+	Bytes    uint64        // Soft limit at which to stop returning data
+}
+
+// StorageRangesPacket represents a storage slot query response.
+type StorageRangesPacket struct {
+	ID    uint64           // ID of the request this is a response for
+	Slots [][]*StorageData // Lists of consecutive storage slots for the requested accounts
+	Proof [][]byte         // Merkle proofs for the *last* slot range, if it's incomplete
+}
+
+// StorageData represents a single storage slot in a query response.
+type StorageData struct {
+	Hash common.Hash // Hash of the storage slot
+	Body []byte      // Data content of the slot
+}
+
+// Unpack retrieves the storage slots from the range packet and returns them in
+// a split flat format that's more consistent with the internal data structures.
+func (p *StorageRangesPacket) Unpack() ([][]common.Hash, [][][]byte) {
+	var (
+		hashset = make([][]common.Hash, len(p.Slots))
+		slotset = make([][][]byte, len(p.Slots))
+	)
+	for i, slots := range p.Slots {
+		hashset[i] = make([]common.Hash, len(slots))
+		slotset[i] = make([][]byte, len(slots))
+		for j, slot := range slots {
+			hashset[i][j] = slot.Hash
+			slotset[i][j] = slot.Body
+		}
+	}
+	return hashset, slotset
+}
+
+// GetByteCodesPacket represents a contract bytecode query.
+type GetByteCodesPacket struct {
+	ID     uint64        // Request ID to match up responses with
+	Hashes []common.Hash // Code hashes to retrieve the code for
+	Bytes  uint64        // Soft limit at which to stop returning data
+}
+
+// ByteCodesPacket represents a contract bytecode query response.
+type ByteCodesPacket struct {
+	ID    uint64   // ID of the request this is a response for
+	Codes [][]byte // Requested contract bytecodes
+}
+
+// GetTrieNodesPacket represents a state trie node query.
+type GetTrieNodesPacket struct {
+	ID    uint64            // Request ID to match up responses with
+	Root  common.Hash       // Root hash of the account trie to serve
+	Paths []TrieNodePathSet // Trie node hashes to retrieve the nodes for
+	Bytes uint64            // Soft limit at which to stop returning data
+}
+
+// TrieNodePathSet is a list of trie node paths to retrieve. A naive way to
+// represent trie nodes would be a simple list of `account || storage` path
+// segments concatenated, but that would be very wasteful on the network.
+//
+// Instead, this array special cases the first element as the path in the
+// account trie and the remaining elements as paths in the storage trie. To
+// address an account node, the slice should have a length of 1 consisting
+// of only the account path. There's no need to be able to address both an
+// account node and a storage node in the same request as it cannot happen
+// that a slot is accessed before the account path is fully expanded.
+type TrieNodePathSet [][]byte
+
+// TrieNodesPacket represents a state trie node query response.
+type TrieNodesPacket struct {
+	ID    uint64   // ID of the request this is a response for
+	Nodes [][]byte // Requested state trie nodes
+}
+
+func (*GetAccountRangePacket) Name() string { return "GetAccountRange" }
+func (*GetAccountRangePacket) Kind() byte   { return GetAccountRangeMsg }
+
+func (*AccountRangePacket) Name() string { return "AccountRange" }
+func (*AccountRangePacket) Kind() byte   { return AccountRangeMsg }
+
+func (*GetStorageRangesPacket) Name() string { return "GetStorageRanges" }
+func (*GetStorageRangesPacket) Kind() byte   { return GetStorageRangesMsg }
+
+func (*StorageRangesPacket) Name() string { return "StorageRanges" }
+func (*StorageRangesPacket) Kind() byte   { return StorageRangesMsg }
+
+func (*GetByteCodesPacket) Name() string { return "GetByteCodes" }
+func (*GetByteCodesPacket) Kind() byte   { return GetByteCodesMsg }
+
+func (*ByteCodesPacket) Name() string { return "ByteCodes" }
+func (*ByteCodesPacket) Kind() byte   { return ByteCodesMsg }
+
+func (*GetTrieNodesPacket) Name() string { return "GetTrieNodes" }
+func (*GetTrieNodesPacket) Kind() byte   { return GetTrieNodesMsg }
+
+func (*TrieNodesPacket) Name() string { return "TrieNodes" }
+func (*TrieNodesPacket) Kind() byte   { return TrieNodesMsg }

--- a/node/cn/snap/range.go
+++ b/node/cn/snap/range.go
@@ -1,0 +1,85 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from eth/protocols/snap/range.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package snap
+
+import (
+	"math/big"
+
+	"github.com/holiman/uint256"
+	"github.com/klaytn/klaytn/common"
+)
+
+// hashRange is a utility to handle ranges of hashes, Split up the
+// hash-space into sections, and 'walk' over the sections
+type hashRange struct {
+	current *uint256.Int
+	step    *uint256.Int
+}
+
+// newHashRange creates a new hashRange, initiated at the start position,
+// and with the step set to fill the desired 'num' chunks
+func newHashRange(start common.Hash, num uint64) *hashRange {
+	left := new(big.Int).Sub(hashSpace, start.Big())
+	step := new(big.Int).Div(
+		new(big.Int).Add(left, new(big.Int).SetUint64(num-1)),
+		new(big.Int).SetUint64(num),
+	)
+	step256 := new(uint256.Int)
+	step256.SetFromBig(step)
+
+	return &hashRange{
+		current: new(uint256.Int).SetBytes32(start[:]),
+		step:    step256,
+	}
+}
+
+// Next pushes the hash range to the next interval.
+func (r *hashRange) Next() bool {
+	next, overflow := new(uint256.Int).AddOverflow(r.current, r.step)
+	if overflow {
+		return false
+	}
+	r.current = next
+	return true
+}
+
+// Start returns the first hash in the current interval.
+func (r *hashRange) Start() common.Hash {
+	return r.current.Bytes32()
+}
+
+// End returns the last hash in the current interval.
+func (r *hashRange) End() common.Hash {
+	// If the end overflows (non divisible range), return a shorter interval
+	next, overflow := new(uint256.Int).AddOverflow(r.current, r.step)
+	if overflow {
+		return common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	}
+	return next.SubUint64(next, 1).Bytes32()
+}
+
+// incHash returns the next hash, in lexicographical order (a.k.a plus one)
+func incHash(h common.Hash) common.Hash {
+	var a uint256.Int
+	a.SetBytes32(h[:])
+	a.AddUint64(&a, 1)
+	return common.Hash(a.Bytes32())
+}

--- a/node/cn/snap/range_test.go
+++ b/node/cn/snap/range_test.go
@@ -1,0 +1,147 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from eth/protocols/snap/range_test.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package snap
+
+import (
+	"testing"
+
+	"github.com/klaytn/klaytn/common"
+)
+
+// Tests that given a starting hash and a density, the hash ranger can correctly
+// split up the remaining hash space into a fixed number of chunks.
+func TestHashRanges(t *testing.T) {
+	tests := []struct {
+		head   common.Hash
+		chunks uint64
+		starts []common.Hash
+		ends   []common.Hash
+	}{
+		// Simple test case to split the entire hash range into 4 chunks
+		{
+			head:   common.Hash{},
+			chunks: 4,
+			starts: []common.Hash{
+				{},
+				common.HexToHash("0x4000000000000000000000000000000000000000000000000000000000000000"),
+				common.HexToHash("0x8000000000000000000000000000000000000000000000000000000000000000"),
+				common.HexToHash("0xc000000000000000000000000000000000000000000000000000000000000000"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0x3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				common.HexToHash("0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				common.HexToHash("0xbfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
+		// Split a divisible part of the hash range up into 2 chunks
+		{
+			head:   common.HexToHash("0x2000000000000000000000000000000000000000000000000000000000000000"),
+			chunks: 2,
+			starts: []common.Hash{
+				{},
+				common.HexToHash("0x9000000000000000000000000000000000000000000000000000000000000000"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0x8fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
+		// Split the entire hash range into a non divisible 3 chunks
+		{
+			head:   common.Hash{},
+			chunks: 3,
+			starts: []common.Hash{
+				{},
+				common.HexToHash("0x5555555555555555555555555555555555555555555555555555555555555556"),
+				common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0x5555555555555555555555555555555555555555555555555555555555555555"),
+				common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
+		// Split a part of hash range into a non divisible 3 chunks
+		{
+			head:   common.HexToHash("0x2000000000000000000000000000000000000000000000000000000000000000"),
+			chunks: 3,
+			starts: []common.Hash{
+				{},
+				common.HexToHash("0x6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"),
+				common.HexToHash("0xb555555555555555555555555555555555555555555555555555555555555556"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0x6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+				common.HexToHash("0xb555555555555555555555555555555555555555555555555555555555555555"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
+		// Split a part of hash range into a non divisible 3 chunks, but with a
+		// meaningful space size for manual verification.
+		//   - The head being 0xff...f0, we have 14 hashes left in the space
+		//   - Chunking up 14 into 3 pieces is 4.(6), but we need the ceil of 5 to avoid a micro-last-chunk
+		//   - Since the range is not divisible, the last interval will be shrter, capped at 0xff...f
+		//   - The chunk ranges thus needs to be [..0, ..5], [..6, ..b], [..c, ..f]
+		{
+			head:   common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0"),
+			chunks: 3,
+			starts: []common.Hash{
+				{},
+				common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6"),
+				common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5"),
+				common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffb"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
+	}
+	for i, tt := range tests {
+		r := newHashRange(tt.head, tt.chunks)
+
+		var (
+			starts = []common.Hash{{}}
+			ends   = []common.Hash{r.End()}
+		)
+		for r.Next() {
+			starts = append(starts, r.Start())
+			ends = append(ends, r.End())
+		}
+		if len(starts) != len(tt.starts) {
+			t.Errorf("test %d: starts count mismatch: have %d, want %d", i, len(starts), len(tt.starts))
+		}
+		for j := 0; j < len(starts) && j < len(tt.starts); j++ {
+			if starts[j] != tt.starts[j] {
+				t.Errorf("test %d, start %d: hash mismatch: have %x, want %x", i, j, starts[j], tt.starts[j])
+			}
+		}
+		if len(ends) != len(tt.ends) {
+			t.Errorf("test %d: ends count mismatch: have %d, want %d", i, len(ends), len(tt.ends))
+		}
+		for j := 0; j < len(ends) && j < len(tt.ends); j++ {
+			if ends[j] != tt.ends[j] {
+				t.Errorf("test %d, end %d: hash mismatch: have %x, want %x", i, j, ends[j], tt.ends[j])
+			}
+		}
+	}
+}

--- a/node/cn/snap/sync.go
+++ b/node/cn/snap/sync.go
@@ -385,8 +385,8 @@ type SyncPeer interface {
 	Log() log.Logger
 }
 
-// Syncer is an Ethereum account and storage trie syncer based on snapshots and
-// the  snap protocol. It's purpose is to download all the accounts and storage
+// Syncer is an Klaytn account and storage trie syncer based on snapshots and
+// the snap protocol. It's purpose is to download all the accounts and storage
 // slots from remote peers and reassemble chunks of the state trie, on top of
 // which a state sync can be run to fix any gaps / overlaps.
 //

--- a/node/cn/snap/sync.go
+++ b/node/cn/snap/sync.go
@@ -901,6 +901,7 @@ func (s *Syncer) assignAccountTasks(success chan *accountResponse, fail chan *ac
 		idlers.caps = append(idlers.caps, s.rates.Capacity(id, AccountRangeMsg, targetTTL))
 	}
 	if len(idlers.ids) == 0 {
+		// TODO-Klaytn-SnapSync enhance logging if necessary
 		return
 	}
 	sort.Sort(sort.Reverse(idlers))

--- a/node/cn/snap/sync.go
+++ b/node/cn/snap/sync.go
@@ -1,0 +1,2884 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from eth/protocols/snap/sync.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package snap
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/klaytn/klaytn/blockchain/state"
+	"github.com/klaytn/klaytn/blockchain/types/account"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/math"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/event"
+	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/networks/p2p/msgrate"
+	"github.com/klaytn/klaytn/rlp"
+	"github.com/klaytn/klaytn/storage/database"
+	"github.com/klaytn/klaytn/storage/statedb"
+	"golang.org/x/crypto/sha3"
+)
+
+var logger = log.NewModuleLogger(log.SnapshotSync)
+
+var (
+	// emptyRoot is the known root hash of an empty trie.
+	emptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+	// emptyCode is the known hash of the empty EVM bytecode.
+	emptyCode = crypto.Keccak256Hash(nil)
+)
+
+const (
+	// minRequestSize is the minimum number of bytes to request from a remote peer.
+	// This number is used as the low cap for account and storage range requests.
+	// Bytecode and trienode are limited inherently by item count (1).
+	minRequestSize = 64 * 1024
+
+	// maxRequestSize is the maximum number of bytes to request from a remote peer.
+	// This number is used as the high cap for account and storage range requests.
+	// Bytecode and trienode are limited more explicitly by the caps below.
+	maxRequestSize = 512 * 1024
+
+	// maxCodeRequestCount is the maximum number of bytecode blobs to request in a
+	// single query. If this number is too low, we're not filling responses fully
+	// and waste round trip times. If it's too high, we're capping responses and
+	// waste bandwidth.
+	//
+	// Depoyed bytecodes are currently capped at 24KB, so the minimum request
+	// size should be maxRequestSize / 24K. Assuming that most contracts do not
+	// come close to that, requesting 4x should be a good approximation.
+	maxCodeRequestCount = maxRequestSize / (24 * 1024) * 4
+
+	// maxTrieRequestCount is the maximum number of trie node blobs to request in
+	// a single query. If this number is too low, we're not filling responses fully
+	// and waste round trip times. If it's too high, we're capping responses and
+	// waste bandwidth.
+	maxTrieRequestCount = maxRequestSize / 512
+)
+
+var (
+	// accountConcurrency is the number of chunks to split the account trie into
+	// to allow concurrent retrievals.
+	accountConcurrency = 16
+
+	// storageConcurrency is the number of chunks to split the a large contract
+	// storage trie into to allow concurrent retrievals.
+	storageConcurrency = 16
+)
+
+// ErrCancelled is returned from snap syncing if the operation was prematurely
+// terminated.
+var ErrCancelled = errors.New("sync cancelled")
+
+// accountRequest tracks a pending account range request to ensure responses are
+// to actual requests and to validate any security constraints.
+//
+// Concurrency note: account requests and responses are handled concurrently from
+// the main runloop to allow Merkle proof verifications on the peer's thread and
+// to drop on invalid response. The request struct must contain all the data to
+// construct the response without accessing runloop internals (i.e. task). That
+// is only included to allow the runloop to match a response to the task being
+// synced without having yet another set of maps.
+type accountRequest struct {
+	peer string    // Peer to which this request is assigned
+	id   uint64    // Request ID of this request
+	time time.Time // Timestamp when the request was sent
+
+	deliver chan *accountResponse // Channel to deliver successful response on
+	revert  chan *accountRequest  // Channel to deliver request failure on
+	cancel  chan struct{}         // Channel to track sync cancellation
+	timeout *time.Timer           // Timer to track delivery timeout
+	stale   chan struct{}         // Channel to signal the request was dropped
+
+	origin common.Hash // First account requested to allow continuation checks
+	limit  common.Hash // Last account requested to allow non-overlapping chunking
+
+	task *accountTask // Task which this request is filling (only access fields through the runloop!!)
+}
+
+// accountResponse is an already Merkle-verified remote response to an account
+// range request. It contains the subtrie for the requested account range and
+// the database that's going to be filled with the internal nodes on commit.
+type accountResponse struct {
+	task *accountTask // Task which this request is filling
+
+	hashes   []common.Hash     // Account hashes in the returned range
+	accounts []account.Account // Expanded accounts in the returned range
+
+	cont bool // Whether the account range has a continuation
+}
+
+// bytecodeRequest tracks a pending bytecode request to ensure responses are to
+// actual requests and to validate any security constraints.
+//
+// Concurrency note: bytecode requests and responses are handled concurrently from
+// the main runloop to allow Keccak256 hash verifications on the peer's thread and
+// to drop on invalid response. The request struct must contain all the data to
+// construct the response without accessing runloop internals (i.e. task). That
+// is only included to allow the runloop to match a response to the task being
+// synced without having yet another set of maps.
+type bytecodeRequest struct {
+	peer string    // Peer to which this request is assigned
+	id   uint64    // Request ID of this request
+	time time.Time // Timestamp when the request was sent
+
+	deliver chan *bytecodeResponse // Channel to deliver successful response on
+	revert  chan *bytecodeRequest  // Channel to deliver request failure on
+	cancel  chan struct{}          // Channel to track sync cancellation
+	timeout *time.Timer            // Timer to track delivery timeout
+	stale   chan struct{}          // Channel to signal the request was dropped
+
+	hashes []common.Hash // Bytecode hashes to validate responses
+	task   *accountTask  // Task which this request is filling (only access fields through the runloop!!)
+}
+
+// bytecodeResponse is an already verified remote response to a bytecode request.
+type bytecodeResponse struct {
+	task *accountTask // Task which this request is filling
+
+	hashes []common.Hash // Hashes of the bytecode to avoid double hashing
+	codes  [][]byte      // Actual bytecodes to store into the database (nil = missing)
+}
+
+// storageRequest tracks a pending storage ranges request to ensure responses are
+// to actual requests and to validate any security constraints.
+//
+// Concurrency note: storage requests and responses are handled concurrently from
+// the main runloop to allow Merkle proof verifications on the peer's thread and
+// to drop on invalid response. The request struct must contain all the data to
+// construct the response without accessing runloop internals (i.e. tasks). That
+// is only included to allow the runloop to match a response to the task being
+// synced without having yet another set of maps.
+type storageRequest struct {
+	peer string    // Peer to which this request is assigned
+	id   uint64    // Request ID of this request
+	time time.Time // Timestamp when the request was sent
+
+	deliver chan *storageResponse // Channel to deliver successful response on
+	revert  chan *storageRequest  // Channel to deliver request failure on
+	cancel  chan struct{}         // Channel to track sync cancellation
+	timeout *time.Timer           // Timer to track delivery timeout
+	stale   chan struct{}         // Channel to signal the request was dropped
+
+	accounts []common.Hash // Account hashes to validate responses
+	roots    []common.Hash // Storage roots to validate responses
+
+	origin common.Hash // First storage slot requested to allow continuation checks
+	limit  common.Hash // Last storage slot requested to allow non-overlapping chunking
+
+	mainTask *accountTask // Task which this response belongs to (only access fields through the runloop!!)
+	subTask  *storageTask // Task which this response is filling (only access fields through the runloop!!)
+}
+
+// storageResponse is an already Merkle-verified remote response to a storage
+// range request. It contains the subtries for the requested storage ranges and
+// the databases that's going to be filled with the internal nodes on commit.
+type storageResponse struct {
+	mainTask *accountTask // Task which this response belongs to
+	subTask  *storageTask // Task which this response is filling
+
+	accounts []common.Hash // Account hashes requested, may be only partially filled
+	roots    []common.Hash // Storage roots requested, may be only partially filled
+
+	hashes [][]common.Hash // Storage slot hashes in the returned range
+	slots  [][][]byte      // Storage slot values in the returned range
+
+	cont bool // Whether the last storage range has a continuation
+}
+
+// trienodeHealRequest tracks a pending state trie request to ensure responses
+// are to actual requests and to validate any security constraints.
+//
+// Concurrency note: trie node requests and responses are handled concurrently from
+// the main runloop to allow Keccak256 hash verifications on the peer's thread and
+// to drop on invalid response. The request struct must contain all the data to
+// construct the response without accessing runloop internals (i.e. task). That
+// is only included to allow the runloop to match a response to the task being
+// synced without having yet another set of maps.
+type trienodeHealRequest struct {
+	peer string    // Peer to which this request is assigned
+	id   uint64    // Request ID of this request
+	time time.Time // Timestamp when the request was sent
+
+	deliver chan *trienodeHealResponse // Channel to deliver successful response on
+	revert  chan *trienodeHealRequest  // Channel to deliver request failure on
+	cancel  chan struct{}              // Channel to track sync cancellation
+	timeout *time.Timer                // Timer to track delivery timeout
+	stale   chan struct{}              // Channel to signal the request was dropped
+
+	hashes []common.Hash      // Trie node hashes to validate responses
+	paths  []statedb.SyncPath // Trie node paths requested for rescheduling
+
+	task *healTask // Task which this request is filling (only access fields through the runloop!!)
+}
+
+// trienodeHealResponse is an already verified remote response to a trie node request.
+type trienodeHealResponse struct {
+	task *healTask // Task which this request is filling
+
+	hashes []common.Hash      // Hashes of the trie nodes to avoid double hashing
+	paths  []statedb.SyncPath // Trie node paths requested for rescheduling missing ones
+	nodes  [][]byte           // Actual trie nodes to store into the database (nil = missing)
+}
+
+// bytecodeHealRequest tracks a pending bytecode request to ensure responses are to
+// actual requests and to validate any security constraints.
+//
+// Concurrency note: bytecode requests and responses are handled concurrently from
+// the main runloop to allow Keccak256 hash verifications on the peer's thread and
+// to drop on invalid response. The request struct must contain all the data to
+// construct the response without accessing runloop internals (i.e. task). That
+// is only included to allow the runloop to match a response to the task being
+// synced without having yet another set of maps.
+type bytecodeHealRequest struct {
+	peer string    // Peer to which this request is assigned
+	id   uint64    // Request ID of this request
+	time time.Time // Timestamp when the request was sent
+
+	deliver chan *bytecodeHealResponse // Channel to deliver successful response on
+	revert  chan *bytecodeHealRequest  // Channel to deliver request failure on
+	cancel  chan struct{}              // Channel to track sync cancellation
+	timeout *time.Timer                // Timer to track delivery timeout
+	stale   chan struct{}              // Channel to signal the request was dropped
+
+	hashes []common.Hash // Bytecode hashes to validate responses
+	task   *healTask     // Task which this request is filling (only access fields through the runloop!!)
+}
+
+// bytecodeHealResponse is an already verified remote response to a bytecode request.
+type bytecodeHealResponse struct {
+	task *healTask // Task which this request is filling
+
+	hashes []common.Hash // Hashes of the bytecode to avoid double hashing
+	codes  [][]byte      // Actual bytecodes to store into the database (nil = missing)
+}
+
+// accountTask represents the sync task for a chunk of the account snapshot.
+type accountTask struct {
+	// These fields get serialized to leveldb on shutdown
+	Next     common.Hash                    // Next account to sync in this interval
+	Last     common.Hash                    // Last account to sync in this interval
+	SubTasks map[common.Hash][]*storageTask // Storage intervals needing fetching for large contracts
+
+	// These fields are internals used during runtime
+	req  *accountRequest  // Pending request to fill this task
+	res  *accountResponse // Validate response filling this task
+	pend int              // Number of pending subtasks for this round
+
+	needCode  []bool // Flags whether the filling accounts need code retrieval
+	needState []bool // Flags whether the filling accounts need storage retrieval
+	needHeal  []bool // Flags whether the filling accounts's state was chunked and need healing
+
+	codeTasks  map[common.Hash]struct{}    // Code hashes that need retrieval
+	stateTasks map[common.Hash]common.Hash // Account hashes->roots that need full state retrieval
+
+	// TODO-Klaytn-Snapsync consider to use stack trie
+	genTrie *statedb.Trie // Node generator from storage slots
+	trieDb  *statedb.Database
+
+	done bool // Flag whether the task can be removed
+}
+
+// storageTask represents the sync task for a chunk of the storage snapshot.
+type storageTask struct {
+	Next common.Hash // Next account to sync in this interval
+	Last common.Hash // Last account to sync in this interval
+
+	// These fields are internals used during runtime
+	root common.Hash     // Storage root hash for this instance
+	req  *storageRequest // Pending request to fill this task
+
+	// TODO-Klaytn-Snapsync consider to use stack trie
+	genTrie *statedb.Trie // Node generator from storage slots
+	trieDb  *statedb.Database
+
+	done bool // Flag whether the task can be removed
+}
+
+// healTask represents the sync task for healing the snap-synced chunk boundaries.
+type healTask struct {
+	scheduler *statedb.TrieSync // State trie sync scheduler defining the tasks
+
+	trieTasks map[common.Hash]statedb.SyncPath // Set of trie node tasks currently queued for retrieval
+	codeTasks map[common.Hash]struct{}         // Set of byte code tasks currently queued for retrieval
+}
+
+// SyncProgress is a database entry to allow suspending and resuming a snapshot state
+// sync. Opposed to full and fast sync, there is no way to restart a suspended
+// snap sync without prior knowledge of the suspension point.
+type SyncProgress struct {
+	Tasks []*accountTask // The suspended account tasks (contract tasks within)
+
+	// Status report during syncing phase
+	AccountSynced  uint64             // Number of accounts downloaded
+	AccountBytes   common.StorageSize // Number of account trie bytes persisted to disk
+	BytecodeSynced uint64             // Number of bytecodes downloaded
+	BytecodeBytes  common.StorageSize // Number of bytecode bytes downloaded
+	StorageSynced  uint64             // Number of storage slots downloaded
+	StorageBytes   common.StorageSize // Number of storage trie bytes persisted to disk
+
+	// Status report during healing phase
+	TrienodeHealSynced uint64             // Number of state trie nodes downloaded
+	TrienodeHealBytes  common.StorageSize // Number of state trie bytes persisted to disk
+	BytecodeHealSynced uint64             // Number of bytecodes downloaded
+	BytecodeHealBytes  common.StorageSize // Number of bytecodes persisted to disk
+}
+
+// SyncPending is analogous to SyncProgress, but it's used to report on pending
+// ephemeral sync progress that doesn't get persisted into the database.
+type SyncPending struct {
+	TrienodeHeal uint64 // Number of state trie nodes pending
+	BytecodeHeal uint64 // Number of bytecodes pending
+}
+
+// SyncPeer abstracts out the methods required for a peer to be synced against
+// with the goal of allowing the construction of mock peers without the full
+// blown networking.
+type SyncPeer interface {
+	// ID retrieves the peer's unique identifier.
+	ID() string
+
+	// RequestAccountRange fetches a batch of accounts rooted in a specific account
+	// trie, starting with the origin.
+	RequestAccountRange(id uint64, root, origin, limit common.Hash, bytes uint64) error
+
+	// RequestStorageRanges fetches a batch of storage slots belonging to one or
+	// more accounts. If slots from only one accout is requested, an origin marker
+	// may also be used to retrieve from there.
+	RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, bytes uint64) error
+
+	// RequestByteCodes fetches a batch of bytecodes by hash.
+	RequestByteCodes(id uint64, hashes []common.Hash, bytes uint64) error
+
+	// RequestTrieNodes fetches a batch of account or storage trie nodes rooted in
+	// a specificstate trie.
+	RequestTrieNodes(id uint64, root common.Hash, paths []TrieNodePathSet, bytes uint64) error
+
+	// Log retrieves the peer's own contextual logger.
+	Log() log.Logger
+}
+
+// Syncer is an Ethereum account and storage trie syncer based on snapshots and
+// the  snap protocol. It's purpose is to download all the accounts and storage
+// slots from remote peers and reassemble chunks of the state trie, on top of
+// which a state sync can be run to fix any gaps / overlaps.
+//
+// Every network request has a variety of failure events:
+//   - The peer disconnects after task assignment, failing to send the request
+//   - The peer disconnects after sending the request, before delivering on it
+//   - The peer remains connected, but does not deliver a response in time
+//   - The peer delivers a stale response after a previous timeout
+//   - The peer delivers a refusal to serve the requested state
+type Syncer struct {
+	db database.DBManager // Database to store the trie nodes into (and dedup)
+
+	root    common.Hash    // Current state trie root being synced
+	tasks   []*accountTask // Current account task set being synced
+	snapped bool           // Flag to signal that snap phase is done
+	healer  *healTask      // Current state healing task being executed
+	update  chan struct{}  // Notification channel for possible sync progression
+
+	peers    map[string]SyncPeer // Currently active peers to download from
+	peerJoin *event.Feed         // Event feed to react to peers joining
+	peerDrop *event.Feed         // Event feed to react to peers dropping
+	rates    *msgrate.Trackers   // Message throughput rates for peers
+
+	// Request tracking during syncing phase
+	statelessPeers map[string]struct{} // Peers that failed to deliver state data
+	accountIdlers  map[string]struct{} // Peers that aren't serving account requests
+	bytecodeIdlers map[string]struct{} // Peers that aren't serving bytecode requests
+	storageIdlers  map[string]struct{} // Peers that aren't serving storage requests
+
+	accountReqs  map[uint64]*accountRequest  // Account requests currently running
+	bytecodeReqs map[uint64]*bytecodeRequest // Bytecode requests currently running
+	storageReqs  map[uint64]*storageRequest  // Storage requests currently running
+
+	accountSynced  uint64             // Number of accounts downloaded
+	accountBytes   common.StorageSize // Number of account trie bytes persisted to disk
+	bytecodeSynced uint64             // Number of bytecodes downloaded
+	bytecodeBytes  common.StorageSize // Number of bytecode bytes downloaded
+	storageSynced  uint64             // Number of storage slots downloaded
+	storageBytes   common.StorageSize // Number of storage trie bytes persisted to disk
+
+	extProgress *SyncProgress // progress that can be exposed to external caller.
+
+	// Request tracking during healing phase
+	trienodeHealIdlers map[string]struct{} // Peers that aren't serving trie node requests
+	bytecodeHealIdlers map[string]struct{} // Peers that aren't serving bytecode requests
+
+	trienodeHealReqs map[uint64]*trienodeHealRequest // Trie node requests currently running
+	bytecodeHealReqs map[uint64]*bytecodeHealRequest // Bytecode requests currently running
+
+	trienodeHealSynced uint64             // Number of state trie nodes downloaded
+	trienodeHealBytes  common.StorageSize // Number of state trie bytes persisted to disk
+	trienodeHealDups   uint64             // Number of state trie nodes already processed
+	trienodeHealNops   uint64             // Number of state trie nodes not requested
+	bytecodeHealSynced uint64             // Number of bytecodes downloaded
+	bytecodeHealBytes  common.StorageSize // Number of bytecodes persisted to disk
+	bytecodeHealDups   uint64             // Number of bytecodes already processed
+	bytecodeHealNops   uint64             // Number of bytecodes not requested
+
+	stateWriter        database.SnapshotDBBatch // Shared batch writer used for persisting raw states
+	accountHealed      uint64                   // Number of accounts downloaded during the healing stage
+	accountHealedBytes common.StorageSize       // Number of raw account bytes persisted to disk during the healing stage
+	storageHealed      uint64                   // Number of storage slots downloaded during the healing stage
+	storageHealedBytes common.StorageSize       // Number of raw storage bytes persisted to disk during the healing stage
+
+	startTime time.Time // Time instance when snapshot sync started
+	logTime   time.Time // Time instance when status was last reported
+
+	pend sync.WaitGroup // Tracks network request goroutines for graceful shutdown
+	lock sync.RWMutex   // Protects fields that can change outside of sync (peers, reqs, root)
+}
+
+// NewSyncer creates a new snapshot syncer to download the Ethereum state over the
+// snap protocol.
+func NewSyncer(db database.DBManager) *Syncer {
+	return &Syncer{
+		db: db,
+
+		peers:    make(map[string]SyncPeer),
+		peerJoin: new(event.Feed),
+		peerDrop: new(event.Feed),
+		rates:    msgrate.NewTrackers(logger.NewWith("proto", "snap")),
+		update:   make(chan struct{}, 1),
+
+		accountIdlers:  make(map[string]struct{}),
+		storageIdlers:  make(map[string]struct{}),
+		bytecodeIdlers: make(map[string]struct{}),
+
+		accountReqs:  make(map[uint64]*accountRequest),
+		storageReqs:  make(map[uint64]*storageRequest),
+		bytecodeReqs: make(map[uint64]*bytecodeRequest),
+
+		trienodeHealIdlers: make(map[string]struct{}),
+		bytecodeHealIdlers: make(map[string]struct{}),
+
+		trienodeHealReqs: make(map[uint64]*trienodeHealRequest),
+		bytecodeHealReqs: make(map[uint64]*bytecodeHealRequest),
+		stateWriter:      db.NewSnapshotDBBatch(),
+
+		extProgress: new(SyncProgress),
+	}
+}
+
+// Register injects a new data source into the syncer's peerset.
+func (s *Syncer) Register(peer SyncPeer) error {
+	// Make sure the peer is not registered yet
+	id := peer.ID()
+
+	s.lock.Lock()
+	if _, ok := s.peers[id]; ok {
+		logger.Error("Snap peer already registered", "id", id)
+
+		s.lock.Unlock()
+		return errors.New("already registered")
+	}
+	s.peers[id] = peer
+	s.rates.Track(id, msgrate.NewTracker(s.rates.MeanCapacities(), s.rates.MedianRoundTrip()))
+
+	// Mark the peer as idle, even if no sync is running
+	s.accountIdlers[id] = struct{}{}
+	s.storageIdlers[id] = struct{}{}
+	s.bytecodeIdlers[id] = struct{}{}
+	s.trienodeHealIdlers[id] = struct{}{}
+	s.bytecodeHealIdlers[id] = struct{}{}
+	s.lock.Unlock()
+
+	// Notify any active syncs that a new peer can be assigned data
+	s.peerJoin.Send(id)
+	return nil
+}
+
+// Unregister injects a new data source into the syncer's peerset.
+func (s *Syncer) Unregister(id string) error {
+	// Remove all traces of the peer from the registry
+	s.lock.Lock()
+	if _, ok := s.peers[id]; !ok {
+		logger.Error("Snap peer not registered", "id", id)
+
+		s.lock.Unlock()
+		return errors.New("not registered")
+	}
+	delete(s.peers, id)
+	s.rates.Untrack(id)
+
+	// Remove status markers, even if no sync is running
+	delete(s.statelessPeers, id)
+
+	delete(s.accountIdlers, id)
+	delete(s.storageIdlers, id)
+	delete(s.bytecodeIdlers, id)
+	delete(s.trienodeHealIdlers, id)
+	delete(s.bytecodeHealIdlers, id)
+	s.lock.Unlock()
+
+	// Notify any active syncs that pending requests need to be reverted
+	s.peerDrop.Send(id)
+	return nil
+}
+
+// Sync starts (or resumes a previous) sync cycle to iterate over an state trie
+// with the given root and reconstruct the nodes based on the snapshot leaves.
+// Previously downloaded segments will not be redownloaded of fixed, rather any
+// errors will be healed after the leaves are fully accumulated.
+func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
+	// Move the trie root from any previous value, revert stateless markers for
+	// any peers and initialize the syncer if it was not yet run
+	s.lock.Lock()
+	s.root = root
+	s.healer = &healTask{
+		scheduler: state.NewStateSync(root, s.db, nil, nil, s.onHealState),
+		trieTasks: make(map[common.Hash]statedb.SyncPath),
+		codeTasks: make(map[common.Hash]struct{}),
+	}
+	s.statelessPeers = make(map[string]struct{})
+	s.lock.Unlock()
+
+	if s.startTime == (time.Time{}) {
+		s.startTime = time.Now()
+	}
+	// Retrieve the previous sync status from LevelDB and abort if already synced
+	s.loadSyncStatus()
+	if len(s.tasks) == 0 && s.healer.scheduler.Pending() == 0 {
+		logger.Debug("Snapshot sync already completed")
+		return nil
+	}
+	defer func() { // Persist any progress, independent of failure
+		for _, task := range s.tasks {
+			s.forwardAccountTask(task)
+		}
+		s.cleanAccountTasks()
+		s.saveSyncStatus()
+	}()
+
+	logger.Debug("Starting snapshot sync cycle", "root", root)
+
+	// Flush out the last committed raw states
+	defer func() {
+		if s.stateWriter.ValueSize() > 0 {
+			s.stateWriter.Write()
+			s.stateWriter.Reset()
+		}
+	}()
+	defer s.report(true)
+
+	// Whether sync completed or not, disregard any future packets
+	defer func() {
+		logger.Debug("Terminating snapshot sync cycle", "root", root)
+		s.lock.Lock()
+		s.accountReqs = make(map[uint64]*accountRequest)
+		s.storageReqs = make(map[uint64]*storageRequest)
+		s.bytecodeReqs = make(map[uint64]*bytecodeRequest)
+		s.trienodeHealReqs = make(map[uint64]*trienodeHealRequest)
+		s.bytecodeHealReqs = make(map[uint64]*bytecodeHealRequest)
+		s.lock.Unlock()
+	}()
+	// Keep scheduling sync tasks
+	peerJoin := make(chan string, 16)
+	peerJoinSub := s.peerJoin.Subscribe(peerJoin)
+	defer peerJoinSub.Unsubscribe()
+
+	peerDrop := make(chan string, 16)
+	peerDropSub := s.peerDrop.Subscribe(peerDrop)
+	defer peerDropSub.Unsubscribe()
+
+	// Create a set of unique channels for this sync cycle. We need these to be
+	// ephemeral so a data race doesn't accidentally deliver something stale on
+	// a persistent channel across syncs (yup, this happened)
+	var (
+		accountReqFails      = make(chan *accountRequest)
+		storageReqFails      = make(chan *storageRequest)
+		bytecodeReqFails     = make(chan *bytecodeRequest)
+		accountResps         = make(chan *accountResponse)
+		storageResps         = make(chan *storageResponse)
+		bytecodeResps        = make(chan *bytecodeResponse)
+		trienodeHealReqFails = make(chan *trienodeHealRequest)
+		bytecodeHealReqFails = make(chan *bytecodeHealRequest)
+		trienodeHealResps    = make(chan *trienodeHealResponse)
+		bytecodeHealResps    = make(chan *bytecodeHealResponse)
+	)
+	for {
+		// Remove all completed tasks and terminate sync if everything's done
+		s.cleanStorageTasks()
+		s.cleanAccountTasks()
+		if len(s.tasks) == 0 && s.healer.scheduler.Pending() == 0 {
+			return nil
+		}
+		// Assign all the data retrieval tasks to any free peers
+		s.assignAccountTasks(accountResps, accountReqFails, cancel)
+		s.assignBytecodeTasks(bytecodeResps, bytecodeReqFails, cancel)
+		s.assignStorageTasks(storageResps, storageReqFails, cancel)
+
+		if len(s.tasks) == 0 {
+			// Sync phase done, run heal phase
+			s.assignTrienodeHealTasks(trienodeHealResps, trienodeHealReqFails, cancel)
+			s.assignBytecodeHealTasks(bytecodeHealResps, bytecodeHealReqFails, cancel)
+		}
+		// Update sync progress
+		s.lock.Lock()
+		s.extProgress = &SyncProgress{
+			AccountSynced:      s.accountSynced,
+			AccountBytes:       s.accountBytes,
+			BytecodeSynced:     s.bytecodeSynced,
+			BytecodeBytes:      s.bytecodeBytes,
+			StorageSynced:      s.storageSynced,
+			StorageBytes:       s.storageBytes,
+			TrienodeHealSynced: s.trienodeHealSynced,
+			TrienodeHealBytes:  s.trienodeHealBytes,
+			BytecodeHealSynced: s.bytecodeHealSynced,
+			BytecodeHealBytes:  s.bytecodeHealBytes,
+		}
+		s.lock.Unlock()
+		// Wait for something to happen
+		select {
+		case <-s.update:
+			// Something happened (new peer, delivery, timeout), recheck tasks
+		case <-peerJoin:
+			// A new peer joined, try to schedule it new tasks
+		case id := <-peerDrop:
+			s.revertRequests(id)
+		case <-cancel:
+			return ErrCancelled
+
+		case req := <-accountReqFails:
+			s.revertAccountRequest(req)
+		case req := <-bytecodeReqFails:
+			s.revertBytecodeRequest(req)
+		case req := <-storageReqFails:
+			s.revertStorageRequest(req)
+		case req := <-trienodeHealReqFails:
+			s.revertTrienodeHealRequest(req)
+		case req := <-bytecodeHealReqFails:
+			s.revertBytecodeHealRequest(req)
+
+		case res := <-accountResps:
+			s.processAccountResponse(res)
+		case res := <-bytecodeResps:
+			s.processBytecodeResponse(res)
+		case res := <-storageResps:
+			s.processStorageResponse(res)
+		case res := <-trienodeHealResps:
+			s.processTrienodeHealResponse(res)
+		case res := <-bytecodeHealResps:
+			s.processBytecodeHealResponse(res)
+		}
+		// Report stats if something meaningful happened
+		s.report(false)
+	}
+}
+
+// loadSyncStatus retrieves a previously aborted sync status from the database,
+// or generates a fresh one if none is available.
+func (s *Syncer) loadSyncStatus() {
+	var progress SyncProgress
+
+	if status := s.db.ReadSnapshotSyncStatus(); status != nil {
+		if err := json.Unmarshal(status, &progress); err != nil {
+			logger.Error("Failed to decode snap sync status", "err", err)
+		} else {
+			for _, task := range progress.Tasks {
+				logger.Debug("Scheduled account sync task", "from", task.Next, "last", task.Last)
+			}
+			s.tasks = progress.Tasks
+			for _, task := range s.tasks {
+				task.trieDb = statedb.NewDatabase(s.db)
+				task.genTrie, err = statedb.NewTrie(common.Hash{}, task.trieDb)
+
+				for _, subtasks := range task.SubTasks {
+					for _, subtask := range subtasks {
+						subtask.trieDb = statedb.NewDatabase(s.db)
+						subtask.genTrie, _ = statedb.NewTrie(common.Hash{}, subtask.trieDb)
+					}
+				}
+			}
+			s.lock.Lock()
+			defer s.lock.Unlock()
+
+			s.snapped = len(s.tasks) == 0
+
+			s.accountSynced = progress.AccountSynced
+			s.accountBytes = progress.AccountBytes
+			s.bytecodeSynced = progress.BytecodeSynced
+			s.bytecodeBytes = progress.BytecodeBytes
+			s.storageSynced = progress.StorageSynced
+			s.storageBytes = progress.StorageBytes
+
+			s.trienodeHealSynced = progress.TrienodeHealSynced
+			s.trienodeHealBytes = progress.TrienodeHealBytes
+			s.bytecodeHealSynced = progress.BytecodeHealSynced
+			s.bytecodeHealBytes = progress.BytecodeHealBytes
+			return
+		}
+	}
+	// Either we've failed to decode the previus state, or there was none.
+	// Start a fresh sync by chunking up the account range and scheduling
+	// them for retrieval.
+	s.tasks = nil
+	s.accountSynced, s.accountBytes = 0, 0
+	s.bytecodeSynced, s.bytecodeBytes = 0, 0
+	s.storageSynced, s.storageBytes = 0, 0
+	s.trienodeHealSynced, s.trienodeHealBytes = 0, 0
+	s.bytecodeHealSynced, s.bytecodeHealBytes = 0, 0
+
+	var next common.Hash
+	step := new(big.Int).Sub(
+		new(big.Int).Div(
+			new(big.Int).Exp(common.Big2, common.Big256, nil),
+			big.NewInt(int64(accountConcurrency)),
+		), common.Big1,
+	)
+	for i := 0; i < accountConcurrency; i++ {
+		last := common.BigToHash(new(big.Int).Add(next.Big(), step))
+		if i == accountConcurrency-1 {
+			// Make sure we don't overflow if the step is not a proper divisor
+			last = common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+		}
+		db := statedb.NewDatabase(s.db)
+		trie, _ := statedb.NewTrie(common.Hash{}, db)
+		s.tasks = append(s.tasks, &accountTask{
+			Next:     next,
+			Last:     last,
+			SubTasks: make(map[common.Hash][]*storageTask),
+			genTrie:  trie,
+			trieDb:   db,
+		})
+		logger.Debug("Created account sync task", "from", next, "last", last)
+		next = common.BigToHash(new(big.Int).Add(last.Big(), common.Big1))
+	}
+}
+
+// saveSyncStatus marshals the remaining sync tasks into leveldb.
+func (s *Syncer) saveSyncStatus() {
+	// Serialize any partial progress to disk before spinning down
+	for _, task := range s.tasks {
+		if err := task.trieDb.Commit(task.genTrie.Hash(), false, 0); err != nil {
+			logger.Error("Failed to persist account slots", "err", err)
+		}
+		for _, subtasks := range task.SubTasks {
+			for _, subtask := range subtasks {
+				if err := subtask.trieDb.Commit(subtask.genTrie.Hash(), false, 0); err != nil {
+					logger.Error("Failed to persist storage slots", "err", err)
+				}
+			}
+		}
+	}
+	// Store the actual progress markers
+	progress := &SyncProgress{
+		Tasks:              s.tasks,
+		AccountSynced:      s.accountSynced,
+		AccountBytes:       s.accountBytes,
+		BytecodeSynced:     s.bytecodeSynced,
+		BytecodeBytes:      s.bytecodeBytes,
+		StorageSynced:      s.storageSynced,
+		StorageBytes:       s.storageBytes,
+		TrienodeHealSynced: s.trienodeHealSynced,
+		TrienodeHealBytes:  s.trienodeHealBytes,
+		BytecodeHealSynced: s.bytecodeHealSynced,
+		BytecodeHealBytes:  s.bytecodeHealBytes,
+	}
+	status, err := json.Marshal(progress)
+	if err != nil {
+		panic(err) // This can only fail during implementation
+	}
+	s.db.WriteSnapshotSyncStatus(status)
+}
+
+// Progress returns the snap sync status statistics.
+func (s *Syncer) Progress() (*SyncProgress, *SyncPending) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	pending := new(SyncPending)
+	if s.healer != nil {
+		pending.TrienodeHeal = uint64(len(s.healer.trieTasks))
+		pending.BytecodeHeal = uint64(len(s.healer.codeTasks))
+	}
+	return s.extProgress, pending
+}
+
+// cleanAccountTasks removes account range retrieval tasks that have already been
+// completed.
+func (s *Syncer) cleanAccountTasks() {
+	// If the sync was already done before, don't even bother
+	if len(s.tasks) == 0 {
+		return
+	}
+	// Sync wasn't finished previously, check for any task that can be finalized
+	for i := 0; i < len(s.tasks); i++ {
+		if s.tasks[i].done {
+			s.tasks = append(s.tasks[:i], s.tasks[i+1:]...)
+			i--
+		}
+	}
+	// If everything was just finalized just, generate the account trie and start heal
+	if len(s.tasks) == 0 {
+		s.lock.Lock()
+		s.snapped = true
+		s.lock.Unlock()
+
+		// Push the final sync report
+		s.reportSyncProgress(true)
+	}
+}
+
+// cleanStorageTasks iterates over all the account tasks and storage sub-tasks
+// within, cleaning any that have been completed.
+func (s *Syncer) cleanStorageTasks() {
+	for _, task := range s.tasks {
+		for account, subtasks := range task.SubTasks {
+			// Remove storage range retrieval tasks that completed
+			for j := 0; j < len(subtasks); j++ {
+				if subtasks[j].done {
+					subtasks = append(subtasks[:j], subtasks[j+1:]...)
+					j--
+				}
+			}
+			if len(subtasks) > 0 {
+				task.SubTasks[account] = subtasks
+				continue
+			}
+			// If all storage chunks are done, mark the account as done too
+			for j, hash := range task.res.hashes {
+				if hash == account {
+					task.needState[j] = false
+				}
+			}
+			delete(task.SubTasks, account)
+			task.pend--
+
+			// If this was the last pending task, forward the account task
+			if task.pend == 0 {
+				s.forwardAccountTask(task)
+			}
+		}
+	}
+}
+
+// assignAccountTasks attempts to match idle peers to pending account range
+// retrievals.
+func (s *Syncer) assignAccountTasks(success chan *accountResponse, fail chan *accountRequest, cancel chan struct{}) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Sort the peers by download capacity to use faster ones if many available
+	idlers := &capacitySort{
+		ids:  make([]string, 0, len(s.accountIdlers)),
+		caps: make([]int, 0, len(s.accountIdlers)),
+	}
+	targetTTL := s.rates.TargetTimeout()
+	for id := range s.accountIdlers {
+		if _, ok := s.statelessPeers[id]; ok {
+			continue
+		}
+		idlers.ids = append(idlers.ids, id)
+		idlers.caps = append(idlers.caps, s.rates.Capacity(id, AccountRangeMsg, targetTTL))
+	}
+	if len(idlers.ids) == 0 {
+		return
+	}
+	sort.Sort(sort.Reverse(idlers))
+
+	// Iterate over all the tasks and try to find a pending one
+	for _, task := range s.tasks {
+		// Skip any tasks already filling
+		if task.req != nil || task.res != nil {
+			continue
+		}
+		// Task pending retrieval, try to find an idle peer. If no such peer
+		// exists, we probably assigned tasks for all (or they are stateless).
+		// Abort the entire assignment mechanism.
+		if len(idlers.ids) == 0 {
+			return
+		}
+		var (
+			idle = idlers.ids[0]
+			peer = s.peers[idle]
+			cap  = idlers.caps[0]
+		)
+		idlers.ids, idlers.caps = idlers.ids[1:], idlers.caps[1:]
+
+		// Matched a pending task to an idle peer, allocate a unique request id
+		var reqid uint64
+		for {
+			reqid = uint64(rand.Int63())
+			if reqid == 0 {
+				continue
+			}
+			if _, ok := s.accountReqs[reqid]; ok {
+				continue
+			}
+			break
+		}
+		// Generate the network query and send it to the peer
+		req := &accountRequest{
+			peer:    idle,
+			id:      reqid,
+			time:    time.Now(),
+			deliver: success,
+			revert:  fail,
+			cancel:  cancel,
+			stale:   make(chan struct{}),
+			origin:  task.Next,
+			limit:   task.Last,
+			task:    task,
+		}
+		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
+			peer.Log().Debug("Account range request timed out", "reqid", reqid)
+			s.rates.Update(idle, AccountRangeMsg, 0, 0)
+			s.scheduleRevertAccountRequest(req)
+		})
+		s.accountReqs[reqid] = req
+		delete(s.accountIdlers, idle)
+
+		s.pend.Add(1)
+		go func(root common.Hash) {
+			defer s.pend.Done()
+
+			// Attempt to send the remote request and revert if it fails
+			if cap > maxRequestSize {
+				cap = maxRequestSize
+			}
+			if cap < minRequestSize { // Don't bother with peers below a bare minimum performance
+				cap = minRequestSize
+			}
+			if err := peer.RequestAccountRange(reqid, root, req.origin, req.limit, uint64(cap)); err != nil {
+				peer.Log().Debug("Failed to request account range", "err", err)
+				s.scheduleRevertAccountRequest(req)
+			}
+		}(s.root)
+
+		// Inject the request into the task to block further assignments
+		task.req = req
+	}
+}
+
+// assignBytecodeTasks attempts to match idle peers to pending code retrievals.
+func (s *Syncer) assignBytecodeTasks(success chan *bytecodeResponse, fail chan *bytecodeRequest, cancel chan struct{}) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Sort the peers by download capacity to use faster ones if many available
+	idlers := &capacitySort{
+		ids:  make([]string, 0, len(s.bytecodeIdlers)),
+		caps: make([]int, 0, len(s.bytecodeIdlers)),
+	}
+	targetTTL := s.rates.TargetTimeout()
+	for id := range s.bytecodeIdlers {
+		if _, ok := s.statelessPeers[id]; ok {
+			continue
+		}
+		idlers.ids = append(idlers.ids, id)
+		idlers.caps = append(idlers.caps, s.rates.Capacity(id, ByteCodesMsg, targetTTL))
+	}
+	if len(idlers.ids) == 0 {
+		return
+	}
+	sort.Sort(sort.Reverse(idlers))
+
+	// Iterate over all the tasks and try to find a pending one
+	for _, task := range s.tasks {
+		// Skip any tasks not in the bytecode retrieval phase
+		if task.res == nil {
+			continue
+		}
+		// Skip tasks that are already retrieving (or done with) all codes
+		if len(task.codeTasks) == 0 {
+			continue
+		}
+		// Task pending retrieval, try to find an idle peer. If no such peer
+		// exists, we probably assigned tasks for all (or they are stateless).
+		// Abort the entire assignment mechanism.
+		if len(idlers.ids) == 0 {
+			return
+		}
+		var (
+			idle = idlers.ids[0]
+			peer = s.peers[idle]
+			cap  = idlers.caps[0]
+		)
+		idlers.ids, idlers.caps = idlers.ids[1:], idlers.caps[1:]
+
+		// Matched a pending task to an idle peer, allocate a unique request id
+		var reqid uint64
+		for {
+			reqid = uint64(rand.Int63())
+			if reqid == 0 {
+				continue
+			}
+			if _, ok := s.bytecodeReqs[reqid]; ok {
+				continue
+			}
+			break
+		}
+		// Generate the network query and send it to the peer
+		if cap > maxCodeRequestCount {
+			cap = maxCodeRequestCount
+		}
+		hashes := make([]common.Hash, 0, cap)
+		for hash := range task.codeTasks {
+			delete(task.codeTasks, hash)
+			hashes = append(hashes, hash)
+			if len(hashes) >= cap {
+				break
+			}
+		}
+		req := &bytecodeRequest{
+			peer:    idle,
+			id:      reqid,
+			time:    time.Now(),
+			deliver: success,
+			revert:  fail,
+			cancel:  cancel,
+			stale:   make(chan struct{}),
+			hashes:  hashes,
+			task:    task,
+		}
+		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
+			peer.Log().Debug("Bytecode request timed out", "reqid", reqid)
+			s.rates.Update(idle, ByteCodesMsg, 0, 0)
+			s.scheduleRevertBytecodeRequest(req)
+		})
+		s.bytecodeReqs[reqid] = req
+		delete(s.bytecodeIdlers, idle)
+
+		s.pend.Add(1)
+		go func() {
+			defer s.pend.Done()
+
+			// Attempt to send the remote request and revert if it fails
+			if err := peer.RequestByteCodes(reqid, hashes, maxRequestSize); err != nil {
+				logger.Debug("Failed to request bytecodes", "err", err)
+				s.scheduleRevertBytecodeRequest(req)
+			}
+		}()
+	}
+}
+
+// assignStorageTasks attempts to match idle peers to pending storage range
+// retrievals.
+func (s *Syncer) assignStorageTasks(success chan *storageResponse, fail chan *storageRequest, cancel chan struct{}) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Sort the peers by download capacity to use faster ones if many available
+	idlers := &capacitySort{
+		ids:  make([]string, 0, len(s.storageIdlers)),
+		caps: make([]int, 0, len(s.storageIdlers)),
+	}
+	targetTTL := s.rates.TargetTimeout()
+	for id := range s.storageIdlers {
+		if _, ok := s.statelessPeers[id]; ok {
+			continue
+		}
+		idlers.ids = append(idlers.ids, id)
+		idlers.caps = append(idlers.caps, s.rates.Capacity(id, StorageRangesMsg, targetTTL))
+	}
+	if len(idlers.ids) == 0 {
+		return
+	}
+	sort.Sort(sort.Reverse(idlers))
+
+	// Iterate over all the tasks and try to find a pending one
+	for _, task := range s.tasks {
+		// Skip any tasks not in the storage retrieval phase
+		if task.res == nil {
+			continue
+		}
+		// Skip tasks that are already retrieving (or done with) all small states
+		if len(task.SubTasks) == 0 && len(task.stateTasks) == 0 {
+			continue
+		}
+		// Task pending retrieval, try to find an idle peer. If no such peer
+		// exists, we probably assigned tasks for all (or they are stateless).
+		// Abort the entire assignment mechanism.
+		if len(idlers.ids) == 0 {
+			return
+		}
+		var (
+			idle = idlers.ids[0]
+			peer = s.peers[idle]
+			cap  = idlers.caps[0]
+		)
+		idlers.ids, idlers.caps = idlers.ids[1:], idlers.caps[1:]
+
+		// Matched a pending task to an idle peer, allocate a unique request id
+		var reqid uint64
+		for {
+			reqid = uint64(rand.Int63())
+			if reqid == 0 {
+				continue
+			}
+			if _, ok := s.storageReqs[reqid]; ok {
+				continue
+			}
+			break
+		}
+		// Generate the network query and send it to the peer. If there are
+		// large contract tasks pending, complete those before diving into
+		// even more new contracts.
+		if cap > maxRequestSize {
+			cap = maxRequestSize
+		}
+		if cap < minRequestSize { // Don't bother with peers below a bare minimum performance
+			cap = minRequestSize
+		}
+		storageSets := cap / 1024
+
+		var (
+			accounts = make([]common.Hash, 0, storageSets)
+			roots    = make([]common.Hash, 0, storageSets)
+			subtask  *storageTask
+		)
+		for account, subtasks := range task.SubTasks {
+			for _, st := range subtasks {
+				// Skip any subtasks already filling
+				if st.req != nil {
+					continue
+				}
+				// Found an incomplete storage chunk, schedule it
+				accounts = append(accounts, account)
+				roots = append(roots, st.root)
+				subtask = st
+				break // Large contract chunks are downloaded individually
+			}
+			if subtask != nil {
+				break // Large contract chunks are downloaded individually
+			}
+		}
+		if subtask == nil {
+			// No large contract required retrieval, but small ones available
+			for acccount, root := range task.stateTasks {
+				delete(task.stateTasks, acccount)
+
+				accounts = append(accounts, acccount)
+				roots = append(roots, root)
+
+				if len(accounts) >= storageSets {
+					break
+				}
+			}
+		}
+		// If nothing was found, it means this task is actually already fully
+		// retrieving, but large contracts are hard to detect. Skip to the next.
+		if len(accounts) == 0 {
+			continue
+		}
+		req := &storageRequest{
+			peer:     idle,
+			id:       reqid,
+			time:     time.Now(),
+			deliver:  success,
+			revert:   fail,
+			cancel:   cancel,
+			stale:    make(chan struct{}),
+			accounts: accounts,
+			roots:    roots,
+			mainTask: task,
+			subTask:  subtask,
+		}
+		if subtask != nil {
+			req.origin = subtask.Next
+			req.limit = subtask.Last
+		}
+		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
+			peer.Log().Debug("Storage request timed out", "reqid", reqid)
+			s.rates.Update(idle, StorageRangesMsg, 0, 0)
+			s.scheduleRevertStorageRequest(req)
+		})
+		s.storageReqs[reqid] = req
+		delete(s.storageIdlers, idle)
+
+		s.pend.Add(1)
+		go func(root common.Hash) {
+			defer s.pend.Done()
+
+			// Attempt to send the remote request and revert if it fails
+			var origin, limit []byte
+			if subtask != nil {
+				origin, limit = req.origin[:], req.limit[:]
+			}
+			if err := peer.RequestStorageRanges(reqid, root, accounts, origin, limit, uint64(cap)); err != nil {
+				logger.Debug("Failed to request storage", "err", err)
+				s.scheduleRevertStorageRequest(req)
+			}
+		}(s.root)
+
+		// Inject the request into the subtask to block further assignments
+		if subtask != nil {
+			subtask.req = req
+		}
+	}
+}
+
+// assignTrienodeHealTasks attempts to match idle peers to trie node requests to
+// heal any trie errors caused by the snap sync's chunked retrieval model.
+func (s *Syncer) assignTrienodeHealTasks(success chan *trienodeHealResponse, fail chan *trienodeHealRequest, cancel chan struct{}) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Sort the peers by download capacity to use faster ones if many available
+	idlers := &capacitySort{
+		ids:  make([]string, 0, len(s.trienodeHealIdlers)),
+		caps: make([]int, 0, len(s.trienodeHealIdlers)),
+	}
+	targetTTL := s.rates.TargetTimeout()
+	for id := range s.trienodeHealIdlers {
+		if _, ok := s.statelessPeers[id]; ok {
+			continue
+		}
+		idlers.ids = append(idlers.ids, id)
+		idlers.caps = append(idlers.caps, s.rates.Capacity(id, TrieNodesMsg, targetTTL))
+	}
+	if len(idlers.ids) == 0 {
+		return
+	}
+	sort.Sort(sort.Reverse(idlers))
+
+	// Iterate over pending tasks and try to find a peer to retrieve with
+	for len(s.healer.trieTasks) > 0 || s.healer.scheduler.Pending() > 0 {
+		// If there are not enough trie tasks queued to fully assign, fill the
+		// queue from the state sync scheduler. The trie synced schedules these
+		// together with bytecodes, so we need to queue them combined.
+		var (
+			have = len(s.healer.trieTasks) + len(s.healer.codeTasks)
+			want = maxTrieRequestCount + maxCodeRequestCount
+		)
+		if have < want {
+			nodes, paths, codes := s.healer.scheduler.Missing(want - have)
+			for i, hash := range nodes {
+				s.healer.trieTasks[hash] = paths[i]
+			}
+			for _, hash := range codes {
+				s.healer.codeTasks[hash] = struct{}{}
+			}
+		}
+		// If all the heal tasks are bytecodes or already downloading, bail
+		if len(s.healer.trieTasks) == 0 {
+			return
+		}
+		// Task pending retrieval, try to find an idle peer. If no such peer
+		// exists, we probably assigned tasks for all (or they are stateless).
+		// Abort the entire assignment mechanism.
+		if len(idlers.ids) == 0 {
+			return
+		}
+		var (
+			idle = idlers.ids[0]
+			peer = s.peers[idle]
+			cap  = idlers.caps[0]
+		)
+		idlers.ids, idlers.caps = idlers.ids[1:], idlers.caps[1:]
+
+		// Matched a pending task to an idle peer, allocate a unique request id
+		var reqid uint64
+		for {
+			reqid = uint64(rand.Int63())
+			if reqid == 0 {
+				continue
+			}
+			if _, ok := s.trienodeHealReqs[reqid]; ok {
+				continue
+			}
+			break
+		}
+		// Generate the network query and send it to the peer
+		if cap > maxTrieRequestCount {
+			cap = maxTrieRequestCount
+		}
+		var (
+			hashes   = make([]common.Hash, 0, cap)
+			paths    = make([]statedb.SyncPath, 0, cap)
+			pathsets = make([]TrieNodePathSet, 0, cap)
+		)
+		for hash, pathset := range s.healer.trieTasks {
+			delete(s.healer.trieTasks, hash)
+
+			hashes = append(hashes, hash)
+			paths = append(paths, pathset)
+			pathsets = append(pathsets, [][]byte(pathset)) // TODO-Klaytn-SnapSync group requests by account hash
+
+			if len(hashes) >= cap {
+				break
+			}
+		}
+		req := &trienodeHealRequest{
+			peer:    idle,
+			id:      reqid,
+			time:    time.Now(),
+			deliver: success,
+			revert:  fail,
+			cancel:  cancel,
+			stale:   make(chan struct{}),
+			hashes:  hashes,
+			paths:   paths,
+			task:    s.healer,
+		}
+		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
+			peer.Log().Debug("Trienode heal request timed out", "reqid", reqid)
+			s.rates.Update(idle, TrieNodesMsg, 0, 0)
+			s.scheduleRevertTrienodeHealRequest(req)
+		})
+		s.trienodeHealReqs[reqid] = req
+		delete(s.trienodeHealIdlers, idle)
+
+		s.pend.Add(1)
+		go func(root common.Hash) {
+			defer s.pend.Done()
+
+			// Attempt to send the remote request and revert if it fails
+			if err := peer.RequestTrieNodes(reqid, root, pathsets, maxRequestSize); err != nil {
+				logger.Debug("Failed to request trienode healers", "err", err)
+				s.scheduleRevertTrienodeHealRequest(req)
+			}
+		}(s.root)
+	}
+}
+
+// assignBytecodeHealTasks attempts to match idle peers to bytecode requests to
+// heal any trie errors caused by the snap sync's chunked retrieval model.
+func (s *Syncer) assignBytecodeHealTasks(success chan *bytecodeHealResponse, fail chan *bytecodeHealRequest, cancel chan struct{}) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Sort the peers by download capacity to use faster ones if many available
+	idlers := &capacitySort{
+		ids:  make([]string, 0, len(s.bytecodeHealIdlers)),
+		caps: make([]int, 0, len(s.bytecodeHealIdlers)),
+	}
+	targetTTL := s.rates.TargetTimeout()
+	for id := range s.bytecodeHealIdlers {
+		if _, ok := s.statelessPeers[id]; ok {
+			continue
+		}
+		idlers.ids = append(idlers.ids, id)
+		idlers.caps = append(idlers.caps, s.rates.Capacity(id, ByteCodesMsg, targetTTL))
+	}
+	if len(idlers.ids) == 0 {
+		return
+	}
+	sort.Sort(sort.Reverse(idlers))
+
+	// Iterate over pending tasks and try to find a peer to retrieve with
+	for len(s.healer.codeTasks) > 0 || s.healer.scheduler.Pending() > 0 {
+		// If there are not enough trie tasks queued to fully assign, fill the
+		// queue from the state sync scheduler. The trie synced schedules these
+		// together with trie nodes, so we need to queue them combined.
+		var (
+			have = len(s.healer.trieTasks) + len(s.healer.codeTasks)
+			want = maxTrieRequestCount + maxCodeRequestCount
+		)
+		if have < want {
+			nodes, paths, codes := s.healer.scheduler.Missing(want - have)
+			for i, hash := range nodes {
+				s.healer.trieTasks[hash] = paths[i]
+			}
+			for _, hash := range codes {
+				s.healer.codeTasks[hash] = struct{}{}
+			}
+		}
+		// If all the heal tasks are trienodes or already downloading, bail
+		if len(s.healer.codeTasks) == 0 {
+			return
+		}
+		// Task pending retrieval, try to find an idle peer. If no such peer
+		// exists, we probably assigned tasks for all (or they are stateless).
+		// Abort the entire assignment mechanism.
+		if len(idlers.ids) == 0 {
+			return
+		}
+		var (
+			idle = idlers.ids[0]
+			peer = s.peers[idle]
+			cap  = idlers.caps[0]
+		)
+		idlers.ids, idlers.caps = idlers.ids[1:], idlers.caps[1:]
+
+		// Matched a pending task to an idle peer, allocate a unique request id
+		var reqid uint64
+		for {
+			reqid = uint64(rand.Int63())
+			if reqid == 0 {
+				continue
+			}
+			if _, ok := s.bytecodeHealReqs[reqid]; ok {
+				continue
+			}
+			break
+		}
+		// Generate the network query and send it to the peer
+		if cap > maxCodeRequestCount {
+			cap = maxCodeRequestCount
+		}
+		hashes := make([]common.Hash, 0, cap)
+		for hash := range s.healer.codeTasks {
+			delete(s.healer.codeTasks, hash)
+
+			hashes = append(hashes, hash)
+			if len(hashes) >= cap {
+				break
+			}
+		}
+		req := &bytecodeHealRequest{
+			peer:    idle,
+			id:      reqid,
+			time:    time.Now(),
+			deliver: success,
+			revert:  fail,
+			cancel:  cancel,
+			stale:   make(chan struct{}),
+			hashes:  hashes,
+			task:    s.healer,
+		}
+		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
+			peer.Log().Debug("Bytecode heal request timed out", "reqid", reqid)
+			s.rates.Update(idle, ByteCodesMsg, 0, 0)
+			s.scheduleRevertBytecodeHealRequest(req)
+		})
+		s.bytecodeHealReqs[reqid] = req
+		delete(s.bytecodeHealIdlers, idle)
+
+		s.pend.Add(1)
+		go func() {
+			defer s.pend.Done()
+
+			// Attempt to send the remote request and revert if it fails
+			if err := peer.RequestByteCodes(reqid, hashes, maxRequestSize); err != nil {
+				logger.Debug("Failed to request bytecode healers", "err", err)
+				s.scheduleRevertBytecodeHealRequest(req)
+			}
+		}()
+	}
+}
+
+// revertRequests locates all the currently pending reuqests from a particular
+// peer and reverts them, rescheduling for others to fulfill.
+func (s *Syncer) revertRequests(peer string) {
+	// Gather the requests first, revertals need the lock too
+	s.lock.Lock()
+	var accountReqs []*accountRequest
+	for _, req := range s.accountReqs {
+		if req.peer == peer {
+			accountReqs = append(accountReqs, req)
+		}
+	}
+	var bytecodeReqs []*bytecodeRequest
+	for _, req := range s.bytecodeReqs {
+		if req.peer == peer {
+			bytecodeReqs = append(bytecodeReqs, req)
+		}
+	}
+	var storageReqs []*storageRequest
+	for _, req := range s.storageReqs {
+		if req.peer == peer {
+			storageReqs = append(storageReqs, req)
+		}
+	}
+	var trienodeHealReqs []*trienodeHealRequest
+	for _, req := range s.trienodeHealReqs {
+		if req.peer == peer {
+			trienodeHealReqs = append(trienodeHealReqs, req)
+		}
+	}
+	var bytecodeHealReqs []*bytecodeHealRequest
+	for _, req := range s.bytecodeHealReqs {
+		if req.peer == peer {
+			bytecodeHealReqs = append(bytecodeHealReqs, req)
+		}
+	}
+	s.lock.Unlock()
+
+	// Revert all the requests matching the peer
+	for _, req := range accountReqs {
+		s.revertAccountRequest(req)
+	}
+	for _, req := range bytecodeReqs {
+		s.revertBytecodeRequest(req)
+	}
+	for _, req := range storageReqs {
+		s.revertStorageRequest(req)
+	}
+	for _, req := range trienodeHealReqs {
+		s.revertTrienodeHealRequest(req)
+	}
+	for _, req := range bytecodeHealReqs {
+		s.revertBytecodeHealRequest(req)
+	}
+}
+
+// scheduleRevertAccountRequest asks the event loop to clean up an account range
+// request and return all failed retrieval tasks to the scheduler for reassignment.
+func (s *Syncer) scheduleRevertAccountRequest(req *accountRequest) {
+	select {
+	case req.revert <- req:
+		// Sync event loop notified
+	case <-req.cancel:
+		// Sync cycle got cancelled
+	case <-req.stale:
+		// Request already reverted
+	}
+}
+
+// revertAccountRequest cleans up an account range request and returns all failed
+// retrieval tasks to the scheduler for reassignment.
+//
+// Note, this needs to run on the event runloop thread to reschedule to idle peers.
+// On peer threads, use scheduleRevertAccountRequest.
+func (s *Syncer) revertAccountRequest(req *accountRequest) {
+	logger.Debug("Reverting account request", "peer", req.peer, "reqid", req.id)
+	select {
+	case <-req.stale:
+		logger.Trace("Account request already reverted", "peer", req.peer, "reqid", req.id)
+		return
+	default:
+	}
+	close(req.stale)
+
+	// Remove the request from the tracked set
+	s.lock.Lock()
+	delete(s.accountReqs, req.id)
+	s.lock.Unlock()
+
+	// If there's a timeout timer still running, abort it and mark the account
+	// task as not-pending, ready for resheduling
+	req.timeout.Stop()
+	if req.task.req == req {
+		req.task.req = nil
+	}
+}
+
+// scheduleRevertBytecodeRequest asks the event loop to clean up a bytecode request
+// and return all failed retrieval tasks to the scheduler for reassignment.
+func (s *Syncer) scheduleRevertBytecodeRequest(req *bytecodeRequest) {
+	select {
+	case req.revert <- req:
+		// Sync event loop notified
+	case <-req.cancel:
+		// Sync cycle got cancelled
+	case <-req.stale:
+		// Request already reverted
+	}
+}
+
+// revertBytecodeRequest cleans up a bytecode request and returns all failed
+// retrieval tasks to the scheduler for reassignment.
+//
+// Note, this needs to run on the event runloop thread to reschedule to idle peers.
+// On peer threads, use scheduleRevertBytecodeRequest.
+func (s *Syncer) revertBytecodeRequest(req *bytecodeRequest) {
+	logger.Debug("Reverting bytecode request", "peer", req.peer)
+	select {
+	case <-req.stale:
+		logger.Trace("Bytecode request already reverted", "peer", req.peer, "reqid", req.id)
+		return
+	default:
+	}
+	close(req.stale)
+
+	// Remove the request from the tracked set
+	s.lock.Lock()
+	delete(s.bytecodeReqs, req.id)
+	s.lock.Unlock()
+
+	// If there's a timeout timer still running, abort it and mark the code
+	// retrievals as not-pending, ready for resheduling
+	req.timeout.Stop()
+	for _, hash := range req.hashes {
+		req.task.codeTasks[hash] = struct{}{}
+	}
+}
+
+// scheduleRevertStorageRequest asks the event loop to clean up a storage range
+// request and return all failed retrieval tasks to the scheduler for reassignment.
+func (s *Syncer) scheduleRevertStorageRequest(req *storageRequest) {
+	select {
+	case req.revert <- req:
+		// Sync event loop notified
+	case <-req.cancel:
+		// Sync cycle got cancelled
+	case <-req.stale:
+		// Request already reverted
+	}
+}
+
+// revertStorageRequest cleans up a storage range request and returns all failed
+// retrieval tasks to the scheduler for reassignment.
+//
+// Note, this needs to run on the event runloop thread to reschedule to idle peers.
+// On peer threads, use scheduleRevertStorageRequest.
+func (s *Syncer) revertStorageRequest(req *storageRequest) {
+	logger.Debug("Reverting storage request", "peer", req.peer)
+	select {
+	case <-req.stale:
+		logger.Trace("Storage request already reverted", "peer", req.peer, "reqid", req.id)
+		return
+	default:
+	}
+	close(req.stale)
+
+	// Remove the request from the tracked set
+	s.lock.Lock()
+	delete(s.storageReqs, req.id)
+	s.lock.Unlock()
+
+	// If there's a timeout timer still running, abort it and mark the storage
+	// task as not-pending, ready for resheduling
+	req.timeout.Stop()
+	if req.subTask != nil {
+		req.subTask.req = nil
+	} else {
+		for i, account := range req.accounts {
+			req.mainTask.stateTasks[account] = req.roots[i]
+		}
+	}
+}
+
+// scheduleRevertTrienodeHealRequest asks the event loop to clean up a trienode heal
+// request and return all failed retrieval tasks to the scheduler for reassignment.
+func (s *Syncer) scheduleRevertTrienodeHealRequest(req *trienodeHealRequest) {
+	select {
+	case req.revert <- req:
+		// Sync event loop notified
+	case <-req.cancel:
+		// Sync cycle got cancelled
+	case <-req.stale:
+		// Request already reverted
+	}
+}
+
+// revertTrienodeHealRequest cleans up a trienode heal request and returns all
+// failed retrieval tasks to the scheduler for reassignment.
+//
+// Note, this needs to run on the event runloop thread to reschedule to idle peers.
+// On peer threads, use scheduleRevertTrienodeHealRequest.
+func (s *Syncer) revertTrienodeHealRequest(req *trienodeHealRequest) {
+	logger.Debug("Reverting trienode heal request", "peer", req.peer)
+	select {
+	case <-req.stale:
+		logger.Trace("Trienode heal request already reverted", "peer", req.peer, "reqid", req.id)
+		return
+	default:
+	}
+	close(req.stale)
+
+	// Remove the request from the tracked set
+	s.lock.Lock()
+	delete(s.trienodeHealReqs, req.id)
+	s.lock.Unlock()
+
+	// If there's a timeout timer still running, abort it and mark the trie node
+	// retrievals as not-pending, ready for resheduling
+	req.timeout.Stop()
+	for i, hash := range req.hashes {
+		req.task.trieTasks[hash] = req.paths[i]
+	}
+}
+
+// scheduleRevertBytecodeHealRequest asks the event loop to clean up a bytecode heal
+// request and return all failed retrieval tasks to the scheduler for reassignment.
+func (s *Syncer) scheduleRevertBytecodeHealRequest(req *bytecodeHealRequest) {
+	select {
+	case req.revert <- req:
+		// Sync event loop notified
+	case <-req.cancel:
+		// Sync cycle got cancelled
+	case <-req.stale:
+		// Request already reverted
+	}
+}
+
+// revertBytecodeHealRequest cleans up a bytecode heal request and returns all
+// failed retrieval tasks to the scheduler for reassignment.
+//
+// Note, this needs to run on the event runloop thread to reschedule to idle peers.
+// On peer threads, use scheduleRevertBytecodeHealRequest.
+func (s *Syncer) revertBytecodeHealRequest(req *bytecodeHealRequest) {
+	logger.Debug("Reverting bytecode heal request", "peer", req.peer)
+	select {
+	case <-req.stale:
+		logger.Trace("Bytecode heal request already reverted", "peer", req.peer, "reqid", req.id)
+		return
+	default:
+	}
+	close(req.stale)
+
+	// Remove the request from the tracked set
+	s.lock.Lock()
+	delete(s.bytecodeHealReqs, req.id)
+	s.lock.Unlock()
+
+	// If there's a timeout timer still running, abort it and mark the code
+	// retrievals as not-pending, ready for resheduling
+	req.timeout.Stop()
+	for _, hash := range req.hashes {
+		req.task.codeTasks[hash] = struct{}{}
+	}
+}
+
+// processAccountResponse integrates an already validated account range response
+// into the account tasks.
+func (s *Syncer) processAccountResponse(res *accountResponse) {
+	// Switch the task from pending to filling
+	res.task.req = nil
+	res.task.res = res
+
+	// Ensure that the response doesn't overflow into the subsequent task
+	last := res.task.Last.Big()
+	for i, hash := range res.hashes {
+		// Mark the range complete if the last is already included.
+		// Keep iteration to delete the extra states if exists.
+		cmp := hash.Big().Cmp(last)
+		if cmp == 0 {
+			res.cont = false
+			continue
+		}
+		if cmp > 0 {
+			// Chunk overflown, cut off excess
+			res.hashes = res.hashes[:i]
+			res.accounts = res.accounts[:i]
+			res.cont = false // Mark range completed
+			break
+		}
+	}
+	// Iterate over all the accounts and assemble which ones need further sub-
+	// filling before the entire account range can be persisted.
+	res.task.needCode = make([]bool, len(res.accounts))
+	res.task.needState = make([]bool, len(res.accounts))
+	res.task.needHeal = make([]bool, len(res.accounts))
+
+	res.task.codeTasks = make(map[common.Hash]struct{})
+	res.task.stateTasks = make(map[common.Hash]common.Hash)
+
+	resumed := make(map[common.Hash]struct{})
+
+	res.task.pend = 0
+	for i, acc := range res.accounts {
+		pacc := account.GetProgramAccount(acc)
+		// Check if the account is a contract with an unknown code
+		if pacc != nil && !bytes.Equal(pacc.GetCodeHash(), emptyCode[:]) {
+			if !s.db.HasCodeWithPrefix(common.BytesToHash(pacc.GetCodeHash())) {
+				res.task.codeTasks[common.BytesToHash(pacc.GetCodeHash())] = struct{}{}
+				res.task.needCode[i] = true
+				res.task.pend++
+			}
+		}
+		// Check if the account is a contract with an unknown storage trie
+		if pacc != nil && pacc.GetStorageRoot() != emptyRoot {
+			if ok, err := s.db.HasStateTrieNode(pacc.GetStorageRoot().Bytes()); err != nil || !ok {
+				// If there was a previous large state retrieval in progress,
+				// don't restart it from scratch. This happens if a sync cycle
+				// is interrupted and resumed later. However, *do* update the
+				// previous root hash.
+				if subtasks, ok := res.task.SubTasks[res.hashes[i]]; ok {
+					logger.Debug("Resuming large storage retrieval", "account", res.hashes[i], "root", pacc.GetStorageRoot())
+					for _, subtask := range subtasks {
+						subtask.root = pacc.GetStorageRoot()
+					}
+					res.task.needHeal[i] = true
+					resumed[res.hashes[i]] = struct{}{}
+				} else {
+					res.task.stateTasks[res.hashes[i]] = pacc.GetStorageRoot()
+				}
+				res.task.needState[i] = true
+				res.task.pend++
+			}
+		}
+	}
+	// Delete any subtasks that have been aborted but not resumed. This may undo
+	// some progress if a new peer gives us less accounts than an old one, but for
+	// now we have to live with that.
+	for hash := range res.task.SubTasks {
+		if _, ok := resumed[hash]; !ok {
+			logger.Debug("Aborting suspended storage retrieval", "account", hash)
+			delete(res.task.SubTasks, hash)
+		}
+	}
+	// If the account range contained no contracts, or all have been fully filled
+	// beforehand, short circuit storage filling and forward to the next task
+	if res.task.pend == 0 {
+		s.forwardAccountTask(res.task)
+		return
+	}
+	// Some accounts are incomplete, leave as is for the storage and contract
+	// task assigners to pick up and fill.
+}
+
+// processBytecodeResponse integrates an already validated bytecode response
+// into the account tasks.
+func (s *Syncer) processBytecodeResponse(res *bytecodeResponse) {
+	batch := s.db.NewBatch(database.StateTrieDB)
+
+	var codes uint64
+	for i, hash := range res.hashes {
+		code := res.codes[i]
+
+		// If the bytecode was not delivered, reschedule it
+		if code == nil {
+			res.task.codeTasks[hash] = struct{}{}
+			continue
+		}
+		// Code was delivered, mark it not needed any more
+		for j, acc := range res.task.res.accounts {
+			pacc := account.GetProgramAccount(acc)
+			if pacc != nil && res.task.needCode[j] && hash == common.BytesToHash(pacc.GetCodeHash()) {
+				res.task.needCode[j] = false
+				res.task.pend--
+			}
+		}
+		// Push the bytecode into a database batch
+		codes++
+		if err := batch.Put(database.CodeKey(hash), code); err != nil {
+			logger.Crit("Failed to store contract code", "err", err)
+		}
+	}
+	bytes := common.StorageSize(batch.ValueSize())
+	if err := batch.Write(); err != nil {
+		logger.Crit("Failed to persist bytecodes", "err", err)
+	}
+	s.bytecodeSynced += codes
+	s.bytecodeBytes += bytes
+
+	logger.Debug("Persisted set of bytecodes", "count", codes, "bytes", bytes)
+
+	// If this delivery completed the last pending task, forward the account task
+	// to the next chunk
+	if res.task.pend == 0 {
+		s.forwardAccountTask(res.task)
+		return
+	}
+	// Some accounts are still incomplete, leave as is for the storage and contract
+	// task assigners to pick up and fill.
+}
+
+// processStorageResponse integrates an already validated storage response
+// into the account tasks.
+func (s *Syncer) processStorageResponse(res *storageResponse) {
+	// Switch the subtask from pending to idle
+	if res.subTask != nil {
+		res.subTask.req = nil
+	}
+	var (
+		slots           int
+		oldStorageBytes = s.storageBytes
+	)
+	// Iterate over all the accounts and reconstruct their storage tries from the
+	// delivered slots
+	for i, accountHash := range res.accounts {
+		// If the account was not delivered, reschedule it
+		if i >= len(res.hashes) {
+			res.mainTask.stateTasks[accountHash] = res.roots[i]
+			continue
+		}
+		// State was delivered, if complete mark as not needed any more, otherwise
+		// mark the account as needing healing
+		for j, hash := range res.mainTask.res.hashes {
+			if accountHash != hash {
+				continue
+			}
+			pacc := account.GetProgramAccount(res.mainTask.res.accounts[j])
+			if pacc == nil {
+				continue
+			}
+
+			// If the packet contains multiple contract storage slots, all
+			// but the last are surely complete. The last contract may be
+			// chunked, so check it's continuation flag.
+			if res.subTask == nil && res.mainTask.needState[j] && (i < len(res.hashes)-1 || !res.cont) {
+				res.mainTask.needState[j] = false
+				res.mainTask.pend--
+			}
+			// If the last contract was chunked, mark it as needing healing
+			// to avoid writing it out to disk prematurely.
+			if res.subTask == nil && !res.mainTask.needHeal[j] && i == len(res.hashes)-1 && res.cont {
+				res.mainTask.needHeal[j] = true
+			}
+			// If the last contract was chunked, we need to switch to large
+			// contract handling mode
+			if res.subTask == nil && i == len(res.hashes)-1 && res.cont {
+				// If we haven't yet started a large-contract retrieval, create
+				// the subtasks for it within the main account task
+				if tasks, ok := res.mainTask.SubTasks[accountHash]; !ok {
+					var (
+						keys    = res.hashes[i]
+						chunks  = uint64(storageConcurrency)
+						lastKey common.Hash
+					)
+					if len(keys) > 0 {
+						lastKey = keys[len(keys)-1]
+					}
+					// If the number of slots remaining is low, decrease the
+					// number of chunks. Somewhere on the order of 10-15K slots
+					// fit into a packet of 500KB. A key/slot pair is maximum 64
+					// bytes, so pessimistically maxRequestSize/64 = 8K.
+					//
+					// Chunk so that at least 2 packets are needed to fill a task.
+					if estimate, err := estimateRemainingSlots(len(keys), lastKey); err == nil {
+						if n := estimate / (2 * (maxRequestSize / 64)); n+1 < chunks {
+							chunks = n + 1
+						}
+						logger.Debug("Chunked large contract", "initiators", len(keys), "tail", lastKey, "remaining", estimate, "chunks", chunks)
+					} else {
+						logger.Debug("Chunked large contract", "initiators", len(keys), "tail", lastKey, "chunks", chunks)
+					}
+					r := newHashRange(lastKey, chunks)
+
+					// Our first task is the one that was just filled by this response.
+					db := statedb.NewDatabase(s.db)
+					trie, _ := statedb.NewTrie(common.Hash{}, db)
+					tasks = append(tasks, &storageTask{
+						Next:    common.Hash{},
+						Last:    r.End(),
+						root:    pacc.GetStorageRoot(),
+						genTrie: trie,
+						trieDb:  db,
+					})
+					for r.Next() {
+						db := statedb.NewDatabase(s.db)
+						trie, _ := statedb.NewTrie(common.Hash{}, db)
+						tasks = append(tasks, &storageTask{
+							Next:    r.Start(),
+							Last:    r.End(),
+							root:    pacc.GetStorageRoot(),
+							genTrie: trie,
+							trieDb:  db,
+						})
+					}
+					for _, task := range tasks {
+						logger.Debug("Created storage sync task", "account", accountHash, "root", pacc.GetStorageRoot(), "from", task.Next, "last", task.Last)
+					}
+					res.mainTask.SubTasks[accountHash] = tasks
+
+					// Since we've just created the sub-tasks, this response
+					// is surely for the first one (zero origin)
+					res.subTask = tasks[0]
+				}
+			}
+			// If we're in large contract delivery mode, forward the subtask
+			if res.subTask != nil {
+				// Ensure the response doesn't overflow into the subsequent task
+				last := res.subTask.Last.Big()
+				// Find the first overflowing key. While at it, mark res as complete
+				// if we find the range to include or pass the 'last'
+				index := sort.Search(len(res.hashes[i]), func(k int) bool {
+					cmp := res.hashes[i][k].Big().Cmp(last)
+					if cmp >= 0 {
+						res.cont = false
+					}
+					return cmp > 0
+				})
+				if index >= 0 {
+					// cut off excess
+					res.hashes[i] = res.hashes[i][:index]
+					res.slots[i] = res.slots[i][:index]
+				}
+				// Forward the relevant storage chunk (even if created just now)
+				if res.cont {
+					res.subTask.Next = incHash(res.hashes[i][len(res.hashes[i])-1])
+				} else {
+					res.subTask.done = true
+				}
+			}
+		}
+		// Iterate over all the complete contracts, reconstruct the trie nodes and
+		// push them to disk. If the contract is chunked, the trie nodes will be
+		// reconstructed later.
+		slots += len(res.hashes[i])
+
+		if i < len(res.hashes)-1 || res.subTask == nil {
+			db := statedb.NewDatabase(s.db)
+			tr, _ := statedb.NewTrie(common.Hash{}, db)
+			for j := 0; j < len(res.hashes[i]); j++ {
+				tr.Update(res.hashes[i][j][:], res.slots[i][j])
+			}
+			root, _ := tr.Commit(nil)
+			_, nodeSize, _ := db.Size()
+			if err := db.Commit(root, false, 0); err != nil {
+				logger.Error("Failed to persist storage slots", "err", err)
+			} else {
+				s.storageBytes += nodeSize
+			}
+		}
+		// Persist the received storage segements. These flat state maybe
+		// outdated during the sync, but it can be fixed later during the
+		// snapshot generation.
+		for j := 0; j < len(res.hashes[i]); j++ {
+			s.stateWriter.WriteStorageSnapshot(accountHash, res.hashes[i][j], res.slots[i][j])
+			s.storageBytes += common.StorageSize(len(database.StorageSnapshotKey(accountHash, res.hashes[i][j])) + len(res.slots[i][j]))
+
+			// If we're storing large contracts, generate the trie nodes
+			// on the fly to not trash the gluing points
+			if i == len(res.hashes)-1 && res.subTask != nil {
+				res.subTask.genTrie.Update(res.hashes[i][j][:], res.slots[i][j])
+			}
+		}
+	}
+	// Large contracts could have generated new trie nodes, flush them to disk
+	if res.subTask != nil {
+		if res.subTask.done {
+			root, _ := res.subTask.genTrie.Commit(nil)
+			_, nodeSize, _ := res.subTask.trieDb.Size()
+
+			if err := res.subTask.trieDb.Commit(root, false, 0); err != nil {
+				logger.Error("Failed to persist stack slots", "root", root, "err", err)
+			} else if root == res.subTask.root {
+				s.storageBytes += nodeSize
+				// If the chunk's root is an overflown but full delivery, clear the heal request
+				for i, account := range res.mainTask.res.hashes {
+					if account == res.accounts[len(res.accounts)-1] {
+						res.mainTask.needHeal[i] = false
+					}
+				}
+			}
+		}
+	}
+	s.storageSynced += uint64(slots)
+
+	logger.Debug("Persisted set of storage slots", "accounts", len(res.hashes), "slots", slots, "bytes", s.storageBytes-oldStorageBytes)
+
+	// If this delivery completed the last pending task, forward the account task
+	// to the next chunk
+	if res.mainTask.pend == 0 {
+		s.forwardAccountTask(res.mainTask)
+		return
+	}
+	// Some accounts are still incomplete, leave as is for the storage and contract
+	// task assigners to pick up and fill.
+}
+
+// processTrienodeHealResponse integrates an already validated trienode response
+// into the healer tasks.
+func (s *Syncer) processTrienodeHealResponse(res *trienodeHealResponse) {
+	for i, hash := range res.hashes {
+		node := res.nodes[i]
+
+		// If the trie node was not delivered, reschedule it
+		if node == nil {
+			res.task.trieTasks[hash] = res.paths[i]
+			continue
+		}
+		// Push the trie node into the state syncer
+		s.trienodeHealSynced++
+		s.trienodeHealBytes += common.StorageSize(len(node))
+
+		err := s.healer.scheduler.Process(statedb.SyncResult{Hash: hash, Data: node})
+		switch err {
+		case nil:
+		case statedb.ErrAlreadyProcessed:
+			s.trienodeHealDups++
+		case statedb.ErrNotRequested:
+			s.trienodeHealNops++
+		default:
+			logger.Error("Invalid trienode processed", "hash", hash, "err", err)
+		}
+	}
+	batch := s.db.NewBatch(database.StateTrieDB)
+	if _, err := s.healer.scheduler.Commit(batch); err != nil {
+		logger.Error("Failed to commit healing data", "err", err)
+	}
+	if err := batch.Write(); err != nil {
+		logger.Crit("Failed to persist healing data", "err", err)
+	}
+	logger.Debug("Persisted set of healing data", "type", "trienodes", "bytes", common.StorageSize(batch.ValueSize()))
+}
+
+// processBytecodeHealResponse integrates an already validated bytecode response
+// into the healer tasks.
+func (s *Syncer) processBytecodeHealResponse(res *bytecodeHealResponse) {
+	for i, hash := range res.hashes {
+		node := res.codes[i]
+
+		// If the trie node was not delivered, reschedule it
+		if node == nil {
+			res.task.codeTasks[hash] = struct{}{}
+			continue
+		}
+		// Push the trie node into the state syncer
+		s.bytecodeHealSynced++
+		s.bytecodeHealBytes += common.StorageSize(len(node))
+
+		err := s.healer.scheduler.Process(statedb.SyncResult{Hash: hash, Data: node})
+		switch err {
+		case nil:
+		case statedb.ErrAlreadyProcessed:
+			s.bytecodeHealDups++
+		case statedb.ErrNotRequested:
+			s.bytecodeHealNops++
+		default:
+			logger.Error("Invalid bytecode processed", "hash", hash, "err", err)
+		}
+	}
+	batch := s.db.NewBatch(database.StateTrieDB)
+	if _, err := s.healer.scheduler.Commit(batch); err != nil {
+		logger.Error("Failed to commit healing data", "err", err)
+	}
+	if err := batch.Write(); err != nil {
+		logger.Crit("Failed to persist healing data", "err", err)
+	}
+	logger.Debug("Persisted set of healing data", "type", "bytecode", "bytes", common.StorageSize(batch.ValueSize()))
+}
+
+// forwardAccountTask takes a filled account task and persists anything available
+// into the database, after which it forwards the next account marker so that the
+// task's next chunk may be filled.
+func (s *Syncer) forwardAccountTask(task *accountTask) {
+	// Remove any pending delivery
+	res := task.res
+	if res == nil {
+		return // nothing to forward
+	}
+	task.res = nil
+
+	// Persist the received account segements. These flat state maybe
+	// outdated during the sync, but it can be fixed later during the
+	// snapshot generation.
+	oldAccountBytes := s.accountBytes
+
+	batch := s.db.NewSnapshotDBBatch()
+	for i, hash := range res.hashes {
+		if task.needCode[i] || task.needState[i] {
+			break
+		}
+		serializer := account.NewAccountSerializerWithAccount(res.accounts[i])
+		bytes, err := rlp.EncodeToBytes(serializer)
+		if err != nil {
+			logger.Error("Failed to encode account")
+		}
+		batch.WriteAccountSnapshot(hash, bytes)
+		s.accountBytes += common.StorageSize(len(database.AccountSnapshotKey(hash)) + len(bytes))
+
+		// If the task is complete, drop it into the trie to generate
+		// account trie nodes for it
+		if !task.needHeal[i] {
+			task.genTrie.Update(hash[:], bytes)
+		}
+	}
+	// Flush anything written just now and update the stats
+	if err := batch.Write(); err != nil {
+		logger.Crit("Failed to persist accounts", "err", err)
+	}
+	s.accountSynced += uint64(len(res.accounts))
+
+	// Task filling persisted, push it the chunk marker forward to the first
+	// account still missing data.
+	for i, hash := range res.hashes {
+		if task.needCode[i] || task.needState[i] {
+			return
+		}
+		task.Next = incHash(hash)
+	}
+	// All accounts marked as complete, track if the entire task is done
+	task.done = !res.cont
+
+	// Trie could have generated trie nodes, push them to disk (we need to
+	// flush after finalizing task.done. It's fine even if we crash and lose this
+	// write as it will only cause more data to be downloaded during heal.
+	if task.done {
+		root, _ := task.genTrie.Commit(nil)
+		_, nodeSize, _ := task.trieDb.Size()
+
+		if err := task.trieDb.Commit(root, false, 0); err != nil {
+			logger.Error("Failed to persist account slots", "root", root.String(), "err", err)
+		} else {
+			s.accountBytes += nodeSize
+		}
+	}
+	logger.Debug("Persisted range of accounts", "accounts", len(res.accounts), "bytes", s.accountBytes-oldAccountBytes)
+}
+
+// OnAccounts is a callback method to invoke when a range of accounts are
+// received from a remote peer.
+func (s *Syncer) OnAccounts(peer SyncPeer, id uint64, hashes []common.Hash, accounts [][]byte, proof [][]byte) error {
+	size := common.StorageSize(len(hashes) * common.HashLength)
+	for _, account := range accounts {
+		size += common.StorageSize(len(account))
+	}
+	for _, node := range proof {
+		size += common.StorageSize(len(node))
+	}
+	logger := peer.Log().NewWith("reqid", id)
+	logger.Trace("Delivering range of accounts", "hashes", len(hashes), "accounts", len(accounts), "proofs", len(proof), "bytes", size)
+
+	// Whether or not the response is valid, we can mark the peer as idle and
+	// notify the scheduler to assign a new task. If the response is invalid,
+	// we'll drop the peer in a bit.
+	s.lock.Lock()
+	if _, ok := s.peers[peer.ID()]; ok {
+		s.accountIdlers[peer.ID()] = struct{}{}
+	}
+	select {
+	case s.update <- struct{}{}:
+	default:
+	}
+	// Ensure the response is for a valid request
+	req, ok := s.accountReqs[id]
+	if !ok {
+		// Request stale, perhaps the peer timed out but came through in the end
+		logger.Warn("Unexpected account range packet")
+		s.lock.Unlock()
+		return nil
+	}
+	delete(s.accountReqs, id)
+	s.rates.Update(peer.ID(), AccountRangeMsg, time.Since(req.time), int(size))
+
+	// Clean up the request timeout timer, we'll see how to proceed further based
+	// on the actual delivered content
+	if !req.timeout.Stop() {
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
+	// Response is valid, but check if peer is signalling that it does not have
+	// the requested data. For account range queries that means the state being
+	// retrieved was either already pruned remotely, or the peer is not yet
+	// synced to our head.
+	if len(hashes) == 0 && len(accounts) == 0 && len(proof) == 0 {
+		logger.Debug("Peer rejected account range request", "root", s.root)
+		s.statelessPeers[peer.ID()] = struct{}{}
+		s.lock.Unlock()
+
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertAccountRequest(req)
+		return nil
+	}
+	root := s.root
+	s.lock.Unlock()
+
+	// Reconstruct a partial trie from the response and verify it
+	keys := make([][]byte, len(hashes))
+	for i, key := range hashes {
+		keys[i] = common.CopyBytes(key[:])
+	}
+	nodes := make(NodeList, len(proof))
+	for i, node := range proof {
+		nodes[i] = node
+	}
+	proofdb := nodes.NodeSet()
+
+	var end []byte
+	if len(keys) > 0 {
+		end = keys[len(keys)-1]
+	}
+	cont, err := statedb.VerifyRangeProof(root, req.origin[:], end, keys, accounts, proofdb)
+	if err != nil {
+		logger.Warn("Account range failed proof", "err", err)
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertAccountRequest(req)
+		return err
+	}
+	accs := make([]account.Account, len(accounts))
+	for i, accBytes := range accounts {
+		serializer := account.NewAccountSerializer()
+		if err := rlp.DecodeBytes(accBytes, serializer); err != nil {
+			panic(err) // We created these blobs, we must be able to decode them
+		}
+		accs[i] = serializer.GetAccount()
+	}
+	response := &accountResponse{
+		task:     req.task,
+		hashes:   hashes,
+		accounts: accs,
+		cont:     cont,
+	}
+	select {
+	case req.deliver <- response:
+	case <-req.cancel:
+	case <-req.stale:
+	}
+	return nil
+}
+
+// OnByteCodes is a callback method to invoke when a batch of contract
+// bytes codes are received from a remote peer.
+func (s *Syncer) OnByteCodes(peer SyncPeer, id uint64, bytecodes [][]byte) error {
+	s.lock.RLock()
+	syncing := !s.snapped
+	s.lock.RUnlock()
+
+	if syncing {
+		return s.onByteCodes(peer, id, bytecodes)
+	}
+	return s.onHealByteCodes(peer, id, bytecodes)
+}
+
+// onByteCodes is a callback method to invoke when a batch of contract
+// bytes codes are received from a remote peer in the syncing phase.
+func (s *Syncer) onByteCodes(peer SyncPeer, id uint64, bytecodes [][]byte) error {
+	var size common.StorageSize
+	for _, code := range bytecodes {
+		size += common.StorageSize(len(code))
+	}
+	logger := peer.Log().NewWith("reqid", id)
+	logger.Trace("Delivering set of bytecodes", "bytecodes", len(bytecodes), "bytes", size)
+
+	// Whether or not the response is valid, we can mark the peer as idle and
+	// notify the scheduler to assign a new task. If the response is invalid,
+	// we'll drop the peer in a bit.
+	s.lock.Lock()
+	if _, ok := s.peers[peer.ID()]; ok {
+		s.bytecodeIdlers[peer.ID()] = struct{}{}
+	}
+	select {
+	case s.update <- struct{}{}:
+	default:
+	}
+	// Ensure the response is for a valid request
+	req, ok := s.bytecodeReqs[id]
+	if !ok {
+		// Request stale, perhaps the peer timed out but came through in the end
+		logger.Warn("Unexpected bytecode packet")
+		s.lock.Unlock()
+		return nil
+	}
+	delete(s.bytecodeReqs, id)
+	s.rates.Update(peer.ID(), ByteCodesMsg, time.Since(req.time), len(bytecodes))
+
+	// Clean up the request timeout timer, we'll see how to proceed further based
+	// on the actual delivered content
+	if !req.timeout.Stop() {
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
+
+	// Response is valid, but check if peer is signalling that it does not have
+	// the requested data. For bytecode range queries that means the peer is not
+	// yet synced.
+	if len(bytecodes) == 0 {
+		logger.Debug("Peer rejected bytecode request")
+		s.statelessPeers[peer.ID()] = struct{}{}
+		s.lock.Unlock()
+
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertBytecodeRequest(req)
+		return nil
+	}
+	s.lock.Unlock()
+
+	// Cross reference the requested bytecodes with the response to find gaps
+	// that the serving node is missing
+	hasher := sha3.NewLegacyKeccak256().(statedb.KeccakState)
+	hash := make([]byte, 32)
+
+	codes := make([][]byte, len(req.hashes))
+	for i, j := 0, 0; i < len(bytecodes); i++ {
+		// Find the next hash that we've been served, leaving misses with nils
+		hasher.Reset()
+		hasher.Write(bytecodes[i])
+		hasher.Read(hash)
+
+		for j < len(req.hashes) && !bytes.Equal(hash, req.hashes[j][:]) {
+			j++
+		}
+		if j < len(req.hashes) {
+			codes[j] = bytecodes[i]
+			j++
+			continue
+		}
+		// We've either ran out of hashes, or got unrequested data
+		logger.Warn("Unexpected bytecodes", "count", len(bytecodes)-i)
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertBytecodeRequest(req)
+		return errors.New("unexpected bytecode")
+	}
+	// Response validated, send it to the scheduler for filling
+	response := &bytecodeResponse{
+		task:   req.task,
+		hashes: req.hashes,
+		codes:  codes,
+	}
+	select {
+	case req.deliver <- response:
+	case <-req.cancel:
+	case <-req.stale:
+	}
+	return nil
+}
+
+// OnStorage is a callback method to invoke when ranges of storage slots
+// are received from a remote peer.
+func (s *Syncer) OnStorage(peer SyncPeer, id uint64, hashes [][]common.Hash, slots [][][]byte, proof [][]byte) error {
+	// Gather some trace stats to aid in debugging issues
+	var (
+		hashCount int
+		slotCount int
+		size      common.StorageSize
+	)
+	for _, hashset := range hashes {
+		size += common.StorageSize(common.HashLength * len(hashset))
+		hashCount += len(hashset)
+	}
+	for _, slotset := range slots {
+		for _, slot := range slotset {
+			size += common.StorageSize(len(slot))
+		}
+		slotCount += len(slotset)
+	}
+	for _, node := range proof {
+		size += common.StorageSize(len(node))
+	}
+	logger := peer.Log().NewWith("reqid", id)
+	logger.Trace("Delivering ranges of storage slots", "accounts", len(hashes), "hashes", hashCount, "slots", slotCount, "proofs", len(proof), "size", size)
+
+	// Whether or not the response is valid, we can mark the peer as idle and
+	// notify the scheduler to assign a new task. If the response is invalid,
+	// we'll drop the peer in a bit.
+	s.lock.Lock()
+	if _, ok := s.peers[peer.ID()]; ok {
+		s.storageIdlers[peer.ID()] = struct{}{}
+	}
+	select {
+	case s.update <- struct{}{}:
+	default:
+	}
+	// Ensure the response is for a valid request
+	req, ok := s.storageReqs[id]
+	if !ok {
+		// Request stale, perhaps the peer timed out but came through in the end
+		logger.Warn("Unexpected storage ranges packet")
+		s.lock.Unlock()
+		return nil
+	}
+	delete(s.storageReqs, id)
+	s.rates.Update(peer.ID(), StorageRangesMsg, time.Since(req.time), int(size))
+
+	// Clean up the request timeout timer, we'll see how to proceed further based
+	// on the actual delivered content
+	if !req.timeout.Stop() {
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
+
+	// Reject the response if the hash sets and slot sets don't match, or if the
+	// peer sent more data than requested.
+	if len(hashes) != len(slots) {
+		s.lock.Unlock()
+		s.scheduleRevertStorageRequest(req) // reschedule request
+		logger.Warn("Hash and slot set size mismatch", "hashset", len(hashes), "slotset", len(slots))
+		return errors.New("hash and slot set size mismatch")
+	}
+	if len(hashes) > len(req.accounts) {
+		s.lock.Unlock()
+		s.scheduleRevertStorageRequest(req) // reschedule request
+		logger.Warn("Hash set larger than requested", "hashset", len(hashes), "requested", len(req.accounts))
+		return errors.New("hash set larger than requested")
+	}
+	// Response is valid, but check if peer is signalling that it does not have
+	// the requested data. For storage range queries that means the state being
+	// retrieved was either already pruned remotely, or the peer is not yet
+	// synced to our head.
+	if len(hashes) == 0 {
+		logger.Debug("Peer rejected storage request")
+		s.statelessPeers[peer.ID()] = struct{}{}
+		s.lock.Unlock()
+		s.scheduleRevertStorageRequest(req) // reschedule request
+		return nil
+	}
+	s.lock.Unlock()
+
+	// Reconstruct the partial tries from the response and verify them
+	var cont bool
+
+	for i := 0; i < len(hashes); i++ {
+		// Convert the keys and proofs into an internal format
+		keys := make([][]byte, len(hashes[i]))
+		for j, key := range hashes[i] {
+			keys[j] = common.CopyBytes(key[:])
+		}
+		nodes := make(NodeList, 0, len(proof))
+		if i == len(hashes)-1 {
+			for _, node := range proof {
+				nodes = append(nodes, node)
+			}
+		}
+		var err error
+		if len(nodes) == 0 {
+			// No proof has been attached, the response must cover the entire key
+			// space and hash to the origin root.
+			_, err = statedb.VerifyRangeProof(req.roots[i], nil, nil, keys, slots[i], nil)
+			if err != nil {
+				s.scheduleRevertStorageRequest(req) // reschedule request
+				logger.Warn("Storage slots failed proof", "err", err)
+				return err
+			}
+		} else {
+			// A proof was attached, the response is only partial, check that the
+			// returned data is indeed part of the storage trie
+			proofdb := nodes.NodeSet()
+
+			var end []byte
+			if len(keys) > 0 {
+				end = keys[len(keys)-1]
+			}
+			cont, err = statedb.VerifyRangeProof(req.roots[i], req.origin[:], end, keys, slots[i], proofdb)
+			if err != nil {
+				s.scheduleRevertStorageRequest(req) // reschedule request
+				logger.Warn("Storage range failed proof", "err", err)
+				return err
+			}
+		}
+	}
+	// Partial tries reconstructed, send them to the scheduler for storage filling
+	response := &storageResponse{
+		mainTask: req.mainTask,
+		subTask:  req.subTask,
+		accounts: req.accounts,
+		roots:    req.roots,
+		hashes:   hashes,
+		slots:    slots,
+		cont:     cont,
+	}
+	select {
+	case req.deliver <- response:
+	case <-req.cancel:
+	case <-req.stale:
+	}
+	return nil
+}
+
+// OnTrieNodes is a callback method to invoke when a batch of trie nodes
+// are received from a remote peer.
+func (s *Syncer) OnTrieNodes(peer SyncPeer, id uint64, trienodes [][]byte) error {
+	var size common.StorageSize
+	for _, node := range trienodes {
+		size += common.StorageSize(len(node))
+	}
+	logger := peer.Log().NewWith("reqid", id)
+	logger.Trace("Delivering set of healing trienodes", "trienodes", len(trienodes), "bytes", size)
+
+	// Whether or not the response is valid, we can mark the peer as idle and
+	// notify the scheduler to assign a new task. If the response is invalid,
+	// we'll drop the peer in a bit.
+	s.lock.Lock()
+	if _, ok := s.peers[peer.ID()]; ok {
+		s.trienodeHealIdlers[peer.ID()] = struct{}{}
+	}
+	select {
+	case s.update <- struct{}{}:
+	default:
+	}
+	// Ensure the response is for a valid request
+	req, ok := s.trienodeHealReqs[id]
+	if !ok {
+		// Request stale, perhaps the peer timed out but came through in the end
+		logger.Warn("Unexpected trienode heal packet")
+		s.lock.Unlock()
+		return nil
+	}
+	delete(s.trienodeHealReqs, id)
+	s.rates.Update(peer.ID(), TrieNodesMsg, time.Since(req.time), len(trienodes))
+
+	// Clean up the request timeout timer, we'll see how to proceed further based
+	// on the actual delivered content
+	if !req.timeout.Stop() {
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
+
+	// Response is valid, but check if peer is signalling that it does not have
+	// the requested data. For bytecode range queries that means the peer is not
+	// yet synced.
+	if len(trienodes) == 0 {
+		logger.Debug("Peer rejected trienode heal request")
+		s.statelessPeers[peer.ID()] = struct{}{}
+		s.lock.Unlock()
+
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertTrienodeHealRequest(req)
+		return nil
+	}
+	s.lock.Unlock()
+
+	// Cross reference the requested trienodes with the response to find gaps
+	// that the serving node is missing
+	hasher := sha3.NewLegacyKeccak256().(statedb.KeccakState)
+	hash := make([]byte, 32)
+
+	nodes := make([][]byte, len(req.hashes))
+	for i, j := 0, 0; i < len(trienodes); i++ {
+		// Find the next hash that we've been served, leaving misses with nils
+		hasher.Reset()
+		hasher.Write(trienodes[i])
+		hasher.Read(hash)
+
+		for j < len(req.hashes) && !bytes.Equal(hash, req.hashes[j][:]) {
+			j++
+		}
+		if j < len(req.hashes) {
+			nodes[j] = trienodes[i]
+			j++
+			continue
+		}
+		// We've either ran out of hashes, or got unrequested data
+		logger.Warn("Unexpected healing trienodes", "count", len(trienodes)-i)
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertTrienodeHealRequest(req)
+		return errors.New("unexpected healing trienode")
+	}
+	// Response validated, send it to the scheduler for filling
+	response := &trienodeHealResponse{
+		task:   req.task,
+		hashes: req.hashes,
+		paths:  req.paths,
+		nodes:  nodes,
+	}
+	select {
+	case req.deliver <- response:
+	case <-req.cancel:
+	case <-req.stale:
+	}
+	return nil
+}
+
+// onHealByteCodes is a callback method to invoke when a batch of contract
+// bytes codes are received from a remote peer in the healing phase.
+func (s *Syncer) onHealByteCodes(peer SyncPeer, id uint64, bytecodes [][]byte) error {
+	var size common.StorageSize
+	for _, code := range bytecodes {
+		size += common.StorageSize(len(code))
+	}
+	logger := peer.Log().NewWith("reqid", id)
+	logger.Trace("Delivering set of healing bytecodes", "bytecodes", len(bytecodes), "bytes", size)
+
+	// Whether or not the response is valid, we can mark the peer as idle and
+	// notify the scheduler to assign a new task. If the response is invalid,
+	// we'll drop the peer in a bit.
+	s.lock.Lock()
+	if _, ok := s.peers[peer.ID()]; ok {
+		s.bytecodeHealIdlers[peer.ID()] = struct{}{}
+	}
+	select {
+	case s.update <- struct{}{}:
+	default:
+	}
+	// Ensure the response is for a valid request
+	req, ok := s.bytecodeHealReqs[id]
+	if !ok {
+		// Request stale, perhaps the peer timed out but came through in the end
+		logger.Warn("Unexpected bytecode heal packet")
+		s.lock.Unlock()
+		return nil
+	}
+	delete(s.bytecodeHealReqs, id)
+	s.rates.Update(peer.ID(), ByteCodesMsg, time.Since(req.time), len(bytecodes))
+
+	// Clean up the request timeout timer, we'll see how to proceed further based
+	// on the actual delivered content
+	if !req.timeout.Stop() {
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
+
+	// Response is valid, but check if peer is signalling that it does not have
+	// the requested data. For bytecode range queries that means the peer is not
+	// yet synced.
+	if len(bytecodes) == 0 {
+		logger.Debug("Peer rejected bytecode heal request")
+		s.statelessPeers[peer.ID()] = struct{}{}
+		s.lock.Unlock()
+
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertBytecodeHealRequest(req)
+		return nil
+	}
+	s.lock.Unlock()
+
+	// Cross reference the requested bytecodes with the response to find gaps
+	// that the serving node is missing
+	hasher := sha3.NewLegacyKeccak256().(statedb.KeccakState)
+	hash := make([]byte, 32)
+
+	codes := make([][]byte, len(req.hashes))
+	for i, j := 0, 0; i < len(bytecodes); i++ {
+		// Find the next hash that we've been served, leaving misses with nils
+		hasher.Reset()
+		hasher.Write(bytecodes[i])
+		hasher.Read(hash)
+
+		for j < len(req.hashes) && !bytes.Equal(hash, req.hashes[j][:]) {
+			j++
+		}
+		if j < len(req.hashes) {
+			codes[j] = bytecodes[i]
+			j++
+			continue
+		}
+		// We've either ran out of hashes, or got unrequested data
+		logger.Warn("Unexpected healing bytecodes", "count", len(bytecodes)-i)
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertBytecodeHealRequest(req)
+		return errors.New("unexpected healing bytecode")
+	}
+	// Response validated, send it to the scheduler for filling
+	response := &bytecodeHealResponse{
+		task:   req.task,
+		hashes: req.hashes,
+		codes:  codes,
+	}
+	select {
+	case req.deliver <- response:
+	case <-req.cancel:
+	case <-req.stale:
+	}
+	return nil
+}
+
+// onHealState is a callback method to invoke when a flat state(account
+// or storage slot) is downloded during the healing stage. The flat states
+// can be persisted blindly and can be fixed later in the generation stage.
+// Note it's not concurrent safe, please handle the concurrent issue outside.
+func (s *Syncer) onHealState(paths [][]byte, value []byte) error {
+	if len(paths) == 1 {
+		s.stateWriter.WriteAccountSnapshot(common.BytesToHash(paths[0]), value)
+		s.accountHealed += 1
+		s.accountHealedBytes += common.StorageSize(1 + common.HashLength + len(value))
+	}
+	if len(paths) == 2 {
+		s.stateWriter.WriteStorageSnapshot(common.BytesToHash(paths[0]), common.BytesToHash(paths[1]), value)
+		s.storageHealed += 1
+		s.storageHealedBytes += common.StorageSize(1 + 2*common.HashLength + len(value))
+	}
+	if s.stateWriter.ValueSize() > database.IdealBatchSize {
+		s.stateWriter.Write() // It's fine to ignore the error here
+		s.stateWriter.Reset()
+	}
+	return nil
+}
+
+// hashSpace is the total size of the 256 bit hash space for accounts.
+var hashSpace = new(big.Int).Exp(common.Big2, common.Big256, nil)
+
+// report calculates various status reports and provides it to the user.
+func (s *Syncer) report(force bool) {
+	if len(s.tasks) > 0 {
+		s.reportSyncProgress(force)
+		return
+	}
+	s.reportHealProgress(force)
+}
+
+// reportSyncProgress calculates various status reports and provides it to the user.
+func (s *Syncer) reportSyncProgress(force bool) {
+	// Don't report all the events, just occasionally
+	if !force && time.Since(s.logTime) < 8*time.Second {
+		return
+	}
+	// Don't report anything until we have a meaningful progress
+	synced := s.accountBytes + s.bytecodeBytes + s.storageBytes
+	if synced == 0 {
+		return
+	}
+	accountGaps := new(big.Int)
+	for _, task := range s.tasks {
+		accountGaps.Add(accountGaps, new(big.Int).Sub(task.Last.Big(), task.Next.Big()))
+	}
+	accountFills := new(big.Int).Sub(hashSpace, accountGaps)
+	if accountFills.BitLen() == 0 {
+		return
+	}
+	s.logTime = time.Now()
+	estBytes := float64(new(big.Int).Div(
+		new(big.Int).Mul(new(big.Int).SetUint64(uint64(synced)), hashSpace),
+		accountFills,
+	).Uint64())
+	// Don't report anything until we have a meaningful progress
+	if estBytes < 1.0 {
+		return
+	}
+	elapsed := time.Since(s.startTime)
+	estTime := elapsed / time.Duration(synced) * time.Duration(estBytes)
+
+	// Create a mega progress report
+	var (
+		progress = fmt.Sprintf("%.2f%%", float64(synced)*100/estBytes)
+		accounts = fmt.Sprintf("%v@%v", s.accountSynced, s.accountBytes.TerminalString())
+		storage  = fmt.Sprintf("%v@%v", s.storageSynced, s.storageBytes.TerminalString())
+		bytecode = fmt.Sprintf("%v@%v", s.bytecodeSynced, s.bytecodeBytes.TerminalString())
+	)
+	logger.Info("State sync in progress", "synced", progress, "state", synced,
+		"accounts", accounts, "slots", storage, "codes", bytecode, "eta", common.PrettyDuration(estTime-elapsed))
+}
+
+// reportHealProgress calculates various status reports and provides it to the user.
+func (s *Syncer) reportHealProgress(force bool) {
+	// Don't report all the events, just occasionally
+	if !force && time.Since(s.logTime) < 8*time.Second {
+		return
+	}
+	s.logTime = time.Now()
+
+	// Create a mega progress report
+	var (
+		trienode = fmt.Sprintf("%v@%v", s.trienodeHealSynced, s.trienodeHealBytes.TerminalString())
+		bytecode = fmt.Sprintf("%v@%v", s.bytecodeHealSynced, s.bytecodeHealBytes.TerminalString())
+		accounts = fmt.Sprintf("%v@%v", s.accountHealed, s.accountHealedBytes.TerminalString())
+		storage  = fmt.Sprintf("%v@%v", s.storageHealed, s.storageHealedBytes.TerminalString())
+	)
+	logger.Info("State heal in progress", "accounts", accounts, "slots", storage,
+		"codes", bytecode, "nodes", trienode, "pending", s.healer.scheduler.Pending())
+}
+
+// estimateRemainingSlots tries to determine roughly how many slots are left in
+// a contract storage, based on the number of keys and the last hash. This method
+// assumes that the hashes are lexicographically ordered and evenly distributed.
+func estimateRemainingSlots(hashes int, last common.Hash) (uint64, error) {
+	if last == (common.Hash{}) {
+		return 0, errors.New("last hash empty")
+	}
+	space := new(big.Int).Mul(math.MaxBig256, big.NewInt(int64(hashes)))
+	space.Div(space, last.Big())
+	if !space.IsUint64() {
+		// Gigantic address space probably due to too few or malicious slots
+		return 0, errors.New("too few slots for estimation")
+	}
+	return space.Uint64() - uint64(hashes), nil
+}
+
+// capacitySort implements the Sort interface, allowing sorting by peer message
+// throughput. Note, callers should use sort.Reverse to get the desired effect
+// of highest capacity being at the front.
+type capacitySort struct {
+	ids  []string
+	caps []int
+}
+
+func (s *capacitySort) Len() int {
+	return len(s.ids)
+}
+
+func (s *capacitySort) Less(i, j int) bool {
+	return s.caps[i] < s.caps[j]
+}
+
+func (s *capacitySort) Swap(i, j int) {
+	s.ids[i], s.ids[j] = s.ids[j], s.ids[i]
+	s.caps[i], s.caps[j] = s.caps[j], s.caps[i]
+}

--- a/node/cn/snap/sync_test.go
+++ b/node/cn/snap/sync_test.go
@@ -1,0 +1,1719 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from eth/protocols/snap/sync_test.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package snap
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/klaytn/klaytn/blockchain/types/account"
+	"github.com/klaytn/klaytn/blockchain/types/accountkey"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/rlp"
+	"github.com/klaytn/klaytn/storage/database"
+	"github.com/klaytn/klaytn/storage/statedb"
+	"golang.org/x/crypto/sha3"
+)
+
+func genExternallyOwnedAccount(nonce uint64, balance *big.Int) (account.Account, error) {
+	return account.NewAccountWithMap(account.ExternallyOwnedAccountType, map[account.AccountValueKeyType]interface{}{
+		account.AccountValueKeyNonce:         nonce,
+		account.AccountValueKeyBalance:       balance,
+		account.AccountValueKeyHumanReadable: false,
+		account.AccountValueKeyAccountKey:    accountkey.NewAccountKeyLegacy(),
+	})
+}
+
+func genSmartContractAccount(nonce uint64, balance *big.Int, storageRoot common.Hash, codeHash []byte) (account.Account, error) {
+	return account.NewAccountWithMap(account.SmartContractAccountType, map[account.AccountValueKeyType]interface{}{
+		account.AccountValueKeyNonce:         nonce,
+		account.AccountValueKeyBalance:       balance,
+		account.AccountValueKeyHumanReadable: false,
+		account.AccountValueKeyAccountKey:    accountkey.NewAccountKeyLegacy(),
+		account.AccountValueKeyStorageRoot:   storageRoot,
+		account.AccountValueKeyCodeHash:      codeHash,
+		account.AccountValueKeyCodeInfo:      params.CodeInfo(0),
+	})
+}
+
+func TestHashing(t *testing.T) {
+	t.Parallel()
+
+	bytecodes := make([][]byte, 10)
+	for i := 0; i < len(bytecodes); i++ {
+		buf := make([]byte, 100)
+		rand.Read(buf)
+		bytecodes[i] = buf
+	}
+	var want, got string
+	old := func() {
+		hasher := sha3.NewLegacyKeccak256()
+		for i := 0; i < len(bytecodes); i++ {
+			hasher.Reset()
+			hasher.Write(bytecodes[i])
+			hash := hasher.Sum(nil)
+			got = fmt.Sprintf("%v\n%v", got, hash)
+		}
+	}
+	new := func() {
+		hasher := sha3.NewLegacyKeccak256().(statedb.KeccakState)
+		hash := make([]byte, 32)
+		for i := 0; i < len(bytecodes); i++ {
+			hasher.Reset()
+			hasher.Write(bytecodes[i])
+			hasher.Read(hash)
+			want = fmt.Sprintf("%v\n%v", want, hash)
+		}
+	}
+	old()
+	new()
+	if want != got {
+		t.Errorf("want\n%v\ngot\n%v\n", want, got)
+	}
+}
+
+func BenchmarkHashing(b *testing.B) {
+	bytecodes := make([][]byte, 10000)
+	for i := 0; i < len(bytecodes); i++ {
+		buf := make([]byte, 100)
+		rand.Read(buf)
+		bytecodes[i] = buf
+	}
+	old := func() {
+		hasher := sha3.NewLegacyKeccak256()
+		for i := 0; i < len(bytecodes); i++ {
+			hasher.Reset()
+			hasher.Write(bytecodes[i])
+			hasher.Sum(nil)
+		}
+	}
+	new := func() {
+		hasher := sha3.NewLegacyKeccak256().(statedb.KeccakState)
+		hash := make([]byte, 32)
+		for i := 0; i < len(bytecodes); i++ {
+			hasher.Reset()
+			hasher.Write(bytecodes[i])
+			hasher.Read(hash)
+		}
+	}
+	b.Run("old", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			old()
+		}
+	})
+	b.Run("new", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			new()
+		}
+	})
+}
+
+type (
+	accountHandlerFunc func(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, limit common.Hash, cap uint64) error
+	storageHandlerFunc func(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error
+	trieHandlerFunc    func(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error
+	codeHandlerFunc    func(t *testPeer, id uint64, hashes []common.Hash, max uint64) error
+)
+
+type testPeer struct {
+	id            string
+	test          *testing.T
+	remote        *Syncer
+	logger        log.Logger
+	accountTrie   *statedb.Trie
+	accountValues entrySlice
+	storageTries  map[common.Hash]*statedb.Trie
+	storageValues map[common.Hash]entrySlice
+
+	accountRequestHandler accountHandlerFunc
+	storageRequestHandler storageHandlerFunc
+	trieRequestHandler    trieHandlerFunc
+	codeRequestHandler    codeHandlerFunc
+	term                  func()
+
+	// counters
+	nAccountRequests  int
+	nStorageRequests  int
+	nBytecodeRequests int
+	nTrienodeRequests int
+}
+
+func newTestPeer(id string, t *testing.T, term func()) *testPeer {
+	peer := &testPeer{
+		id:                    id,
+		test:                  t,
+		logger:                logger.NewWith("id", id),
+		accountRequestHandler: defaultAccountRequestHandler,
+		trieRequestHandler:    defaultTrieRequestHandler,
+		storageRequestHandler: defaultStorageRequestHandler,
+		codeRequestHandler:    defaultCodeRequestHandler,
+		term:                  term,
+	}
+	// stderrHandler := log.StreamHandler(os.Stderr, log.TerminalFormat(true))
+	// peer.logger.SetHandler(stderrHandler)
+	return peer
+}
+
+func (t *testPeer) ID() string      { return t.id }
+func (t *testPeer) Log() log.Logger { return t.logger }
+
+func (t *testPeer) Stats() string {
+	return fmt.Sprintf(`Account requests: %d
+Storage requests: %d
+Bytecode requests: %d
+Trienode requests: %d
+`, t.nAccountRequests, t.nStorageRequests, t.nBytecodeRequests, t.nTrienodeRequests)
+}
+
+func (t *testPeer) RequestAccountRange(id uint64, root, origin, limit common.Hash, bytes uint64) error {
+	t.logger.Trace("Fetching range of accounts", "reqid", id, "root", root, "origin", origin, "limit", limit, "bytes", common.StorageSize(bytes))
+	t.nAccountRequests++
+	go t.accountRequestHandler(t, id, root, origin, limit, bytes)
+	return nil
+}
+
+func (t *testPeer) RequestTrieNodes(id uint64, root common.Hash, paths []TrieNodePathSet, bytes uint64) error {
+	t.logger.Trace("Fetching set of trie nodes", "reqid", id, "root", root, "pathsets", len(paths), "bytes", common.StorageSize(bytes))
+	t.nTrienodeRequests++
+	go t.trieRequestHandler(t, id, root, paths, bytes)
+	return nil
+}
+
+func (t *testPeer) RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, bytes uint64) error {
+	t.nStorageRequests++
+	if len(accounts) == 1 && origin != nil {
+		t.logger.Trace("Fetching range of large storage slots", "reqid", id, "root", root, "account", accounts[0], "origin", common.BytesToHash(origin), "limit", common.BytesToHash(limit), "bytes", common.StorageSize(bytes))
+	} else {
+		t.logger.Trace("Fetching ranges of small storage slots", "reqid", id, "root", root, "accounts", len(accounts), "first", accounts[0], "bytes", common.StorageSize(bytes))
+	}
+	go t.storageRequestHandler(t, id, root, accounts, origin, limit, bytes)
+	return nil
+}
+
+func (t *testPeer) RequestByteCodes(id uint64, hashes []common.Hash, bytes uint64) error {
+	t.nBytecodeRequests++
+	t.logger.Trace("Fetching set of byte codes", "reqid", id, "hashes", len(hashes), "bytes", common.StorageSize(bytes))
+	go t.codeRequestHandler(t, id, hashes, bytes)
+	return nil
+}
+
+// defaultTrieRequestHandler is a well-behaving handler for trie healing requests
+func defaultTrieRequestHandler(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error {
+	// Pass the response
+	var nodes [][]byte
+	for _, pathset := range paths {
+		switch len(pathset) {
+		case 1:
+			blob, _, err := t.accountTrie.TryGetNode(pathset[0])
+			if err != nil {
+				t.logger.Info("Error handling req", "error", err)
+				break
+			}
+			nodes = append(nodes, blob)
+		default:
+			account := t.storageTries[(common.BytesToHash(pathset[0]))]
+			for _, path := range pathset[1:] {
+				blob, _, err := account.TryGetNode(path)
+				if err != nil {
+					t.logger.Info("Error handling req", "error", err)
+					break
+				}
+				nodes = append(nodes, blob)
+			}
+		}
+	}
+	t.remote.OnTrieNodes(t, requestId, nodes)
+	return nil
+}
+
+// defaultAccountRequestHandler is a well-behaving handler for AccountRangeRequests
+func defaultAccountRequestHandler(t *testPeer, id uint64, root common.Hash, origin common.Hash, limit common.Hash, cap uint64) error {
+	keys, vals, proofs := createAccountRequestResponse(t, root, origin, limit, cap)
+	if err := t.remote.OnAccounts(t, id, keys, vals, proofs); err != nil {
+		t.test.Errorf("Remote side rejected our delivery: %v", err)
+		t.term()
+		return err
+	}
+	return nil
+}
+
+func createAccountRequestResponse(t *testPeer, root common.Hash, origin common.Hash, limit common.Hash, cap uint64) (keys []common.Hash, vals [][]byte, proofs [][]byte) {
+	var size uint64
+	if limit == (common.Hash{}) {
+		limit = common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	}
+	for _, entry := range t.accountValues {
+		if size > cap {
+			break
+		}
+		if bytes.Compare(origin[:], entry.k) <= 0 {
+			keys = append(keys, common.BytesToHash(entry.k))
+			vals = append(vals, entry.v)
+			size += uint64(32 + len(entry.v))
+		}
+		// If we've exceeded the request threshold, abort
+		if bytes.Compare(entry.k, limit[:]) >= 0 {
+			break
+		}
+	}
+	// Unless we send the entire trie, we need to supply proofs
+	// Actually, we need to supply proofs either way! This seems to be an implementation
+	// quirk in go-ethereum
+	proof := NewNodeSet()
+	if err := t.accountTrie.Prove(origin[:], 0, proof); err != nil {
+		t.logger.Error("Could not prove inexistence of origin", "origin", origin, "error", err)
+	}
+	if len(keys) > 0 {
+		lastK := (keys[len(keys)-1])[:]
+		if err := t.accountTrie.Prove(lastK, 0, proof); err != nil {
+			t.logger.Error("Could not prove last item", "error", err)
+		}
+	}
+	for _, blob := range proof.NodeList() {
+		proofs = append(proofs, blob)
+	}
+	return keys, vals, proofs
+}
+
+// defaultStorageRequestHandler is a well-behaving storage request handler
+func defaultStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, bOrigin, bLimit []byte, max uint64) error {
+	hashes, slots, proofs := createStorageRequestResponse(t, root, accounts, bOrigin, bLimit, max)
+	if err := t.remote.OnStorage(t, requestId, hashes, slots, proofs); err != nil {
+		t.test.Errorf("Remote side rejected our delivery: %v", err)
+		t.term()
+	}
+	return nil
+}
+
+func defaultCodeRequestHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+	bytecodes := make([][]byte, 0, len(hashes))
+	for _, h := range hashes {
+		bytecodes = append(bytecodes, getCodeByHash(h))
+	}
+	if err := t.remote.OnByteCodes(t, id, bytecodes); err != nil {
+		t.test.Errorf("Remote side rejected our delivery: %v", err)
+		t.term()
+	}
+	return nil
+}
+
+func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) (hashes [][]common.Hash, slots [][][]byte, proofs [][]byte) {
+	var size uint64
+	for _, account := range accounts {
+		// The first account might start from a different origin and end sooner
+		var originHash common.Hash
+		if len(origin) > 0 {
+			originHash = common.BytesToHash(origin)
+		}
+		limitHash := common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+		if len(limit) > 0 {
+			limitHash = common.BytesToHash(limit)
+		}
+		var (
+			keys  []common.Hash
+			vals  [][]byte
+			abort bool
+		)
+		for _, entry := range t.storageValues[account] {
+			if size >= max {
+				abort = true
+				break
+			}
+			if bytes.Compare(entry.k, originHash[:]) < 0 {
+				continue
+			}
+			keys = append(keys, common.BytesToHash(entry.k))
+			vals = append(vals, entry.v)
+			size += uint64(32 + len(entry.v))
+			if bytes.Compare(entry.k, limitHash[:]) >= 0 {
+				break
+			}
+		}
+		hashes = append(hashes, keys)
+		slots = append(slots, vals)
+
+		// Generate the Merkle proofs for the first and last storage slot, but
+		// only if the response was capped. If the entire storage trie included
+		// in the response, no need for any proofs.
+		if originHash != (common.Hash{}) || abort {
+			// If we're aborting, we need to prove the first and last item
+			// This terminates the response (and thus the loop)
+			proof := NewNodeSet()
+			stTrie := t.storageTries[account]
+
+			// Here's a potential gotcha: when constructing the proof, we cannot
+			// use the 'origin' slice directly, but must use the full 32-byte
+			// hash form.
+			if err := stTrie.Prove(originHash[:], 0, proof); err != nil {
+				t.logger.Error("Could not prove inexistence of origin", "origin", originHash, "error", err)
+			}
+			if len(keys) > 0 {
+				lastK := (keys[len(keys)-1])[:]
+				if err := stTrie.Prove(lastK, 0, proof); err != nil {
+					t.logger.Error("Could not prove last item", "error", err)
+				}
+			}
+			for _, blob := range proof.NodeList() {
+				proofs = append(proofs, blob)
+			}
+			break
+		}
+	}
+	return hashes, slots, proofs
+}
+
+// createStorageRequestResponseAlwaysProve tests a corner case, where it always
+// supplies the proof for the last account, even if it is 'complete'.
+func createStorageRequestResponseAlwaysProve(t *testPeer, root common.Hash, accounts []common.Hash, bOrigin, bLimit []byte, max uint64) (hashes [][]common.Hash, slots [][][]byte, proofs [][]byte) {
+	var size uint64
+	max = max * 3 / 4
+
+	var origin common.Hash
+	if len(bOrigin) > 0 {
+		origin = common.BytesToHash(bOrigin)
+	}
+	var exit bool
+	for i, account := range accounts {
+		var keys []common.Hash
+		var vals [][]byte
+		for _, entry := range t.storageValues[account] {
+			if bytes.Compare(entry.k, origin[:]) < 0 {
+				exit = true
+			}
+			keys = append(keys, common.BytesToHash(entry.k))
+			vals = append(vals, entry.v)
+			size += uint64(32 + len(entry.v))
+			if size > max {
+				exit = true
+			}
+		}
+		if i == len(accounts)-1 {
+			exit = true
+		}
+		hashes = append(hashes, keys)
+		slots = append(slots, vals)
+
+		if exit {
+			// If we're aborting, we need to prove the first and last item
+			// This terminates the response (and thus the loop)
+			proof := NewNodeSet()
+			stTrie := t.storageTries[account]
+
+			// Here's a potential gotcha: when constructing the proof, we cannot
+			// use the 'origin' slice directly, but must use the full 32-byte
+			// hash form.
+			if err := stTrie.Prove(origin[:], 0, proof); err != nil {
+				t.logger.Error("Could not prove inexistence of origin", "origin", origin,
+					"error", err)
+			}
+			if len(keys) > 0 {
+				lastK := (keys[len(keys)-1])[:]
+				if err := stTrie.Prove(lastK, 0, proof); err != nil {
+					t.logger.Error("Could not prove last item", "error", err)
+				}
+			}
+			for _, blob := range proof.NodeList() {
+				proofs = append(proofs, blob)
+			}
+			break
+		}
+	}
+	return hashes, slots, proofs
+}
+
+// emptyRequestAccountRangeFn is a rejects AccountRangeRequests
+func emptyRequestAccountRangeFn(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, limit common.Hash, cap uint64) error {
+	t.remote.OnAccounts(t, requestId, nil, nil, nil)
+	return nil
+}
+
+func nonResponsiveRequestAccountRangeFn(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, limit common.Hash, cap uint64) error {
+	return nil
+}
+
+func emptyTrieRequestHandler(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error {
+	t.remote.OnTrieNodes(t, requestId, nil)
+	return nil
+}
+
+func nonResponsiveTrieRequestHandler(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error {
+	return nil
+}
+
+func emptyStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	t.remote.OnStorage(t, requestId, nil, nil, nil)
+	return nil
+}
+
+func nonResponsiveStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	return nil
+}
+
+func proofHappyStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	hashes, slots, proofs := createStorageRequestResponseAlwaysProve(t, root, accounts, origin, limit, max)
+	if err := t.remote.OnStorage(t, requestId, hashes, slots, proofs); err != nil {
+		t.test.Errorf("Remote side rejected our delivery: %v", err)
+		t.term()
+	}
+	return nil
+}
+
+//func emptyCodeRequestHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+//	var bytecodes [][]byte
+//	t.remote.OnByteCodes(t, id, bytecodes)
+//	return nil
+//}
+
+func corruptCodeRequestHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+	bytecodes := make([][]byte, 0, len(hashes))
+	for _, h := range hashes {
+		// Send back the hashes
+		bytecodes = append(bytecodes, h[:])
+	}
+	if err := t.remote.OnByteCodes(t, id, bytecodes); err != nil {
+		t.logger.Info("remote error on delivery (as expected)", "error", err)
+		// Mimic the real-life handler, which drops a peer on errors
+		t.remote.Unregister(t.id)
+	}
+	return nil
+}
+
+func cappedCodeRequestHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+	bytecodes := make([][]byte, 0, 1)
+	for _, h := range hashes[:1] {
+		bytecodes = append(bytecodes, getCodeByHash(h))
+	}
+	// Missing bytecode can be retrieved again, no error expected
+	if err := t.remote.OnByteCodes(t, id, bytecodes); err != nil {
+		t.test.Errorf("Remote side rejected our delivery: %v", err)
+		t.term()
+	}
+	return nil
+}
+
+// starvingStorageRequestHandler is somewhat well-behaving storage handler, but it caps the returned results to be very small
+func starvingStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	return defaultStorageRequestHandler(t, requestId, root, accounts, origin, limit, 500)
+}
+
+func starvingAccountRequestHandler(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, limit common.Hash, cap uint64) error {
+	return defaultAccountRequestHandler(t, requestId, root, origin, limit, 500)
+}
+
+//func misdeliveringAccountRequestHandler(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
+//	return defaultAccountRequestHandler(t, requestId-1, root, origin, 500)
+//}
+
+func corruptAccountRequestHandler(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, limit common.Hash, cap uint64) error {
+	hashes, accounts, proofs := createAccountRequestResponse(t, root, origin, limit, cap)
+	if len(proofs) > 0 {
+		proofs = proofs[1:]
+	}
+	if err := t.remote.OnAccounts(t, requestId, hashes, accounts, proofs); err != nil {
+		t.logger.Info("remote error on delivery (as expected)", "error", err)
+		// Mimic the real-life handler, which drops a peer on errors
+		t.remote.Unregister(t.id)
+	}
+	return nil
+}
+
+// corruptStorageRequestHandler doesn't provide good proofs
+func corruptStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	hashes, slots, proofs := createStorageRequestResponse(t, root, accounts, origin, limit, max)
+	if len(proofs) > 0 {
+		proofs = proofs[1:]
+	}
+	if err := t.remote.OnStorage(t, requestId, hashes, slots, proofs); err != nil {
+		t.logger.Info("remote error on delivery (as expected)", "error", err)
+		// Mimic the real-life handler, which drops a peer on errors
+		t.remote.Unregister(t.id)
+	}
+	return nil
+}
+
+func noProofStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	hashes, slots, _ := createStorageRequestResponse(t, root, accounts, origin, limit, max)
+	if err := t.remote.OnStorage(t, requestId, hashes, slots, nil); err != nil {
+		t.logger.Info("remote error on delivery (as expected)", "error", err)
+		// Mimic the real-life handler, which drops a peer on errors
+		t.remote.Unregister(t.id)
+	}
+	return nil
+}
+
+// TestSyncBloatedProof tests a scenario where we provide only _one_ value, but
+// also ship the entire trie inside the proof. If the attack is successful,
+// the remote side does not do any follow-up requests
+func TestSyncBloatedProof(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(100)
+	source := newTestPeer("source", t, term)
+	source.accountTrie = sourceAccountTrie
+	source.accountValues = elems
+
+	source.accountRequestHandler = func(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, limit common.Hash, cap uint64) error {
+		var (
+			proofs [][]byte
+			keys   []common.Hash
+			vals   [][]byte
+		)
+		// The values
+		for _, entry := range t.accountValues {
+			if bytes.Compare(entry.k, origin[:]) < 0 {
+				continue
+			}
+			if bytes.Compare(entry.k, limit[:]) > 0 {
+				continue
+			}
+			keys = append(keys, common.BytesToHash(entry.k))
+			vals = append(vals, entry.v)
+		}
+		// The proofs
+		proof := NewNodeSet()
+		if err := t.accountTrie.Prove(origin[:], 0, proof); err != nil {
+			t.logger.Error("Could not prove origin", "origin", origin, "error", err)
+		}
+		// The bloat: add proof of every single element
+		for _, entry := range t.accountValues {
+			if err := t.accountTrie.Prove(entry.k, 0, proof); err != nil {
+				t.logger.Error("Could not prove item", "error", err)
+			}
+		}
+		// And remove one item from the elements
+		if len(keys) > 2 {
+			keys = append(keys[:1], keys[2:]...)
+			vals = append(vals[:1], vals[2:]...)
+		}
+		for _, blob := range proof.NodeList() {
+			proofs = append(proofs, blob)
+		}
+		if err := t.remote.OnAccounts(t, requestId, keys, vals, proofs); err != nil {
+			t.logger.Info("remote error on delivery (as expected)", "error", err)
+			t.term()
+			// This is actually correct, signal to exit the test successfully
+		}
+		return nil
+	}
+	syncer := setupSyncer(source)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err == nil {
+		t.Fatal("No error returned from incomplete/cancelled sync")
+	}
+}
+
+func setupSyncer(peers ...*testPeer) *Syncer {
+	stateDb := database.NewMemoryDBManager()
+	syncer := NewSyncer(stateDb)
+	for _, peer := range peers {
+		syncer.Register(peer)
+		peer.remote = syncer
+	}
+	return syncer
+}
+
+// TestSync tests a basic sync with one peer
+func TestSync(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(100)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		return source
+	}
+	syncer := setupSyncer(mkSource("source"))
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestSyncTinyTriePanic tests a basic sync with one peer, and a tiny trie. This caused a
+// panic within the prover
+func TestSyncTinyTriePanic(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(1)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		return source
+	}
+	syncer := setupSyncer(mkSource("source"))
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestMultiSync tests a basic sync with multiple peers
+func TestMultiSync(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(100)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		return source
+	}
+	syncer := setupSyncer(mkSource("sourceA"), mkSource("sourceB"))
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestSyncWithStorage tests  basic sync using accounts + storage + code
+func TestSyncWithStorage(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(3, 3000, true, false)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+		return source
+	}
+	syncer := setupSyncer(mkSource("sourceA"))
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestMultiSyncManyUseless contains one good peer, and many which doesn't return anything valuable at all
+func TestMultiSyncManyUseless(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true, false)
+
+	mkSource := func(name string, noAccount, noStorage, noTrieNode bool) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+
+		if !noAccount {
+			source.accountRequestHandler = emptyRequestAccountRangeFn
+		}
+		if !noStorage {
+			source.storageRequestHandler = emptyStorageRequestHandler
+		}
+		if !noTrieNode {
+			source.trieRequestHandler = emptyTrieRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("full", true, true, true),
+		mkSource("noAccounts", false, true, true),
+		mkSource("noStorage", true, false, true),
+		mkSource("noTrie", true, true, false),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestMultiSyncManyUseless contains one good peer, and many which doesn't return anything valuable at all
+func TestMultiSyncManyUselessWithLowTimeout(t *testing.T) {
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true, false)
+
+	mkSource := func(name string, noAccount, noStorage, noTrieNode bool) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+
+		if !noAccount {
+			source.accountRequestHandler = emptyRequestAccountRangeFn
+		}
+		if !noStorage {
+			source.storageRequestHandler = emptyStorageRequestHandler
+		}
+		if !noTrieNode {
+			source.trieRequestHandler = emptyTrieRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("full", true, true, true),
+		mkSource("noAccounts", false, true, true),
+		mkSource("noStorage", true, false, true),
+		mkSource("noTrie", true, true, false),
+	)
+	// We're setting the timeout to very low, to increase the chance of the timeout
+	// being triggered. This was previously a cause of panic, when a response
+	// arrived simultaneously as a timeout was triggered.
+	syncer.rates.OverrideTTLLimit = time.Millisecond
+
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestMultiSyncManyUnresponsive contains one good peer, and many which doesn't respond at all
+func TestMultiSyncManyUnresponsive(t *testing.T) {
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true, false)
+
+	mkSource := func(name string, noAccount, noStorage, noTrieNode bool) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+
+		if !noAccount {
+			source.accountRequestHandler = nonResponsiveRequestAccountRangeFn
+		}
+		if !noStorage {
+			source.storageRequestHandler = nonResponsiveStorageRequestHandler
+		}
+		if !noTrieNode {
+			source.trieRequestHandler = nonResponsiveTrieRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("full", true, true, true),
+		mkSource("noAccounts", false, true, true),
+		mkSource("noStorage", true, false, true),
+		mkSource("noTrie", true, true, false),
+	)
+	// We're setting the timeout to very low, to make the test run a bit faster
+	syncer.rates.OverrideTTLLimit = time.Millisecond
+
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+func checkStall(t *testing.T, term func()) chan struct{} {
+	testDone := make(chan struct{})
+	go func() {
+		select {
+		case <-time.After(time.Minute): // TODO(karalabe): Make tests smaller, this is too much
+			t.Log("Sync stalled")
+			term()
+		case <-testDone:
+			return
+		}
+	}()
+	return testDone
+}
+
+// TestSyncBoundaryAccountTrie tests sync against a few normal peers, but the
+// account trie has a few boundary elements.
+func TestSyncBoundaryAccountTrie(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeBoundaryAccountTrie(3000)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		return source
+	}
+	syncer := setupSyncer(
+		mkSource("peer-a"),
+		mkSource("peer-b"),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestSyncNoStorageAndOneCappedPeer tests sync using accounts and no storage, where one peer is
+// consistently returning very small results
+func TestSyncNoStorageAndOneCappedPeer(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(3000)
+
+	mkSource := func(name string, slow bool) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+
+		if slow {
+			source.accountRequestHandler = starvingAccountRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("nice-a", false),
+		mkSource("nice-b", false),
+		mkSource("nice-c", false),
+		mkSource("capped", true),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestSyncNoStorageAndOneCodeCorruptPeer has one peer which doesn't deliver
+// code requests properly.
+func TestSyncNoStorageAndOneCodeCorruptPeer(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(3000)
+
+	mkSource := func(name string, codeFn codeHandlerFunc) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.codeRequestHandler = codeFn
+		return source
+	}
+	// One is capped, one is corrupt. If we don't use a capped one, there's a 50%
+	// chance that the full set of codes requested are sent only to the
+	// non-corrupt peer, which delivers everything in one go, and makes the
+	// test moot
+	syncer := setupSyncer(
+		mkSource("capped", cappedCodeRequestHandler),
+		mkSource("corrupt", corruptCodeRequestHandler),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+func TestSyncNoStorageAndOneAccountCorruptPeer(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(3000)
+
+	mkSource := func(name string, accFn accountHandlerFunc) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.accountRequestHandler = accFn
+		return source
+	}
+	// One is capped, one is corrupt. If we don't use a capped one, there's a 50%
+	// chance that the full set of codes requested are sent only to the
+	// non-corrupt peer, which delivers everything in one go, and makes the
+	// test moot
+	syncer := setupSyncer(
+		mkSource("capped", defaultAccountRequestHandler),
+		mkSource("corrupt", corruptAccountRequestHandler),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestSyncNoStorageAndOneCodeCappedPeer has one peer which delivers code hashes
+// one by one
+func TestSyncNoStorageAndOneCodeCappedPeer(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(3000)
+
+	mkSource := func(name string, codeFn codeHandlerFunc) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.codeRequestHandler = codeFn
+		return source
+	}
+	// Count how many times it's invoked. Remember, there are only 8 unique hashes,
+	// so it shouldn't be more than that
+	var counter int
+	syncer := setupSyncer(
+		mkSource("capped", func(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+			counter++
+			return cappedCodeRequestHandler(t, id, hashes, max)
+		}),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	// There are only 8 unique hashes, and 3K accounts. However, the code
+	// deduplication is per request batch. If it were a perfect global dedup,
+	// we would expect only 8 requests. If there were no dedup, there would be
+	// 3k requests.
+	// We expect somewhere below 100 requests for these 8 unique hashes.
+	if threshold := 100; counter > threshold {
+		t.Fatalf("Error, expected < %d invocations, got %d", threshold, counter)
+	}
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestSyncBoundaryStorageTrie tests sync against a few normal peers, but the
+// storage trie has a few boundary elements.
+func TestSyncBoundaryStorageTrie(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(10, 1000, false, true)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+		return source
+	}
+	syncer := setupSyncer(
+		mkSource("peer-a"),
+		mkSource("peer-b"),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestSyncWithStorageAndOneCappedPeer tests sync using accounts + storage, where one peer is
+// consistently returning very small results
+func TestSyncWithStorageAndOneCappedPeer(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(300, 1000, false, false)
+
+	mkSource := func(name string, slow bool) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+
+		if slow {
+			source.storageRequestHandler = starvingStorageRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("nice-a", false),
+		mkSource("slow", true),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestSyncWithStorageAndCorruptPeer tests sync using accounts + storage, where one peer is
+// sometimes sending bad proofs
+func TestSyncWithStorageAndCorruptPeer(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true, false)
+
+	mkSource := func(name string, handler storageHandlerFunc) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+		source.storageRequestHandler = handler
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("nice-a", defaultStorageRequestHandler),
+		mkSource("nice-b", defaultStorageRequestHandler),
+		mkSource("nice-c", defaultStorageRequestHandler),
+		mkSource("corrupt", corruptStorageRequestHandler),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+func TestSyncWithStorageAndNonProvingPeer(t *testing.T) {
+	t.Parallel()
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true, false)
+
+	mkSource := func(name string, handler storageHandlerFunc) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+		source.storageRequestHandler = handler
+		return source
+	}
+	syncer := setupSyncer(
+		mkSource("nice-a", defaultStorageRequestHandler),
+		mkSource("nice-b", defaultStorageRequestHandler),
+		mkSource("nice-c", defaultStorageRequestHandler),
+		mkSource("corrupt", noProofStorageRequestHandler),
+	)
+	done := checkStall(t, term)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+// TestSyncWithStorageMisbehavingProve tests basic sync using accounts + storage + code, against
+// a peer who insists on delivering full storage sets _and_ proofs. This triggered
+// an error, where the recipient erroneously clipped the boundary nodes, but
+// did not mark the account for healing.
+func TestSyncWithStorageMisbehavingProve(t *testing.T) {
+	t.Parallel()
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorageWithUniqueStorage(10, 30, false)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+		source.storageRequestHandler = proofHappyStorageRequestHandler
+		return source
+	}
+	syncer := setupSyncer(mkSource("sourceA"))
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+}
+
+type kv struct {
+	k, v []byte
+}
+
+// Some helpers for sorting
+type entrySlice []*kv
+
+func (p entrySlice) Len() int           { return len(p) }
+func (p entrySlice) Less(i, j int) bool { return bytes.Compare(p[i].k, p[j].k) < 0 }
+func (p entrySlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func key32(i uint64) []byte {
+	key := make([]byte, 32)
+	binary.LittleEndian.PutUint64(key, i)
+	return key
+}
+
+var codehashes = []common.Hash{
+	crypto.Keccak256Hash([]byte{0}),
+	crypto.Keccak256Hash([]byte{1}),
+	crypto.Keccak256Hash([]byte{2}),
+	crypto.Keccak256Hash([]byte{3}),
+	crypto.Keccak256Hash([]byte{4}),
+	crypto.Keccak256Hash([]byte{5}),
+	crypto.Keccak256Hash([]byte{6}),
+	crypto.Keccak256Hash([]byte{7}),
+}
+
+// getCodeHash returns a pseudo-random code hash
+func getCodeHash(i uint64) []byte {
+	h := codehashes[int(i)%len(codehashes)]
+	return common.CopyBytes(h[:])
+}
+
+// getCodeByHash convenience function to lookup the code from the code hash
+func getCodeByHash(hash common.Hash) []byte {
+	if hash == emptyCode {
+		return nil
+	}
+	for i, h := range codehashes {
+		if h == hash {
+			return []byte{byte(i)}
+		}
+	}
+	return nil
+}
+
+// makeAccountTrieNoStorage spits out a trie, along with the leafs
+func makeAccountTrieNoStorage(n int) (*statedb.Trie, entrySlice) {
+	db := statedb.NewDatabase(database.NewMemoryDBManager())
+	accTrie, _ := statedb.NewTrie(common.Hash{}, db)
+	var entries entrySlice
+	for i := uint64(1); i <= uint64(n); i++ {
+		acc, _ := genExternallyOwnedAccount(i, big.NewInt(int64(i)))
+		serializer := account.NewAccountSerializerWithAccount(acc)
+		value, _ := rlp.EncodeToBytes(serializer)
+		key := key32(i)
+		elem := &kv{key, value}
+		accTrie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+	}
+	sort.Sort(entries)
+	accTrie.Commit(nil)
+	return accTrie, entries
+}
+
+// makeBoundaryAccountTrie constructs an account trie. Instead of filling
+// accounts normally, this function will fill a few accounts which have
+// boundary hash.
+func makeBoundaryAccountTrie(n int) (*statedb.Trie, entrySlice) {
+	var (
+		entries    entrySlice
+		boundaries []common.Hash
+
+		db      = statedb.NewDatabase(database.NewMemoryDBManager())
+		trie, _ = statedb.NewTrie(common.Hash{}, db)
+	)
+	// Initialize boundaries
+	var next common.Hash
+	step := new(big.Int).Sub(
+		new(big.Int).Div(
+			new(big.Int).Exp(common.Big2, common.Big256, nil),
+			big.NewInt(int64(accountConcurrency)),
+		), common.Big1,
+	)
+	for i := 0; i < accountConcurrency; i++ {
+		last := common.BigToHash(new(big.Int).Add(next.Big(), step))
+		if i == accountConcurrency-1 {
+			last = common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+		}
+		boundaries = append(boundaries, last)
+		next = common.BigToHash(new(big.Int).Add(last.Big(), common.Big1))
+	}
+	// Fill boundary accounts
+	for i := 0; i < len(boundaries); i++ {
+		acc, _ := genSmartContractAccount(uint64(0), big.NewInt(int64(i)), emptyRoot, getCodeHash(uint64(i)))
+		serializer := account.NewAccountSerializerWithAccount(acc)
+		value, _ := rlp.EncodeToBytes(serializer)
+		elem := &kv{boundaries[i].Bytes(), value}
+		trie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+	}
+	// Fill other accounts if required
+	for i := uint64(1); i <= uint64(n); i++ {
+		acc, _ := genSmartContractAccount(i, big.NewInt(int64(i)), emptyRoot, getCodeHash(i))
+		serializer := account.NewAccountSerializerWithAccount(acc)
+		value, _ := rlp.EncodeToBytes(serializer)
+		elem := &kv{key32(i), value}
+		trie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+	}
+	sort.Sort(entries)
+	trie.Commit(nil)
+	return trie, entries
+}
+
+// makeAccountTrieWithStorageWithUniqueStorage creates an account trie where each accounts
+// has a unique storage set.
+func makeAccountTrieWithStorageWithUniqueStorage(accounts, slots int, code bool) (*statedb.Trie, entrySlice, map[common.Hash]*statedb.Trie, map[common.Hash]entrySlice) {
+	var (
+		db             = statedb.NewDatabase(database.NewMemoryDBManager())
+		accTrie, _     = statedb.NewTrie(common.Hash{}, db)
+		entries        entrySlice
+		storageTries   = make(map[common.Hash]*statedb.Trie)
+		storageEntries = make(map[common.Hash]entrySlice)
+	)
+	// Create n accounts in the trie
+	for i := uint64(1); i <= uint64(accounts); i++ {
+		key := key32(i)
+		codehash := emptyCode[:]
+		if code {
+			codehash = getCodeHash(i)
+		}
+		// Create a storage trie
+		stTrie, stEntries := makeStorageTrieWithSeed(uint64(slots), i, db)
+		stRoot := stTrie.Hash()
+		stTrie.Commit(nil)
+		acc, _ := genSmartContractAccount(i, big.NewInt(int64(i)), stRoot, codehash)
+		serializer := account.NewAccountSerializerWithAccount(acc)
+		value, _ := rlp.EncodeToBytes(serializer)
+		elem := &kv{key, value}
+		accTrie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+
+		storageTries[common.BytesToHash(key)] = stTrie
+		storageEntries[common.BytesToHash(key)] = stEntries
+	}
+	sort.Sort(entries)
+
+	accTrie.Commit(nil)
+	return accTrie, entries, storageTries, storageEntries
+}
+
+// makeAccountTrieWithStorage spits out a trie, along with the leafs
+func makeAccountTrieWithStorage(accounts, slots int, code, boundary bool) (*statedb.Trie, entrySlice, map[common.Hash]*statedb.Trie, map[common.Hash]entrySlice) {
+	var (
+		db             = statedb.NewDatabase(database.NewMemoryDBManager())
+		accTrie, _     = statedb.NewTrie(common.Hash{}, db)
+		entries        entrySlice
+		storageTries   = make(map[common.Hash]*statedb.Trie)
+		storageEntries = make(map[common.Hash]entrySlice)
+	)
+	// Make a storage trie which we reuse for the whole lot
+	var (
+		stTrie    *statedb.Trie
+		stEntries entrySlice
+	)
+	if boundary {
+		stTrie, stEntries = makeBoundaryStorageTrie(slots, db)
+	} else {
+		stTrie, stEntries = makeStorageTrieWithSeed(uint64(slots), 0, db)
+	}
+	stRoot := stTrie.Hash()
+
+	// Create n accounts in the trie
+	for i := uint64(1); i <= uint64(accounts); i++ {
+		key := key32(i)
+		codehash := emptyCode[:]
+		if code {
+			codehash = getCodeHash(i)
+		}
+		acc, _ := genSmartContractAccount(i, big.NewInt(int64(i)), stRoot, codehash)
+		serializer := account.NewAccountSerializerWithAccount(acc)
+		value, _ := rlp.EncodeToBytes(serializer)
+		elem := &kv{key, value}
+		accTrie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+		// we reuse the same one for all accounts
+		storageTries[common.BytesToHash(key)] = stTrie
+		storageEntries[common.BytesToHash(key)] = stEntries
+	}
+	sort.Sort(entries)
+	stTrie.Commit(nil)
+	accTrie.Commit(nil)
+	return accTrie, entries, storageTries, storageEntries
+}
+
+// makeStorageTrieWithSeed fills a storage trie with n items, returning the
+// not-yet-committed trie and the sorted entries. The seeds can be used to ensure
+// that tries are unique.
+func makeStorageTrieWithSeed(n, seed uint64, db *statedb.Database) (*statedb.Trie, entrySlice) {
+	trie, _ := statedb.NewTrie(common.Hash{}, db)
+	var entries entrySlice
+	for i := uint64(1); i <= n; i++ {
+		// store 'x' at slot 'x'
+		slotValue := key32(i + seed)
+		rlpSlotValue, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(slotValue[:]))
+
+		slotKey := key32(i)
+		key := crypto.Keccak256Hash(slotKey[:])
+
+		elem := &kv{key[:], rlpSlotValue}
+		trie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+	}
+	sort.Sort(entries)
+	trie.Commit(nil)
+	return trie, entries
+}
+
+// makeBoundaryStorageTrie constructs a storage trie. Instead of filling
+// storage slots normally, this function will fill a few slots which have
+// boundary hash.
+func makeBoundaryStorageTrie(n int, db *statedb.Database) (*statedb.Trie, entrySlice) {
+	var (
+		entries    entrySlice
+		boundaries []common.Hash
+		trie, _    = statedb.NewTrie(common.Hash{}, db)
+	)
+	// Initialize boundaries
+	var next common.Hash
+	step := new(big.Int).Sub(
+		new(big.Int).Div(
+			new(big.Int).Exp(common.Big2, common.Big256, nil),
+			big.NewInt(int64(accountConcurrency)),
+		), common.Big1,
+	)
+	for i := 0; i < accountConcurrency; i++ {
+		last := common.BigToHash(new(big.Int).Add(next.Big(), step))
+		if i == accountConcurrency-1 {
+			last = common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+		}
+		boundaries = append(boundaries, last)
+		next = common.BigToHash(new(big.Int).Add(last.Big(), common.Big1))
+	}
+	// Fill boundary slots
+	for i := 0; i < len(boundaries); i++ {
+		key := boundaries[i]
+		val := []byte{0xde, 0xad, 0xbe, 0xef}
+
+		elem := &kv{key[:], val}
+		trie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+	}
+	// Fill other slots if required
+	for i := uint64(1); i <= uint64(n); i++ {
+		slotKey := key32(i)
+		key := crypto.Keccak256Hash(slotKey[:])
+
+		slotValue := key32(i)
+		rlpSlotValue, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(slotValue[:]))
+
+		elem := &kv{key[:], rlpSlotValue}
+		trie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+	}
+	sort.Sort(entries)
+	trie.Commit(nil)
+	return trie, entries
+}
+
+func verifyTrie(db database.DBManager, root common.Hash, t *testing.T) {
+	t.Helper()
+	triedb := statedb.NewDatabase(db)
+	accTrie, err := statedb.NewTrie(root, triedb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accounts, slots := 0, 0
+	accIt := statedb.NewIterator(accTrie.NodeIterator(nil))
+	for accIt.Next() {
+		serializer := account.NewAccountSerializer()
+		if err := rlp.DecodeBytes(accIt.Value, serializer); err != nil {
+			logger.Crit("Invalid account encountered during snapshot creation", "err", err)
+		}
+		acc := serializer.GetAccount()
+		pacc := account.GetProgramAccount(acc)
+		accounts++
+		if pacc != nil && pacc.GetStorageRoot() != emptyRoot {
+			storeTrie, err := statedb.NewSecureTrie(pacc.GetStorageRoot(), triedb)
+			if err != nil {
+				t.Fatal(err)
+			}
+			storeIt := statedb.NewIterator(storeTrie.NodeIterator(nil))
+			for storeIt.Next() {
+				slots++
+			}
+			if err := storeIt.Err; err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := accIt.Err; err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("accounts: %d, slots: %d", accounts, slots)
+}
+
+// TestSyncAccountPerformance tests how efficient the snap algo is at minimizing
+// state healing
+func TestSyncAccountPerformance(t *testing.T) {
+	// Set the account concurrency to 1. This _should_ result in the
+	// range root to become correct, and there should be no healing needed
+	defer func(old int) { accountConcurrency = old }(accountConcurrency)
+	accountConcurrency = 1
+
+	var (
+		once   sync.Once
+		cancel = make(chan struct{})
+		term   = func() {
+			once.Do(func() {
+				close(cancel)
+			})
+		}
+	)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(100)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, term)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		return source
+	}
+	src := mkSource("source")
+	syncer := setupSyncer(src)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	verifyTrie(syncer.db, sourceAccountTrie.Hash(), t)
+	// The trie root will always be requested, since it is added when the snap
+	// sync cycle starts. When popping the queue, we do not look it up again.
+	// Doing so would bring this number down to zero in this artificial testcase,
+	// but only add extra IO for no reason in practice.
+	if have, want := src.nTrienodeRequests, 1; have != want {
+		fmt.Printf(src.Stats())
+		t.Errorf("trie node heal requests wrong, want %d, have %d", want, have)
+	}
+}
+
+func TestSlotEstimation(t *testing.T) {
+	for i, tc := range []struct {
+		last  common.Hash
+		count int
+		want  uint64
+	}{
+		{
+			// Half the space
+			common.HexToHash("0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			100,
+			100,
+		},
+		{
+			// 1 / 16th
+			common.HexToHash("0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			100,
+			1500,
+		},
+		{
+			// Bit more than 1 / 16th
+			common.HexToHash("0x1000000000000000000000000000000000000000000000000000000000000000"),
+			100,
+			1499,
+		},
+		{
+			// Almost everything
+			common.HexToHash("0xF000000000000000000000000000000000000000000000000000000000000000"),
+			100,
+			6,
+		},
+		{
+			// Almost nothing -- should lead to error
+			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+			1,
+			0,
+		},
+		{
+			// Nothing -- should lead to error
+			common.Hash{},
+			100,
+			0,
+		},
+	} {
+		have, _ := estimateRemainingSlots(tc.count, tc.last)
+		if want := tc.want; have != want {
+			t.Errorf("test %d: have %d want %d", i, have, want)
+		}
+	}
+}

--- a/node/cn/snap/tracker.go
+++ b/node/cn/snap/tracker.go
@@ -1,0 +1,30 @@
+// Modifications Copyright 2022 The klaytn Authors
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from eth/protocols/snap/tracker.go (2022/06/29).
+// Modified and improved for the klaytn development.
+
+package snap
+
+import (
+	"time"
+
+	"github.com/klaytn/klaytn/networks/p2p/tracker"
+)
+
+// requestTracker is a singleton tracker for request times.
+var requestTracker = tracker.New(ProtocolName, time.Minute)

--- a/node/cn/sync.go
+++ b/node/cn/sync.go
@@ -165,7 +165,10 @@ func (pm *ProtocolManager) syncer() {
 
 // getSyncMode returns SyncMode based on currentBlockNumber.
 func (pm *ProtocolManager) getSyncMode(currentBlock *types.Block) downloader.SyncMode {
-	if atomic.LoadUint32(&pm.fastSync) == 1 {
+	if atomic.LoadUint32(&pm.snapSync) == 1 {
+		// Snap sync was explicitly requested, and explicitly granted
+		return downloader.SnapSync
+	} else if atomic.LoadUint32(&pm.fastSync) == 1 {
 		// Fast sync was explicitly requested, and explicitly granted
 		return downloader.FastSync
 	} else if currentBlock.NumberU64() == 0 && pm.blockchain.CurrentFastBlock().NumberU64() > 0 {
@@ -174,8 +177,8 @@ func (pm *ProtocolManager) getSyncMode(currentBlock *types.Block) downloader.Syn
 		// The only scenario where this can happen is if the user manually (or via a
 		// bad block) rolled back a fast sync node below the sync point. In this case
 		// however it's safe to reenable fast sync.
-		atomic.StoreUint32(&pm.fastSync, 1)
-		return downloader.FastSync
+		atomic.StoreUint32(&pm.snapSync, 1)
+		return downloader.SnapSync
 	}
 	return downloader.FullSync
 }
@@ -196,7 +199,7 @@ func (pm *ProtocolManager) synchronise(peer Peer) {
 	}
 	// Otherwise try to sync with the downloader
 	mode := pm.getSyncMode(currentBlock)
-	if mode == downloader.FastSync {
+	if mode == downloader.FastSync || mode == downloader.SnapSync {
 		// Make sure the peer's total blockscore we are synchronizing is higher.
 		if pm.blockchain.GetTdByHash(pm.blockchain.CurrentFastBlock().Hash()).Cmp(pTd) >= 0 {
 			return
@@ -210,6 +213,10 @@ func (pm *ProtocolManager) synchronise(peer Peer) {
 	if atomic.LoadUint32(&pm.fastSync) == 1 {
 		logger.Info("Fast sync complete, auto disabling")
 		atomic.StoreUint32(&pm.fastSync, 0)
+	}
+	if atomic.LoadUint32(&pm.snapSync) == 1 {
+		logger.Info("Snap sync complete, auto disabling")
+		atomic.StoreUint32(&pm.snapSync, 0)
 	}
 	atomic.StoreUint32(&pm.acceptTxs, 1) // Mark initial sync done
 	if head := pm.blockchain.CurrentBlock(); head.NumberU64() > 0 {

--- a/node/cn/sync.go
+++ b/node/cn/sync.go
@@ -135,6 +135,9 @@ func (pm *ProtocolManager) txsyncLoop() {
 // syncer is responsible for periodically synchronising with the network, both
 // downloading hashes and blocks as well as handling the announcement handler.
 func (pm *ProtocolManager) syncer() {
+	pm.wg.Add(1)
+	defer pm.wg.Done()
+
 	// Start and ensure cleanup of sync mechanisms
 	pm.fetcher.Start()
 	defer pm.fetcher.Stop()

--- a/storage/database/batch.go
+++ b/storage/database/batch.go
@@ -48,28 +48,3 @@ type Batcher interface {
 	// until a final write is called.
 	NewBatch() Batch
 }
-
-// HookedBatch wraps an arbitrary batch where each operation may be hooked into
-// to monitor from black box code.
-type HookedBatch struct {
-	Batch
-
-	OnPut    func(key []byte, value []byte) // Callback if a key is inserted
-	OnDelete func(key []byte)               // Callback if a key is deleted
-}
-
-// Put inserts the given value into the key-value data store.
-func (b HookedBatch) Put(key []byte, value []byte) error {
-	if b.OnPut != nil {
-		b.OnPut(key, value)
-	}
-	return b.Batch.Put(key, value)
-}
-
-// Delete removes the key from the key-value data store.
-func (b HookedBatch) Delete(key []byte) error {
-	if b.OnDelete != nil {
-		b.OnDelete(key)
-	}
-	return b.Batch.Delete(key)
-}

--- a/storage/database/batch.go
+++ b/storage/database/batch.go
@@ -48,3 +48,28 @@ type Batcher interface {
 	// until a final write is called.
 	NewBatch() Batch
 }
+
+// HookedBatch wraps an arbitrary batch where each operation may be hooked into
+// to monitor from black box code.
+type HookedBatch struct {
+	Batch
+
+	OnPut    func(key []byte, value []byte) // Callback if a key is inserted
+	OnDelete func(key []byte)               // Callback if a key is deleted
+}
+
+// Put inserts the given value into the key-value data store.
+func (b HookedBatch) Put(key []byte, value []byte) error {
+	if b.OnPut != nil {
+		b.OnPut(key, value)
+	}
+	return b.Batch.Put(key, value)
+}
+
+// Delete removes the key from the key-value data store.
+func (b HookedBatch) Delete(key []byte) error {
+	if b.OnDelete != nil {
+		b.OnDelete(key)
+	}
+	return b.Batch.Delete(key)
+}

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -211,6 +211,10 @@ type DBManager interface {
 	WriteSnapshotRecoveryNumber(number uint64)
 	DeleteSnapshotRecoveryNumber()
 
+	ReadSnapshotSyncStatus() []byte
+	WriteSnapshotSyncStatus(status []byte)
+	DeleteSnapshotSyncStatus()
+
 	ReadSnapshotRoot() common.Hash
 	WriteSnapshotRoot(root common.Hash)
 	DeleteSnapshotRoot()
@@ -2160,6 +2164,30 @@ func (dbm *databaseManager) DeleteSnapshotRecoveryNumber() {
 	db := dbm.getDatabase(SnapshotDB)
 	if err := db.Delete(snapshotRecoveryKey); err != nil {
 		logger.Crit("Failed to remove snapshot recovery number", "err", err)
+	}
+}
+
+// ReadSnapshotSyncStatus retrieves the serialized sync status saved at shutdown.
+func (dbm *databaseManager) ReadSnapshotSyncStatus() []byte {
+	db := dbm.getDatabase(SnapshotDB)
+	data, _ := db.Get(snapshotSyncStatusKey)
+	return data
+}
+
+// WriteSnapshotSyncStatus stores the serialized sync status to save at shutdown.
+func (dbm *databaseManager) WriteSnapshotSyncStatus(status []byte) {
+	db := dbm.getDatabase(SnapshotDB)
+	if err := db.Put(snapshotSyncStatusKey, status); err != nil {
+		logger.Crit("Failed to store snapshot sync status", "err", err)
+	}
+}
+
+// DeleteSnapshotSyncStatus deletes the serialized sync status saved at the last
+// shutdown
+func (dbm *databaseManager) DeleteSnapshotSyncStatus() {
+	db := dbm.getDatabase(SnapshotDB)
+	if err := db.Delete(snapshotSyncStatusKey); err != nil {
+		logger.Crit("Failed to remove snapshot sync status", "err", err)
 	}
 }
 

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -64,6 +64,9 @@ var (
 	// snapshotRecoveryKey tracks the snapshot recovery marker across restarts.
 	snapshotRecoveryKey = []byte("SnapshotRecovery")
 
+	// snapshotSyncStatusKey tracks the snapshot sync status across restarts.
+	snapshotSyncStatusKey = []byte("SnapshotSyncStatus")
+
 	// snapshotRootKey tracks the hash of the last snapshot.
 	snapshotRootKey = []byte("SnapshotRoot")
 

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -1018,7 +1018,7 @@ func (db *Database) uncache(hash common.Hash) {
 
 // Size returns the current database size of the memory cache in front of the
 // persistent database layer.
-func (db *Database) Size() (common.StorageSize, common.StorageSize) {
+func (db *Database) Size() (common.StorageSize, common.StorageSize, common.StorageSize) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
@@ -1026,7 +1026,7 @@ func (db *Database) Size() (common.StorageSize, common.StorageSize) {
 	// the total memory consumption, the maintenance metadata is also needed to be
 	// counted. For every useful node, we track 2 extra hashes as the flushlist.
 	flushlistSize := common.StorageSize((len(db.nodes) - 1) * 2 * common.HashLength)
-	return db.nodesSize + flushlistSize, db.preimagesSize
+	return db.nodesSize + flushlistSize, db.nodesSize, db.preimagesSize
 }
 
 // verifyIntegrity is a debug method to iterate over the entire trie stored in

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -91,7 +91,7 @@ func TestDatabase_Size(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
 	db := NewDatabaseWithNewCache(memDB, &TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMiB: 128})
 
-	totalMemorySize, preimagesSize := db.Size()
+	totalMemorySize, _, preimagesSize := db.Size()
 	assert.Equal(t, common.StorageSize(0), totalMemorySize)
 	assert.Equal(t, common.StorageSize(0), preimagesSize)
 
@@ -102,12 +102,12 @@ func TestDatabase_Size(t *testing.T) {
 
 	db.Reference(childHash, parentHash)
 
-	totalMemorySize, preimagesSize = db.Size()
+	totalMemorySize, _, preimagesSize = db.Size()
 	assert.Equal(t, common.StorageSize(128), totalMemorySize)
 	assert.Equal(t, common.StorageSize(0), preimagesSize)
 
 	db.preimagesSize += 100
-	totalMemorySize, preimagesSize = db.Size()
+	totalMemorySize, _, preimagesSize = db.Size()
 	assert.Equal(t, common.StorageSize(128), totalMemorySize)
 	assert.Equal(t, common.StorageSize(100), preimagesSize)
 }

--- a/storage/statedb/hasher.go
+++ b/storage/statedb/hasher.go
@@ -31,14 +31,14 @@ import (
 
 type hasher struct {
 	tmp    sliceBuffer
-	sha    keccakState
+	sha    KeccakState
 	onleaf LeafCallback
 }
 
-// keccakState wraps sha3.state. In addition to the usual hash methods, it also supports
+// KeccakState wraps sha3.state. In addition to the usual hash methods, it also supports
 // Read to get a variable amount of data from the hash state. Read is faster than Sum
 // because it doesn't copy the internal state, but also modifies the internal state.
-type keccakState interface {
+type KeccakState interface {
 	hash.Hash
 	Read([]byte) (int, error)
 }
@@ -59,7 +59,7 @@ var hasherPool = sync.Pool{
 	New: func() interface{} {
 		return &hasher{
 			tmp: make(sliceBuffer, 0, 550), // cap is as large as a full fullNode.
-			sha: sha3.NewKeccak256().(keccakState),
+			sha: sha3.NewKeccak256().(KeccakState),
 		}
 	},
 }
@@ -278,12 +278,12 @@ func (h *hasher) store(n node, db *Database, force bool) (node, uint16) {
 			switch n := n.(type) {
 			case *shortNode:
 				if child, ok := n.Val.(valueNode); ok {
-					h.onleaf(nil, child, hash, 0)
+					h.onleaf(nil, nil, child, hash, 0)
 				}
 			case *fullNode:
 				for i := 0; i < 16; i++ {
 					if child, ok := n.Children[i].(valueNode); ok {
-						h.onleaf(nil, child, hash, 0)
+						h.onleaf(nil, nil, child, hash, 0)
 					}
 				}
 			}

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -38,9 +38,20 @@ var (
 )
 
 // LeafCallback is a callback type invoked when a trie operation reaches a leaf
-// node. It's used by state sync and commit to allow handling external references
-// between account and database tries.
-type LeafCallback func(path []byte, leaf []byte, parent common.Hash, parentDepth int) error
+// node.
+//
+// The paths is a path tuple identifying a particular trie node either in a single
+// trie (account) or a layered trie (account -> storage). Each path in the tuple
+// is in the raw format(32 bytes).
+//
+// The hexpath is a composite hexary path identifying the trie node. All the key
+// bytes are converted to the hexary nibbles and composited with the parent path
+// if the trie node is in a layered trie.
+//
+// It's used by state sync and commit to allow handling external references
+// between account and storage tries. And also it's used in the state healing
+// for extracting the raw states(leaf nodes) with corresponding paths.
+type LeafCallback func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash, parentDepth int) error
 
 // Trie is a Merkle Patricia Trie.
 // The zero value is an empty trie with no database.
@@ -173,6 +184,10 @@ func (t *Trie) TryGetNode(path []byte) ([]byte, int, error) {
 }
 
 func (t *Trie) tryGetNode(origNode node, path []byte, pos int) (item []byte, newnode node, resolved int, err error) {
+	// If non-existent path requested, abort
+	if origNode == nil {
+		return nil, nil, 0, nil
+	}
 	// If we reached the requested path, return the current node
 	if pos >= len(path) {
 		// Although we most probably have the original node expanded, encoding
@@ -192,10 +207,6 @@ func (t *Trie) tryGetNode(origNode node, path []byte, pos int) (item []byte, new
 	}
 	// Path still needs to be traversed, descend into children
 	switch n := (origNode).(type) {
-	case nil:
-		// Non-existent path requested, abort
-		return nil, nil, 0, nil
-
 	case valueNode:
 		// Path prematurely ended, abort
 		return nil, nil, 0, nil

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -19,6 +19,7 @@ import (
 	event "github.com/klaytn/klaytn/event"
 	params "github.com/klaytn/klaytn/params"
 	rlp "github.com/klaytn/klaytn/rlp"
+	snapshot "github.com/klaytn/klaytn/snapshot"
 )
 
 // MockBlockChain is a mock of BlockChain interface.
@@ -112,6 +113,21 @@ func (m *MockBlockChain) Config() *params.ChainConfig {
 func (mr *MockBlockChainMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockBlockChain)(nil).Config))
+}
+
+// ContractCode mocks base method
+func (m *MockBlockChain) ContractCode(arg0 common.Hash) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContractCode", arg0)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContractCode indicates an expected call of ContractCode
+func (mr *MockBlockChainMockRecorder) ContractCode(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractCode", reflect.TypeOf((*MockBlockChain)(nil).ContractCode), arg0)
 }
 
 // ContractCodeWithPrefix mocks base method
@@ -725,6 +741,20 @@ func (m *MockBlockChain) SetUseGiniCoeff(arg0 bool) {
 func (mr *MockBlockChainMockRecorder) SetUseGiniCoeff(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUseGiniCoeff", reflect.TypeOf((*MockBlockChain)(nil).SetUseGiniCoeff), arg0)
+}
+
+// Snapshots mocks base method.
+func (m *MockBlockChain) Snapshots() *snapshot.Tree {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Snapshots")
+	ret0, _ := ret[0].(*snapshot.Tree)
+	return ret0
+}
+
+// Snapshots indicates an expected call of Snapshots.
+func (mr *MockBlockChainMockRecorder) Snapshots() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshots", reflect.TypeOf((*MockBlockChain)(nil).Snapshots))
 }
 
 // StartCollectingTrieStats mocks base method.

--- a/work/work.go
+++ b/work/work.go
@@ -38,6 +38,7 @@ import (
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
+	"github.com/klaytn/klaytn/snapshot"
 	"github.com/klaytn/klaytn/storage/database"
 )
 
@@ -246,6 +247,7 @@ type BlockChain interface {
 
 	InsertChain(chain types.Blocks) (int, error)
 	TrieNode(hash common.Hash) ([]byte, error)
+	ContractCode(hash common.Hash) ([]byte, error)
 	ContractCodeWithPrefix(hash common.Hash) ([]byte, error)
 	Config() *params.ChainConfig
 	State() (*state.StateDB, error)
@@ -311,4 +313,7 @@ type BlockChain interface {
 	// KES
 	BlockSubscriptionLoop(pool *blockchain.TxPool)
 	CloseBlockSubscriptionLoop()
+
+	// Snapshot
+	Snapshots() *snapshot.Tree
 }


### PR DESCRIPTION
## Proposed changes

snapsync is a faster synchronisation feature derived from Ethereum. This PR ported the snapsync related PR from Ethereum. 

### Synchronisation methods from Ethereum
1. `full` sync: fetch headers and bodies (transactions) only, but reexecute the downloaded transactions to output transaction receipts and world states. Klaytn supports only full sync for now.
2. `fast` sync: fetch headers, bodies, and receipts until pivot block (no trie verification), and download all the trie nodes on the pivot.
3. `snap` sync: fetch headers, bodies, and receipts until pivot block and download snapshot data (trie leaf nodes) on the pivot after which the entire trie is reconstructed.

We had to fetch staking information as well to verify headers.

### Snap sync components
1. *snap protocol*: a message protocol to send the snapshot data including accounts, storages, bytecodes as well as trie nodes data. Basically, it sends all the data which is needed to reconstruct a state trie on a specific pivot block. Snap protocol is independent to the original `klay`/`istanbul` protocol.
2. *snap syncer*: snap syncer schedules the snapshot data fetching and healing the reconstructed trie. The healing phase is explained later.

### Snap sync process
1. Assuming that the remote peers have the snapshot data which is qualified to serve snap protocol.
2. Fetch a pivot block first. Pivot block is a specific block where the state trie is reconstructed. Pivot block is dynamically moved forward by 64 blocks. This is because a remote peer hold snapshot data about recent 128 blocks. 
3. Snap sync is started. Snap syncer scheduling the data retrieval. At the beginning, It divides hash space (`0x000...000` ... `0xfff...fff`) to 16 spaces, and it requests the range to retrieve the snapshot account data whose key is within that range. So, max 16 snap peers can be served to send those data.
4. The remote peers iterates the snapshot data in the increasing order of the keys, and pack the data to send back to the requested peer. At this moment, the merkle proof is added to the packet. 
5. After receiving the account data, it stores the data to database. If the account is smart contract, schedule code and storage retrieval as well. If all related data is downloaded, it processes the data such that creating partial state trie and persisting the data (range of accounts, and partial trie nodes) to database.
6. The syncer synchronises the snapshot data based on a state root hash. However, the root would be changed every time the pivot moves. So, the downloaded snapshot data might be out-dated. We considered this data as correct even though it is not and will be fixed in heal stage.
7. After all account data is downloaded, the state trie has to be healed since the out-dated accounts were inserted to the trie. In this stage, heal task is scheduled. It first fetch root and then children recursively. If it meets a subtrie root, then it doesn't go into deeper trie. Likewise it can heal the entire trie from root node.
8. After reconstructing the state trie, the sync mode is changed to full, and it will creates block as we know.

### TODO
- log enhancement
- add metrics
- stack trie update

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
