### PR TITLE
fix WriteCode method for db migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,6 +384,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             make test-others
+    resource_class: xlarge
 
   test-rpc:
     executor: test-executor

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -201,6 +201,7 @@ type BlockChain struct {
 	pendingCnt            int
 	progress              float64
 	migrationErr          error
+	testMigrationHook     func()
 
 	// Warm up
 	lastCommittedBlock uint64

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -149,6 +149,10 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 	stateTrieBatch := dstState.TrieDB().DiskDB().NewBatch(database.StateTrieDB)
 	stats := migrationStats{initialStartTime: start, startTime: mclock.Now()}
 
+	if bc.testMigrationHook != nil {
+		bc.testMigrationHook()
+	}
+
 	// Migration main loop
 	for trieSync.Pending() > 0 {
 		nodes, _, codes := trieSync.Missing(1024)

--- a/blockchain/state_migration_test.go
+++ b/blockchain/state_migration_test.go
@@ -1,0 +1,91 @@
+// Copyright 2022 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package blockchain
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/klaytn/klaytn/blockchain/vm"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/gxhash"
+	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/storage/database"
+)
+
+func createLocalTestDB(t *testing.T) (string, database.DBManager) {
+	dir, err := ioutil.TempDir("", "klaytn-test-migration")
+	if err != nil {
+		t.Fatalf("failed to create a database: %v", err)
+	}
+	dbc := &database.DBConfig{Dir: dir, DBType: database.LevelDB, LevelDBCacheSize: 128, OpenFilesLimit: 128}
+	db := database.NewDBManager(dbc)
+	return dir, db
+}
+
+func TestBlockChain_migrateState(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
+
+	dir, testdb := createLocalTestDB(t)
+	defer os.RemoveAll(dir)
+
+	var (
+		gspec = &Genesis{Config: params.TestChainConfig}
+		_     = gspec.MustCommit(testdb)
+	)
+
+	chain, err := NewBlockChain(testdb, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to create local chain, %v", err)
+	}
+	defer chain.Stop()
+
+	chain.testMigrationHook = func() {
+		// sleep 2 seconds to write byte codes while migrating statedb
+		t.Log("taking 2 seconds for testing purpose...")
+		time.Sleep(2 * time.Second)
+	}
+
+	if err := chain.PrepareStateMigration(); err != nil {
+		t.Fatalf("failed to prepare state migration: %v", err)
+	}
+
+	b := chain.CurrentBlock()
+	if err := chain.StartStateMigration(b.NumberU64(), b.Root()); err != nil {
+		t.Fatalf("failed to start state migration: %v", err)
+	}
+
+	// write code while statedb migration
+	expectedCode := []byte{0x60, 0x80, 0x60, 0x40}
+	codeHash := common.BytesToHash(expectedCode)
+	chain.stateCache.TrieDB().DiskDB().WriteCode(codeHash, expectedCode)
+
+	for chain.db.InMigration() {
+		t.Log("It is in migration, sleeping 1 second")
+		time.Sleep(1 * time.Second)
+	}
+
+	// read code after deleting the original db
+	actualCode := chain.db.ReadCode(codeHash)
+	if actualCode == nil || bytes.Compare(expectedCode, actualCode) != 0 {
+		t.Fatalf("mismatch bytecodes: (expected: %v, actual: %v)", common.Bytes2Hex(expectedCode), common.Bytes2Hex(actualCode))
+	}
+}

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1659,7 +1659,7 @@ func (dbm *databaseManager) WriteCode(hash common.Hash, code []byte) {
 	dbm.lockInMigration.RLock()
 	defer dbm.lockInMigration.RUnlock()
 
-	var dbs []Database
+	dbs := make([]Database, 0, 2)
 	if dbm.inMigration {
 		dbs = append(dbs, dbm.getDatabase(StateTrieMigrationDB))
 	}

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -109,6 +109,7 @@ func createDBManagers(configs []*DBConfig) []DBManager {
 
 // TestDBManager_IsParallelDBWrite compares the return value of IsParallelDBWrite with the value in the config.
 func TestDBManager_IsParallelDBWrite(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for i, dbm := range dbManagers {
 		c := dbConfigs[i]
 		assert.Equal(t, c.ParallelDBWrite, dbm.IsParallelDBWrite())
@@ -117,6 +118,7 @@ func TestDBManager_IsParallelDBWrite(t *testing.T) {
 
 // TestDBManager_CanonicalHash tests read, write and delete operations of canonical hash.
 func TestDBManager_CanonicalHash(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		// 1. Read from empty database, shouldn't be found.
 		assert.Equal(t, common.Hash{}, dbm.ReadCanonicalHash(0))
@@ -147,6 +149,7 @@ func TestDBManager_CanonicalHash(t *testing.T) {
 
 // TestDBManager_HeadHeaderHash tests read and write operations of head header hash.
 func TestDBManager_HeadHeaderHash(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		assert.Equal(t, common.Hash{}, dbm.ReadHeadHeaderHash())
 
@@ -160,6 +163,7 @@ func TestDBManager_HeadHeaderHash(t *testing.T) {
 
 // TestDBManager_HeadBlockHash tests read and write operations of head block hash.
 func TestDBManager_HeadBlockHash(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		assert.Equal(t, common.Hash{}, dbm.ReadHeadBlockHash())
 
@@ -173,6 +177,7 @@ func TestDBManager_HeadBlockHash(t *testing.T) {
 
 // TestDBManager_HeadFastBlockHash tests read and write operations of head fast block hash.
 func TestDBManager_HeadFastBlockHash(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		assert.Equal(t, common.Hash{}, dbm.ReadHeadFastBlockHash())
 
@@ -186,6 +191,7 @@ func TestDBManager_HeadFastBlockHash(t *testing.T) {
 
 // TestDBManager_FastTrieProgress tests read and write operations of fast trie progress.
 func TestDBManager_FastTrieProgress(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		assert.Equal(t, uint64(0), dbm.ReadFastTrieProgress())
 
@@ -199,6 +205,7 @@ func TestDBManager_FastTrieProgress(t *testing.T) {
 
 // TestDBManager_Header tests read, write and delete operations of blockchain headers.
 func TestDBManager_Header(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	header := &types.Header{Number: big.NewInt(int64(num1))}
 	headerHash := header.Hash()
 
@@ -229,6 +236,7 @@ func TestDBManager_Header(t *testing.T) {
 
 // TestDBManager_Body tests read, write and delete operations of blockchain bodies.
 func TestDBManager_Body(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	body := &types.Body{Transactions: types.Transactions{}}
 	encodedBody, err := rlp.EncodeToBytes(body)
 	if err != nil {
@@ -282,6 +290,7 @@ func TestDBManager_Body(t *testing.T) {
 
 // TestDBManager_Td tests read, write and delete operations of blockchain headers' total difficulty.
 func TestDBManager_Td(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		assert.Nil(t, dbm.ReadTd(hash1, num1))
 
@@ -298,6 +307,7 @@ func TestDBManager_Td(t *testing.T) {
 
 // TestDBManager_Receipts read, write and delete operations of blockchain receipts.
 func TestDBManager_Receipts(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	header := &types.Header{Number: big.NewInt(int64(num1))}
 	headerHash := header.Hash()
 	receipts := types.Receipts{genReceipt(111)}
@@ -321,6 +331,7 @@ func TestDBManager_Receipts(t *testing.T) {
 
 // TestDBManager_Block read, write and delete operations of blockchain blocks.
 func TestDBManager_Block(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	header := &types.Header{Number: big.NewInt(int64(num1))}
 	headerHash := header.Hash()
 	block := types.NewBlockWithHeader(header)
@@ -355,6 +366,7 @@ func TestDBManager_Block(t *testing.T) {
 }
 
 func TestDBManager_BadBlock(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	header := &types.Header{Number: big.NewInt(int64(num1))}
 	headertwo := &types.Header{Number: big.NewInt(int64(num2))}
 	for _, dbm := range dbManagers {
@@ -423,6 +435,7 @@ func TestDBManager_BadBlock(t *testing.T) {
 
 // TestDBManager_IstanbulSnapshot tests read and write operations of istanbul snapshots.
 func TestDBManager_IstanbulSnapshot(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		snapshot, _ := dbm.ReadIstanbulSnapshot(hash3)
 		assert.Nil(t, snapshot)
@@ -439,6 +452,7 @@ func TestDBManager_IstanbulSnapshot(t *testing.T) {
 
 // TestDBManager_TrieNode tests read and write operations of state trie nodes.
 func TestDBManager_TrieNode(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		cachedNode, _ := dbm.ReadCachedTrieNode(hash1)
 		assert.Nil(t, cachedNode)
@@ -522,6 +536,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 
 // TestDBManager_TxLookupEntry tests read, write and delete operations of TxLookupEntries.
 func TestDBManager_TxLookupEntry(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	tx, err := genTransaction(num1)
 	assert.NoError(t, err, "Failed to generate a transaction")
 
@@ -571,6 +586,7 @@ func TestDBManager_TxLookupEntry(t *testing.T) {
 
 // TestDBManager_BloomBits tests read, write and delete operations of bloom bits
 func TestDBManager_BloomBits(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		hash1 := common.HexToHash("123456")
 		hash2 := common.HexToHash("654321")
@@ -604,6 +620,7 @@ func TestDBManager_BloomBits(t *testing.T) {
 
 // TestDBManager_Sections tests read, write and delete operations of ValidSections and SectionHead.
 func TestDBManager_Sections(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		// ValidSections
 		vs, _ := dbm.ReadValidSections()
@@ -632,6 +649,7 @@ func TestDBManager_Sections(t *testing.T) {
 
 // TestDBManager_DatabaseVersion tests read/write operations of database version.
 func TestDBManager_DatabaseVersion(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		assert.Nil(t, dbm.ReadDatabaseVersion())
 
@@ -647,6 +665,7 @@ func TestDBManager_DatabaseVersion(t *testing.T) {
 
 // TestDBManager_ChainConfig tests read/write operations of chain configuration.
 func TestDBManager_ChainConfig(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		assert.Nil(t, nil, dbm.ReadChainConfig(hash1))
 
@@ -665,6 +684,7 @@ func TestDBManager_ChainConfig(t *testing.T) {
 
 // TestDBManager_Preimage tests read/write operations of preimages.
 func TestDBManager_Preimage(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		assert.Nil(t, nil, dbm.ReadPreimage(hash1))
 
@@ -684,6 +704,7 @@ func TestDBManager_Preimage(t *testing.T) {
 
 // TestDBManager_ParentChain tests service chain related database operations, used in the parent chain.
 func TestDBManager_ParentChain(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		// 1. Read/Write SerivceChainTxHash
 		assert.Equal(t, common.Hash{}, dbm.ConvertChildChainBlockHashToParentChainTxHash(hash1))
@@ -707,6 +728,7 @@ func TestDBManager_ParentChain(t *testing.T) {
 
 // TestDBManager_ChildChain tests service chain related database operations, used in the child chain.
 func TestDBManager_ChildChain(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		// 1. Read/Write AnchoredBlockNumber
 		assert.Equal(t, uint64(0), dbm.ReadAnchoredBlockNumber())
@@ -733,6 +755,7 @@ func TestDBManager_ChildChain(t *testing.T) {
 
 // TestDBManager_CliqueSnapshot tests read and write operations of clique snapshots.
 func TestDBManager_CliqueSnapshot(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
 		data, err := dbm.ReadCliqueSnapshot(hash1)
 		assert.NotNil(t, err)
@@ -753,10 +776,12 @@ func TestDBManager_CliqueSnapshot(t *testing.T) {
 }
 
 func TestDBManager_Governance(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	// TODO-Klaytn-Database Implement this!
 }
 
 func TestDatabaseManager_CreateMigrationDBAndSetStatus(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for i, dbm := range dbManagers {
 		if dbConfigs[i].DBType == MemoryDB {
 			continue
@@ -827,6 +852,7 @@ func TestDatabaseManager_CreateMigrationDBAndSetStatus(t *testing.T) {
 }
 
 func TestDatabaseManager_FinishStateMigration(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for i, dbm := range dbManagers {
 		if dbm.IsSingle() || dbConfigs[i].DBType == MemoryDB {
 			continue
@@ -921,6 +947,7 @@ func TestDatabaseManager_FinishStateMigration(t *testing.T) {
 
 // While state trie migration, directory should be created with expected name
 func TestDBManager_StateMigrationDBPath(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for i, dbm := range dbManagers {
 		if dbm.IsSingle() || dbConfigs[i].DBType == MemoryDB {
 			continue
@@ -990,6 +1017,7 @@ func TestDBManager_StateMigrationDBPath(t *testing.T) {
 }
 
 func TestDBManager_WriteGovernanceIdx(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	testIdxes := []uint64{100, 200, 300}
 
 	for _, dbm := range dbManagers {
@@ -1021,6 +1049,7 @@ func TestDBManager_WriteGovernanceIdx(t *testing.T) {
 }
 
 func TestDBManager_ReadRecentGovernanceIdx(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	testIdxes := []uint64{100, 200, 300}
 
 	for _, dbm := range dbManagers {
@@ -1096,6 +1125,7 @@ func getFilesInDir(t *testing.T, dirPath string, substr string) []string {
 }
 
 func TestDBManager_WriteAndReadAccountSnapshot(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	var (
 		hash     common.Hash
 		expected []byte
@@ -1129,6 +1159,7 @@ func TestDBManager_WriteAndReadAccountSnapshot(t *testing.T) {
 }
 
 func TestDBManager_DeleteAccountSnapshot(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	var (
 		hash     common.Hash
 		expected []byte


### PR DESCRIPTION
## Proposed changes

After statedb migration, a bad block occurred because of missing bytecodes. The reason is because the deployed contract bytecodes while statedb migration were not stored into newly created database. So, this PR fixes this problem.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
