### PR TITLE
changed suggestGasPrice to return baseFee * 2

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1113,14 +1113,8 @@ func (args *EthTransactionArgs) setDefaults(ctx context.Context, b Backend) erro
 				}
 				args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 			}
-			if isMagma {
-				if args.MaxFeePerGas.ToInt().Cmp(gasPrice) < 0 {
-					return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
-				}
-			} else {
-				if args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0 {
-					return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
-				}
+			if !isMagma && (args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0) {
+				return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
 			}
 			if args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
 				return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1113,8 +1113,14 @@ func (args *EthTransactionArgs) setDefaults(ctx context.Context, b Backend) erro
 				}
 				args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 			}
-			if !isMagma && (args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0) {
-				return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
+			if isMagma {
+				if args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
+					return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
+				}
+			} else {
+				if args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0 {
+					return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
+				}
 			}
 			if args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
 				return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1109,7 +1109,7 @@ func (args *EthTransactionArgs) setDefaults(ctx context.Context, b Backend) erro
 				)
 				if isMagma {
 					// After Magma hard fork, `gasFeeCap` was set to `baseFee*2` by default.
-					gasFeeCap = new(big.Int).Mul(gasPrice, big.NewInt(2))
+					gasFeeCap = gasPrice
 				}
 				args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 			}

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1113,8 +1113,10 @@ func (args *EthTransactionArgs) setDefaults(ctx context.Context, b Backend) erro
 				}
 				args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 			}
-			if isMagma && args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
-				return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
+			if isMagma {
+				if args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
+					return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
+				}
 			} else if args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0 {
 				return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
 			}

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1113,14 +1113,10 @@ func (args *EthTransactionArgs) setDefaults(ctx context.Context, b Backend) erro
 				}
 				args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 			}
-			if isMagma {
-				if args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
-					return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
-				}
-			} else {
-				if args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0 {
-					return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
-				}
+			if isMagma && args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
+				return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
+			} else if args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0 {
+				return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
 			}
 			if args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
 				return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)

--- a/api/api_public_klay.go
+++ b/api/api_public_klay.go
@@ -24,10 +24,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"math/big"
 
 	"github.com/klaytn/klaytn/blockchain/types/accountkey"
-	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/rlp"
@@ -47,7 +45,6 @@ func NewPublicKlayAPI(b Backend) *PublicKlayAPI {
 // GasPrice returns a suggestion for a gas price (baseFee * 2).
 func (s *PublicKlayAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 	price, err := s.b.SuggestPrice(ctx)
-	price = new(big.Int).Mul(price, common.Big2)
 	return (*hexutil.Big)(price), err
 }
 

--- a/api/api_public_klay.go
+++ b/api/api_public_klay.go
@@ -24,8 +24,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math/big"
 
 	"github.com/klaytn/klaytn/blockchain/types/accountkey"
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/rlp"
@@ -42,9 +44,10 @@ func NewPublicKlayAPI(b Backend) *PublicKlayAPI {
 	return &PublicKlayAPI{b}
 }
 
-// GasPrice returns a suggestion for a gas price.
+// GasPrice returns a suggestion for a gas price (baseFee * 2).
 func (s *PublicKlayAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 	price, err := s.b.SuggestPrice(ctx)
+	price = new(big.Int).Mul(price, common.Big2)
 	return (*hexutil.Big)(price), err
 }
 

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -185,10 +185,8 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 			}
 			args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 		}
-		if isMagma {
-			if args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
-				return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
-			}
+		if isMagma && args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
+			return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
 		} else if args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0 {
 			return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
 		}

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -186,7 +186,7 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 			args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 		}
 		if isMagma {
-			if args.MaxFeePerGas.ToInt().Cmp(gasPrice) < 0 {
+			if args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
 				return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
 			}
 		} else if args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0 {

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -157,15 +157,12 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	// For the transaction that do not use the gasPrice field, the default value of gasPrice is not set.
 	if args.Price == nil && *args.TypeInt != types.TxTypeEthereumDynamicFee {
 		// b.SuggestPrice = unitPrice, for before Magma
-		//                = baseFee,   for after Magma
+		//                = baseFee * 2,   for after Magma
 		price, err := b.SuggestPrice(ctx)
 		if err != nil {
 			return err
 		}
-		if isMagma {
-			// we need to set baseFee * 2 after Magma hard fork
-			price = new(big.Int).Mul(price, common.Big2)
-		}
+		price = new(big.Int).Mul(price, common.Big2)
 		args.Price = (*hexutil.Big)(price)
 	}
 
@@ -185,7 +182,7 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 			)
 			if isMagma {
 				// After Magma hard fork, `gasFeeCap` was set to `baseFee*2` by default.
-				gasFeeCap = new(big.Int).Mul(gasPrice, big.NewInt(2))
+				gasFeeCap = gasPrice
 			}
 			args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 		}

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -185,8 +185,10 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 			}
 			args.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
 		}
-		if isMagma && args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
-			return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
+		if isMagma {
+			if args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
+				return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
+			}
 		} else if args.MaxPriorityFeePerGas.ToInt().Cmp(gasPrice) != 0 || args.MaxFeePerGas.ToInt().Cmp(gasPrice) != 0 {
 			return fmt.Errorf("only %s is allowed to be used as maxFeePerGas and maxPriorityPerGas", gasPrice.Text(16))
 		}

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -281,11 +281,7 @@ func (b *CNAPIBackend) ProtocolVersion() int {
 // If current block is magma hard forked, it returns the baseFee * 2.
 // Other cases, it returns the unitPrice.
 func (b *CNAPIBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
-	suggestedPrice, _ := b.gpo.SuggestPrice(ctx)
-	if b.ChainConfig().IsMagmaForkEnabled(new(big.Int).Add(b.CurrentBlock().Number(), common.Big1)) {
-		return new(big.Int).Mul(suggestedPrice, common.Big2), nil
-	}
-	return suggestedPrice, nil
+	return b.gpo.SuggestPrice(ctx)
 }
 
 func (b *CNAPIBackend) UpperBoundGasPrice(ctx context.Context) *big.Int {

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -278,8 +278,14 @@ func (b *CNAPIBackend) ProtocolVersion() int {
 	return b.cn.ProtocolVersion()
 }
 
+// If current block is magma hard forked, it returns the baseFee * 2.
+// Other cases, it returns the unitPrice.
 func (b *CNAPIBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
-	return b.gpo.SuggestPrice(ctx)
+	suggestedPrice, _ := b.gpo.SuggestPrice(ctx)
+	if b.ChainConfig().IsMagmaForkEnabled(b.CurrentBlock().Number()) {
+		return new(big.Int).Mul(suggestedPrice, common.Big2), nil
+	}
+	return suggestedPrice, nil
 }
 
 func (b *CNAPIBackend) UpperBoundGasPrice(ctx context.Context) *big.Int {

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -278,7 +278,7 @@ func (b *CNAPIBackend) ProtocolVersion() int {
 	return b.cn.ProtocolVersion()
 }
 
-// If current block is magma hard forked, it returns the baseFee * 2.
+// SuggestPrice returns the baseFee * 2 if the current block is magma hard forked.
 // Other cases, it returns the unitPrice.
 func (b *CNAPIBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
 	return b.gpo.SuggestPrice(ctx)

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -282,7 +282,7 @@ func (b *CNAPIBackend) ProtocolVersion() int {
 // Other cases, it returns the unitPrice.
 func (b *CNAPIBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
 	suggestedPrice, _ := b.gpo.SuggestPrice(ctx)
-	if b.ChainConfig().IsMagmaForkEnabled(b.CurrentBlock().Number()) {
+	if b.ChainConfig().IsMagmaForkEnabled(new(big.Int).Add(b.CurrentBlock().Number(), common.Big1)) {
 		return new(big.Int).Mul(suggestedPrice, common.Big2), nil
 	}
 	return suggestedPrice, nil

--- a/node/cn/gasprice/gasprice_test.go
+++ b/node/cn/gasprice/gasprice_test.go
@@ -72,7 +72,7 @@ func (b *testBackend) ChainConfig() *params.ChainConfig {
 }
 
 func (b *testBackend) CurrentBlock() *types.Block {
-	return b.CurrentBlock()
+	return b.chain.CurrentBlock()
 }
 
 func newTestBackend(t *testing.T) *testBackend {
@@ -167,6 +167,10 @@ func TestGasPrice_SuggestPrice(t *testing.T) {
 	chainConfig.UnitPrice = 0
 	txPoolWith0 := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, chainConfig, testBackend.chain)
 	oracle := NewOracle(mockBackend, params, txPoolWith0)
+
+	currentBlock := testBackend.CurrentBlock()
+	mockBackend.EXPECT().ChainConfig().Return(chainConfig).Times(2)
+	mockBackend.EXPECT().CurrentBlock().Return(currentBlock).Times(2)
 
 	price, err := oracle.SuggestPrice(nil)
 	assert.Equal(t, price, common.Big0)

--- a/node/cn/gasprice/gasprice_test.go
+++ b/node/cn/gasprice/gasprice_test.go
@@ -71,6 +71,10 @@ func (b *testBackend) ChainConfig() *params.ChainConfig {
 	return b.chain.Config()
 }
 
+func (b *testBackend) CurrentBlock() *types.Block {
+	return b.CurrentBlock()
+}
+
 func newTestBackend(t *testing.T) *testBackend {
 	var (
 		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")


### PR DESCRIPTION
## Proposed changes

- This change makes the `eth_gasPrice`, `klay_gasPrice` API to return current `baseFee * 2`
- It also makes users to use this API to set the gasPrice field in transaction.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules


