### PR TITLE
fixed DoCall for free to transaction with no any price fields

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1241,6 +1241,9 @@ func (args *EthTransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int,
 		} else if args.MaxFeePerGas != nil {
 			// User specified 1559 gas fields (or none), use those
 			gasPrice = args.MaxFeePerGas.ToInt()
+		} else {
+			// User specified neither GasPrice nor MaxFeePerGas, use baseFee
+			gasPrice = new(big.Int).Mul(baseFee, common.Big2)
 		}
 	}
 
@@ -1577,6 +1580,9 @@ func EthDoCall(ctx context.Context, b Backend, args EthTransactionArgs, blockNrO
 	msg, err := args.ToMessage(globalGasCap, baseFee, intrinsicGas)
 	if err != nil {
 		return nil, 0, 0, err
+	}
+	if args.From == nil {
+		st.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.GasPrice()))
 	}
 	// The intrinsicGas is checked again later in the blockchain.ApplyMessage function,
 	// but we check in advance here in order to keep StateTransition.TransactionDb method as unchanged as possible

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1226,6 +1226,7 @@ func (args *EthTransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int,
 		gas = globalGasCap
 	}
 
+	// gasPrice is 0 if the user don't specified any fields.
 	gasPrice := new(big.Int)
 	if baseFee.Cmp(new(big.Int).SetUint64(params.ZeroBaseFee)) == 0 {
 		// If there's no basefee, then it must be a non-1559 execution
@@ -1240,9 +1241,6 @@ func (args *EthTransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int,
 		} else if args.MaxFeePerGas != nil {
 			// User specified 1559 gas fields (or none), use those
 			gasPrice = args.MaxFeePerGas.ToInt()
-		} else {
-			// User specified neither GasPrice nor MaxFeePerGas, use baseFee
-			gasPrice = new(big.Int).Mul(baseFee, common.Big2)
 		}
 	}
 

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1581,14 +1581,12 @@ func EthDoCall(ctx context.Context, b Backend, args EthTransactionArgs, blockNrO
 	if err != nil {
 		return nil, 0, 0, err
 	}
-	if args.From == nil {
-		st.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.GasPrice()))
-	}
+	st.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.GasPrice()))
+
 	// The intrinsicGas is checked again later in the blockchain.ApplyMessage function,
 	// but we check in advance here in order to keep StateTransition.TransactionDb method as unchanged as possible
 	// and to clarify error reason correctly to serve eth namespace APIs.
 	// This case is handled by EthDoEstimateGas function.
-
 	if msg.Gas() < intrinsicGas {
 		return nil, 0, 0, fmt.Errorf("%w: msg.gas %d, want %d", blockchain.ErrIntrinsicGas, msg.Gas(), intrinsicGas)
 	}

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -690,6 +690,7 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 		gas = globalGasCap
 	}
 
+	// gasPrice is 0 if the user don't specified any fields.
 	gasPrice := new(big.Int)
 	if baseFee.Cmp(new(big.Int).SetUint64(params.ZeroBaseFee)) == 0 {
 		// If baseFee is zero, then it must be a magma hardfork
@@ -704,9 +705,6 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 		} else if args.MaxFeePerGas != nil {
 			// User specified 1559 gas fields (or none), use those
 			gasPrice = args.MaxFeePerGas.ToInt()
-		} else {
-			// User specified neither GasPrice nor MaxFeePerGas, use baseFee
-			gasPrice = new(big.Int).Mul(baseFee, common.Big2)
 		}
 	}
 	value := new(big.Int)

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -705,6 +705,9 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 		} else if args.MaxFeePerGas != nil {
 			// User specified 1559 gas fields (or none), use those
 			gasPrice = args.MaxFeePerGas.ToInt()
+		} else {
+			// User specified neither GasPrice nor MaxFeePerGas, use baseFee
+			gasPrice = new(big.Int).Mul(baseFee, common.Big2)
 		}
 	}
 	value := new(big.Int)

--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -54,14 +54,10 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author
 	} else {
 		beneficiary = *author
 	}
+
 	if header.BaseFee != nil {
 		baseFee = header.BaseFee
-		if msg.GasPrice().BitLen() == 0 {
-			// Is is called from contract call API.
-			effectiveGasPrice = msg.GasPrice()
-		} else {
-			effectiveGasPrice = header.BaseFee
-		}
+		effectiveGasPrice = header.BaseFee
 	} else {
 		// before magma hardfork, base fee is 0, effectiveGasPrice is unitPrice
 		baseFee = new(big.Int).SetUint64(params.ZeroBaseFee)

--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -54,11 +54,16 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author
 	} else {
 		beneficiary = *author
 	}
-	// before magma hardfork, base fee is 0, effectiveGasPrice is unitPrice
 	if header.BaseFee != nil {
 		baseFee = header.BaseFee
-		effectiveGasPrice = header.BaseFee
+		if msg.GasPrice().BitLen() == 0 {
+			// Is is called from contract call API.
+			effectiveGasPrice = msg.GasPrice()
+		} else {
+			effectiveGasPrice = header.BaseFee
+		}
 	} else {
+		// before magma hardfork, base fee is 0, effectiveGasPrice is unitPrice
 		baseFee = new(big.Int).SetUint64(params.ZeroBaseFee)
 		effectiveGasPrice = msg.GasPrice()
 	}

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -394,13 +394,6 @@ func (st *StateTransition) refundGas() {
 	// Return KLAY for remaining gas, exchanged at the original rate.
 	remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gas), st.gasPrice)
 
-	// remaining := new(big.Int)
-	// if st.evm.ChainConfig().IsMagmaForkEnabled(st.evm.BlockNumber) {
-	// 	remaining = remaining.Mul(new(big.Int).SetUint64(st.gas), st.evm.BaseFee)
-	// } else {
-	// 	remaining = remaining.Mul(new(big.Int).SetUint64(st.gas), st.gasPrice)
-	// }
-
 	validatedFeePayer := st.msg.ValidatedFeePayer()
 	validatedSender := st.msg.ValidatedSender()
 	feeRatio, isRatioTx := st.msg.FeeRatio()

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -28,8 +28,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/klaytn/klaytn/reward"
-
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -43,6 +41,7 @@ import (
 	"github.com/klaytn/klaytn/crypto/sha3"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/rlp"
 )
 


### PR DESCRIPTION
## Proposed changes

- Introduction
  - It is for contract call API (eth_call) to be called from user with no any gas price fields (gasPrice, maxFeePerGas)
- Issue
  - After dynamic gas fee mechanism implemented, It is changed for the evm always to use baseFee.
  - It causes the call API like eth_call to be failed with insufficient balance error.
- Resolve
  - Add some balance to the validated fee payer as it is done at klay_call.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

