### PR TITLE
Enable ContractEngine by hardfork

### DIFF
--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -127,6 +127,7 @@ Args :
 		istanbulCompatibleBlockNumberFlag,
 		londonCompatibleBlockNumberFlag,
 		ethTxTypeCompatibleBlockNumberFlag,
+		contractGovCompatibleBlockNumberFlag,
 	},
 	ArgsUsage: "type",
 }
@@ -515,6 +516,7 @@ func gen(ctx *cli.Context) error {
 	genesisJson.Config.IstanbulCompatibleBlock = big.NewInt(ctx.Int64(istanbulCompatibleBlockNumberFlag.Name))
 	genesisJson.Config.LondonCompatibleBlock = big.NewInt(ctx.Int64(londonCompatibleBlockNumberFlag.Name))
 	genesisJson.Config.EthTxTypeCompatibleBlock = big.NewInt(ctx.Int64(ethTxTypeCompatibleBlockNumberFlag.Name))
+	genesisJson.Config.ContractGovCompatibleBlock = big.NewInt(ctx.Int64(contractGovCompatibleBlockNumberFlag.Name))
 
 	genesisJsonBytes, _ = json.MarshalIndent(genesisJson, "", "    ")
 	genValidatorKeystore(privKeys)

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -111,6 +111,7 @@ Args :
 		governanceFlag,
 		govModeFlag,
 		governingNodeFlag,
+		govContractFlag,
 		rewardMintAmountFlag,
 		rewardRatioFlag,
 		rewardGiniCoeffFlag,
@@ -211,12 +212,17 @@ func genGovernanceConfig(ctx *cli.Context) *params.GovernanceConfig {
 	govMode := ctx.String(govModeFlag.Name)
 	governingNode := ctx.String(governingNodeFlag.Name)
 	if !common.IsHexAddress(governingNode) {
-		log.Fatalf("Governing Node is invalid hex address", "value", governingNode)
+		log.Fatalf("Governing Node is not a valid hex address", "value", governingNode)
+	}
+	govContract := ctx.String(govContractFlag.Name)
+	if !common.IsHexAddress(govContract) {
+		log.Fatalf("Governance Contract is not a valid hex address", "value", govContract)
 	}
 	return &params.GovernanceConfig{
-		GoverningNode:  common.HexToAddress(governingNode),
-		GovernanceMode: govMode,
-		Reward:         genRewardConfig(ctx),
+		GovernanceMode:     govMode,
+		GoverningNode:      common.HexToAddress(governingNode),
+		GovernanceContract: common.HexToAddress(govContract),
+		Reward:             genRewardConfig(ctx),
 	}
 }
 

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -256,6 +256,12 @@ var (
 		Value: params.DefaultGoverningNode,
 	}
 
+	govContractFlag = cli.StringFlag{
+		Name:  "gov-contract",
+		Usage: "the governance contract [default: 0x0000000000000000000000000000000000000000]",
+		Value: params.DefaultGovernanceContract,
+	}
+
 	rewardMintAmountFlag = cli.StringFlag{
 		Name:  "reward-mint-amount",
 		Usage: "governance minting amount",

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -349,4 +349,10 @@ var (
 		Usage: "ethTxTypeCompatible blockNumber",
 		Value: 0,
 	}
+
+	contractGovCompatibleBlockNumberFlag = cli.Int64Flag{
+		Name:  "contract-gov-compatible-blocknumber",
+		Usage: "contractGovCompatible blockNumber",
+		Value: 0,
+	}
 )

--- a/contracts/generate.go
+++ b/contracts/generate.go
@@ -16,6 +16,8 @@
 
 package contracts
 
+//go:generate abigen --sol ./gov/GovParam.sol --pkg gov --out ./gov/GovParam.go
+
 //go:generate abigen --sol ./bridge/Bridge.sol --pkg bridge --out ./bridge/Bridge.go
 //go:generate abigen --sol ./extbridge/ext_bridge.sol --pkg extbridge --out ./extbridge/ext_bridge.go
 

--- a/contracts/gov/GovParam.go
+++ b/contracts/gov/GovParam.go
@@ -1,0 +1,2257 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package gov
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/klaytn/klaytn"
+	"github.com/klaytn/klaytn/accounts/abi"
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = klaytn.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// GovParamParam is an auto generated low-level Go binding around an user-defined struct.
+type GovParamParam struct {
+	Exists  bool
+	Votable bool
+	Value   []byte
+}
+
+// AddressUpgradeableABI is the input ABI used to generate the binding from.
+const AddressUpgradeableABI = "[]"
+
+// AddressUpgradeableBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const AddressUpgradeableBinRuntime = `73000000000000000000000000000000000000000030146080604052600080fdfea26469706673582212208a4aba28524878c6400bb81f8dc1e1a301c0cbbe6a6d969f445f02128571c88964736f6c634300080e0033`
+
+// AddressUpgradeableBin is the compiled bytecode used for deploying new contracts.
+var AddressUpgradeableBin = "0x60566037600b82828239805160001a607314602a57634e487b7160e01b600052600060045260246000fd5b30600052607381538281f3fe73000000000000000000000000000000000000000030146080604052600080fdfea26469706673582212208a4aba28524878c6400bb81f8dc1e1a301c0cbbe6a6d969f445f02128571c88964736f6c634300080e0033"
+
+// DeployAddressUpgradeable deploys a new Klaytn contract, binding an instance of AddressUpgradeable to it.
+func DeployAddressUpgradeable(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *AddressUpgradeable, error) {
+	parsed, err := abi.JSON(strings.NewReader(AddressUpgradeableABI))
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(AddressUpgradeableBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &AddressUpgradeable{AddressUpgradeableCaller: AddressUpgradeableCaller{contract: contract}, AddressUpgradeableTransactor: AddressUpgradeableTransactor{contract: contract}, AddressUpgradeableFilterer: AddressUpgradeableFilterer{contract: contract}}, nil
+}
+
+// AddressUpgradeable is an auto generated Go binding around a Klaytn contract.
+type AddressUpgradeable struct {
+	AddressUpgradeableCaller     // Read-only binding to the contract
+	AddressUpgradeableTransactor // Write-only binding to the contract
+	AddressUpgradeableFilterer   // Log filterer for contract events
+}
+
+// AddressUpgradeableCaller is an auto generated read-only Go binding around a Klaytn contract.
+type AddressUpgradeableCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AddressUpgradeableTransactor is an auto generated write-only Go binding around a Klaytn contract.
+type AddressUpgradeableTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AddressUpgradeableFilterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type AddressUpgradeableFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AddressUpgradeableSession is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type AddressUpgradeableSession struct {
+	Contract     *AddressUpgradeable // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts       // Call options to use throughout this session
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// AddressUpgradeableCallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type AddressUpgradeableCallerSession struct {
+	Contract *AddressUpgradeableCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts             // Call options to use throughout this session
+}
+
+// AddressUpgradeableTransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type AddressUpgradeableTransactorSession struct {
+	Contract     *AddressUpgradeableTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts             // Transaction auth options to use throughout this session
+}
+
+// AddressUpgradeableRaw is an auto generated low-level Go binding around a Klaytn contract.
+type AddressUpgradeableRaw struct {
+	Contract *AddressUpgradeable // Generic contract binding to access the raw methods on
+}
+
+// AddressUpgradeableCallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type AddressUpgradeableCallerRaw struct {
+	Contract *AddressUpgradeableCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// AddressUpgradeableTransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type AddressUpgradeableTransactorRaw struct {
+	Contract *AddressUpgradeableTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewAddressUpgradeable creates a new instance of AddressUpgradeable, bound to a specific deployed contract.
+func NewAddressUpgradeable(address common.Address, backend bind.ContractBackend) (*AddressUpgradeable, error) {
+	contract, err := bindAddressUpgradeable(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &AddressUpgradeable{AddressUpgradeableCaller: AddressUpgradeableCaller{contract: contract}, AddressUpgradeableTransactor: AddressUpgradeableTransactor{contract: contract}, AddressUpgradeableFilterer: AddressUpgradeableFilterer{contract: contract}}, nil
+}
+
+// NewAddressUpgradeableCaller creates a new read-only instance of AddressUpgradeable, bound to a specific deployed contract.
+func NewAddressUpgradeableCaller(address common.Address, caller bind.ContractCaller) (*AddressUpgradeableCaller, error) {
+	contract, err := bindAddressUpgradeable(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AddressUpgradeableCaller{contract: contract}, nil
+}
+
+// NewAddressUpgradeableTransactor creates a new write-only instance of AddressUpgradeable, bound to a specific deployed contract.
+func NewAddressUpgradeableTransactor(address common.Address, transactor bind.ContractTransactor) (*AddressUpgradeableTransactor, error) {
+	contract, err := bindAddressUpgradeable(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AddressUpgradeableTransactor{contract: contract}, nil
+}
+
+// NewAddressUpgradeableFilterer creates a new log filterer instance of AddressUpgradeable, bound to a specific deployed contract.
+func NewAddressUpgradeableFilterer(address common.Address, filterer bind.ContractFilterer) (*AddressUpgradeableFilterer, error) {
+	contract, err := bindAddressUpgradeable(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &AddressUpgradeableFilterer{contract: contract}, nil
+}
+
+// bindAddressUpgradeable binds a generic wrapper to an already deployed contract.
+func bindAddressUpgradeable(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(AddressUpgradeableABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AddressUpgradeable *AddressUpgradeableRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _AddressUpgradeable.Contract.AddressUpgradeableCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AddressUpgradeable *AddressUpgradeableRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AddressUpgradeable.Contract.AddressUpgradeableTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AddressUpgradeable *AddressUpgradeableRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AddressUpgradeable.Contract.AddressUpgradeableTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AddressUpgradeable *AddressUpgradeableCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _AddressUpgradeable.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AddressUpgradeable *AddressUpgradeableTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AddressUpgradeable.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AddressUpgradeable *AddressUpgradeableTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AddressUpgradeable.Contract.contract.Transact(opts, method, params...)
+}
+
+// ContextUpgradeableABI is the input ABI used to generate the binding from.
+const ContextUpgradeableABI = "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"}]"
+
+// ContextUpgradeableBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const ContextUpgradeableBinRuntime = ``
+
+// ContextUpgradeable is an auto generated Go binding around a Klaytn contract.
+type ContextUpgradeable struct {
+	ContextUpgradeableCaller     // Read-only binding to the contract
+	ContextUpgradeableTransactor // Write-only binding to the contract
+	ContextUpgradeableFilterer   // Log filterer for contract events
+}
+
+// ContextUpgradeableCaller is an auto generated read-only Go binding around a Klaytn contract.
+type ContextUpgradeableCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ContextUpgradeableTransactor is an auto generated write-only Go binding around a Klaytn contract.
+type ContextUpgradeableTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ContextUpgradeableFilterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type ContextUpgradeableFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ContextUpgradeableSession is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type ContextUpgradeableSession struct {
+	Contract     *ContextUpgradeable // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts       // Call options to use throughout this session
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// ContextUpgradeableCallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type ContextUpgradeableCallerSession struct {
+	Contract *ContextUpgradeableCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts             // Call options to use throughout this session
+}
+
+// ContextUpgradeableTransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type ContextUpgradeableTransactorSession struct {
+	Contract     *ContextUpgradeableTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts             // Transaction auth options to use throughout this session
+}
+
+// ContextUpgradeableRaw is an auto generated low-level Go binding around a Klaytn contract.
+type ContextUpgradeableRaw struct {
+	Contract *ContextUpgradeable // Generic contract binding to access the raw methods on
+}
+
+// ContextUpgradeableCallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type ContextUpgradeableCallerRaw struct {
+	Contract *ContextUpgradeableCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ContextUpgradeableTransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type ContextUpgradeableTransactorRaw struct {
+	Contract *ContextUpgradeableTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewContextUpgradeable creates a new instance of ContextUpgradeable, bound to a specific deployed contract.
+func NewContextUpgradeable(address common.Address, backend bind.ContractBackend) (*ContextUpgradeable, error) {
+	contract, err := bindContextUpgradeable(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &ContextUpgradeable{ContextUpgradeableCaller: ContextUpgradeableCaller{contract: contract}, ContextUpgradeableTransactor: ContextUpgradeableTransactor{contract: contract}, ContextUpgradeableFilterer: ContextUpgradeableFilterer{contract: contract}}, nil
+}
+
+// NewContextUpgradeableCaller creates a new read-only instance of ContextUpgradeable, bound to a specific deployed contract.
+func NewContextUpgradeableCaller(address common.Address, caller bind.ContractCaller) (*ContextUpgradeableCaller, error) {
+	contract, err := bindContextUpgradeable(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ContextUpgradeableCaller{contract: contract}, nil
+}
+
+// NewContextUpgradeableTransactor creates a new write-only instance of ContextUpgradeable, bound to a specific deployed contract.
+func NewContextUpgradeableTransactor(address common.Address, transactor bind.ContractTransactor) (*ContextUpgradeableTransactor, error) {
+	contract, err := bindContextUpgradeable(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ContextUpgradeableTransactor{contract: contract}, nil
+}
+
+// NewContextUpgradeableFilterer creates a new log filterer instance of ContextUpgradeable, bound to a specific deployed contract.
+func NewContextUpgradeableFilterer(address common.Address, filterer bind.ContractFilterer) (*ContextUpgradeableFilterer, error) {
+	contract, err := bindContextUpgradeable(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ContextUpgradeableFilterer{contract: contract}, nil
+}
+
+// bindContextUpgradeable binds a generic wrapper to an already deployed contract.
+func bindContextUpgradeable(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(ContextUpgradeableABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ContextUpgradeable *ContextUpgradeableRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _ContextUpgradeable.Contract.ContextUpgradeableCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ContextUpgradeable *ContextUpgradeableRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ContextUpgradeable.Contract.ContextUpgradeableTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ContextUpgradeable *ContextUpgradeableRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ContextUpgradeable.Contract.ContextUpgradeableTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ContextUpgradeable *ContextUpgradeableCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _ContextUpgradeable.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ContextUpgradeable *ContextUpgradeableTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ContextUpgradeable.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ContextUpgradeable *ContextUpgradeableTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ContextUpgradeable.Contract.contract.Transact(opts, method, params...)
+}
+
+// ContextUpgradeableInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the ContextUpgradeable contract.
+type ContextUpgradeableInitializedIterator struct {
+	Event *ContextUpgradeableInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ContextUpgradeableInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ContextUpgradeableInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ContextUpgradeableInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ContextUpgradeableInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ContextUpgradeableInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ContextUpgradeableInitialized represents a Initialized event raised by the ContextUpgradeable contract.
+type ContextUpgradeableInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_ContextUpgradeable *ContextUpgradeableFilterer) FilterInitialized(opts *bind.FilterOpts) (*ContextUpgradeableInitializedIterator, error) {
+
+	logs, sub, err := _ContextUpgradeable.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &ContextUpgradeableInitializedIterator{contract: _ContextUpgradeable.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_ContextUpgradeable *ContextUpgradeableFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *ContextUpgradeableInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _ContextUpgradeable.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ContextUpgradeableInitialized)
+				if err := _ContextUpgradeable.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_ContextUpgradeable *ContextUpgradeableFilterer) ParseInitialized(log types.Log) (*ContextUpgradeableInitialized, error) {
+	event := new(ContextUpgradeableInitialized)
+	if err := _ContextUpgradeable.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// GovParamABI is the input ABI used to generate the binding from.
+const GovParamABI = "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"SetParam\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"name\":\"SetParamVotable\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"getAllParams\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"exists\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"votable\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"value\",\"type\":\"bytes\"}],\"internalType\":\"structGovParam.Param[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getGovernaceAddress\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getParam\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"governanceAddr\",\"type\":\"address\"}],\"name\":\"setGovernanceAddr\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"bytes\",\"name\":\"value\",\"type\":\"bytes\"}],\"name\":\"setParam\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"bytes\",\"name\":\"value\",\"type\":\"bytes\"}],\"name\":\"setParamByOwner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"setParamVotable\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+
+// GovParamBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const GovParamBinRuntime = `608060405234801561001057600080fd5b50600436106100a95760003560e01c80638da5cb5b116100715780638da5cb5b1461011a5780638e87fc1a1461013f578063a170052e14610152578063c4d66de814610168578063ee9c780a1461017b578063f2fde38b1461018c57600080fd5b806305d2b1bb146100ae5780632b813437146100c3578063400e3f6f146100d65780635d4f71d4146100e9578063715018a614610112575b600080fd5b6100c16100bc366004610ea0565b61019f565b005b6100c16100d1366004610ea0565b610270565b6100c16100e4366004610f22565b610379565b6100fc6100f7366004610f22565b61050b565b604051610109919061102b565b60405180910390f35b6100c16105f9565b6033546001600160a01b03165b6040516001600160a01b039091168152602001610109565b6100c161014d366004611045565b61062f565b61015a6106ee565b60405161010992919061106e565b6100c1610176366004611045565b610a02565b6067546001600160a01b0316610127565b6100c161019a366004611045565b610a90565b6033546001600160a01b031633146101d25760405162461bcd60e51b81526004016101c990611145565b60405180910390fd5b606684846040516101e492919061117a565b9081526040519081900360200190205460ff610100909104161561025e5760405162461bcd60e51b815260206004820152602b60248201527f476f76506172616d3a20706172616d566f7461626c65206d757374206265207360448201526a657420746f2066616c736560a81b60648201526084016101c9565b61026a84848484610b2b565b50505050565b6067546001600160a01b0316336001600160a01b0316146102e95760405162461bcd60e51b815260206004820152602d60248201527f476f76506172616d3a2063616c6c6572206973206e6f74206120476f7665726e60448201526c185b98d94810dbdb9d1c9858dd609a1b60648201526084016101c9565b606684846040516102fb92919061117a565b9081526040519081900360200190205460ff61010090910416151560011461025e5760405162461bcd60e51b815260206004820152602b60248201527f476f76506172616d3a20706172616d566f7461626c65206d757374206265202060448201526a73657420746f207472756560a81b60648201526084016101c9565b6033546001600160a01b031633146103a35760405162461bcd60e51b81526004016101c990611145565b60008151116103f45760405162461bcd60e51b815260206004820152601e60248201527f476f76506172616d3a206e616d652063616e6e6f7420626520656d707479000060448201526064016101c9565b606681604051610404919061118a565b9081526040519081900360200190205460ff1661046f5760405162461bcd60e51b815260206004820152602360248201527f476f76506172616d3a20706172616d6574657220646f6573206e6f742065786960448201526273747360e81b60648201526084016101c9565b6001606682604051610481919061118a565b90815260405190819003602001812080549215156101000261ff0019909316929092179091557f064a476da825aa99a31c682cc490b34f462457006480bda5cb27151a201213f59082906066906104d990839061118a565b90815260405190819003602001812054610500929160ff61010090920491909116906111a6565b60405180910390a150565b606060668260405161051d919061118a565b9081526040519081900360200190205460ff1661054857505060408051602081019091526000815290565b606682604051610558919061118a565b90815260200160405180910390206001018054610574906111ca565b80601f01602080910402602001604051908101604052809291908181526020018280546105a0906111ca565b80156105ed5780601f106105c2576101008083540402835291602001916105ed565b820191906000526020600020905b8154815290600101906020018083116105d057829003601f168201915b50505050509050919050565b6033546001600160a01b031633146106235760405162461bcd60e51b81526004016101c990611145565b61062d6000610c8a565b565b6033546001600160a01b031633146106595760405162461bcd60e51b81526004016101c990611145565b6001600160a01b0381166106cc5760405162461bcd60e51b815260206004820152603460248201527f476f76506172616d3a20676f7665726e616e636520636f6e74726163742063616044820152736e6e6f74206265207a65726f206164647265737360601b60648201526084016101c9565b606780546001600160a01b0319166001600160a01b0392909216919091179055565b606080600060658054905067ffffffffffffffff81111561071157610711610f0c565b60405190808252806020026020018201604052801561075e57816020015b6040805160608082018352600080835260208301529181019190915281526020019060019003908161072f5790505b50905060005b6065548110156109225760006065828154811061078357610783611204565b906000526020600020018054610798906111ca565b80601f01602080910402602001604051908101604052809291908181526020018280546107c4906111ca565b80156108115780601f106107e657610100808354040283529160200191610811565b820191906000526020600020905b8154815290600101906020018083116107f457829003601f168201915b50505050509050606681604051610828919061118a565b908152604080519182900360209081018320606084018352805460ff8082161515865261010090910416151591840191909152600181018054919284019161086f906111ca565b80601f016020809104026020016040519081016040528092919081815260200182805461089b906111ca565b80156108e85780601f106108bd576101008083540402835291602001916108e8565b820191906000526020600020905b8154815290600101906020018083116108cb57829003601f168201915b50505050508152505083838151811061090357610903611204565b602002602001018190525050808061091a9061121a565b915050610764565b5060658181805480602002602001604051908101604052809291908181526020016000905b828210156109f3578382906000526020600020018054610966906111ca565b80601f0160208091040260200160405190810160405280929190818152602001828054610992906111ca565b80156109df5780601f106109b4576101008083540402835291602001916109df565b820191906000526020600020905b8154815290600101906020018083116109c257829003601f168201915b505050505081526020019060010190610947565b50505050915092509250509091565b6000610a0e6001610cdc565b90508015610a26576000805461ff0019166101001790555b610a2e610d64565b6001600160a01b03821615610a4657610a4682610c8a565b8015610a8c576000805461ff0019169055604051600181527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b5050565b6033546001600160a01b03163314610aba5760405162461bcd60e51b81526004016101c990611145565b6001600160a01b038116610b1f5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b60648201526084016101c9565b610b2881610c8a565b50565b82610b785760405162461bcd60e51b815260206004820152601e60248201527f476f76506172616d3a206e616d652063616e6e6f7420626520656d707479000060448201526064016101c9565b60668484604051610b8a92919061117a565b9081526040519081900360200190205460ff16610c1457600160668585604051610bb592919061117a565b908152604051908190036020019020805491151560ff1990921691909117905560658054600181018255600091909152610c12907f8ff97419363ffd7000167f130ef7168fbea05faf9251824ca5043f113cc6a7c7018585610dbe565b505b818160668686604051610c2892919061117a565b90815260200160405180910390206001019190610c46929190610dbe565b507f9067e93c0b7173962f200e7f543c8b0496b9d00bcf35715553da6a4a9f66d0a784848484604051610c7c949392919061126a565b60405180910390a150505050565b603380546001600160a01b038381166001600160a01b0319831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b60008054610100900460ff1615610d23578160ff166001148015610cff5750303b155b610d1b5760405162461bcd60e51b81526004016101c99061129c565b506000919050565b60005460ff808416911610610d4a5760405162461bcd60e51b81526004016101c99061129c565b506000805460ff191660ff92909216919091179055600190565b600054610100900460ff16610d8b5760405162461bcd60e51b81526004016101c9906112ea565b61062d600054610100900460ff16610db55760405162461bcd60e51b81526004016101c9906112ea565b61062d33610c8a565b828054610dca906111ca565b90600052602060002090601f016020900481019282610dec5760008555610e32565b82601f10610e055782800160ff19823516178555610e32565b82800160010185558215610e32579182015b82811115610e32578235825591602001919060010190610e17565b50610e3e929150610e42565b5090565b5b80821115610e3e5760008155600101610e43565b60008083601f840112610e6957600080fd5b50813567ffffffffffffffff811115610e8157600080fd5b602083019150836020828501011115610e9957600080fd5b9250929050565b60008060008060408587031215610eb657600080fd5b843567ffffffffffffffff80821115610ece57600080fd5b610eda88838901610e57565b90965094506020870135915080821115610ef357600080fd5b50610f0087828801610e57565b95989497509550505050565b634e487b7160e01b600052604160045260246000fd5b600060208284031215610f3457600080fd5b813567ffffffffffffffff80821115610f4c57600080fd5b818401915084601f830112610f6057600080fd5b813581811115610f7257610f72610f0c565b604051601f8201601f19908116603f01168101908382118183101715610f9a57610f9a610f0c565b81604052828152876020848701011115610fb357600080fd5b826020860160208301376000928101602001929092525095945050505050565b60005b83811015610fee578181015183820152602001610fd6565b8381111561026a5750506000910152565b60008151808452611017816020860160208601610fd3565b601f01601f19169290920160200192915050565b60208152600061103e6020830184610fff565b9392505050565b60006020828403121561105757600080fd5b81356001600160a01b038116811461103e57600080fd5b60006040808301818452808651808352606092508286019150828160051b8701016020808a0160005b848110156110c557605f198a85030186526110b3848351610fff565b95830195935090820190600101611097565b505087820381890152885180835281830194509250600583901b8201810189820160005b8581101561113457848303601f1901875281518051151584528481015115158585015289015189840189905261112189850182610fff565b97850197935050908301906001016110e9565b50909b9a5050505050505050505050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b8183823760009101908152919050565b6000825161119c818460208701610fd3565b9190910192915050565b6040815260006111b96040830185610fff565b905082151560208301529392505050565b600181811c908216806111de57607f821691505b6020821081036111fe57634e487b7160e01b600052602260045260246000fd5b50919050565b634e487b7160e01b600052603260045260246000fd5b60006001820161123a57634e487b7160e01b600052601160045260246000fd5b5060010190565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b60408152600061127e604083018688611241565b8281036020840152611291818587611241565b979650505050505050565b6020808252602e908201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160408201526d191e481a5b9a5d1a585b1a5e995960921b606082015260800190565b6020808252602b908201527f496e697469616c697a61626c653a20636f6e7472616374206973206e6f74206960408201526a6e697469616c697a696e6760a81b60608201526080019056fea2646970667358221220c462d6dbdae6628f5995bb10b97bc2f5d900ffe41f89c1a37108105f6d0091a464736f6c634300080e0033`
+
+// GovParamFuncSigs maps the 4-byte function signature to its string representation.
+var GovParamFuncSigs = map[string]string{
+	"a170052e": "getAllParams()",
+	"ee9c780a": "getGovernaceAddress()",
+	"5d4f71d4": "getParam(string)",
+	"c4d66de8": "initialize(address)",
+	"8da5cb5b": "owner()",
+	"715018a6": "renounceOwnership()",
+	"8e87fc1a": "setGovernanceAddr(address)",
+	"2b813437": "setParam(string,bytes)",
+	"05d2b1bb": "setParamByOwner(string,bytes)",
+	"400e3f6f": "setParamVotable(string)",
+	"f2fde38b": "transferOwnership(address)",
+}
+
+// GovParamBin is the compiled bytecode used for deploying new contracts.
+var GovParamBin = "0x608060405234801561001057600080fd5b5061136b806100206000396000f3fe608060405234801561001057600080fd5b50600436106100a95760003560e01c80638da5cb5b116100715780638da5cb5b1461011a5780638e87fc1a1461013f578063a170052e14610152578063c4d66de814610168578063ee9c780a1461017b578063f2fde38b1461018c57600080fd5b806305d2b1bb146100ae5780632b813437146100c3578063400e3f6f146100d65780635d4f71d4146100e9578063715018a614610112575b600080fd5b6100c16100bc366004610ea0565b61019f565b005b6100c16100d1366004610ea0565b610270565b6100c16100e4366004610f22565b610379565b6100fc6100f7366004610f22565b61050b565b604051610109919061102b565b60405180910390f35b6100c16105f9565b6033546001600160a01b03165b6040516001600160a01b039091168152602001610109565b6100c161014d366004611045565b61062f565b61015a6106ee565b60405161010992919061106e565b6100c1610176366004611045565b610a02565b6067546001600160a01b0316610127565b6100c161019a366004611045565b610a90565b6033546001600160a01b031633146101d25760405162461bcd60e51b81526004016101c990611145565b60405180910390fd5b606684846040516101e492919061117a565b9081526040519081900360200190205460ff610100909104161561025e5760405162461bcd60e51b815260206004820152602b60248201527f476f76506172616d3a20706172616d566f7461626c65206d757374206265207360448201526a657420746f2066616c736560a81b60648201526084016101c9565b61026a84848484610b2b565b50505050565b6067546001600160a01b0316336001600160a01b0316146102e95760405162461bcd60e51b815260206004820152602d60248201527f476f76506172616d3a2063616c6c6572206973206e6f74206120476f7665726e60448201526c185b98d94810dbdb9d1c9858dd609a1b60648201526084016101c9565b606684846040516102fb92919061117a565b9081526040519081900360200190205460ff61010090910416151560011461025e5760405162461bcd60e51b815260206004820152602b60248201527f476f76506172616d3a20706172616d566f7461626c65206d757374206265202060448201526a73657420746f207472756560a81b60648201526084016101c9565b6033546001600160a01b031633146103a35760405162461bcd60e51b81526004016101c990611145565b60008151116103f45760405162461bcd60e51b815260206004820152601e60248201527f476f76506172616d3a206e616d652063616e6e6f7420626520656d707479000060448201526064016101c9565b606681604051610404919061118a565b9081526040519081900360200190205460ff1661046f5760405162461bcd60e51b815260206004820152602360248201527f476f76506172616d3a20706172616d6574657220646f6573206e6f742065786960448201526273747360e81b60648201526084016101c9565b6001606682604051610481919061118a565b90815260405190819003602001812080549215156101000261ff0019909316929092179091557f064a476da825aa99a31c682cc490b34f462457006480bda5cb27151a201213f59082906066906104d990839061118a565b90815260405190819003602001812054610500929160ff61010090920491909116906111a6565b60405180910390a150565b606060668260405161051d919061118a565b9081526040519081900360200190205460ff1661054857505060408051602081019091526000815290565b606682604051610558919061118a565b90815260200160405180910390206001018054610574906111ca565b80601f01602080910402602001604051908101604052809291908181526020018280546105a0906111ca565b80156105ed5780601f106105c2576101008083540402835291602001916105ed565b820191906000526020600020905b8154815290600101906020018083116105d057829003601f168201915b50505050509050919050565b6033546001600160a01b031633146106235760405162461bcd60e51b81526004016101c990611145565b61062d6000610c8a565b565b6033546001600160a01b031633146106595760405162461bcd60e51b81526004016101c990611145565b6001600160a01b0381166106cc5760405162461bcd60e51b815260206004820152603460248201527f476f76506172616d3a20676f7665726e616e636520636f6e74726163742063616044820152736e6e6f74206265207a65726f206164647265737360601b60648201526084016101c9565b606780546001600160a01b0319166001600160a01b0392909216919091179055565b606080600060658054905067ffffffffffffffff81111561071157610711610f0c565b60405190808252806020026020018201604052801561075e57816020015b6040805160608082018352600080835260208301529181019190915281526020019060019003908161072f5790505b50905060005b6065548110156109225760006065828154811061078357610783611204565b906000526020600020018054610798906111ca565b80601f01602080910402602001604051908101604052809291908181526020018280546107c4906111ca565b80156108115780601f106107e657610100808354040283529160200191610811565b820191906000526020600020905b8154815290600101906020018083116107f457829003601f168201915b50505050509050606681604051610828919061118a565b908152604080519182900360209081018320606084018352805460ff8082161515865261010090910416151591840191909152600181018054919284019161086f906111ca565b80601f016020809104026020016040519081016040528092919081815260200182805461089b906111ca565b80156108e85780601f106108bd576101008083540402835291602001916108e8565b820191906000526020600020905b8154815290600101906020018083116108cb57829003601f168201915b50505050508152505083838151811061090357610903611204565b602002602001018190525050808061091a9061121a565b915050610764565b5060658181805480602002602001604051908101604052809291908181526020016000905b828210156109f3578382906000526020600020018054610966906111ca565b80601f0160208091040260200160405190810160405280929190818152602001828054610992906111ca565b80156109df5780601f106109b4576101008083540402835291602001916109df565b820191906000526020600020905b8154815290600101906020018083116109c257829003601f168201915b505050505081526020019060010190610947565b50505050915092509250509091565b6000610a0e6001610cdc565b90508015610a26576000805461ff0019166101001790555b610a2e610d64565b6001600160a01b03821615610a4657610a4682610c8a565b8015610a8c576000805461ff0019169055604051600181527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b5050565b6033546001600160a01b03163314610aba5760405162461bcd60e51b81526004016101c990611145565b6001600160a01b038116610b1f5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b60648201526084016101c9565b610b2881610c8a565b50565b82610b785760405162461bcd60e51b815260206004820152601e60248201527f476f76506172616d3a206e616d652063616e6e6f7420626520656d707479000060448201526064016101c9565b60668484604051610b8a92919061117a565b9081526040519081900360200190205460ff16610c1457600160668585604051610bb592919061117a565b908152604051908190036020019020805491151560ff1990921691909117905560658054600181018255600091909152610c12907f8ff97419363ffd7000167f130ef7168fbea05faf9251824ca5043f113cc6a7c7018585610dbe565b505b818160668686604051610c2892919061117a565b90815260200160405180910390206001019190610c46929190610dbe565b507f9067e93c0b7173962f200e7f543c8b0496b9d00bcf35715553da6a4a9f66d0a784848484604051610c7c949392919061126a565b60405180910390a150505050565b603380546001600160a01b038381166001600160a01b0319831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b60008054610100900460ff1615610d23578160ff166001148015610cff5750303b155b610d1b5760405162461bcd60e51b81526004016101c99061129c565b506000919050565b60005460ff808416911610610d4a5760405162461bcd60e51b81526004016101c99061129c565b506000805460ff191660ff92909216919091179055600190565b600054610100900460ff16610d8b5760405162461bcd60e51b81526004016101c9906112ea565b61062d600054610100900460ff16610db55760405162461bcd60e51b81526004016101c9906112ea565b61062d33610c8a565b828054610dca906111ca565b90600052602060002090601f016020900481019282610dec5760008555610e32565b82601f10610e055782800160ff19823516178555610e32565b82800160010185558215610e32579182015b82811115610e32578235825591602001919060010190610e17565b50610e3e929150610e42565b5090565b5b80821115610e3e5760008155600101610e43565b60008083601f840112610e6957600080fd5b50813567ffffffffffffffff811115610e8157600080fd5b602083019150836020828501011115610e9957600080fd5b9250929050565b60008060008060408587031215610eb657600080fd5b843567ffffffffffffffff80821115610ece57600080fd5b610eda88838901610e57565b90965094506020870135915080821115610ef357600080fd5b50610f0087828801610e57565b95989497509550505050565b634e487b7160e01b600052604160045260246000fd5b600060208284031215610f3457600080fd5b813567ffffffffffffffff80821115610f4c57600080fd5b818401915084601f830112610f6057600080fd5b813581811115610f7257610f72610f0c565b604051601f8201601f19908116603f01168101908382118183101715610f9a57610f9a610f0c565b81604052828152876020848701011115610fb357600080fd5b826020860160208301376000928101602001929092525095945050505050565b60005b83811015610fee578181015183820152602001610fd6565b8381111561026a5750506000910152565b60008151808452611017816020860160208601610fd3565b601f01601f19169290920160200192915050565b60208152600061103e6020830184610fff565b9392505050565b60006020828403121561105757600080fd5b81356001600160a01b038116811461103e57600080fd5b60006040808301818452808651808352606092508286019150828160051b8701016020808a0160005b848110156110c557605f198a85030186526110b3848351610fff565b95830195935090820190600101611097565b505087820381890152885180835281830194509250600583901b8201810189820160005b8581101561113457848303601f1901875281518051151584528481015115158585015289015189840189905261112189850182610fff565b97850197935050908301906001016110e9565b50909b9a5050505050505050505050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b8183823760009101908152919050565b6000825161119c818460208701610fd3565b9190910192915050565b6040815260006111b96040830185610fff565b905082151560208301529392505050565b600181811c908216806111de57607f821691505b6020821081036111fe57634e487b7160e01b600052602260045260246000fd5b50919050565b634e487b7160e01b600052603260045260246000fd5b60006001820161123a57634e487b7160e01b600052601160045260246000fd5b5060010190565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b60408152600061127e604083018688611241565b8281036020840152611291818587611241565b979650505050505050565b6020808252602e908201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160408201526d191e481a5b9a5d1a585b1a5e995960921b606082015260800190565b6020808252602b908201527f496e697469616c697a61626c653a20636f6e7472616374206973206e6f74206960408201526a6e697469616c697a696e6760a81b60608201526080019056fea2646970667358221220c462d6dbdae6628f5995bb10b97bc2f5d900ffe41f89c1a37108105f6d0091a464736f6c634300080e0033"
+
+// DeployGovParam deploys a new Klaytn contract, binding an instance of GovParam to it.
+func DeployGovParam(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *GovParam, error) {
+	parsed, err := abi.JSON(strings.NewReader(GovParamABI))
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(GovParamBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &GovParam{GovParamCaller: GovParamCaller{contract: contract}, GovParamTransactor: GovParamTransactor{contract: contract}, GovParamFilterer: GovParamFilterer{contract: contract}}, nil
+}
+
+// GovParam is an auto generated Go binding around a Klaytn contract.
+type GovParam struct {
+	GovParamCaller     // Read-only binding to the contract
+	GovParamTransactor // Write-only binding to the contract
+	GovParamFilterer   // Log filterer for contract events
+}
+
+// GovParamCaller is an auto generated read-only Go binding around a Klaytn contract.
+type GovParamCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GovParamTransactor is an auto generated write-only Go binding around a Klaytn contract.
+type GovParamTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GovParamFilterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type GovParamFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GovParamSession is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type GovParamSession struct {
+	Contract     *GovParam         // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// GovParamCallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type GovParamCallerSession struct {
+	Contract *GovParamCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts   // Call options to use throughout this session
+}
+
+// GovParamTransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type GovParamTransactorSession struct {
+	Contract     *GovParamTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// GovParamRaw is an auto generated low-level Go binding around a Klaytn contract.
+type GovParamRaw struct {
+	Contract *GovParam // Generic contract binding to access the raw methods on
+}
+
+// GovParamCallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type GovParamCallerRaw struct {
+	Contract *GovParamCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// GovParamTransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type GovParamTransactorRaw struct {
+	Contract *GovParamTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewGovParam creates a new instance of GovParam, bound to a specific deployed contract.
+func NewGovParam(address common.Address, backend bind.ContractBackend) (*GovParam, error) {
+	contract, err := bindGovParam(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &GovParam{GovParamCaller: GovParamCaller{contract: contract}, GovParamTransactor: GovParamTransactor{contract: contract}, GovParamFilterer: GovParamFilterer{contract: contract}}, nil
+}
+
+// NewGovParamCaller creates a new read-only instance of GovParam, bound to a specific deployed contract.
+func NewGovParamCaller(address common.Address, caller bind.ContractCaller) (*GovParamCaller, error) {
+	contract, err := bindGovParam(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &GovParamCaller{contract: contract}, nil
+}
+
+// NewGovParamTransactor creates a new write-only instance of GovParam, bound to a specific deployed contract.
+func NewGovParamTransactor(address common.Address, transactor bind.ContractTransactor) (*GovParamTransactor, error) {
+	contract, err := bindGovParam(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &GovParamTransactor{contract: contract}, nil
+}
+
+// NewGovParamFilterer creates a new log filterer instance of GovParam, bound to a specific deployed contract.
+func NewGovParamFilterer(address common.Address, filterer bind.ContractFilterer) (*GovParamFilterer, error) {
+	contract, err := bindGovParam(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &GovParamFilterer{contract: contract}, nil
+}
+
+// bindGovParam binds a generic wrapper to an already deployed contract.
+func bindGovParam(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(GovParamABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_GovParam *GovParamRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _GovParam.Contract.GovParamCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_GovParam *GovParamRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GovParam.Contract.GovParamTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_GovParam *GovParamRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _GovParam.Contract.GovParamTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_GovParam *GovParamCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _GovParam.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_GovParam *GovParamTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GovParam.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_GovParam *GovParamTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _GovParam.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetAllParams is a free data retrieval call binding the contract method 0xa170052e.
+//
+// Solidity: function getAllParams() view returns(string[], (bool,bool,bytes)[])
+func (_GovParam *GovParamCaller) GetAllParams(opts *bind.CallOpts) ([]string, []GovParamParam, error) {
+	var (
+		ret0 = new([]string)
+		ret1 = new([]GovParamParam)
+	)
+	out := &[]interface{}{
+		ret0,
+		ret1,
+	}
+	err := _GovParam.contract.Call(opts, out, "getAllParams")
+	return *ret0, *ret1, err
+}
+
+// GetAllParams is a free data retrieval call binding the contract method 0xa170052e.
+//
+// Solidity: function getAllParams() view returns(string[], (bool,bool,bytes)[])
+func (_GovParam *GovParamSession) GetAllParams() ([]string, []GovParamParam, error) {
+	return _GovParam.Contract.GetAllParams(&_GovParam.CallOpts)
+}
+
+// GetAllParams is a free data retrieval call binding the contract method 0xa170052e.
+//
+// Solidity: function getAllParams() view returns(string[], (bool,bool,bytes)[])
+func (_GovParam *GovParamCallerSession) GetAllParams() ([]string, []GovParamParam, error) {
+	return _GovParam.Contract.GetAllParams(&_GovParam.CallOpts)
+}
+
+// GetGovernaceAddress is a free data retrieval call binding the contract method 0xee9c780a.
+//
+// Solidity: function getGovernaceAddress() view returns(address)
+func (_GovParam *GovParamCaller) GetGovernaceAddress(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _GovParam.contract.Call(opts, out, "getGovernaceAddress")
+	return *ret0, err
+}
+
+// GetGovernaceAddress is a free data retrieval call binding the contract method 0xee9c780a.
+//
+// Solidity: function getGovernaceAddress() view returns(address)
+func (_GovParam *GovParamSession) GetGovernaceAddress() (common.Address, error) {
+	return _GovParam.Contract.GetGovernaceAddress(&_GovParam.CallOpts)
+}
+
+// GetGovernaceAddress is a free data retrieval call binding the contract method 0xee9c780a.
+//
+// Solidity: function getGovernaceAddress() view returns(address)
+func (_GovParam *GovParamCallerSession) GetGovernaceAddress() (common.Address, error) {
+	return _GovParam.Contract.GetGovernaceAddress(&_GovParam.CallOpts)
+}
+
+// GetParam is a free data retrieval call binding the contract method 0x5d4f71d4.
+//
+// Solidity: function getParam(string name) view returns(bytes)
+func (_GovParam *GovParamCaller) GetParam(opts *bind.CallOpts, name string) ([]byte, error) {
+	var (
+		ret0 = new([]byte)
+	)
+	out := ret0
+	err := _GovParam.contract.Call(opts, out, "getParam", name)
+	return *ret0, err
+}
+
+// GetParam is a free data retrieval call binding the contract method 0x5d4f71d4.
+//
+// Solidity: function getParam(string name) view returns(bytes)
+func (_GovParam *GovParamSession) GetParam(name string) ([]byte, error) {
+	return _GovParam.Contract.GetParam(&_GovParam.CallOpts, name)
+}
+
+// GetParam is a free data retrieval call binding the contract method 0x5d4f71d4.
+//
+// Solidity: function getParam(string name) view returns(bytes)
+func (_GovParam *GovParamCallerSession) GetParam(name string) ([]byte, error) {
+	return _GovParam.Contract.GetParam(&_GovParam.CallOpts, name)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_GovParam *GovParamCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _GovParam.contract.Call(opts, out, "owner")
+	return *ret0, err
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_GovParam *GovParamSession) Owner() (common.Address, error) {
+	return _GovParam.Contract.Owner(&_GovParam.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_GovParam *GovParamCallerSession) Owner() (common.Address, error) {
+	return _GovParam.Contract.Owner(&_GovParam.CallOpts)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+//
+// Solidity: function initialize(address owner) returns()
+func (_GovParam *GovParamTransactor) Initialize(opts *bind.TransactOpts, owner common.Address) (*types.Transaction, error) {
+	return _GovParam.contract.Transact(opts, "initialize", owner)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+//
+// Solidity: function initialize(address owner) returns()
+func (_GovParam *GovParamSession) Initialize(owner common.Address) (*types.Transaction, error) {
+	return _GovParam.Contract.Initialize(&_GovParam.TransactOpts, owner)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+//
+// Solidity: function initialize(address owner) returns()
+func (_GovParam *GovParamTransactorSession) Initialize(owner common.Address) (*types.Transaction, error) {
+	return _GovParam.Contract.Initialize(&_GovParam.TransactOpts, owner)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_GovParam *GovParamTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GovParam.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_GovParam *GovParamSession) RenounceOwnership() (*types.Transaction, error) {
+	return _GovParam.Contract.RenounceOwnership(&_GovParam.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_GovParam *GovParamTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _GovParam.Contract.RenounceOwnership(&_GovParam.TransactOpts)
+}
+
+// SetGovernanceAddr is a paid mutator transaction binding the contract method 0x8e87fc1a.
+//
+// Solidity: function setGovernanceAddr(address governanceAddr) returns()
+func (_GovParam *GovParamTransactor) SetGovernanceAddr(opts *bind.TransactOpts, governanceAddr common.Address) (*types.Transaction, error) {
+	return _GovParam.contract.Transact(opts, "setGovernanceAddr", governanceAddr)
+}
+
+// SetGovernanceAddr is a paid mutator transaction binding the contract method 0x8e87fc1a.
+//
+// Solidity: function setGovernanceAddr(address governanceAddr) returns()
+func (_GovParam *GovParamSession) SetGovernanceAddr(governanceAddr common.Address) (*types.Transaction, error) {
+	return _GovParam.Contract.SetGovernanceAddr(&_GovParam.TransactOpts, governanceAddr)
+}
+
+// SetGovernanceAddr is a paid mutator transaction binding the contract method 0x8e87fc1a.
+//
+// Solidity: function setGovernanceAddr(address governanceAddr) returns()
+func (_GovParam *GovParamTransactorSession) SetGovernanceAddr(governanceAddr common.Address) (*types.Transaction, error) {
+	return _GovParam.Contract.SetGovernanceAddr(&_GovParam.TransactOpts, governanceAddr)
+}
+
+// SetParam is a paid mutator transaction binding the contract method 0x2b813437.
+//
+// Solidity: function setParam(string name, bytes value) returns()
+func (_GovParam *GovParamTransactor) SetParam(opts *bind.TransactOpts, name string, value []byte) (*types.Transaction, error) {
+	return _GovParam.contract.Transact(opts, "setParam", name, value)
+}
+
+// SetParam is a paid mutator transaction binding the contract method 0x2b813437.
+//
+// Solidity: function setParam(string name, bytes value) returns()
+func (_GovParam *GovParamSession) SetParam(name string, value []byte) (*types.Transaction, error) {
+	return _GovParam.Contract.SetParam(&_GovParam.TransactOpts, name, value)
+}
+
+// SetParam is a paid mutator transaction binding the contract method 0x2b813437.
+//
+// Solidity: function setParam(string name, bytes value) returns()
+func (_GovParam *GovParamTransactorSession) SetParam(name string, value []byte) (*types.Transaction, error) {
+	return _GovParam.Contract.SetParam(&_GovParam.TransactOpts, name, value)
+}
+
+// SetParamByOwner is a paid mutator transaction binding the contract method 0x05d2b1bb.
+//
+// Solidity: function setParamByOwner(string name, bytes value) returns()
+func (_GovParam *GovParamTransactor) SetParamByOwner(opts *bind.TransactOpts, name string, value []byte) (*types.Transaction, error) {
+	return _GovParam.contract.Transact(opts, "setParamByOwner", name, value)
+}
+
+// SetParamByOwner is a paid mutator transaction binding the contract method 0x05d2b1bb.
+//
+// Solidity: function setParamByOwner(string name, bytes value) returns()
+func (_GovParam *GovParamSession) SetParamByOwner(name string, value []byte) (*types.Transaction, error) {
+	return _GovParam.Contract.SetParamByOwner(&_GovParam.TransactOpts, name, value)
+}
+
+// SetParamByOwner is a paid mutator transaction binding the contract method 0x05d2b1bb.
+//
+// Solidity: function setParamByOwner(string name, bytes value) returns()
+func (_GovParam *GovParamTransactorSession) SetParamByOwner(name string, value []byte) (*types.Transaction, error) {
+	return _GovParam.Contract.SetParamByOwner(&_GovParam.TransactOpts, name, value)
+}
+
+// SetParamVotable is a paid mutator transaction binding the contract method 0x400e3f6f.
+//
+// Solidity: function setParamVotable(string name) returns()
+func (_GovParam *GovParamTransactor) SetParamVotable(opts *bind.TransactOpts, name string) (*types.Transaction, error) {
+	return _GovParam.contract.Transact(opts, "setParamVotable", name)
+}
+
+// SetParamVotable is a paid mutator transaction binding the contract method 0x400e3f6f.
+//
+// Solidity: function setParamVotable(string name) returns()
+func (_GovParam *GovParamSession) SetParamVotable(name string) (*types.Transaction, error) {
+	return _GovParam.Contract.SetParamVotable(&_GovParam.TransactOpts, name)
+}
+
+// SetParamVotable is a paid mutator transaction binding the contract method 0x400e3f6f.
+//
+// Solidity: function setParamVotable(string name) returns()
+func (_GovParam *GovParamTransactorSession) SetParamVotable(name string) (*types.Transaction, error) {
+	return _GovParam.Contract.SetParamVotable(&_GovParam.TransactOpts, name)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_GovParam *GovParamTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _GovParam.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_GovParam *GovParamSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _GovParam.Contract.TransferOwnership(&_GovParam.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_GovParam *GovParamTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _GovParam.Contract.TransferOwnership(&_GovParam.TransactOpts, newOwner)
+}
+
+// GovParamInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the GovParam contract.
+type GovParamInitializedIterator struct {
+	Event *GovParamInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GovParamInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GovParamInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GovParamInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GovParamInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GovParamInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GovParamInitialized represents a Initialized event raised by the GovParam contract.
+type GovParamInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_GovParam *GovParamFilterer) FilterInitialized(opts *bind.FilterOpts) (*GovParamInitializedIterator, error) {
+
+	logs, sub, err := _GovParam.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &GovParamInitializedIterator{contract: _GovParam.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_GovParam *GovParamFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *GovParamInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _GovParam.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GovParamInitialized)
+				if err := _GovParam.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_GovParam *GovParamFilterer) ParseInitialized(log types.Log) (*GovParamInitialized, error) {
+	event := new(GovParamInitialized)
+	if err := _GovParam.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// GovParamOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the GovParam contract.
+type GovParamOwnershipTransferredIterator struct {
+	Event *GovParamOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GovParamOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GovParamOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GovParamOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GovParamOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GovParamOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GovParamOwnershipTransferred represents a OwnershipTransferred event raised by the GovParam contract.
+type GovParamOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_GovParam *GovParamFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*GovParamOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _GovParam.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GovParamOwnershipTransferredIterator{contract: _GovParam.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_GovParam *GovParamFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *GovParamOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _GovParam.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GovParamOwnershipTransferred)
+				if err := _GovParam.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_GovParam *GovParamFilterer) ParseOwnershipTransferred(log types.Log) (*GovParamOwnershipTransferred, error) {
+	event := new(GovParamOwnershipTransferred)
+	if err := _GovParam.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// GovParamSetParamIterator is returned from FilterSetParam and is used to iterate over the raw logs and unpacked data for SetParam events raised by the GovParam contract.
+type GovParamSetParamIterator struct {
+	Event *GovParamSetParam // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GovParamSetParamIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GovParamSetParam)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GovParamSetParam)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GovParamSetParamIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GovParamSetParamIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GovParamSetParam represents a SetParam event raised by the GovParam contract.
+type GovParamSetParam struct {
+	Arg0 string
+	Arg1 []byte
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterSetParam is a free log retrieval operation binding the contract event 0x9067e93c0b7173962f200e7f543c8b0496b9d00bcf35715553da6a4a9f66d0a7.
+//
+// Solidity: event SetParam(string arg0, bytes arg1)
+func (_GovParam *GovParamFilterer) FilterSetParam(opts *bind.FilterOpts) (*GovParamSetParamIterator, error) {
+
+	logs, sub, err := _GovParam.contract.FilterLogs(opts, "SetParam")
+	if err != nil {
+		return nil, err
+	}
+	return &GovParamSetParamIterator{contract: _GovParam.contract, event: "SetParam", logs: logs, sub: sub}, nil
+}
+
+// WatchSetParam is a free log subscription operation binding the contract event 0x9067e93c0b7173962f200e7f543c8b0496b9d00bcf35715553da6a4a9f66d0a7.
+//
+// Solidity: event SetParam(string arg0, bytes arg1)
+func (_GovParam *GovParamFilterer) WatchSetParam(opts *bind.WatchOpts, sink chan<- *GovParamSetParam) (event.Subscription, error) {
+
+	logs, sub, err := _GovParam.contract.WatchLogs(opts, "SetParam")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GovParamSetParam)
+				if err := _GovParam.contract.UnpackLog(event, "SetParam", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSetParam is a log parse operation binding the contract event 0x9067e93c0b7173962f200e7f543c8b0496b9d00bcf35715553da6a4a9f66d0a7.
+//
+// Solidity: event SetParam(string arg0, bytes arg1)
+func (_GovParam *GovParamFilterer) ParseSetParam(log types.Log) (*GovParamSetParam, error) {
+	event := new(GovParamSetParam)
+	if err := _GovParam.contract.UnpackLog(event, "SetParam", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// GovParamSetParamVotableIterator is returned from FilterSetParamVotable and is used to iterate over the raw logs and unpacked data for SetParamVotable events raised by the GovParam contract.
+type GovParamSetParamVotableIterator struct {
+	Event *GovParamSetParamVotable // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GovParamSetParamVotableIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GovParamSetParamVotable)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GovParamSetParamVotable)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GovParamSetParamVotableIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GovParamSetParamVotableIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GovParamSetParamVotable represents a SetParamVotable event raised by the GovParam contract.
+type GovParamSetParamVotable struct {
+	Arg0 string
+	Arg1 bool
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterSetParamVotable is a free log retrieval operation binding the contract event 0x064a476da825aa99a31c682cc490b34f462457006480bda5cb27151a201213f5.
+//
+// Solidity: event SetParamVotable(string arg0, bool arg1)
+func (_GovParam *GovParamFilterer) FilterSetParamVotable(opts *bind.FilterOpts) (*GovParamSetParamVotableIterator, error) {
+
+	logs, sub, err := _GovParam.contract.FilterLogs(opts, "SetParamVotable")
+	if err != nil {
+		return nil, err
+	}
+	return &GovParamSetParamVotableIterator{contract: _GovParam.contract, event: "SetParamVotable", logs: logs, sub: sub}, nil
+}
+
+// WatchSetParamVotable is a free log subscription operation binding the contract event 0x064a476da825aa99a31c682cc490b34f462457006480bda5cb27151a201213f5.
+//
+// Solidity: event SetParamVotable(string arg0, bool arg1)
+func (_GovParam *GovParamFilterer) WatchSetParamVotable(opts *bind.WatchOpts, sink chan<- *GovParamSetParamVotable) (event.Subscription, error) {
+
+	logs, sub, err := _GovParam.contract.WatchLogs(opts, "SetParamVotable")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GovParamSetParamVotable)
+				if err := _GovParam.contract.UnpackLog(event, "SetParamVotable", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSetParamVotable is a log parse operation binding the contract event 0x064a476da825aa99a31c682cc490b34f462457006480bda5cb27151a201213f5.
+//
+// Solidity: event SetParamVotable(string arg0, bool arg1)
+func (_GovParam *GovParamFilterer) ParseSetParamVotable(log types.Log) (*GovParamSetParamVotable, error) {
+	event := new(GovParamSetParamVotable)
+	if err := _GovParam.contract.UnpackLog(event, "SetParamVotable", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// InitializableABI is the input ABI used to generate the binding from.
+const InitializableABI = "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"}]"
+
+// InitializableBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const InitializableBinRuntime = ``
+
+// Initializable is an auto generated Go binding around a Klaytn contract.
+type Initializable struct {
+	InitializableCaller     // Read-only binding to the contract
+	InitializableTransactor // Write-only binding to the contract
+	InitializableFilterer   // Log filterer for contract events
+}
+
+// InitializableCaller is an auto generated read-only Go binding around a Klaytn contract.
+type InitializableCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// InitializableTransactor is an auto generated write-only Go binding around a Klaytn contract.
+type InitializableTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// InitializableFilterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type InitializableFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// InitializableSession is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type InitializableSession struct {
+	Contract     *Initializable    // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// InitializableCallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type InitializableCallerSession struct {
+	Contract *InitializableCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts        // Call options to use throughout this session
+}
+
+// InitializableTransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type InitializableTransactorSession struct {
+	Contract     *InitializableTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// InitializableRaw is an auto generated low-level Go binding around a Klaytn contract.
+type InitializableRaw struct {
+	Contract *Initializable // Generic contract binding to access the raw methods on
+}
+
+// InitializableCallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type InitializableCallerRaw struct {
+	Contract *InitializableCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// InitializableTransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type InitializableTransactorRaw struct {
+	Contract *InitializableTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewInitializable creates a new instance of Initializable, bound to a specific deployed contract.
+func NewInitializable(address common.Address, backend bind.ContractBackend) (*Initializable, error) {
+	contract, err := bindInitializable(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Initializable{InitializableCaller: InitializableCaller{contract: contract}, InitializableTransactor: InitializableTransactor{contract: contract}, InitializableFilterer: InitializableFilterer{contract: contract}}, nil
+}
+
+// NewInitializableCaller creates a new read-only instance of Initializable, bound to a specific deployed contract.
+func NewInitializableCaller(address common.Address, caller bind.ContractCaller) (*InitializableCaller, error) {
+	contract, err := bindInitializable(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &InitializableCaller{contract: contract}, nil
+}
+
+// NewInitializableTransactor creates a new write-only instance of Initializable, bound to a specific deployed contract.
+func NewInitializableTransactor(address common.Address, transactor bind.ContractTransactor) (*InitializableTransactor, error) {
+	contract, err := bindInitializable(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &InitializableTransactor{contract: contract}, nil
+}
+
+// NewInitializableFilterer creates a new log filterer instance of Initializable, bound to a specific deployed contract.
+func NewInitializableFilterer(address common.Address, filterer bind.ContractFilterer) (*InitializableFilterer, error) {
+	contract, err := bindInitializable(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &InitializableFilterer{contract: contract}, nil
+}
+
+// bindInitializable binds a generic wrapper to an already deployed contract.
+func bindInitializable(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(InitializableABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Initializable *InitializableRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Initializable.Contract.InitializableCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Initializable *InitializableRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Initializable.Contract.InitializableTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Initializable *InitializableRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Initializable.Contract.InitializableTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Initializable *InitializableCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Initializable.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Initializable *InitializableTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Initializable.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Initializable *InitializableTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Initializable.Contract.contract.Transact(opts, method, params...)
+}
+
+// InitializableInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Initializable contract.
+type InitializableInitializedIterator struct {
+	Event *InitializableInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *InitializableInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(InitializableInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(InitializableInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *InitializableInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *InitializableInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// InitializableInitialized represents a Initialized event raised by the Initializable contract.
+type InitializableInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_Initializable *InitializableFilterer) FilterInitialized(opts *bind.FilterOpts) (*InitializableInitializedIterator, error) {
+
+	logs, sub, err := _Initializable.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &InitializableInitializedIterator{contract: _Initializable.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_Initializable *InitializableFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *InitializableInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Initializable.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(InitializableInitialized)
+				if err := _Initializable.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_Initializable *InitializableFilterer) ParseInitialized(log types.Log) (*InitializableInitialized, error) {
+	event := new(InitializableInitialized)
+	if err := _Initializable.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// OwnableUpgradeableABI is the input ABI used to generate the binding from.
+const OwnableUpgradeableABI = "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+
+// OwnableUpgradeableBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const OwnableUpgradeableBinRuntime = ``
+
+// OwnableUpgradeableFuncSigs maps the 4-byte function signature to its string representation.
+var OwnableUpgradeableFuncSigs = map[string]string{
+	"8da5cb5b": "owner()",
+	"715018a6": "renounceOwnership()",
+	"f2fde38b": "transferOwnership(address)",
+}
+
+// OwnableUpgradeable is an auto generated Go binding around a Klaytn contract.
+type OwnableUpgradeable struct {
+	OwnableUpgradeableCaller     // Read-only binding to the contract
+	OwnableUpgradeableTransactor // Write-only binding to the contract
+	OwnableUpgradeableFilterer   // Log filterer for contract events
+}
+
+// OwnableUpgradeableCaller is an auto generated read-only Go binding around a Klaytn contract.
+type OwnableUpgradeableCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OwnableUpgradeableTransactor is an auto generated write-only Go binding around a Klaytn contract.
+type OwnableUpgradeableTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OwnableUpgradeableFilterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type OwnableUpgradeableFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OwnableUpgradeableSession is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type OwnableUpgradeableSession struct {
+	Contract     *OwnableUpgradeable // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts       // Call options to use throughout this session
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// OwnableUpgradeableCallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type OwnableUpgradeableCallerSession struct {
+	Contract *OwnableUpgradeableCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts             // Call options to use throughout this session
+}
+
+// OwnableUpgradeableTransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type OwnableUpgradeableTransactorSession struct {
+	Contract     *OwnableUpgradeableTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts             // Transaction auth options to use throughout this session
+}
+
+// OwnableUpgradeableRaw is an auto generated low-level Go binding around a Klaytn contract.
+type OwnableUpgradeableRaw struct {
+	Contract *OwnableUpgradeable // Generic contract binding to access the raw methods on
+}
+
+// OwnableUpgradeableCallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type OwnableUpgradeableCallerRaw struct {
+	Contract *OwnableUpgradeableCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// OwnableUpgradeableTransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type OwnableUpgradeableTransactorRaw struct {
+	Contract *OwnableUpgradeableTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewOwnableUpgradeable creates a new instance of OwnableUpgradeable, bound to a specific deployed contract.
+func NewOwnableUpgradeable(address common.Address, backend bind.ContractBackend) (*OwnableUpgradeable, error) {
+	contract, err := bindOwnableUpgradeable(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableUpgradeable{OwnableUpgradeableCaller: OwnableUpgradeableCaller{contract: contract}, OwnableUpgradeableTransactor: OwnableUpgradeableTransactor{contract: contract}, OwnableUpgradeableFilterer: OwnableUpgradeableFilterer{contract: contract}}, nil
+}
+
+// NewOwnableUpgradeableCaller creates a new read-only instance of OwnableUpgradeable, bound to a specific deployed contract.
+func NewOwnableUpgradeableCaller(address common.Address, caller bind.ContractCaller) (*OwnableUpgradeableCaller, error) {
+	contract, err := bindOwnableUpgradeable(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableUpgradeableCaller{contract: contract}, nil
+}
+
+// NewOwnableUpgradeableTransactor creates a new write-only instance of OwnableUpgradeable, bound to a specific deployed contract.
+func NewOwnableUpgradeableTransactor(address common.Address, transactor bind.ContractTransactor) (*OwnableUpgradeableTransactor, error) {
+	contract, err := bindOwnableUpgradeable(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableUpgradeableTransactor{contract: contract}, nil
+}
+
+// NewOwnableUpgradeableFilterer creates a new log filterer instance of OwnableUpgradeable, bound to a specific deployed contract.
+func NewOwnableUpgradeableFilterer(address common.Address, filterer bind.ContractFilterer) (*OwnableUpgradeableFilterer, error) {
+	contract, err := bindOwnableUpgradeable(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableUpgradeableFilterer{contract: contract}, nil
+}
+
+// bindOwnableUpgradeable binds a generic wrapper to an already deployed contract.
+func bindOwnableUpgradeable(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(OwnableUpgradeableABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_OwnableUpgradeable *OwnableUpgradeableRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _OwnableUpgradeable.Contract.OwnableUpgradeableCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_OwnableUpgradeable *OwnableUpgradeableRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OwnableUpgradeable.Contract.OwnableUpgradeableTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_OwnableUpgradeable *OwnableUpgradeableRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _OwnableUpgradeable.Contract.OwnableUpgradeableTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_OwnableUpgradeable *OwnableUpgradeableCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _OwnableUpgradeable.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_OwnableUpgradeable *OwnableUpgradeableTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OwnableUpgradeable.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_OwnableUpgradeable *OwnableUpgradeableTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _OwnableUpgradeable.Contract.contract.Transact(opts, method, params...)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_OwnableUpgradeable *OwnableUpgradeableCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _OwnableUpgradeable.contract.Call(opts, out, "owner")
+	return *ret0, err
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_OwnableUpgradeable *OwnableUpgradeableSession) Owner() (common.Address, error) {
+	return _OwnableUpgradeable.Contract.Owner(&_OwnableUpgradeable.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_OwnableUpgradeable *OwnableUpgradeableCallerSession) Owner() (common.Address, error) {
+	return _OwnableUpgradeable.Contract.Owner(&_OwnableUpgradeable.CallOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_OwnableUpgradeable *OwnableUpgradeableTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OwnableUpgradeable.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_OwnableUpgradeable *OwnableUpgradeableSession) RenounceOwnership() (*types.Transaction, error) {
+	return _OwnableUpgradeable.Contract.RenounceOwnership(&_OwnableUpgradeable.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_OwnableUpgradeable *OwnableUpgradeableTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _OwnableUpgradeable.Contract.RenounceOwnership(&_OwnableUpgradeable.TransactOpts)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_OwnableUpgradeable *OwnableUpgradeableTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _OwnableUpgradeable.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_OwnableUpgradeable *OwnableUpgradeableSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _OwnableUpgradeable.Contract.TransferOwnership(&_OwnableUpgradeable.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_OwnableUpgradeable *OwnableUpgradeableTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _OwnableUpgradeable.Contract.TransferOwnership(&_OwnableUpgradeable.TransactOpts, newOwner)
+}
+
+// OwnableUpgradeableInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the OwnableUpgradeable contract.
+type OwnableUpgradeableInitializedIterator struct {
+	Event *OwnableUpgradeableInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OwnableUpgradeableInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OwnableUpgradeableInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OwnableUpgradeableInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OwnableUpgradeableInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OwnableUpgradeableInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OwnableUpgradeableInitialized represents a Initialized event raised by the OwnableUpgradeable contract.
+type OwnableUpgradeableInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_OwnableUpgradeable *OwnableUpgradeableFilterer) FilterInitialized(opts *bind.FilterOpts) (*OwnableUpgradeableInitializedIterator, error) {
+
+	logs, sub, err := _OwnableUpgradeable.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableUpgradeableInitializedIterator{contract: _OwnableUpgradeable.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_OwnableUpgradeable *OwnableUpgradeableFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *OwnableUpgradeableInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _OwnableUpgradeable.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OwnableUpgradeableInitialized)
+				if err := _OwnableUpgradeable.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_OwnableUpgradeable *OwnableUpgradeableFilterer) ParseInitialized(log types.Log) (*OwnableUpgradeableInitialized, error) {
+	event := new(OwnableUpgradeableInitialized)
+	if err := _OwnableUpgradeable.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// OwnableUpgradeableOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the OwnableUpgradeable contract.
+type OwnableUpgradeableOwnershipTransferredIterator struct {
+	Event *OwnableUpgradeableOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OwnableUpgradeableOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OwnableUpgradeableOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OwnableUpgradeableOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OwnableUpgradeableOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OwnableUpgradeableOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OwnableUpgradeableOwnershipTransferred represents a OwnershipTransferred event raised by the OwnableUpgradeable contract.
+type OwnableUpgradeableOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_OwnableUpgradeable *OwnableUpgradeableFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*OwnableUpgradeableOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _OwnableUpgradeable.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableUpgradeableOwnershipTransferredIterator{contract: _OwnableUpgradeable.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_OwnableUpgradeable *OwnableUpgradeableFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *OwnableUpgradeableOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _OwnableUpgradeable.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OwnableUpgradeableOwnershipTransferred)
+				if err := _OwnableUpgradeable.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_OwnableUpgradeable *OwnableUpgradeableFilterer) ParseOwnershipTransferred(log types.Log) (*OwnableUpgradeableOwnershipTransferred, error) {
+	event := new(OwnableUpgradeableOwnershipTransferred)
+	if err := _OwnableUpgradeable.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}

--- a/contracts/gov/GovParam.sol
+++ b/contracts/gov/GovParam.sol
@@ -1,0 +1,645 @@
+// Sources flattened with hardhat v2.9.3 https://hardhat.org
+
+// File @openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol@v4.6.0
+
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.5.0) (utils/Address.sol)
+
+pragma solidity ^0.8.1;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library AddressUpgradeable {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     *
+     * [IMPORTANT]
+     * ====
+     * You shouldn't rely on `isContract` to protect against flash loan attacks!
+     *
+     * Preventing calls from contracts is highly discouraged. It breaks composability, breaks support for smart wallets
+     * like Gnosis Safe, and does not provide security since it can be circumvented by calling from a contract
+     * constructor.
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize/address.code.length, which returns 0
+        // for contracts in construction, since the code is only stored at the end
+        // of the constructor execution.
+
+        return account.code.length > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain `call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        return verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Tool to verifies that a low level call was successful, and revert if it wasn't, either by bubbling the
+     * revert reason using the provided one.
+     *
+     * _Available since v4.3._
+     */
+    function verifyCallResult(
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) internal pure returns (bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// File @openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol@v4.6.0
+
+// OpenZeppelin Contracts (last updated v4.6.0) (proxy/utils/Initializable.sol)
+
+pragma solidity ^0.8.2;
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since proxied contracts do not make use of a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ *
+ * The initialization functions use a version number. Once a version number is used, it is consumed and cannot be
+ * reused. This mechanism prevents re-execution of each "step" but allows the creation of new initialization steps in
+ * case an upgrade adds a module that needs to be initialized.
+ *
+ * For example:
+ *
+ * [.hljs-theme-light.nopadding]
+ * ```
+ * contract MyToken is ERC20Upgradeable {
+ *     function initialize() initializer public {
+ *         __ERC20_init("MyToken", "MTK");
+ *     }
+ * }
+ * contract MyTokenV2 is MyToken, ERC20PermitUpgradeable {
+ *     function initializeV2() reinitializer(2) public {
+ *         __ERC20Permit_init("MyToken");
+ *     }
+ * }
+ * ```
+ *
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {ERC1967Proxy-constructor}.
+ *
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ *
+ * [CAUTION]
+ * ====
+ * Avoid leaving a contract uninitialized.
+ *
+ * An uninitialized contract can be taken over by an attacker. This applies to both a proxy and its implementation
+ * contract, which may impact the proxy. To prevent the implementation contract from being used, you should invoke
+ * the {_disableInitializers} function in the constructor to automatically lock it when it is deployed:
+ *
+ * [.hljs-theme-light.nopadding]
+ * ```
+ * /// @custom:oz-upgrades-unsafe-allow constructor
+ * constructor() {
+ *     _disableInitializers();
+ * }
+ * ```
+ * ====
+ */
+abstract contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     * @custom:oz-retyped-from bool
+     */
+    uint8 private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private _initializing;
+
+    /**
+     * @dev Triggered when the contract has been initialized or reinitialized.
+     */
+    event Initialized(uint8 version);
+
+    /**
+     * @dev A modifier that defines a protected initializer function that can be invoked at most once. In its scope,
+     * `onlyInitializing` functions can be used to initialize parent contracts. Equivalent to `reinitializer(1)`.
+     */
+    modifier initializer() {
+        bool isTopLevelCall = _setInitializedVersion(1);
+        if (isTopLevelCall) {
+            _initializing = true;
+        }
+        _;
+        if (isTopLevelCall) {
+            _initializing = false;
+            emit Initialized(1);
+        }
+    }
+
+    /**
+     * @dev A modifier that defines a protected reinitializer function that can be invoked at most once, and only if the
+     * contract hasn't been initialized to a greater version before. In its scope, `onlyInitializing` functions can be
+     * used to initialize parent contracts.
+     *
+     * `initializer` is equivalent to `reinitializer(1)`, so a reinitializer may be used after the original
+     * initialization step. This is essential to configure modules that are added through upgrades and that require
+     * initialization.
+     *
+     * Note that versions can jump in increments greater than 1; this implies that if multiple reinitializers coexist in
+     * a contract, executing them in the right order is up to the developer or operator.
+     */
+    modifier reinitializer(uint8 version) {
+        bool isTopLevelCall = _setInitializedVersion(version);
+        if (isTopLevelCall) {
+            _initializing = true;
+        }
+        _;
+        if (isTopLevelCall) {
+            _initializing = false;
+            emit Initialized(version);
+        }
+    }
+
+    /**
+     * @dev Modifier to protect an initialization function so that it can only be invoked by functions with the
+     * {initializer} and {reinitializer} modifiers, directly or indirectly.
+     */
+    modifier onlyInitializing() {
+        require(_initializing, "Initializable: contract is not initializing");
+        _;
+    }
+
+    /**
+     * @dev Locks the contract, preventing any future reinitialization. This cannot be part of an initializer call.
+     * Calling this in the constructor of a contract will prevent that contract from being initialized or reinitialized
+     * to any version. It is recommended to use this to lock implementation contracts that are designed to be called
+     * through proxies.
+     */
+    function _disableInitializers() internal virtual {
+        _setInitializedVersion(type(uint8).max);
+    }
+
+    function _setInitializedVersion(uint8 version) private returns (bool) {
+        // If the contract is initializing we ignore whether _initialized is set in order to support multiple
+        // inheritance patterns, but we only do this in the context of a constructor, and for the lowest level
+        // of initializers, because in other contexts the contract may have been reentered.
+        if (_initializing) {
+            require(
+                version == 1 && !AddressUpgradeable.isContract(address(this)),
+                "Initializable: contract is already initialized"
+            );
+            return false;
+        } else {
+            require(_initialized < version, "Initializable: contract is already initialized");
+            _initialized = version;
+            return true;
+        }
+    }
+}
+
+
+// File @openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol@v4.6.0
+
+// OpenZeppelin Contracts v4.4.1 (utils/Context.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract ContextUpgradeable is Initializable {
+    function __Context_init() internal onlyInitializing {
+    }
+
+    function __Context_init_unchained() internal onlyInitializing {
+    }
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[50] private __gap;
+}
+
+
+// File @openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol@v4.6.0
+
+// OpenZeppelin Contracts v4.4.1 (access/Ownable.sol)
+
+pragma solidity ^0.8.0;
+
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function __Ownable_init() internal onlyInitializing {
+        __Ownable_init_unchained();
+    }
+
+    function __Ownable_init_unchained() internal onlyInitializing {
+        _transferOwnership(_msgSender());
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[49] private __gap;
+}
+
+
+// File contracts/GovParam.sol
+
+pragma solidity ^0.8.0;
+
+
+
+/**
+ *
+ * @dev Contract to store and update governance parameters
+ * This contract can be called by node to read the param values in the future blocks
+ *
+ */
+contract GovParam is Initializable, OwnableUpgradeable {
+    string[] private _paramNames;
+    mapping(string => Param) private _params;
+    address private _governanceAddr;
+
+    struct Param {
+        bool exists; // True for all params
+        bool votable; // True to allow governance contract to change it.
+        bytes value; // Bytes encoded value
+    }
+
+    event SetParam(string, bytes);
+    event SetParamVotable(string, bool);
+
+    /**
+     * @dev Modifier to make a function callable only by a governance contract
+     *
+     */
+    modifier onlyGovernance() {
+        require(
+            _msgSender() == _governanceAddr,
+            "GovParam: caller is not a Governance Contract"
+        );
+        _;
+    }
+
+    /**
+     * @dev Initializes the contract setting the initial owner
+     */
+    function initialize(address owner) public initializer {
+        __Ownable_init();
+        if (owner != address(0)) {
+            _transferOwnership(owner);
+        }
+    }
+
+    /**
+     * @dev sets the value of a parameter
+     *
+     * @param name is the name of the parameter eg: gasLimit
+     * @param value is the value of the parameter eg: 250000000
+     */
+    function setParam(
+        string calldata name,
+        bytes calldata value
+    ) external onlyGovernance {
+        require(
+            _params[name].votable == true,
+            "GovParam: paramVotable must be  set to true"
+        );
+        _setParam(name, value);
+    }
+
+    /**
+     * @dev sets the value of a parameter
+     *
+     * @param name is the name of the parameter eg: gasLimit
+     * @param value is the value of the parameter eg: 250000000
+     */
+    function setParamByOwner(
+        string calldata name,
+        bytes calldata value
+    ) external onlyOwner {
+        require(
+            _params[name].votable == false,
+            "GovParam: paramVotable must be set to false"
+        );
+        _setParam(name, value);
+    }
+
+    /**
+     * @dev internal function to set the value of a parameter
+     * By default _params[name].votable is false
+     *
+     * @param name is the name of the parameter eg: gasLimit
+     * @param value is the value of the parameter eg: 250000000
+     */
+    function _setParam(
+        string calldata name,
+        bytes calldata value
+    ) internal {
+        require(bytes(name).length > 0, "GovParam: name cannot be empty");
+
+        if (!_params[name].exists) {
+            // First time setting this param.
+            _params[name].exists = true;
+            _paramNames.push(name);
+        }
+
+        _params[name].value = value;
+
+        emit SetParam(name, value);
+    }
+
+    /**
+     * @dev sets the governanceAddress
+     *
+     * @param governanceAddr is the address of the governance contract which is the voting contract
+     */
+    function setGovernanceAddr(address governanceAddr) external onlyOwner {
+        require(
+            governanceAddr != address(0),
+            "GovParam: governance contract cannot be zero address"
+        );
+        _governanceAddr = governanceAddr;
+    }
+
+    /**
+     * @dev Make a parameter votable, so a parameter can be changed by governance contract
+     *
+     * @param name is the name of the parameter eg: gasLimit
+     * - Requirements : By default _params[name].votable is false
+     */
+    function setParamVotable(string memory name) external onlyOwner {
+        require(bytes(name).length > 0, "GovParam: name cannot be empty");
+        require(_params[name].exists, "GovParam: parameter does not exists");
+
+        _params[name].votable = true;
+        emit SetParamVotable(name, _params[name].votable);
+    }
+
+    /**
+     * @dev Returns the parameter value the current block
+     *
+     * @param name of the parameter
+     */
+    function getParam(string memory name) external view returns (bytes memory) {
+        if (!_params[name].exists) {
+            return "";
+        }
+        return _params[name].value;
+    }
+
+    /**
+     * @dev Returns all the parameter's value at the current blocknumber
+     *
+     */
+    function getAllParams() external view returns (string[] memory, Param[] memory) {
+        Param[] memory params = new Param[](_paramNames.length);
+        for (uint256 i = 0; i < _paramNames.length; i++) {
+            string memory name = _paramNames[i];
+            params[i] = _params[name];
+        }
+        return (_paramNames, params);
+    }
+
+    /**
+     * @dev Returns the address of the governance contract
+     *
+     */
+    function getGovernaceAddress() external view returns (address) {
+        return _governanceAddr;
+    }
+}

--- a/governance/api.go
+++ b/governance/api.go
@@ -141,11 +141,11 @@ func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interf
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
-	_, data, error := api.governance.ReadGovernance(blockNumber)
-	if error == nil {
-		return data, error
+
+	if pset, err := api.governance.ParamsAt(blockNumber); err != nil {
+		return nil, err
 	} else {
-		return nil, error
+		return pset.StrMap(), nil
 	}
 }
 

--- a/governance/contract.go
+++ b/governance/contract.go
@@ -29,6 +29,7 @@ type ContractEngine struct {
 	chain      blockChain  // To access the contract state DB
 }
 
+// TODO: remove defaultGov if not necessary
 func NewContractEngine(config *params.ChainConfig, defaultGov *Governance) *ContractEngine {
 	e := &ContractEngine{
 		chainConfig:   config,

--- a/governance/contract.go
+++ b/governance/contract.go
@@ -1,0 +1,231 @@
+package governance
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	"github.com/klaytn/klaytn/accounts/abi"
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/blockchain/vm"
+	"github.com/klaytn/klaytn/common"
+	govcontract "github.com/klaytn/klaytn/contracts/gov"
+	"github.com/klaytn/klaytn/params"
+)
+
+var (
+	errContractEngineNotReady = errors.New("ContractEngine is not ready")
+
+	govParamAbi, _ = abi.JSON(strings.NewReader(govcontract.GovParamABI))
+)
+
+type ContractEngine struct {
+	chainConfig   *params.ChainConfig
+	currentParams *params.GovParamSet
+	initialParams *params.GovParamSet // equals to initial ChainConfig
+
+	defaultGov *Governance // To find the contract address at any block number
+	chain      blockChain  // To access the contract state DB
+}
+
+func NewContractEngine(config *params.ChainConfig, defaultGov *Governance) *ContractEngine {
+	e := &ContractEngine{
+		chainConfig:   config,
+		currentParams: params.NewGovParamSet(),
+		defaultGov:    defaultGov,
+	}
+
+	if pset, err := params.NewGovParamSetChainConfig(config); err == nil {
+		e.initialParams = pset
+		e.currentParams = pset
+	} else {
+		logger.Crit("Error parsing initial ChainConfig", "err", err)
+	}
+	return e
+}
+
+func (e *ContractEngine) SetBlockchain(chain blockChain) {
+	e.chain = chain
+}
+
+// Params effective at upcoming block (head+1)
+func (e *ContractEngine) Params() *params.GovParamSet {
+	return e.currentParams
+}
+
+// Params effective at requested block (num)
+func (e *ContractEngine) ParamsAt(num uint64) (*params.GovParamSet, error) {
+	if e.chain == nil {
+		logger.Error("Invoked ParamsAt() before SetBlockchain", "num", num)
+		return nil, errContractEngineNotReady
+	}
+
+	head := e.chain.CurrentHeader().Number.Uint64()
+	if num > head {
+		// Sometimes future blocks are requested.
+		// ex) reward distributor in istanbul.engine.Finalize() requests ParamsAt(head+1)
+		// ex) governance_itemsAt(num) API requests arbitrary num
+		// In those cases we refer to the head block.
+		num = head + 1
+	}
+
+	pset, err := e.contractGetAllParams(num)
+	if err != nil {
+		return nil, err
+	}
+	return params.NewGovParamSetMerged(e.initialParams, pset), nil
+}
+
+func (e *ContractEngine) UpdateParams() error {
+	if e.chain == nil {
+		logger.Error("Invoked UpdateParams() before SetBlockchain")
+		return errContractEngineNotReady
+	}
+
+	head := e.chain.CurrentHeader().Number.Uint64()
+	pset, err := e.contractGetAllParams(head + 1)
+	if err != nil {
+		return err
+	}
+
+	e.currentParams = params.NewGovParamSetMerged(e.initialParams, pset)
+	return nil
+}
+
+func (e *ContractEngine) contractGetAllParams(num uint64) (*params.GovParamSet, error) {
+	if e.chain == nil {
+		logger.Error("Invoked ContractEngine before SetBlockchain")
+		return nil, errContractEngineNotReady
+	}
+
+	addr := e.contractAddrAt(num)
+	if common.EmptyAddress(addr) {
+		logger.Error("Invoked ContractEngine but address is empty", "num", num)
+		return nil, errContractEngineNotReady
+	}
+
+	caller := &contractCaller{
+		chainConfig:  e.chainConfig,
+		chain:        e.chain,
+		contractAddr: addr,
+	}
+	if num > 0 {
+		num -= 1
+	}
+	return caller.getAllParams(new(big.Int).SetUint64(num))
+}
+
+// Return the GovernanceContract address effective at given block number
+func (e *ContractEngine) contractAddrAt(num uint64) common.Address {
+	// TODO: Load from HeaderEngine
+
+	// If database don't have the item, fallback to ChainConfig
+	if e.chainConfig.Governance != nil {
+		return e.chainConfig.Governance.GovernanceContract
+	}
+
+	return common.Address{}
+}
+
+type contractCaller struct {
+	chainConfig  *params.ChainConfig
+	chain        blockChain
+	contractAddr common.Address
+}
+
+func (c *contractCaller) getAllParams(num *big.Int) (*params.GovParamSet, error) {
+	tx, err := c.makeTx(num, govParamAbi, "getAllParams")
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.callTx(num, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse results into GovParamSet
+
+	// Cannot parse empty data
+	if len(res) == 0 {
+		return params.NewGovParamSet(), nil
+	}
+
+	var ( // c.f. contracts/gov/GovParam.go:GetAllParams()
+		pNames  = new([]string)                    // *[]string = nil
+		pValues = new([]govcontract.GovParamParam) // *[]govcontract.GovParamParam = nil
+		out     = &[]interface{}{pNames, pValues}  // array of pointers
+	)
+	if err := govParamAbi.Unpack(out, "getAllParams", res); err != nil {
+		return nil, err
+	}
+	var ( // Retrieve the slices allocated inside Unpack().
+		names  = *pNames
+		values = *pValues
+	)
+
+	if len(names) != len(values) {
+		logger.Error("Malformed contract.getAllParams result",
+			"len(names)", len(names), "len(values)", len(values))
+		return params.NewGovParamSet(), nil
+	}
+
+	bytesMap := make(map[string][]byte)
+	for i := 0; i < len(names); i++ {
+		bytesMap[names[i]] = values[i].Value
+	}
+	return params.NewGovParamSetBytesMap(bytesMap)
+}
+
+// Make contract execution transaction
+func (c *contractCaller) makeTx(num *big.Int, contractAbi abi.ABI, fn string, args ...interface{},
+) (*types.Transaction, error) {
+	calldata, err := contractAbi.Pack(fn, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	rules := c.chainConfig.Rules(num)
+	intrinsicGas, err := types.IntrinsicGas(calldata, nil, false, rules)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		from       = common.Address{}
+		to         = &c.contractAddr
+		nonce      = uint64(0)
+		amount     = big.NewInt(0)
+		gasLimit   = uint64(1e8)
+		gasPrice   = big.NewInt(0)
+		checkNonce = false
+	)
+	tx := types.NewMessage(from, to, nonce, amount, gasLimit, gasPrice, calldata,
+		checkNonce, intrinsicGas)
+	return tx, nil
+}
+
+// Execute contract call using state at block `num`.
+func (c *contractCaller) callTx(num *big.Int, tx *types.Transaction) ([]byte, error) {
+	// Load state at given block
+	block := c.chain.GetBlockByNumber(num.Uint64())
+	if block == nil {
+		return nil, errors.New("No such block")
+	}
+	statedb, err := c.chain.StateAt(block.Root())
+	if err != nil {
+		return nil, err
+	}
+
+	// Run EVM at given states
+	evmCtx := blockchain.NewEVMContext(tx, block.Header(), c.chain, nil)
+	evm := vm.NewEVM(evmCtx, statedb, c.chain.Config(), &vm.Config{})
+
+	res, _, kerr := blockchain.ApplyMessage(evm, tx)
+	if kerr.ErrTxInvalid != nil {
+		return nil, kerr.ErrTxInvalid
+	}
+
+	return res, nil
+}

--- a/governance/contract_test.go
+++ b/governance/contract_test.go
@@ -1,0 +1,97 @@
+package governance
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	govcontract "github.com/klaytn/klaytn/contracts/gov"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func prepareSimulatedContract(t *testing.T) ([]*bind.TransactOpts, *backends.SimulatedBackend, common.Address, *govcontract.GovParam) {
+	// Create accounts and simulated blockchain
+	accounts := []*bind.TransactOpts{}
+	alloc := blockchain.GenesisAlloc{}
+	for i := 0; i < 1; i++ {
+		key, _ := crypto.GenerateKey()
+		account := bind.NewKeyedTransactor(key)
+		accounts = append(accounts, account)
+		alloc[account.From] = blockchain.GenesisAccount{Balance: big.NewInt(params.KLAY)}
+	}
+	sim := backends.NewSimulatedBackend(alloc)
+
+	// Deploy contract
+	owner := accounts[0]
+	address, _, contract, err := govcontract.DeployGovParam(owner, sim)
+	require.Nil(t, err)
+	sim.Commit()
+
+	tx, err := contract.Initialize(owner, owner.From)
+	require.Nil(t, err)
+	sim.Commit()
+
+	receipt, _ := sim.TransactionReceipt(nil, tx.Hash())
+	require.NotNil(t, receipt)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	return accounts, sim, address, contract
+}
+
+func TestContractEngine_Simulated(t *testing.T) {
+	accounts, sim, _, contract := prepareSimulatedContract(t)
+
+	var (
+		owner  = accounts[0]
+		name   = "istanbul.committeesize"
+		valueA = []byte{0xa}
+		valueB = []byte{0xb}
+	)
+
+	// Empty array before SetParam()
+	names, values, err := contract.GetAllParams(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(names))
+	assert.Equal(t, 0, len(values))
+
+	// Call SetParam()
+	tx, err := contract.SetParamByOwner(owner, name, valueA)
+	require.Nil(t, err)
+	sim.Commit()
+
+	receipt, _ := sim.TransactionReceipt(nil, tx.Hash())
+	require.NotNil(t, receipt)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	// Value exists after SetParam()
+	names, values, err = contract.GetAllParams(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(names))
+	assert.Equal(t, 1, len(values))
+	assert.Equal(t, name, names[0])
+	assert.Equal(t, valueA, values[0].Value)
+
+	// Call SetParam() again
+	tx, err = contract.SetParamByOwner(owner, name, valueB)
+	require.Nil(t, err)
+	sim.Commit()
+
+	receipt, _ = sim.TransactionReceipt(nil, tx.Hash())
+	require.NotNil(t, receipt)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	// Value changed after SetParam()
+	names, values, err = contract.GetAllParams(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(names))
+	assert.Equal(t, 1, len(values))
+	assert.Equal(t, name, names[0])
+	assert.Equal(t, valueB, values[0].Value)
+}

--- a/governance/default.go
+++ b/governance/default.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/params"
@@ -158,13 +157,6 @@ type VoteMap struct {
 // txPool is an interface for blockchain.TxPool used in governance package.
 type txPool interface {
 	SetGasPrice(price *big.Int)
-}
-
-// blockChain is an interface for blockchain.Blockchain used in governance package.
-type blockChain interface {
-	CurrentHeader() *types.Header
-	SetProposerPolicy(val uint64)
-	SetUseGiniCoeff(val bool)
 }
 
 type Governance struct {

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -17,6 +17,8 @@
 package governance
 
 import (
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus/istanbul"
@@ -97,4 +99,17 @@ type HeaderEngine interface {
 	SetMyVotingPower(t uint64)
 	SetBlockchain(chain blockChain)
 	SetTxPool(txpool txPool)
+}
+
+// blockChain is an interface for blockchain.Blockchain used in governance package.
+type blockChain interface {
+	blockchain.ChainContext
+
+	CurrentHeader() *types.Header
+	GetBlockByNumber(num uint64) *types.Block
+	StateAt(root common.Hash) (*state.StateDB, error)
+	Config() *params.ChainConfig
+
+	SetProposerPolicy(val uint64)
+	SetUseGiniCoeff(val bool)
 }

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -266,6 +266,9 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	cn.blockchain = bc
 	governance.SetBlockchain(cn.blockchain)
+	if err := governance.UpdateParams(); err != nil {
+		return nil, err
+	}
 	// Synchronize proposerpolicy & useGiniCoeff
 	if cn.blockchain.Config().Istanbul != nil {
 		cn.blockchain.Config().Istanbul.ProposerPolicy = governance.Params().Policy()

--- a/params/config.go
+++ b/params/config.go
@@ -35,6 +35,7 @@ var (
 	BaobabGenesisHash       = common.HexToHash("0xe33ff05ceec2581ca9496f38a2bf9baad5d4eed629e896ccb33d1dc991bc4b4a") // baobab genesis hash to enforce below configs on
 	AuthorAddressForTesting = common.HexToAddress("0xc0ea08a2d404d3172d2add29a45be56da40e2949")
 	mintingAmount, _        = new(big.Int).SetString("9600000000000000000", 10)
+	logger                  = log.NewModuleLogger(log.Governance)
 )
 
 var (
@@ -46,8 +47,9 @@ var (
 		EthTxTypeCompatibleBlock: big.NewInt(86816005),
 		DeriveShaImpl:            2,
 		Governance: &GovernanceConfig{
-			GoverningNode:  common.HexToAddress("0x52d41ca72af615a1ac3301b0a93efa222ecc7541"),
-			GovernanceMode: "single",
+			GoverningNode:      common.HexToAddress("0x52d41ca72af615a1ac3301b0a93efa222ecc7541"),
+			GovernanceMode:     "single",
+			GovernanceContract: common.HexToAddress("0x0"),
 			Reward: &RewardConfig{
 				MintingAmount:          mintingAmount,
 				Ratio:                  "34/54/12",
@@ -74,8 +76,9 @@ var (
 		EthTxTypeCompatibleBlock: big.NewInt(86513895),
 		DeriveShaImpl:            2,
 		Governance: &GovernanceConfig{
-			GoverningNode:  common.HexToAddress("0x99fb17d324fa0e07f23b49d09028ac0919414db6"),
-			GovernanceMode: "single",
+			GoverningNode:      common.HexToAddress("0x99fb17d324fa0e07f23b49d09028ac0919414db6"),
+			GovernanceMode:     "single",
+			GovernanceContract: common.HexToAddress("0x0"),
 			Reward: &RewardConfig{
 				MintingAmount:          mintingAmount,
 				Ratio:                  "34/54/12",
@@ -182,9 +185,10 @@ type ChainConfig struct {
 
 // GovernanceConfig stores governance information for a network
 type GovernanceConfig struct {
-	GoverningNode  common.Address `json:"governingNode"`
-	GovernanceMode string         `json:"governanceMode"`
-	Reward         *RewardConfig  `json:"reward,omitempty"`
+	GoverningNode      common.Address `json:"governingNode"`
+	GovernanceMode     string         `json:"governanceMode"`
+	GovernanceContract common.Address `json:"governanceContract"`
+	Reward             *RewardConfig  `json:"reward,omitempty"`
 }
 
 func (g *GovernanceConfig) DeferredTxFee() bool {
@@ -361,7 +365,6 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 
 // SetDefaults fills undefined chain config with default values.
 func (c *ChainConfig) SetDefaults() {
-	logger := log.NewModuleLogger(log.Governance)
 
 	if c.Clique == nil && c.Istanbul == nil {
 		c.Istanbul = GetDefaultIstanbulConfig()
@@ -475,9 +478,10 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 
 func GetDefaultGovernanceConfig() *GovernanceConfig {
 	gov := &GovernanceConfig{
-		GovernanceMode: DefaultGovernanceMode,
-		GoverningNode:  common.HexToAddress(DefaultGoverningNode),
-		Reward:         GetDefaultRewardConfig(),
+		GovernanceMode:     DefaultGovernanceMode,
+		GoverningNode:      common.HexToAddress(DefaultGoverningNode),
+		GovernanceContract: common.HexToAddress(DefaultGovernanceContract),
+		Reward:             GetDefaultRewardConfig(),
 	}
 	return gov
 }

--- a/params/config.go
+++ b/params/config.go
@@ -169,9 +169,10 @@ type ChainConfig struct {
 
 	// "Compatible" means that it is EVM compatible(the opcode and precompiled contracts are the same as Ethereum EVM).
 	// In other words, not all the hard fork items are included.
-	IstanbulCompatibleBlock  *big.Int `json:"istanbulCompatibleBlock,omitempty"`  // IstanbulCompatibleBlock switch block (nil = no fork, 0 = already on istanbul)
-	LondonCompatibleBlock    *big.Int `json:"londonCompatibleBlock,omitempty"`    // LondonCompatibleBlock switch block (nil = no fork, 0 = already on london)
-	EthTxTypeCompatibleBlock *big.Int `json:"ethTxTypeCompatibleBlock,omitempty"` // EthTxTypeCompatibleBlock switch block (nil = no fork, 0 = already on ethTxType)
+	IstanbulCompatibleBlock    *big.Int `json:"istanbulCompatibleBlock,omitempty"`    // IstanbulCompatibleBlock switch block (nil = no fork, 0 = already on istanbul)
+	LondonCompatibleBlock      *big.Int `json:"londonCompatibleBlock,omitempty"`      // LondonCompatibleBlock switch block (nil = no fork, 0 = already on london)
+	EthTxTypeCompatibleBlock   *big.Int `json:"ethTxTypeCompatibleBlock,omitempty"`   // EthTxTypeCompatibleBlock switch block (nil = no fork, 0 = already on ethTxType)
+	ContractGovCompatibleBlock *big.Int `json:"contractGovCompatibleBlock,omitempty"` // ContractGovCompatibleBlock switch block (nil = no fork, 0 = already on contractGov)
 
 	// Various consensus engines
 	Gxhash   *GxhashConfig   `json:"gxhash,omitempty"` // (deprecated) not supported engine
@@ -252,22 +253,24 @@ func (c *ChainConfig) String() string {
 		engine = "unknown"
 	}
 	if c.Istanbul != nil {
-		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v SubGroupSize: %d UnitPrice: %d DeriveShaImpl: %d Engine: %v}",
+		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v ContractGovCompatibleBlock: %v SubGroupSize: %d UnitPrice: %d DeriveShaImpl: %d Engine: %v}",
 			c.ChainID,
 			c.IstanbulCompatibleBlock,
 			c.LondonCompatibleBlock,
 			c.EthTxTypeCompatibleBlock,
+			c.ContractGovCompatibleBlock,
 			c.Istanbul.SubGroupSize,
 			c.UnitPrice,
 			c.DeriveShaImpl,
 			engine,
 		)
 	} else {
-		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v UnitPrice: %d DeriveShaImpl: %d Engine: %v }",
+		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v ContractGovCompatibleBlock: %v UnitPrice: %d DeriveShaImpl: %d Engine: %v }",
 			c.ChainID,
 			c.IstanbulCompatibleBlock,
 			c.LondonCompatibleBlock,
 			c.EthTxTypeCompatibleBlock,
+			c.ContractGovCompatibleBlock,
 			c.UnitPrice,
 			c.DeriveShaImpl,
 			engine,
@@ -295,6 +298,11 @@ func (c *ChainConfig) IsLondonForkEnabled(num *big.Int) bool {
 // IsEthTxTypeForkEnabled returns whether num is either equal to the ethTxType block or greater.
 func (c *ChainConfig) IsEthTxTypeForkEnabled(num *big.Int) bool {
 	return isForked(c.EthTxTypeCompatibleBlock, num)
+}
+
+// IsContractGovForkEnabled returns whether num is either equal to the contractGov block or greater.
+func (c *ChainConfig) IsContractGovForkEnabled(num *big.Int) bool {
+	return isForked(c.ContractGovCompatibleBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -328,6 +336,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "istanbulBlock", block: c.IstanbulCompatibleBlock},
 		{name: "londonBlock", block: c.LondonCompatibleBlock},
 		{name: "ethTxTypeBlock", block: c.EthTxTypeCompatibleBlock},
+		{name: "contractGovBlock", block: c.ContractGovCompatibleBlock},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -359,6 +368,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	}
 	if isForkIncompatible(c.EthTxTypeCompatibleBlock, newcfg.EthTxTypeCompatibleBlock, head) {
 		return newCompatError("EthTxType Block", c.EthTxTypeCompatibleBlock, newcfg.EthTxTypeCompatibleBlock)
+	}
+	if isForkIncompatible(c.ContractGovCompatibleBlock, newcfg.ContractGovCompatibleBlock, head) {
+		return newCompatError("ContractGov Block", c.ContractGovCompatibleBlock, newcfg.ContractGovCompatibleBlock)
 	}
 	return nil
 }

--- a/params/governance_params.go
+++ b/params/governance_params.go
@@ -77,6 +77,7 @@ var (
 	// Default Values: Constants used for getting default values for configuration
 	DefaultGovernanceMode          = "none"
 	DefaultGoverningNode           = "0x0000000000000000000000000000000000000000"
+	DefaultGovernanceContract      = "0x0000000000000000000000000000000000000000"
 	DefaultEpoch                   = uint64(604800)
 	DefaultProposerPolicy          = uint64(RoundRobin)
 	DefaultSubGroupSize            = uint64(21)

--- a/params/governance_params.go
+++ b/params/governance_params.go
@@ -56,6 +56,7 @@ const (
 	ConstTxGasHumanReadable
 	CliqueEpoch
 	Timeout
+	GovernanceContract
 )
 
 const (

--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -210,6 +210,7 @@ var govParamTypes = map[int]*govParamType{
 	MinimumStake:            govParamTypeBigInt,
 	StakeUpdateInterval:     govParamTypeUint64,
 	ProposerRefreshInterval: govParamTypeUint64,
+	GovernanceContract:      govParamTypeAddress,
 }
 
 var govParamNames = map[string]int{
@@ -226,6 +227,7 @@ var govParamNames = map[string]int{
 	"reward.minimumstake":           MinimumStake,
 	"reward.stakingupdateinterval":  StakeUpdateInterval,
 	"reward.proposerupdateinterval": ProposerRefreshInterval,
+	"governance.governancecontract": GovernanceContract,
 }
 
 var govParamNamesReverse = map[int]string{}
@@ -320,6 +322,7 @@ func NewGovParamSetChainConfig(config *ChainConfig) (*GovParamSet, error) {
 	if config.Governance != nil {
 		items[GoverningNode] = config.Governance.GoverningNode
 		items[GovernanceMode] = config.Governance.GovernanceMode
+		items[GovernanceContract] = config.Governance.GovernanceContract
 		if config.Governance.Reward != nil {
 			if config.Governance.Reward.MintingAmount != nil {
 				items[MintingAmount] = config.Governance.Reward.MintingAmount.String()
@@ -470,4 +473,8 @@ func (p *GovParamSet) ProposerRefreshInterval() uint64 {
 
 func (p *GovParamSet) Timeout() uint64 {
 	return p.MustGet(Timeout).(uint64)
+}
+
+func (p *GovParamSet) GovernanceContract() common.Address {
+	return p.MustGet(GovernanceContract).(common.Address)
 }

--- a/params/governance_paramset_test.go
+++ b/params/governance_paramset_test.go
@@ -70,8 +70,7 @@ func TestGovParamSet_ParseValue(t *testing.T) {
 func TestGovParamSet_ParseBytes(t *testing.T) {
 	zeroAddrHex := "0x0000000000000000000000000000000000000000"
 	zeroAddr := common.HexToAddress(zeroAddrHex)
-	mintingAmount := "9600000000000000000"
-	mintingAmountBig, _ := new(big.Int).SetString(mintingAmount, 10)
+	mintingAmountStr := "9600000000000000000"
 
 	testcases := []struct {
 		ty     *govParamType
@@ -91,8 +90,9 @@ func TestGovParamSet_ParseBytes(t *testing.T) {
 		{govParamTypeUint64, []byte{1, 2, 3, 4, 5, 6, 7, 8}, uint64(0x0102030405060708), true},
 		{govParamTypeUint64, []byte{1, 1, 2, 3, 4, 5, 6, 7, 8}, nil, false},
 
-		{govParamTypeBigInt, mintingAmountBig.Bytes(), mintingAmount, true},
-		{govParamTypeBigInt, []byte{0x12, 0x34}, "4660", true},
+		{govParamTypeBigInt, []byte(mintingAmountStr), mintingAmountStr, true},
+		{govParamTypeBigInt, []byte("abcd"), nil, false},
+		{govParamTypeBigInt, []byte(""), nil, false},
 
 		{govParamTypeRatio, []byte("100/0/0"), "100/0/0", true},
 		{govParamTypeRatio, []byte("10/20/30/40"), nil, false},

--- a/params/governance_paramset_test.go
+++ b/params/governance_paramset_test.go
@@ -151,6 +151,7 @@ func TestGovParamSet_Nominal(t *testing.T) {
 	assert.Equal(t, c.UnitPrice, p.UnitPrice())
 	assert.Equal(t, c.Governance.GovernanceMode, p.GovernanceModeStr())
 	assert.Equal(t, c.Governance.GoverningNode, p.GoverningNode())
+	assert.Equal(t, c.Governance.GovernanceContract, p.GovernanceContract())
 	assert.Equal(t, c.Governance.Reward.MintingAmount.String(), p.MintingAmountStr())
 	assert.Equal(t, c.Governance.Reward.MintingAmount, p.MintingAmountBig())
 	assert.Equal(t, c.Governance.Reward.Ratio, p.Ratio())

--- a/tests/gov_contract_test.go
+++ b/tests/gov_contract_test.go
@@ -1,0 +1,227 @@
+package tests
+
+import (
+	"encoding/hex"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/klaytn/klaytn/accounts/abi"
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	govcontract "github.com/klaytn/klaytn/contracts/gov"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/governance"
+	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/node/cn"
+	"github.com/klaytn/klaytn/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGovernance_ContractEngine(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+
+	fullNode, node, validator, chainId, workspace := newBlockchain(t)
+	defer os.RemoveAll(workspace)
+	defer fullNode.Stop()
+
+	var (
+		chain        = node.BlockChain().(*blockchain.BlockChain)
+		config       = chain.Config()
+		owner        = validator
+		contractAddr = crypto.CreateAddress(owner.Addr, owner.Nonce)
+
+		paramName     = "istanbul.committeesize"
+		fallbackValue = config.Istanbul.SubGroupSize
+		paramValue    = uint64(22)
+		paramBytes    = []byte{22}
+
+		deployBlock   uint64 // Before deploy: 0, After deploy: the deployed block
+		setParamBlock uint64 // Before setParam: 0, After setParam: the setParam'd block
+	)
+
+	// Here we are running (tx sender) and (param reader) in parallel.
+	// This is to check that param reader works under various situations such as
+	// (a) contract is not yet deployed (b) parameter is not yet set (c) parameter is set.
+
+	// Run tx sender thread
+	go func() {
+		num, _, _ := deployGovParamTx_constructor(t, node, owner, chainId)
+		deployBlock = num
+
+		num, _ = deployGovParamTx_setParam(t, node, owner, chainId, contractAddr, paramName, paramBytes)
+		setParamBlock = num
+	}()
+
+	// Run param reader thread
+	config.Governance.GovernanceContract = contractAddr
+	engine := governance.NewContractEngine(config, nil)
+	engine.SetBlockchain(chain)
+
+	// Validate current params from engine.Params(), alongside block processing.
+	// At block #N, Params() returns the parameters to be used when building
+	// block #N+1 (i.e. pending block).
+	chainEventCh := make(chan blockchain.ChainEvent)
+	subscription := chain.SubscribeChainEvent(chainEventCh)
+	defer subscription.Unsubscribe()
+	for {
+		ev := <-chainEventCh
+		time.Sleep(100 * time.Millisecond) // wait for tx sender thread to set deployBlock, etc.
+
+		num := ev.Block.Number().Uint64()
+		err := engine.UpdateParams()
+		assert.Nil(t, err)
+
+		value, _ := engine.Params().Get(params.CommitteeSize)
+		t.Logf("Params() at block=%2d: %v", num, value)
+
+		if deployBlock == 0 { // not yet deployed
+			assert.Equal(t, fallbackValue, value)
+		} else if setParamBlock == 0 { // not yet setParam'd
+			assert.Equal(t, fallbackValue, value)
+		} else { // after setParam
+			assert.Equal(t, paramValue, value)
+		}
+		if setParamBlock != 0 && num >= setParamBlock+2 {
+			break
+		}
+	}
+
+	// Validate historic params from engine.ParamsAt(n)
+	for num := uint64(0); num <= setParamBlock+2; num++ {
+		pset, err := engine.ParamsAt(num)
+		assert.Nil(t, err)
+		assert.NotNil(t, pset)
+
+		value, _ := pset.Get(params.CommitteeSize)
+		t.Logf("ParamsAt(block=%2d): %v", num, value)
+		if num < deployBlock { // not yet deployed
+			assert.Equal(t, fallbackValue, value)
+		} else if num <= setParamBlock { // not yet setParam'd
+			assert.Equal(t, fallbackValue, value)
+		} else { // after setParam
+			assert.Equal(t, paramValue, value)
+		}
+	}
+}
+
+func deployGovParamTx_constructor(t *testing.T, node *cn.CN, owner *TestAccountType, chainId *big.Int,
+) (uint64, common.Address, *types.Transaction) {
+	var (
+		// Deploy contract: constructor(address _owner)
+		contractAbi, _ = abi.JSON(strings.NewReader(govcontract.GovParamABI))
+		contractBin    = govcontract.GovParamBin
+		ctorArgs, _    = contractAbi.Pack("")
+		code           = contractBin + hex.EncodeToString(ctorArgs)
+		initArgs, _    = contractAbi.Pack("initialize", owner.Addr)
+		initData       = common.ToHex(initArgs)
+	)
+
+	// Deploy contract
+	tx, addr := deployContractDeployTx(t, node.TxPool(), chainId, owner, code)
+
+	chain := node.BlockChain().(*blockchain.BlockChain)
+	receipt := waitReceipt(chain, tx.Hash())
+	require.NotNil(t, receipt)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	_, _, num, _ := chain.GetTxAndLookupInfo(tx.Hash())
+	t.Logf("GovParam deployed at block=%2d, addr=%s", num, addr.Hex())
+
+	// Call initialize()
+	tx = deployContractExecutionTx(t, node.TxPool(), chainId, owner, addr, initData)
+	receipt = waitReceipt(chain, tx.Hash())
+	require.NotNil(t, receipt)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	return num, addr, tx
+}
+
+func deployGovParamTx_setParam(t *testing.T, node *cn.CN, owner *TestAccountType, chainId *big.Int,
+	contractAddr common.Address, name string, value []byte,
+) (uint64, *types.Transaction) {
+	var (
+		// Set parameter: setParam(string name, bytes value)
+		contractAbi, _ = abi.JSON(strings.NewReader(govcontract.GovParamABI))
+		callArgs, _    = contractAbi.Pack("setParamByOwner", name, value)
+		data           = common.ToHex(callArgs)
+	)
+
+	tx := deployContractExecutionTx(t, node.TxPool(), chainId, owner, contractAddr, data)
+
+	chain := node.BlockChain().(*blockchain.BlockChain)
+	receipt := waitReceipt(chain, tx.Hash())
+	require.NotNil(t, receipt)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	_, _, num, _ := chain.GetTxAndLookupInfo(tx.Hash())
+	t.Logf("GovParam.setParam executed at block=%2d", num)
+	return num, tx
+}
+
+func deployGovParamTx_batchSetParam(t *testing.T, node *cn.CN, owner *TestAccountType, chainId *big.Int,
+	contractAddr common.Address, bytesMap map[string][]byte,
+) []*types.Transaction {
+	var (
+		chain          = node.BlockChain().(*blockchain.BlockChain)
+		beginBlock     = chain.CurrentHeader().Number.Uint64()
+		contractAbi, _ = abi.JSON(strings.NewReader(govcontract.GovParamABI))
+		txs            = []*types.Transaction{}
+	)
+
+	// Send all setParam() calls at once
+	for name, value := range bytesMap {
+		// Set parameter: setParam(string name, bytes value)
+		callArgs, _ := contractAbi.Pack("setParamByOwner", name, value)
+		data := common.ToHex(callArgs)
+		tx := deployContractExecutionTx(t, node.TxPool(), chainId, owner, contractAddr, data)
+		txs = append(txs, tx)
+	}
+
+	// Wait for all txs
+	for _, tx := range txs {
+		receipt := waitReceipt(chain, tx.Hash())
+		require.NotNil(t, receipt)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+	}
+	num := chain.CurrentHeader().Number.Uint64()
+	t.Logf("GovParam.setParam executed %d times between blocks=%2d,%2d", len(txs), beginBlock, num)
+	return txs
+}
+
+// Klaytn node only decodes the byte-array param values (refer to params/governance_paramset.go).
+// Encoding is the job of transaction senders (i.e. clients and dApps).
+// This is a reference implementation of such encoder.
+func chainConfigToBytesMap(t *testing.T, config *params.ChainConfig) map[string][]byte {
+	pset, err := params.NewGovParamSetChainConfig(config)
+	require.Nil(t, err)
+	strMap := pset.StrMap()
+
+	bytesMap := map[string][]byte{}
+	for name, value := range strMap {
+		switch value.(type) {
+		case string:
+			bytesMap[name] = []byte(value.(string))
+		case common.Address:
+			bytesMap[name] = value.(common.Address).Bytes()
+		case uint64:
+			bytesMap[name] = new(big.Int).SetUint64(value.(uint64)).Bytes()
+		case bool:
+			if value.(bool) == true {
+				bytesMap[name] = []byte{0x01}
+			} else {
+				bytesMap[name] = []byte{0x00}
+			}
+		}
+	}
+
+	// Check that bytesMap is correct just in case
+	qset, err := params.NewGovParamSetBytesMap(bytesMap)
+	require.Nil(t, err)
+	require.Equal(t, pset.StrMap(), qset.StrMap())
+	return bytesMap
+}

--- a/tests/klay_blockchain_test.go
+++ b/tests/klay_blockchain_test.go
@@ -170,6 +170,9 @@ func newKlaytnNode(t *testing.T, dir string, validator *TestAccountType) (*node.
 	genesis.Config = params.CypressChainConfig.Copy()
 	genesis.Config.Istanbul.SubGroupSize = 1
 	genesis.Config.Istanbul.ProposerPolicy = uint64(istanbul.RoundRobin)
+	genesis.Config.Governance.GoverningNode = validator.Addr
+	genesis.Config.Governance.GovernanceMode = "none"
+	genesis.Config.Governance.GovernanceContract = crypto.CreateAddress(validator.Addr, validator.Nonce)
 	genesis.Config.Governance.Reward.MintingAmount = new(big.Int).Mul(big.NewInt(9000000000000000000), big.NewInt(params.KLAY))
 
 	cnConf := cn.GetDefaultConfig()

--- a/tests/klay_blockchain_test.go
+++ b/tests/klay_blockchain_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/klaytn/klaytn/work"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSimpleBlockchain
@@ -54,15 +55,16 @@ func TestSimpleBlockchain(t *testing.T) {
 
 	contractDeployCode := "0x608060405234801561001057600080fd5b506000808190555060646001819055506101848061002f6000396000f300608060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806302e5329e14610067578063197e70e41461009457806349b667d2146100c157806367e0badb146100ec575b600080fd5b34801561007357600080fd5b5061009260048036038101908080359060200190929190505050610117565b005b3480156100a057600080fd5b506100bf60048036038101908080359060200190929190505050610121565b005b3480156100cd57600080fd5b506100d6610145565b6040518082815260200191505060405180910390f35b3480156100f857600080fd5b5061010161014f565b6040518082815260200191505060405180910390f35b8060018190555050565b806000540160008190555060015460005481151561013b57fe5b0660008190555050565b6000600154905090565b600080549050905600a165627a7a72305820ef4e7e564c744de3a36cb74000c35687f7de9ecf1d29abdd3c4bcc66db981c160029"
 	for i := 0; i < numAccounts; i++ {
-		contractAccounts[i].Addr = deployContractDeployTx(t, node.TxPool(), chainId, richAccount, contractDeployCode)
+		_, contractAccounts[i].Addr = deployContractDeployTx(t, node.TxPool(), chainId, richAccount, contractDeployCode)
 	}
 	time.Sleep(time.Second) // need to make a block before contract execution
 
 	// deploy
+	calldata := "0x197e70e40000000000000000000000000000000000000000000000000000000000000001"
 	for i := 0; i < numAccounts; i++ {
 		deployRandomTxs(t, node.TxPool(), chainId, richAccount, 10)
 		deployValueTransferTx(t, node.TxPool(), chainId, richAccount, accounts[i%numAccounts])
-		deployContractExecutionTx(t, node.TxPool(), chainId, richAccount, contractAccounts[i%numAccounts].Addr)
+		deployContractExecutionTx(t, node.TxPool(), chainId, richAccount, contractAccounts[i%numAccounts].Addr, calldata)
 
 		// time.Sleep(time.Second) // wait until txpool is flushed if needed
 	}
@@ -195,10 +197,11 @@ func newKlaytnNode(t *testing.T, dir string, validator *TestAccountType) (*node.
 }
 
 // deployRandomTxs creates a random transaction
-func deployRandomTxs(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, txNum int) {
+func deployRandomTxs(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, txNum int) []*types.Transaction {
 	var tx *types.Transaction
+	var txs []*types.Transaction
 	signer := types.LatestSignerForChainID(chainId)
-	gasPrice := big.NewInt(25 * params.Ston)
+	gasPrice := txpool.GasPrice()
 
 	txNuminABlock := 100
 	for i := 0; i < txNum; i++ {
@@ -207,86 +210,139 @@ func deployRandomTxs(t *testing.T, txpool work.TxPool, chainId *big.Int, sender 
 		}
 
 		receiver, err := createAnonymousAccount(getRandomPrivateKeyString(t))
-		if err != nil {
-			t.Fatal()
-		}
+		require.Nil(t, err)
 
 		tx, _ = genLegacyTransaction(t, signer, sender, receiver, nil, gasPrice)
-		if err := txpool.AddLocal(tx); err != nil && err != blockchain.ErrAlreadyNonceExistInPool {
-			t.Fatal(err)
-		}
+
+		err = txpool.AddLocal(tx)
+		require.True(t, err == nil || err == blockchain.ErrAlreadyNonceExistInPool)
+
+		txs = append(txs, tx)
 		sender.AddNonce()
 	}
+	return txs
 }
 
 // deployValueTransferTx deploy value transfer transactions
-func deployValueTransferTx(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, toAcc *TestAccountType) {
+func deployValueTransferTx(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, toAcc *TestAccountType) *types.Transaction {
 	signer := types.LatestSignerForChainID(chainId)
-	gasPrice := big.NewInt(25 * params.Ston)
+	gasPrice := txpool.GasPrice()
 
 	tx, _ := genLegacyTransaction(t, signer, sender, toAcc, nil, gasPrice)
-	if err := txpool.AddLocal(tx); err != nil && err != blockchain.ErrAlreadyNonceExistInPool {
-		t.Fatal(err)
-	}
+
+	err := txpool.AddLocal(tx)
+	require.True(t, err == nil || err == blockchain.ErrAlreadyNonceExistInPool)
+
 	sender.AddNonce()
+	return tx
 }
 
-// deployContractDeployTx deploy contrac
-func deployContractDeployTx(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, contractDeployCode string) common.Address {
+// deployContractDeployTx deploys a contract
+func deployContractDeployTx(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, code string) (*types.Transaction, common.Address) {
 	signer := types.LatestSignerForChainID(chainId)
-	gasPrice := big.NewInt(25 * params.Ston)
+	gasPrice := txpool.GasPrice()
 
 	values := map[types.TxValueKeyType]interface{}{
 		types.TxValueKeyNonce:         sender.GetNonce(),
-		types.TxValueKeyAmount:        new(big.Int).SetUint64(0),
-		types.TxValueKeyGasLimit:      uint64(1000000),
-		types.TxValueKeyGasPrice:      gasPrice,
-		types.TxValueKeyHumanReadable: false,
 		types.TxValueKeyFrom:          sender.GetAddr(),
-		types.TxValueKeyData:          common.FromHex(contractDeployCode),
-		types.TxValueKeyCodeFormat:    params.CodeFormatEVM,
 		types.TxValueKeyTo:            (*common.Address)(nil),
+		types.TxValueKeyAmount:        new(big.Int).SetUint64(0),
+		types.TxValueKeyGasLimit:      uint64(1e9),
+		types.TxValueKeyGasPrice:      gasPrice,
+		types.TxValueKeyData:          common.FromHex(code),
+		types.TxValueKeyCodeFormat:    params.CodeFormatEVM,
+		types.TxValueKeyHumanReadable: false,
 	}
+
 	tx, err := types.NewTransactionWithMap(types.TxTypeSmartContractDeploy, values)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := tx.SignWithKeys(signer, sender.GetTxKeys()); err != nil {
-		t.Fatal(err)
-	}
-	if err := txpool.AddLocal(tx); err != nil && err != blockchain.ErrAlreadyNonceExistInPool {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
+
+	err = tx.SignWithKeys(signer, sender.GetTxKeys())
+	require.Nil(t, err)
+
+	err = txpool.AddLocal(tx)
+	require.True(t, err == nil || err == blockchain.ErrAlreadyNonceExistInPool)
+
 	contractAddr := crypto.CreateAddress(sender.Addr, sender.Nonce)
 	sender.AddNonce()
-
-	return contractAddr
+	return tx, contractAddr
 }
 
-func deployContractExecutionTx(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, contractAddr common.Address) {
+func deployContractExecutionTx(t *testing.T, txpool work.TxPool, chainId *big.Int, sender *TestAccountType, contractAddr common.Address, calldata string) *types.Transaction {
 	signer := types.LatestSignerForChainID(chainId)
-	gasPrice := big.NewInt(25 * params.Ston)
-	contractExecutionPayload := "0x197e70e40000000000000000000000000000000000000000000000000000000000000001"
+	gasPrice := txpool.GasPrice()
 
 	values := map[types.TxValueKeyType]interface{}{
 		types.TxValueKeyNonce:    sender.GetNonce(),
 		types.TxValueKeyFrom:     sender.GetAddr(),
 		types.TxValueKeyTo:       contractAddr,
 		types.TxValueKeyAmount:   new(big.Int).SetUint64(0),
-		types.TxValueKeyGasLimit: uint64(100000),
+		types.TxValueKeyGasLimit: uint64(1e9),
 		types.TxValueKeyGasPrice: gasPrice,
-		types.TxValueKeyData:     common.FromHex(contractExecutionPayload),
-	}
-	tx, err := types.NewTransactionWithMap(types.TxTypeSmartContractExecution, values)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := tx.SignWithKeys(signer, sender.GetTxKeys()); err != nil {
-		t.Fatal(err)
+		types.TxValueKeyData:     common.FromHex(calldata),
 	}
 
-	if err := txpool.AddLocal(tx); err != nil && err != blockchain.ErrAlreadyNonceExistInPool {
-		t.Fatal(err)
-	}
+	tx, err := types.NewTransactionWithMap(types.TxTypeSmartContractExecution, values)
+	require.Nil(t, err)
+
+	err = tx.SignWithKeys(signer, sender.GetTxKeys())
+	require.Nil(t, err)
+
+	err = txpool.AddLocal(tx)
+	require.True(t, err == nil || err == blockchain.ErrAlreadyNonceExistInPool)
+
 	sender.AddNonce()
+	return tx
+}
+
+// Wait until the receipt for `txhash` is ready
+// Returns the receipt
+// Returns nil after a reasonable timeout
+func waitReceipt(chain *blockchain.BlockChain, txhash common.Hash) *types.Receipt {
+	if receipt := chain.GetReceiptByTxHash(txhash); receipt != nil {
+		return receipt
+	}
+	chainEventCh := make(chan blockchain.ChainEvent)
+	subscription := chain.SubscribeChainEvent(chainEventCh)
+	defer subscription.Unsubscribe()
+	timeout := time.NewTimer(15 * time.Second)
+	for {
+		select {
+		case <-timeout.C:
+			return nil
+		case <-chainEventCh:
+			receipt := chain.GetReceiptByTxHash(txhash)
+			if receipt != nil {
+				return receipt
+			}
+		}
+	}
+}
+
+// Wait until `num` block is mined
+// Returns the header with the number larger or equal to `num`
+// Returns nil after a reasonable timeout
+func waitBlock(chain *blockchain.BlockChain, num uint64) *types.Header {
+	head := chain.CurrentHeader()
+	if head.Number.Uint64() >= num {
+		return head
+	}
+
+	chainEventCh := make(chan blockchain.ChainEvent)
+	subscription := chain.SubscribeChainEvent(chainEventCh)
+	defer subscription.Unsubscribe()
+	// Wait until desired `num` plus 10 seconds margin
+	timeoutSec := num - head.Number.Uint64() + 10
+	timeout := time.NewTimer(time.Duration(timeoutSec) * time.Second)
+	for {
+		select {
+		case <-timeout.C:
+			return nil
+		case <-chainEventCh:
+			head := chain.CurrentHeader()
+			if head.Number.Uint64() >= num {
+				return head
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Proposed changes

Merging into a feature branch.

This PR is mutually exclusive with #1436.

- Add new hardfork block number
  - Add ChainConfig item `ContractGovCompatibleBlock`
  - Add homi options`--contract-gov-compatible-blocknumber`

- MixedEngine uses ContractEngine after hardfork block, otherwise default Governance

| `n` or `head.Number`                         	| HF-2     	| HF-1      	| HF        	| Notes                      	|
|--------------------------	|-------------	|--------------	|--------------	|----------------------------	|
| ParamsAt(n)              	| use default 	| use default  	| use contract 	| IsContractEnabled (n)      	|
| Params(), UpdateParams() 	| use default 	| use contract 	| use contract 	| IsContractEnabled (head+1) 	|


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

https://github.com/klaytn/klaytn/issues/1375

## Further comments

Sample scenario

- Sample scenario
  - Case 1. Enable ContractEngine in a new chain
    - Allocate the GovParam.sol contract at a genesis address
    - Set `ChainConfig.Governance.GovernanceContract` to the address
    - Set `ChainConfig.ContractGovCompatibleBlock` to 0
    - Start the chain
  - Case 2. Enable ContractEngine in an existing chain
    - Deploy GovParam.sol contract
    - Set `ChainConfig.Governance.GovernanceContract` to the address
    - Set `ChainConfig.ContractGovCompatibleBlock` to some future block number

- This PR will be rebased after these are merged.
  - [x] #1424
  - [x] #1428
  - [ ] #1432

