### PR TITLE
fixed error using before initilizing governance when making genesis b…

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -329,7 +329,7 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 	}
 	// TODO-klaytn should set genesis block's base fee
 	if g.Config != nil && g.Config.IsKIP71ForkEnabled(common.Big0) {
-		head.BaseFee = new(big.Int).SetUint64(g.Config.Governance.KIP71.LowerBoundBaseFee)
+		head.BaseFee = new(big.Int).SetUint64(params.DefaultLowerBoundBaseFee)
 	}
 	stateDB.Commit(false)
 	stateDB.Database().TrieDB().Commit(root, true, g.Number)


### PR DESCRIPTION
## Proposed changes

- When activating from genesis block, It should have baseFee in header.
- It is fixed by changing from governance parameter to hard coded `lowerboundbasefee` because the governance parameter is not initialized at that time.
- NOTE : the `baseFee` of the next block will be calculated within normal range of the governance parameter (lower - upper) even if the `baseFee` of genesis block is out of range (lower - upper) by calculation logic of `NextBlockBaseFee`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
