### PR TITLE
Use both 'go get' and 'go install' to install xgo

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -1007,14 +1007,13 @@ func doXgo(cmdline []string) {
 	flag.CommandLine.Parse(cmdline)
 	env := build.Env()
 
-	subCmd := "get"
-	if strings.HasPrefix(runtime.Version(), "go1.18") {
-		subCmd = "install"
-	}
-
 	// Make sure xgo is available for cross compilation
-	gogetxgo := goTool(subCmd, "github.com/klaytn/xgo")
-	build.MustRun(gogetxgo)
+	build.MustRun(goTool("get", "github.com/klaytn/xgo"))
+
+	// From go1.18, golang requires 'go install' to install a package binary
+	if strings.Compare(runtime.Version(), "go1.18") >= 0 {
+		build.MustRun(goTool("install", "github.com/klaytn/xgo"))
+	}
 
 	// If all tools building is requested, build everything the builder wants
 	args := append(buildFlags(env), flag.Args()...)


### PR DESCRIPTION
## Proposed changes

From go1.18, go requires another way to install packages.
It registers a package in `go.mod` using`go get` and installs the package binary using `go install` 
(Reference: search 'go get' in https://tip.golang.org/doc/go1.18)

After merging https://github.com/klaytn/klaytn/pull/1385, `xgo` is removed from `go.mod`.
So, we need to call both `go get` and `go install` to install `xgo` with go1.18 or later. 


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
