### PR TITLE
changed from curBlockNum to curBlockNum - 1 when getting kip71 config…

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -193,7 +193,12 @@ func (sb *backend) verifyHeader(chain consensus.ChainReader, header *types.Heade
 
 	// Header verify before/after magma fork
 	if chain.Config().IsMagmaForkEnabled(header.Number) {
-		_, data, err := sb.governance.ReadGovernance(header.Number.Uint64())
+		// the kip71Config used when creating the block number is a previous block config.
+		blockNum := header.Number.Uint64()
+		if header.Number.BitLen() != 0 {
+			blockNum = blockNum - 1
+		}
+		_, data, err := sb.governance.ReadGovernance(blockNum)
 		if err != nil {
 			return err
 		}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -273,8 +273,8 @@ func (sb *backend) verifyCascadingFields(chain consensus.ChainReader, header *ty
 	}
 
 	// At every epoch governance data will come in block header. Verify it.
-	currentBlockNum := chain.CurrentHeader().Number
-	if number%sb.governance.Epoch() == 0 && len(header.Governance) > 0 && currentBlockNum.Cmp(header.Number) != 0 {
+	pendingBlockNum := new(big.Int).Add(chain.CurrentHeader().Number, common.Big1)
+	if number%sb.governance.Epoch() == 0 && len(header.Governance) > 0 && pendingBlockNum.Cmp(header.Number) == 0 {
 		return sb.governance.VerifyGovernance(header.Governance)
 	}
 	return sb.verifyCommittedSeals(chain, header, parents)

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -273,7 +273,8 @@ func (sb *backend) verifyCascadingFields(chain consensus.ChainReader, header *ty
 	}
 
 	// At every epoch governance data will come in block header. Verify it.
-	if number%sb.governance.Epoch() == 0 && len(header.Governance) > 0 {
+	currentBlockNum := chain.CurrentHeader().Number
+	if number%sb.governance.Epoch() == 0 && len(header.Governance) > 0 && currentBlockNum.Cmp(header.Number) != 0 {
 		return sb.governance.VerifyGovernance(header.Governance)
 	}
 	return sb.verifyCommittedSeals(chain, header, parents)


### PR DESCRIPTION
… in verifyMagmaHeader

## Proposed changes

- Issue 1
  - When a block is mined, the kip71 configs are used as governance parameters.
  - If a governance parameter is voted, the value is changed at the calculated epoch time.
  - When updating the config parameter voted in block number 5 and epoch 10, the issue occurs in 20 block number.
    - block process |------- block mine --------|--------- concensus ---------|--------- insert ---------|
    - kip71 config-- |----- previous config------|------ updated config--------|--- updated config ------|
  - A mined block with previous config can not be verified with updated config.
- Issue 2
  - When debug_traceBlock API for a specific block number verifies the header, it includes the verification about governance.
  - If the header has the voted governance data, the governance verification would be failed especially epoch number because the changeSet is maintained from the voted block to the latest block. In other words, when verifying the header about a past block by debug_traceBlock the governance doesn't have changeSet in the past.
- resolve
  - (issue 1) when verifying the magmaHeader, It can use the previous config.
  - (issue 2) when verifying the governance, check if the header has pending block number (latest block number + 1)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

