### PR TITLE
Verify with the block number config

### DIFF
--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -240,7 +240,7 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 		Time:   time,
 	}
 	if chain.Config().IsMagmaForkEnabled(header.Number) {
-		header.BaseFee = misc.NextBlockBaseFee(parent.Header(), chain.Config())
+		header.BaseFee = misc.NextMagmaBlockBaseFee(parent.Header(), chain.Config().Governance.KIP71)
 	}
 	return header
 }

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -480,7 +480,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 
 	// It need to update gas price of tx pool after magma hardfork
 	if pool.magma {
-		pool.gasPrice = misc.NextBlockBaseFee(newHead, pool.chainconfig)
+		pool.gasPrice = misc.NextMagmaBlockBaseFee(newHead, pool.chainconfig.Governance.KIP71)
 	}
 }
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -28,9 +28,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/klaytn/klaytn/governance"
-	"github.com/klaytn/klaytn/reward"
-
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -42,8 +39,10 @@ import (
 	"github.com/klaytn/klaytn/consensus/istanbul/validator"
 	"github.com/klaytn/klaytn/consensus/misc"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/governance"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/rlp"
 )
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -219,10 +219,8 @@ func (sb *backend) verifyHeader(chain consensus.ChainReader, header *types.Heade
 		if err := misc.VerifyMagmaHeader(parents[len(parents)-1], header, kip71); err != nil {
 			return err
 		}
-	} else {
-		if header.BaseFee != nil {
-			return consensus.ErrInvalidBaseFee
-		}
+	} else if header.BaseFee != nil {
+		return consensus.ErrInvalidBaseFee
 	}
 
 	// Don't waste time checking blocks from the future

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -184,35 +184,31 @@ func (sb *backend) VerifyHeader(chain consensus.ChainReader, header *types.Heade
 }
 
 func getCopiedKIP71ConfigAt(sb *backend, config *params.ChainConfig, blockNum uint64) (*params.ChainConfig, error) {
+	_, data, err := sb.governance.ReadGovernance(blockNum)
+	if err != nil {
+		return nil, err
+	}
+
+	kip71 := params.GetDefaultKIP71Config()
 	gkmr := governance.GovernanceKeyMapReverse
-	l, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.LowerBoundBaseFee])
-	if err != nil {
-		return nil, err
+	if l := data[gkmr[params.LowerBoundBaseFee]]; l != nil {
+		kip71.LowerBoundBaseFee = l.(uint64)
 	}
-	u, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.UpperBoundBaseFee])
-	if err != nil {
-		return nil, err
+	if u := data[gkmr[params.UpperBoundBaseFee]]; u != nil {
+		kip71.UpperBoundBaseFee = u.(uint64)
 	}
-	g, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.GasTarget])
-	if err != nil {
-		return nil, err
+	if g := data[gkmr[params.GasTarget]]; g != nil {
+		kip71.GasTarget = g.(uint64)
 	}
-	d, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.BaseFeeDenominator])
-	if err != nil {
-		return nil, err
+	if b := data[gkmr[params.BaseFeeDenominator]]; b != nil {
+		kip71.BaseFeeDenominator = b.(uint64)
 	}
-	m, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.MaxBlockGasUsedForBaseFee])
-	if err != nil {
-		return nil, err
+	if m := data[gkmr[params.MaxBlockGasUsedForBaseFee]]; m != nil {
+		kip71.MaxBlockGasUsedForBaseFee = m.(uint64)
 	}
+
 	copiedConfig := config.Copy()
-	copiedConfig.Governance.KIP71 = &params.KIP71Config{
-		LowerBoundBaseFee:         l.(uint64),
-		UpperBoundBaseFee:         u.(uint64),
-		GasTarget:                 g.(uint64),
-		BaseFeeDenominator:        d.(uint64),
-		MaxBlockGasUsedForBaseFee: m.(uint64),
-	}
+	copiedConfig.Governance.KIP71 = kip71
 	return copiedConfig, nil
 }
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -183,25 +183,25 @@ func (sb *backend) VerifyHeader(chain consensus.ChainReader, header *types.Heade
 	return sb.verifyHeader(chain, header, parent)
 }
 
-func getCopiedKIP71ConfigAt(sb *backend, config *params.ChainConfig, header *types.Header) (*params.ChainConfig, error) {
+func getCopiedKIP71ConfigAt(sb *backend, config *params.ChainConfig, blockNum uint64) (*params.ChainConfig, error) {
 	gkmr := governance.GovernanceKeyMapReverse
-	l, err := sb.governance.GetGovernanceItemAtNumber(header.Number.Uint64(), gkmr[params.LowerBoundBaseFee])
+	l, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.LowerBoundBaseFee])
 	if err != nil {
 		return nil, err
 	}
-	u, err := sb.governance.GetGovernanceItemAtNumber(header.Number.Uint64(), gkmr[params.UpperBoundBaseFee])
+	u, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.UpperBoundBaseFee])
 	if err != nil {
 		return nil, err
 	}
-	g, err := sb.governance.GetGovernanceItemAtNumber(header.Number.Uint64(), gkmr[params.GasTarget])
+	g, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.GasTarget])
 	if err != nil {
 		return nil, err
 	}
-	d, err := sb.governance.GetGovernanceItemAtNumber(header.Number.Uint64(), gkmr[params.BaseFeeDenominator])
+	d, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.BaseFeeDenominator])
 	if err != nil {
 		return nil, err
 	}
-	m, err := sb.governance.GetGovernanceItemAtNumber(header.Number.Uint64(), gkmr[params.MaxBlockGasUsedForBaseFee])
+	m, err := sb.governance.GetGovernanceItemAtNumber(blockNum, gkmr[params.MaxBlockGasUsedForBaseFee])
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (sb *backend) verifyHeader(chain consensus.ChainReader, header *types.Heade
 			return consensus.ErrInvalidBaseFee
 		}
 	} else {
-		kip71ConfigAt, err := getCopiedKIP71ConfigAt(sb, chain.Config(), header)
+		kip71ConfigAt, err := getCopiedKIP71ConfigAt(sb, chain.Config(), header.Number.Uint64())
 		if err != nil {
 			return err
 		}

--- a/consensus/misc/kip71_test.go
+++ b/consensus/misc/kip71_test.go
@@ -88,9 +88,7 @@ func TestEvenBaseFee(t *testing.T) {
 			GasUsed: test.parentGasUsed,
 			BaseFee: new(big.Int).SetUint64(test.parentBaseFee),
 		}
-    
 		even := NextMagmaBlockBaseFee(parent, testConfig.Governance.KIP71)
-
 		// even check
 		if even.Bit(0) != 0 {
 			t.Errorf("NextBlockBaseFee:%d is not a even number", even)

--- a/consensus/misc/kip71_test.go
+++ b/consensus/misc/kip71_test.go
@@ -20,6 +20,90 @@ func getTestConfig(forkedBlockNum *big.Int) *params.ChainConfig {
 	return testConfig
 }
 
+func TestEvenBaseFee(t *testing.T) {
+	tests := []struct {
+		upperBoundBaseFee         uint64
+		lowerBoundBaseFee         uint64
+		gasTarget                 uint64
+		baseFeeDenominator        uint64
+		maxBlockGasUsedForBaseFee uint64
+		parentGasUsed             uint64
+		parentBaseFee             uint64
+	}{
+		// Current default setting
+		{750000000000, 25000000000, 30000000, 20, 60000000, 43212345, 13009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 34857284, 83009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 0, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 0, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 0, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 69856837, 34958439443},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 18275847, 43459029443},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 34857359, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 28914728, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 83597392, 43238573843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 28472874, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 34895734, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 17274858, 18432574843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 39093494, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 18981884, 28574384343},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 12873, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 18273, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 1, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 18949, 43009212843},
+		{750000000000, 25000000000, 30000000, 20, 60000000, 19828, 43009212843},
+		// monkey test 1
+		{750000000001, 25123987327, 30000000, 20, 38573282, 83212345, 750000000000},
+		{750000000003, 25000000000, 30000000, 20, 83478211, 43212345, 48572839123},
+		{750000000005, 25000000000, 30000000, 20, 48471293, 43212345, 48572839123},
+		{750000000006, 25000000000, 30000000, 20, 43852728, 43212345, 48572839123},
+		{750000000007, 25000000000, 30000000, 20, 11282848, 43212345, 48572839123},
+		{750000000009, 25000000000, 30000000, 20, 38574848, 43212345, 48572839123},
+		{800000001233, 25000000000, 30000000, 20, 83839191, 43212345, 48572839123},
+		{751231231233, 25000000000, 30000000, 20, 88391928, 43212345, 48572839123},
+		{750321321321, 25000000000, 30000000, 20, 60000000, 43212345, 48572839123},
+		{750000000777, 25000000000, 30000000, 20, 60000000, 43212345, 48572839123},
+		// monkey test 2
+		{750000000000, 28347289478, 30000000, 20, 60000000, 43212345, 75489234128},
+		{750000000000, 28729584848, 30000000, 20, 60000000, 43212345, 75489234128},
+		{0, 0, 30000000, 20, 60000000, 0, 43009212843},
+		{750000000000, 29999999999, 30000000, 20, 60000000, 43212345, 75489234128},
+		{750000000000, 19999999999, 30000000, 20, 60000000, 43212345, 75489234128},
+		{750000000000, 0, 30000000, 20, 60000000, 43212345, 75489234128},
+		{750000000000, 1, 30000000, 1, 60000000, 0, 10},
+		{750000000000, 0, 30000000, 20, 60000000, 43212345, 75489234128},
+		{0, 0, 30000000, 20, 60000000, 43212345, 75489234128},
+		{0, 0, 30000000, 20, 60000000, 43212345, 75489234128},
+	}
+
+	testConfig := getTestConfig(big.NewInt(3))
+	for _, test := range tests {
+		testConfig.Governance.KIP71.LowerBoundBaseFee = test.lowerBoundBaseFee
+		testConfig.Governance.KIP71.UpperBoundBaseFee = test.upperBoundBaseFee
+		testConfig.Governance.KIP71.GasTarget = test.gasTarget
+		testConfig.Governance.KIP71.MaxBlockGasUsedForBaseFee = test.maxBlockGasUsedForBaseFee
+		testConfig.Governance.KIP71.BaseFeeDenominator = test.baseFeeDenominator
+
+		parent := &types.Header{
+			Number:  common.Big3,
+			GasUsed: test.parentGasUsed,
+			BaseFee: new(big.Int).SetUint64(test.parentBaseFee),
+		}
+		even := NextMagmaBlockBaseFee(parent, testConfig.Governance.KIP71)
+		// even check
+		if even.Bit(0) != 0 {
+			t.Errorf("NextBlockBaseFee:%d is not a even number", even)
+		}
+		// lower bound check
+		if even.Cmp(new(big.Int).SetUint64(test.lowerBoundBaseFee)) < 0 {
+			t.Errorf("NextBlockBaseFee:%d is lower than lowerBoudnBaseFee:%d", even, test.lowerBoundBaseFee)
+		}
+		// upper bound check
+		if even.Cmp(new(big.Int).SetUint64(test.upperBoundBaseFee)) > 0 {
+			t.Errorf("NextBlockBaseFee:%d exceeded upperBoudnBaseFee:%d", even, test.upperBoundBaseFee)
+		}
+	}
+}
+
 func TestNextBlockBaseFee(t *testing.T) {
 	tests := []struct {
 		parentBaseFee int64
@@ -36,7 +120,10 @@ func TestNextBlockBaseFee(t *testing.T) {
 			GasUsed: test.parentGasUsed,
 			BaseFee: big.NewInt(test.parentBaseFee),
 		}
-		if have, want := NextBlockBaseFee(parent, getTestConfig(big.NewInt(3))), big.NewInt(test.nextBaseFee); have.Cmp(want) != 0 {
+		if have, want := NextMagmaBlockBaseFee(
+			parent,
+			getTestConfig(big.NewInt(3)).Governance.KIP71),
+			big.NewInt(test.nextBaseFee); have.Cmp(want) != 0 {
 			t.Errorf("test %d: have %d  want %d, ", i, have, want)
 		}
 	}
@@ -68,7 +155,7 @@ func TestNextBlockBaseFeeWhenGovernanceUpdated(t *testing.T) {
 			GasUsed: test.parentGasUsed,
 			BaseFee: big.NewInt(test.parentBaseFee),
 		}
-		if have, want := NextBlockBaseFee(parent, config), big.NewInt(test.nextBaseFee); have.Cmp(want) != 0 {
+		if have, want := NextMagmaBlockBaseFee(parent, config.Governance.KIP71), big.NewInt(test.nextBaseFee); have.Cmp(want) != 0 {
 			t.Errorf("test %d: have %d  want %d, ", i, have, want)
 		}
 	}
@@ -135,7 +222,7 @@ func blocksToReachExpectedBaseFee(t *testing.T, testCase BaseFeeTestCase) {
 			GasUsed: testCase.GasUsed,
 			BaseFee: parentBaseFee,
 		}
-		parentBaseFee = NextBlockBaseFee(parent, testConfig)
+		parentBaseFee = NextMagmaBlockBaseFee(parent, testConfig.Governance.KIP71)
 
 		if testCase.compMethod(parentBaseFee, testCase.expectedBaseFee) {
 			break
@@ -151,9 +238,8 @@ func TestInactieDynamicPolicyBeforeForkedBlock(t *testing.T) {
 	parent := &types.Header{
 		Number:  common.Big3,
 		GasUsed: 84000000,
-		BaseFee: parentBaseFee,
 	}
-	nextBaseFee := NextBlockBaseFee(parent, getTestConfig(big.NewInt(5)))
+	nextBaseFee := NextMagmaBlockBaseFee(parent, getTestConfig(big.NewInt(5)).Governance.KIP71)
 	if parentBaseFee.Cmp(nextBaseFee) < 0 {
 		t.Errorf("before fork, dynamic base fee policy should be inactive, current base fee: %d  next base fee: %d", parentBaseFee, nextBaseFee)
 	}
@@ -166,7 +252,7 @@ func TestActieDynamicPolicyAfterForkedBlock(t *testing.T) {
 		GasUsed: 84000000,
 		BaseFee: parentBaseFee,
 	}
-	nextBaseFee := NextBlockBaseFee(parent, getTestConfig(big.NewInt(2)))
+	nextBaseFee := NextMagmaBlockBaseFee(parent, getTestConfig(big.NewInt(2)).Governance.KIP71)
 	if parentBaseFee.Cmp(nextBaseFee) > 0 {
 		t.Errorf("after fork, dynamic base fee policy should be active, current base fee: %d  next base fee: %d", parentBaseFee, nextBaseFee)
 	}
@@ -185,7 +271,7 @@ func BenchmarkNextBlockBaseFeeRandom(b *testing.B) {
 		} else {
 			parent.GasUsed = 40000000
 		}
-		_ = NextBlockBaseFee(parent, getTestConfig(big.NewInt(2)))
+		_ = NextMagmaBlockBaseFee(parent, getTestConfig(big.NewInt(2)).Governance.KIP71)
 	}
 }
 
@@ -197,7 +283,7 @@ func BenchmarkNextBlockBaseFeeUpperBound(b *testing.B) {
 		BaseFee: parentBaseFee,
 	}
 	for i := 0; i < b.N; i++ {
-		_ = NextBlockBaseFee(parent, getTestConfig(big.NewInt(2)))
+		_ = NextMagmaBlockBaseFee(parent, getTestConfig(big.NewInt(2)).Governance.KIP71)
 	}
 }
 
@@ -209,6 +295,6 @@ func BenchmarkNextBlockBaseFeeLowerBound(b *testing.B) {
 		BaseFee: parentBaseFee,
 	}
 	for i := 0; i < b.N; i++ {
-		_ = NextBlockBaseFee(parent, getTestConfig(big.NewInt(2)))
+		_ = NextMagmaBlockBaseFee(parent, getTestConfig(big.NewInt(2)).Governance.KIP71)
 	}
 }

--- a/node/cn/gasprice/feehistory.go
+++ b/node/cn/gasprice/feehistory.go
@@ -96,7 +96,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	}
 	// TODO-Klaytn: If we implement baseFee feature like Ethereum does, we should calculate nextBaseFee from parent block header.
 	if chainconfig.IsMagmaForkEnabled(big.NewInt(int64(bf.blockNumber + 1))) {
-		bf.results.nextBaseFee = misc.NextBlockBaseFee(bf.header, chainconfig)
+		bf.results.nextBaseFee = misc.NextMagmaBlockBaseFee(bf.header, chainconfig.Governance.KIP71)
 	} else {
 		bf.results.nextBaseFee = new(big.Int).SetUint64(params.ZeroBaseFee)
 	}

--- a/tests/klay_test_blockchain_test.go
+++ b/tests/klay_test_blockchain_test.go
@@ -167,7 +167,7 @@ func (bcdata *BCData) prepareHeader() (*types.Header, error) {
 		Vote:       common.Hex2Bytes("e194e733cb4d279da696f30d470f8c04decb54fcb0d28565706f6368853330303030"),
 	}
 	if bcdata.bc.Config().IsMagmaForkEnabled(num) {
-		header.BaseFee = misc.NextBlockBaseFee(parent.Header(), bcdata.bc.Config())
+		header.BaseFee = misc.NextMagmaBlockBaseFee(parent.Header(), bcdata.bc.Config().Governance.KIP71)
 	}
 
 	if err := bcdata.engine.Prepare(bcdata.bc, header); err != nil {

--- a/work/worker.go
+++ b/work/worker.go
@@ -501,7 +501,7 @@ func (self *worker) commitNewWork() {
 		if self.config.IsMagmaForkEnabled(nextBlockNum) {
 			// NOTE-klaytn NextBlockBaseFee needs the header of parent, self.chain.CurrentBlock
 			// So above code, TxPool().Pending(), is separated with this and can be refactored later.
-			nextBaseFee = misc.NextBlockBaseFee(parent.Header(), self.config)
+			nextBaseFee = misc.NextMagmaBlockBaseFee(parent.Header(), self.config.Governance.KIP71)
 			pending = types.FilterTransactionWithBaseFee(pending, nextBaseFee)
 		}
 	}


### PR DESCRIPTION
## Proposed changes

- Issue
  - Debug API (`TraceBlock`, `StandardTraceBlock`) calls `VerifyHeader` of consensus engine with latest `chainConfig`.
  - After the `KIP-71 config` has been updated, if you call the API with previous block number then it verify the header with latest config, not the config at the block number.
  - It cause the incorrect validation for the header.

- Propose
  - Getting the config at the block number by governance in `verifyHeader` of the consensus engine.
  - Copying the latest `ChainConfig` and update the `KIP-71 config`.
 
- Notes
  - The `ChainConfig` cannot be directly updated because the `ChainConfig.governance.KIP71Config` is a pointer.
  - The side effect will be affect other operations as well.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

