### PR TITLE
Optimize computation of gas fee

### DIFF
--- a/consensus/misc/kip71.go
+++ b/consensus/misc/kip71.go
@@ -53,6 +53,7 @@ func NextBlockBaseFee(parentHeader *types.Header, config *params.ChainConfig) *b
 	} else if parentGasUsed > gasTarget {
 		// If the parent block used more gas than its target,
 		// the baseFee of the next block should increase.
+		// baseFeeDelta = max(1, parentBaseFee * (parentGasUsed - gasTarget) / gasTarget / baseFeeDenominator)
 		gasUsedDelta := new(big.Int).SetUint64(parentGasUsed - gasTarget)
 		x := new(big.Int).Mul(parentBaseFee, gasUsedDelta)
 		y := x.Div(x, new(big.Int).SetUint64(gasTarget))
@@ -66,6 +67,7 @@ func NextBlockBaseFee(parentHeader *types.Header, config *params.ChainConfig) *b
 	} else {
 		// Otherwise if the parent block used less gas than its target,
 		// the baseFee of the next block should decrease.
+		// baseFeeDelta = parentBaseFee * (gasTarget - parentGasUsed) / gasTarget / baseFeeDenominator
 		gasUsedDelta := new(big.Int).SetUint64(gasTarget - parentGasUsed)
 		x := new(big.Int).Mul(parentBaseFee, gasUsedDelta)
 		y := x.Div(x, new(big.Int).SetUint64(gasTarget))

--- a/consensus/misc/kip71.go
+++ b/consensus/misc/kip71.go
@@ -51,6 +51,10 @@ func NextBlockBaseFee(parentHeader *types.Header, config *params.ChainConfig) *b
 	if parentGasUsed == gasTarget {
 		return new(big.Int).Set(parentHeader.BaseFee)
 	} else if parentGasUsed > gasTarget {
+		// shortcut. If parentBaseFee is already reached upperbound, do not calculate.
+		if parentBaseFee.Cmp(upperBoundBaseFee) >= 0 {
+			return upperBoundBaseFee
+		}
 		// If the parent block used more gas than its target,
 		// the baseFee of the next block should increase.
 		// baseFeeDelta = max(1, parentBaseFee * (parentGasUsed - gasTarget) / gasTarget / baseFeeDenominator)
@@ -65,6 +69,10 @@ func NextBlockBaseFee(parentHeader *types.Header, config *params.ChainConfig) *b
 		}
 		return nextBaseFee
 	} else {
+		// shortcut. If parentBaseFee is already reached lower bound, do not calculate.
+		if parentBaseFee.Cmp(lowerBoundBaseFee) <= 0 {
+			return lowerBoundBaseFee
+		}
 		// Otherwise if the parent block used less gas than its target,
 		// the baseFee of the next block should decrease.
 		// baseFeeDelta = parentBaseFee * (gasTarget - parentGasUsed) / gasTarget / baseFeeDenominator

--- a/consensus/misc/kip71_test.go
+++ b/consensus/misc/kip71_test.go
@@ -2,6 +2,7 @@ package misc
 
 import (
 	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -136,5 +137,46 @@ func TestActieDynamicPolicyAfterForkedBlock(t *testing.T) {
 	nextBaseFee := NextBlockBaseFee(parent, getTestConfig(big.NewInt(2)))
 	if parentBaseFee.Cmp(nextBaseFee) > 0 {
 		t.Errorf("after fork, dynamic base fee policy should be active, current base fee: %d  next base fee: %d", parentBaseFee, nextBaseFee)
+	}
+}
+
+func BenchmarkNextBlockBaseFeeRandom(b *testing.B) {
+	parentBaseFee := big.NewInt(500000000000)
+	parent := &types.Header{
+		Number:  common.Big3,
+		GasUsed: 10000000,
+		BaseFee: parentBaseFee,
+	}
+	for i := 0; i < b.N; i++ {
+		if rand.Int()%2 == 0 {
+			parent.GasUsed = 10000000
+		} else {
+			parent.GasUsed = 40000000
+		}
+		_ = NextBlockBaseFee(parent, getTestConfig(big.NewInt(2)))
+	}
+}
+
+func BenchmarkNextBlockBaseFeeUpperBound(b *testing.B) {
+	parentBaseFee := big.NewInt(750000000000)
+	parent := &types.Header{
+		Number:  common.Big3,
+		GasUsed: 40000000,
+		BaseFee: parentBaseFee,
+	}
+	for i := 0; i < b.N; i++ {
+		_ = NextBlockBaseFee(parent, getTestConfig(big.NewInt(2)))
+	}
+}
+
+func BenchmarkNextBlockBaseFeeLowerBound(b *testing.B) {
+	parentBaseFee := big.NewInt(25000000000)
+	parent := &types.Header{
+		Number:  common.Big3,
+		GasUsed: 10000000,
+		BaseFee: parentBaseFee,
+	}
+	for i := 0; i < b.N; i++ {
+		_ = NextBlockBaseFee(parent, getTestConfig(big.NewInt(2)))
 	}
 }


### PR DESCRIPTION
## Proposed changes

- Add the formula for better understanding of dynamic base fee calculation
- Do not calculate delta if the parent gas price already reached to the upper bound or the lower bound.
- The performance result:

### Keep touching the lower bound condition
    - Shortcut enabled
        - BenchmarkNextBlockBaseFeeLowerBound-10    	 6949518	       167.4 ns/op
    - Shortcut disabled
        - BenchmarkNextBlockBaseFeeLowerBound-10    	 4421775	       268.3 ns/op

**37% performance improved.**

### Keep touching the upper bound condition
    - Shortcut enabled
      - BenchmarkNextBlockBaseFeeUpperBound-10    	 7683355	       153.3 ns/op
    - Shortcut disabled
      - BenchmarkNextBlockBaseFeeUpperBound-10    	 4369462	       270.1 ns/op

**43% performance improved.**


### Random 
    - Shortcut enabled
      - BenchmarkNextBlockBaseFeeRandom-10    	 3875472	       315.2 ns/op
    - Shortcut disabled
      - BenchmarkNextBlockBaseFeeRandom-10    	 3912888	       302.1 ns/op

**4% performance degradation**

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

