### PR TITLE
Fix addressBookConnector EVM call error

### DIFF
--- a/reward/addressbook_connector.go
+++ b/reward/addressbook_connector.go
@@ -42,6 +42,8 @@ const (
 
 var errAddressBookIncomplete = errors.New("incomplete node information from AddressBook")
 
+var addressBookContractAddress = contract.AddressBookContractAddress
+
 type addressBookConnector struct {
 	bc              blockChain
 	gh              governanceHelper
@@ -55,7 +57,7 @@ func newAddressBookConnector(bc blockChain, gh governanceHelper) *addressBookCon
 		bc:              bc,
 		gh:              gh,
 		abi:             contract.AddressBookABI,
-		contractAddress: common.HexToAddress(contract.AddressBookContractAddress),
+		contractAddress: common.HexToAddress(addressBookContractAddress),
 	}
 }
 
@@ -199,4 +201,9 @@ func (ac *addressBookConnector) getStakingInfoFromAddressBook(blockNum uint64) (
 	}
 
 	return newStakingInfo(ac.bc, ac.gh, blockNum, nodeAddrs, stakingAddrs, rewardAddrs, KIRAddr, PoCAddr)
+}
+
+// Only for testing purpose.
+func SetTestAddressBookAddress(addr common.Address) {
+	addressBookContractAddress = addr.Hex()
 }

--- a/reward/addressbook_connector.go
+++ b/reward/addressbook_connector.go
@@ -80,8 +80,17 @@ func (ac *addressBookConnector) makeMsgToAddressBook(r params.Rules) (*types.Tra
 
 	// Create new call message
 	// TODO-Klaytn-Issue1166 Decide who will be sender(i.e. from)
-	msg := types.NewMessage(common.Address{}, &ac.contractAddress, 0, big.NewInt(0), 10000000, big.NewInt(0), data, false, intrinsicGas)
-
+	var (
+		from       = common.Address{}
+		to         = &ac.contractAddress
+		nonce      = uint64(0)
+		amount     = big.NewInt(0)
+		gasLimit   = uint64(10000000)
+		gasPrice   = big.NewInt(0)
+		checkNonce = false
+	)
+	msg := types.NewMessage(from, to, nonce, amount, gasLimit, gasPrice,
+		data, checkNonce, intrinsicGas)
 	return msg, nil
 }
 
@@ -180,6 +189,10 @@ func (ac *addressBookConnector) getStakingInfoFromAddressBook(blockNum uint64) (
 
 	// Create a new context to be used in the EVM environment
 	context := blockchain.NewEVMContext(msg, intervalBlock.Header(), ac.bc, nil)
+	// EVM demands the sender to have enough KLAY balance (gasPrice * gasLimit) in buyGas()
+	// After KIP-71, gasPrice is baseFee (=nonzero), regardless of the msg.gasPrice (=zero)
+	// But our sender (0x0) won't have enough balance. Instead we override gasPrice = 0 here
+	context.GasPrice = big.NewInt(0)
 	evm := vm.NewEVM(context, statedb, ac.bc.Config(), &vm.Config{})
 
 	res, gas, kerr := blockchain.ApplyMessage(evm, msg)

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -299,6 +299,22 @@ func StakingManagerUnsubscribe() {
 }
 
 // TODO-Klaytn-Reward the following methods are used for testing purpose, it needs to be moved into test files.
+// Unlike NewStakingManager(), SetTestStakingManager*() do not trigger once.Do().
+// This way you can avoid irreversible side effects during tests.
+
+// SetTestStakingManagerWithChain sets a full-featured staking manager with blockchain, database and cache.
+// Note that this method is used only for testing purpose.
+func SetTestStakingManagerWithChain(bc blockChain, gh governanceHelper, db stakingInfoDB) {
+	SetTestStakingManager(&StakingManager{
+		addressBookConnector: newAddressBookConnector(bc, gh),
+		stakingInfoCache:     newStakingInfoCache(),
+		stakingInfoDB:        db,
+		governanceHelper:     gh,
+		blockchain:           bc,
+		chainHeadChan:        make(chan blockchain.ChainHeadEvent, chainHeadChanSize),
+	})
+}
+
 // SetTestStakingManagerWithDB sets the staking manager with the given database.
 // Note that this method is used only for testing purpose.
 func SetTestStakingManagerWithDB(testDB stakingInfoDB) {

--- a/tests/staking_info_test.go
+++ b/tests/staking_info_test.go
@@ -19,13 +19,11 @@ import (
 )
 
 func TestAddressBookConnector(t *testing.T) {
-	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
 
 	fullNode, node, validator, chainId, workspace := newBlockchain(t)
 	defer os.RemoveAll(workspace)
 	defer fullNode.Stop()
-	_ = validator
-	_ = chainId
 
 	var (
 		chain  = node.BlockChain().(*blockchain.BlockChain)
@@ -86,8 +84,9 @@ func TestAddressBookConnector(t *testing.T) {
 	defer func() { params.SetStakingUpdateInterval(oldInterval) }()
 
 	// Create the StakingManager singleton
-	stakingManager := reward.NewStakingManager(chain, gov, db)
-	require.NotNil(t, stakingManager)
+	oldStakingManager := reward.GetStakingManager()
+	reward.SetTestStakingManagerWithChain(chain, gov, db)
+	defer reward.SetTestStakingManager(oldStakingManager)
 
 	// Attempt to read contract
 	require.NotNil(t, waitBlock(chain, deployBlock+3))

--- a/tests/staking_info_test.go
+++ b/tests/staking_info_test.go
@@ -1,3 +1,19 @@
+// Copyright 2022 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
 package tests
 
 import (

--- a/tests/staking_info_test.go
+++ b/tests/staking_info_test.go
@@ -1,0 +1,98 @@
+package tests
+
+import (
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	rewardcontract "github.com/klaytn/klaytn/contracts/reward/contract"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/governance"
+	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/reward"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressBookConnector(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
+
+	fullNode, node, validator, chainId, workspace := newBlockchain(t)
+	defer os.RemoveAll(workspace)
+	defer fullNode.Stop()
+	_ = validator
+	_ = chainId
+
+	var (
+		chain  = node.BlockChain().(*blockchain.BlockChain)
+		config = chain.Config()
+		txpool = node.TxPool()
+		db     = node.ChainDB()
+		gov    = governance.NewMixedEngine(config, db)
+
+		deployAddr  common.Address
+		deployBlock uint64
+	)
+
+	// Deploy AddressBook
+	{
+		sender := validator
+		signer := types.LatestSignerForChainID(chainId)
+
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:         sender.GetNonce(),
+			types.TxValueKeyAmount:        new(big.Int).SetUint64(0),
+			types.TxValueKeyGasLimit:      uint64(1e9),
+			types.TxValueKeyGasPrice:      big.NewInt(25 * params.Ston),
+			types.TxValueKeyHumanReadable: false,
+			types.TxValueKeyFrom:          sender.GetAddr(),
+			types.TxValueKeyData:          common.FromHex(rewardcontract.AddressBookBin),
+			types.TxValueKeyCodeFormat:    params.CodeFormatEVM,
+			types.TxValueKeyTo:            (*common.Address)(nil),
+		}
+
+		tx, err := types.NewTransactionWithMap(types.TxTypeSmartContractDeploy, values)
+		require.Nil(t, err)
+
+		err = tx.SignWithKeys(signer, sender.GetTxKeys())
+		require.Nil(t, err)
+
+		err = txpool.AddLocal(tx)
+		require.True(t, err == nil || err == blockchain.ErrAlreadyNonceExistInPool, "err=%v", err)
+
+		deployAddr = crypto.CreateAddress(sender.Addr, sender.Nonce)
+		sender.AddNonce()
+
+		receipt := waitReceipt(chain, tx.Hash())
+		require.NotNil(t, receipt)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+		_, _, deployBlock, _ = chain.GetTxAndLookupInfo(tx.Hash())
+		t.Logf("AddressBook deployed at block=%2d", deployBlock)
+	}
+
+	// Temporarily use the newly deployed address in addressBookConnector
+	oldAddr := common.HexToAddress(rewardcontract.AddressBookContractAddress)
+	reward.SetTestAddressBookAddress(deployAddr)
+	defer reward.SetTestAddressBookAddress(oldAddr)
+
+	// Temporarily lower the StakingUpdateInterval
+	oldInterval := params.StakingUpdateInterval()
+	params.SetStakingUpdateInterval(3)
+	defer func() { params.SetStakingUpdateInterval(oldInterval) }()
+
+	// Create the StakingManager singleton
+	stakingManager := reward.NewStakingManager(chain, gov, db)
+	require.NotNil(t, stakingManager)
+
+	// Attempt to read contract
+	require.NotNil(t, waitBlock(chain, deployBlock+3))
+	stakingInfo := reward.GetStakingInfo(deployBlock + 6)
+	assert.NotNil(t, stakingInfo)
+
+	t.Logf("StakingInfo=%s", stakingInfo)
+}


### PR DESCRIPTION
## Proposed changes

Fixes `addressBookConnector` to work after KIP-71.

- Problems reported
  - With KIP-71 enabled, `governance_getStakingInfo` API returns `nil`.
- Cause
  - The `addressBookConnector.getStakingInfoFromAddressBook()` function is somewhat similar to `EthDoCall()`.
  - It executes one transaction with `tx.gasPrice = 0` to query on-chain information.
  - With KIP-71, EVM demands the sender to have at least `baseFee*gasLimit` even if `tx.gasPrice = 0`.
  - The sender, currently empty address, does not have the balance.
- Proposed fix
  - Tell EVM that the GasPrice = 0. (i.e. EVM `Context.GasPrice = 0`)

How to test

- How to reproduce
  1. Pull this PR branch ([tutorial](https://blog.outsider.ne.kr/1204))
  2. Uncomment some lines in `tests/klay_blockchain_test.go` to enable KIP-71 in tests
  3. Comment the newly added line in `reward/addressbook_connector.go:getStakingInfoFromAddressBook()`
  4. Run test `cd tests && go run -v -run=AddressBook`
  5. Watch the error `failed to update stakingInfo ... failed to call AddressBook contract. root err: insufficient balance of the fee payer to pay for gas` is printed
- See the fix works
  1. Pull this PR branch
  2. Uncomment some lines in `tests/klay_blockchain_test.go` to enable KIP-71 in tests
  3. Run test `cd tests && go run -v -run=AddressBook`
  4. Test passes


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

Other fixes I've considered
1. Use [`api.DoCall()`](https://github.com/klaytn/klaytn/blob/v1.9.0-rc.1/api/api_public_blockchain.go#L281) or [`api.EthDoCall()`](https://github.com/klaytn/klaytn/blob/v1.9.0-rc.1/api/api_ethereum.go#L1539)
  - Not possible because of import cycle
2. `state.AddBalance` before calling EVM like in api.DoCall ([code](https://github.com/klaytn/klaytn/blob/v1.9.0-rc.1/api/api_public_blockchain.go#L317))
  - To implement this is `addressBookConnector` we'll have to (1) determine if current block is KIP-71 enabled (2) if so, get baseFee at requested block (3) AddBalance `baseFee*gasLimit`
  - This method is the "same" with `api.DoCall()`
3. I think current fix is simpler solution to the problem. Any comments are welcome.