### PR TITLE
fix unnecessary ancestor lookup + add spinlock for staking info req

### DIFF
--- a/blockchain/chain_indexer.go
+++ b/blockchain/chain_indexer.go
@@ -205,13 +205,13 @@ func (c *ChainIndexer) eventLoop(currentHeader *types.Header, events chan ChainE
 			}
 			header := ev.Block.Header()
 			if header.ParentHash != prevHash {
-				// Reorg to the common ancestor (might not exist in light sync mode, skip reorg then)
+				// Reorg to the common ancestor if needed (might not exist in light sync mode, skip reorg then)
 				// TODO(karalabe, zsfelfoldi): This seems a bit brittle, can we detect this case explicitly?
 
-				// TODO(karalabe): This operation is expensive and might block, causing the event system to
-				// potentially also lock up. We need to do with on a different thread somehow.
-				if h := c.chainDB.FindCommonAncestor(prevHeader, header); h != nil {
-					c.newHead(h.Number.Uint64(), true)
+				if c.chainDB.ReadCanonicalHash(prevHeader.Number.Uint64()) != prevHash {
+					if h := c.chainDB.FindCommonAncestor(prevHeader, header); h != nil {
+						c.newHead(h.Number.Uint64(), true)
+					}
 				}
 			}
 			c.newHead(header.Number.Uint64(), false)

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -1505,7 +1505,8 @@ func (d *Downloader) processHeaders(origin uint64, td *big.Int) error {
 				// Unless we're doing light chains, schedule the headers for associated content retrieval
 				if mode == FullSync || mode == SnapSync || mode == FastSync {
 					// If we've reached the allowed number of pending headers, stall a bit
-					for d.queue.PendingBlocks() >= maxQueuedHeaders || d.queue.PendingReceipts() >= maxQueuedHeaders {
+					for d.queue.PendingBlocks() >= maxQueuedHeaders || d.queue.PendingReceipts() >= maxQueuedHeaders ||
+						d.queue.PendingStakingInfos() >= maxQueuedHeaders {
 						select {
 						case <-d.cancelCh:
 							rollbackErr = errCanceled


### PR DESCRIPTION
## Proposed changes

This PR fixes two points.
- The downloader spinlock is not added for staking information requests. It plays a role of throttling not to process extra tasks 

Weirdly, right after the snap sync it takes too much time to restart full sync. The change resolve this problem.
- check out this PR: https://github.com/ethereum/go-ethereum/pull/17825

I did `kill -abrt <ken pid>` and attached the logs partially. 

```
298226 goroutine 201714 [select, 40 minutes]:
298227 reflect.rselect(0xc0037bd810, 0x2, 0x4, 0x1c9e950, 0xe)
298228         /usr/local/go/src/runtime/select.go:566 +0x390
298229 reflect.Select(0xc01b83c2a0, 0x2, 0x4, 0x1b5c7a0, 0xc051addb90, 0x99, 0x0, 0x3)
298230         /usr/local/go/src/reflect/value.go:2260 +0x19c
298231 github.com/klaytn/klaytn/event.(*Feed).Send(0xc0000120b8, 0x1b5c7a0, 0xc051addb90, 0xc051addb90)
298232         /ext-go/3/src/github.com/klaytn/klaytn/event/feed.go:172 +0x5a5
298233 github.com/klaytn/klaytn/blockchain.(*BlockChain).PostChainEvents(0xc000012000, 0xc00ac68e00, 0x36, 0x70, 0xc041d9a570, 0x5, 0x6)
298234         /ext-go/3/src/github.com/klaytn/klaytn/blockchain/blockchain.go:2359 +0x1de
298235 github.com/klaytn/klaytn/blockchain.(*BlockChain).InsertChain(0xc000012000, 0xc003948540, 0x35, 0x35, 0x0, 0x0, 0x100)
298236         /ext-go/3/src/github.com/klaytn/klaytn/blockchain/blockchain.go:1726 +0xd2
298237 github.com/klaytn/klaytn/datasync/downloader.(*Downloader).importBlockResults(0xc0108843c0, 0xc01677a600, 0x35, 0x40, 0xc002864460, 0x0)
298238         /ext-go/3/src/github.com/klaytn/klaytn/datasync/downloader/downloader.go:1585 +0x539
298239 github.com/klaytn/klaytn/datasync/downloader.(*Downloader).processFastSyncContent(0xc0108843c0, 0x0, 0x0)
298240         /ext-go/3/src/github.com/klaytn/klaytn/datasync/downloader/downloader.go:1703 +0x93c
298241 github.com/klaytn/klaytn/datasync/downloader.(*Downloader).syncWithPeer.func8(0x3d87a6aab4b10791, 0x9034087b141cd0e4)
298242         /ext-go/3/src/github.com/klaytn/klaytn/datasync/downloader/downloader.go:539 +0x2a
298243 github.com/klaytn/klaytn/datasync/downloader.(*Downloader).spawnSync.func1(0xc0108843c0, 0xc006881200, 0xc01e090450)
298244         /ext-go/3/src/github.com/klaytn/klaytn/datasync/downloader/downloader.go:556 +0x5b
298245 created by github.com/klaytn/klaytn/datasync/downloader.(*Downloader).spawnSync
298246         /ext-go/3/src/github.com/klaytn/klaytn/datasync/downloader/downloader.go:556 +0x16f
```

```
297448 goroutine 196 [runnable]:
297449 github.com/syndtr/goleveldb/leveldb.(*iComparer).uCompare(...)
297450         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/comparer.go:22
297451 github.com/syndtr/goleveldb/leveldb.(*iComparer).Compare(0xc00088e2a0, 0xc0345c8c31, 0x12, 0x2ec4e, 0xc054967180, 0x31, 0x31, 0xffffffffffffffff)
297452         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/comparer.go:38 +0xe7
297453 github.com/syndtr/goleveldb/leveldb/table.(*block).seek.func1(0x1b7, 0xc059e14700)
297454         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/table/reader.go:71 +0x1d3
297455 sort.Search(0x10ee, 0xc0005ff270, 0xc000680400)
297456         /usr/local/go/src/sort/search.go:66 +0x58
297457 github.com/syndtr/goleveldb/leveldb/table.(*block).seek(0xc03b3e0580, 0x1fa0b80, 0xc00088e2a0, 0x0, 0x10ee, 0xc054967180, 0x31, 0x31, 0x1f76fc0, 0x4499bb, ...)
297458         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/table/reader.go:65 +0xc5
297459 github.com/syndtr/goleveldb/leveldb/table.(*blockIter).Seek(0xc00853a0f0, 0xc054967180, 0x31, 0x31, 0x0)
297460         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/table/reader.go:232 +0xe5
297461 github.com/syndtr/goleveldb/leveldb/table.(*Reader).find(0xc0593229c0, 0xc054967180, 0x31, 0x31, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
297462         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/table/reader.go:838 +0x225
297463 github.com/syndtr/goleveldb/leveldb/table.(*Reader).Find(...)
297464         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/table/reader.go:922
297465 github.com/syndtr/goleveldb/leveldb.(*tOps).find(0xc000721560, 0xc04ee922d0, 0xc054967180, 0x31, 0x31, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
297466         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/table.go:450 +0x150
297467 github.com/syndtr/goleveldb/leveldb.(*version).get.func1(0x0, 0xc04ee922d0, 0xc054967180)
297468         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/version.go:180 +0x465
297469 github.com/syndtr/goleveldb/leveldb.(*version).walkOverlapping(0xc028370180, 0x0, 0x0, 0x0, 0xc054967180, 0x31, 0x31, 0xc0005ff820, 0xc0005ff7f0)
297470         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/version.go:119 +0x2a9
297471 github.com/syndtr/goleveldb/leveldb.(*version).get(0xc028370180, 0x0, 0x0, 0x0, 0xc054967180, 0x31, 0x31, 0x0, 0x12fff00, 0x0, ...)
297472         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/version.go:164 +0x2f1
297473 github.com/syndtr/goleveldb/leveldb.(*DB).get(0xc000245500, 0x0, 0x0, 0x0, 0x0, 0xc045c6b050, 0x29, 0x30, 0x16cb5e3d, 0x0, ...)
297474         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/db.go:785 +0x38d
297475 github.com/syndtr/goleveldb/leveldb.(*DB).Get(0xc000245500, 0xc045c6b050, 0x29, 0x30, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
297476         /go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/db.go:851 +0x13b
297477 github.com/klaytn/klaytn/storage/database.(*levelDB).get(0xc00018f400, 0xc045c6b050, 0x29, 0x30, 0x10, 0x29, 0xc045c6b050, 0x9, 0x30)
297478         /ext-go/3/src/github.com/klaytn/klaytn/storage/database/leveldb_database.go:299 +0x65
297479 github.com/klaytn/klaytn/storage/database.(*levelDB).Get(0xc00018f400, 0xc045c6b050, 0x29, 0x30, 0xfe9e9667030b86fd, 0xc045c6b050, 0x29, 0x30, 0xfe9e9667030b86fd)
297480         /ext-go/3/src/github.com/klaytn/klaytn/storage/database/leveldb_database.go:290 +0xa5
297481 github.com/klaytn/klaytn/storage/database.(*databaseManager).ReadHeaderRLP(0xc000130410, 0x422d56c4ca8325b5, 0xaa4e41bf553ce7e5, 0x8f8c8b8589c1e844, 0xfe9e9667030b86fd, 0x3913ba3, 0xc008538380, 0x338, 0x380)
297482         /ext-go/3/src/github.com/klaytn/klaytn/storage/database/db_manager.go:1018 +0xc7
297483 github.com/klaytn/klaytn/storage/database.(*databaseManager).ReadHeader(0xc000130410, 0x422d56c4ca8325b5, 0xaa4e41bf553ce7e5, 0x8f8c8b8589c1e844, 0xfe9e9667030b86fd, 0x3913ba3, 0xc008536900)
297484         /ext-go/3/src/github.com/klaytn/klaytn/storage/database/db_manager.go:1000 +0xa5
297485 github.com/klaytn/klaytn/storage/database.(*databaseManager).FindCommonAncestor(0xc000130410, 0xc00021a6c0, 0xc002375b00, 0x0)
297486         /ext-go/3/src/github.com/klaytn/klaytn/storage/database/db_manager.go:1465 +0x1ca
297487 github.com/klaytn/klaytn/blockchain.(*ChainIndexer).eventLoop(0xc000aba180, 0xc00021a6c0, 0xc000ab1a40, 0x1f8a4c0, 0xc0007c3a80)
297488         /ext-go/3/src/github.com/klaytn/klaytn/blockchain/chain_indexer.go:213 +0x318
297489 created by github.com/klaytn/klaytn/blockchain.(*ChainIndexer).Start
297490         /ext-go/3/src/github.com/klaytn/klaytn/blockchain/chain_indexer.go:136 +0xcf
```


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

