### PR TITLE
apply kip71 hardfork to check a request of transactions

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -793,10 +793,8 @@ func newEthRPCTransaction(block *types.Block, tx *types.Transaction, blockHash c
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
 		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
 		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
-		// TODO-Klaytn: If we change the gas price policy from fixed to dynamic,
-		// we should change the params.ZeroBaseFee(fixed value) to dynamic value.
-		if block != nil && block.Header().BaseFee != nil {
-			result.GasPrice = (*hexutil.Big)(block.Header().BaseFee)
+		if block != nil {
+			result.GasPrice = (*hexutil.Big)(tx.EffectiveGasPrice(block.Header()))
 		} else {
 			price := math.BigMin(new(big.Int).Add(tx.GasTipCap(), new(big.Int).SetUint64(params.ZeroBaseFee)), tx.GasFeeCap())
 			result.GasPrice = (*hexutil.Big)(price)

--- a/api/api_public_transaction_pool_test.go
+++ b/api/api_public_transaction_pool_test.go
@@ -100,6 +100,9 @@ func TestTxTypeSupport(t *testing.T) {
 	mockAccountManager := mock_accounts.NewMockAccountManager(mockCtrl)
 
 	mockBackend.EXPECT().AccountManager().Return(mockAccountManager).AnyTimes()
+	mockBackend.EXPECT().CurrentBlock().Return(
+		types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(0)}),
+	).AnyTimes()
 	mockBackend.EXPECT().SuggestPrice(ctx).Return((*big.Int)(testGasPrice), nil).AnyTimes()
 	mockBackend.EXPECT().GetPoolNonce(ctx, gomock.Any()).Return(uint64(testNonce)).AnyTimes()
 	mockBackend.EXPECT().SendTx(ctx, gomock.Any()).Return(nil).AnyTimes()

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -138,6 +138,9 @@ type SendTxArgs struct {
 
 // setDefaults is a helper function that fills in default values for unspecified common tx fields.
 func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
+	head := b.CurrentBlock().Header()
+	isKIP71 := head.BaseFee != nil
+
 	if args.TypeInt == nil {
 		args.TypeInt = new(types.TxType)
 		*args.TypeInt = types.TxTypeLegacyTransaction
@@ -154,33 +157,43 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	}
 	// For the transaction that do not use the gasPrice field, the default value of gasPrice is not set.
 	if args.Price == nil && *args.TypeInt != types.TxTypeEthereumDynamicFee {
-		// TODO-Klaytn: needs to be fixed to double the BaseFee
+		// b.SuggestPrice = unitPrice, for before KIP71
+		//                = baseFee,   for after KIP71
 		price, err := b.SuggestPrice(ctx)
 		if err != nil {
 			return err
 		}
 		args.Price = (*hexutil.Big)(price)
 	}
-	// TODO-Klaytn: need to delete this logic, klaytn namespace doesn't have EthereumDynamicFee type
+
 	if *args.TypeInt == types.TxTypeEthereumDynamicFee {
-		// TODO-Klaytn: The logic below is valid only when using a fixed gas price.
-		fixedGasPrice, err := b.SuggestPrice(ctx)
+		gasPrice, err := b.SuggestPrice(ctx)
 		if err != nil {
 			return err
 		}
 		if args.MaxPriorityFeePerGas == nil {
-			args.MaxPriorityFeePerGas = (*hexutil.Big)(fixedGasPrice)
+			args.MaxPriorityFeePerGas = (*hexutil.Big)(gasPrice)
 		}
 		if args.MaxFeePerGas == nil {
-			fixedBaseFee := new(big.Int).SetUint64(params.ZeroBaseFee)
+			// Before KIP-71 hard fork, `gasFeeCap` was set to `baseFee*2 + maxPriorityFeePerGas` by default.
 			gasFeeCap := new(big.Int).Add(
 				(*big.Int)(args.MaxPriorityFeePerGas),
-				new(big.Int).Mul(fixedBaseFee, big.NewInt(2)),
+				new(big.Int).Mul(new(big.Int).SetUint64(params.ZeroBaseFee), big.NewInt(2)),
 			)
+			if isKIP71 {
+				// After KIP-71 hard fork, `gasFeeCap` was set to `baseFee*2` by default.
+				gasFeeCap = new(big.Int).Mul(gasPrice, big.NewInt(2))
+			}
 			args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 		}
-		if args.MaxPriorityFeePerGas.ToInt().Cmp(fixedGasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(fixedGasPrice) != 0 {
-			return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", fixedGasPrice.Text(16))
+		if isKIP71 {
+			if args.MaxFeePerGas.ToInt().Cmp(gasPrice) < 0 {
+				return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
+			}
+		} else {
+			if args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0 {
+				return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
+			}
 		}
 		if args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
 			return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)


### PR DESCRIPTION
## Proposed changes

We missed to apply kip71 hardfork to the method of `setDefaults` at `tx_args.go`
- apply kip71 hardfork to check the request of transaction arguments

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
