### PR TITLE
governance: remove return error at VerifyGovernance length check logic

### DIFF
--- a/governance/default.go
+++ b/governance/default.go
@@ -954,7 +954,6 @@ func (gov *Governance) VerifyGovernance(received []byte) error {
 
 	if len(rChangeSet) != gov.changeSet.Size() {
 		logger.Error("Verification Error", "len(receivedChangeSet)", len(rChangeSet), "len(changeSet)", gov.changeSet.Size())
-		return ErrVoteValueMismatch
 	}
 
 	for k, v := range rChangeSet {


### PR DESCRIPTION
## Proposed changes
- A new governance validation logic is added at https://github.com/klaytn/klaytn/pull/1220, however returning error is too much because it can cause bad block. So, only logging error is remained, and returning error is removed.

closes https://github.com/klaytn/klaytn/issues/1420
## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
