### PR TITLE
Support pre-155 transactions

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -670,7 +670,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 	gasFeePayer := uint64(0)
 
 	// Check chain Id first.
-	if tx.ChainId().Cmp(pool.chainconfig.ChainID) != 0 {
+	if tx.Protected() && tx.ChainId().Cmp(pool.chainconfig.ChainID) != 0 {
 		return ErrInvalidChainId
 	}
 

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -340,6 +340,29 @@ func testSetNonce(pool *TxPool, addr common.Address, nonce uint64) {
 	pool.mu.Unlock()
 }
 
+func TestHomesteadTransaction(t *testing.T) {
+	t.Parallel()
+	baseFee := big.NewInt(30)
+
+	pool, _ := setupTxPoolWithConfig(kip71Config)
+	defer pool.Stop()
+	pool.SetBaseFee(baseFee)
+
+	rlpTx := common.Hex2Bytes("f87e8085174876e800830186a08080ad601f80600e600039806000f350fe60003681823780368234f58015156014578182fd5b80825250506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222")
+	tx := new(types.Transaction)
+
+	err := rlp.DecodeBytes(rlpTx, tx)
+	assert.NoError(t, err)
+
+	from, err := types.EIP155Signer{}.Sender(tx)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x4c8D290a1B368ac4728d83a9e8321fC3af2b39b1", from.String())
+
+	testAddBalance(pool, from, new(big.Int).Mul(big.NewInt(10), big.NewInt(params.KLAY)))
+	err = pool.AddRemote(tx)
+	assert.NoError(t, err)
+}
+
 func TestInvalidTransactions(t *testing.T) {
 	t.Parallel()
 

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -212,6 +212,17 @@ func TestEIP2930Signer(t *testing.T) {
 	}
 }
 
+func TestHomesteadSigner(t *testing.T) {
+	rlpTx := common.Hex2Bytes("f87e8085174876e800830186a08080ad601f80600e600039806000f350fe60003681823780368234f58015156014578182fd5b80825250506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222")
+
+	tx, err := decodeTx(rlpTx)
+	assert.NoError(t, err)
+
+	addr, err := EIP155Signer{}.Sender(tx)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x4c8D290a1B368ac4728d83a9e8321fC3af2b39b1", addr.String())
+}
+
 // This test checks signature operations on dynamic fee transactions.
 func TestLondonSigner(t *testing.T) {
 	var (

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -119,7 +119,10 @@ var (
 	errValueKeyGasTipCapMustBigInt       = errors.New("GasTipCap must be a type of *big.Int")
 	errValueKeyGasFeeCapMustBigInt       = errors.New("GasFeeCap must be a type of *big.Int")
 
-	ErrTxTypeNotSupported = errors.New("transaction type not supported")
+	ErrTxTypeNotSupported         = errors.New("transaction type not supported")
+	ErrSenderPubkeyNotSupported   = errors.New("SenderPubkey is not supported for this signer")
+	ErrSenderFeePayerNotSupported = errors.New("SenderFeePayer is not supported for this signer")
+	ErrHashFeePayerNotSupported   = errors.New("HashFeePayer is not supported for this signer")
 )
 
 func (t TxValueKeyType) String() string {


### PR DESCRIPTION
## Proposed changes

- To support  pre-EIP-155 transactions, we need to revert the removal of FrontierSigner and HomesteadSigner.
- refer to https://github.com/ProjectOpenSea/seaport/blob/main/docs/Deployment.md

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments
