### PR TITLE
More validations for tracer output converting logic

### DIFF
--- a/blockchain/vm/internaltx_trace_json_test.go
+++ b/blockchain/vm/internaltx_trace_json_test.go
@@ -258,3 +258,14 @@ func TestInternalTxTrace_MarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestInternalTxTracer_result_invalidOutput(t *testing.T) {
+	tracer := NewInternalTxTracer()
+	tracer.ctx["error"] = errEvmExecutionReverted
+	tracer.ctx["output"] = "0x08c379a0000000000000000000000000000000000000000000000000ffffffffffffffff000000000000000000000000000000000000000000000000ffffffffffffffff"
+
+	_, err := tracer.result()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/blockchain/vm/internaltx_trace_json_test.go
+++ b/blockchain/vm/internaltx_trace_json_test.go
@@ -262,6 +262,7 @@ func TestInternalTxTrace_MarshalJSON(t *testing.T) {
 func TestInternalTxTracer_result_invalidOutput(t *testing.T) {
 	tracer := NewInternalTxTracer()
 	tracer.ctx["error"] = errEvmExecutionReverted
+	// An 8 bytes value that might cause a string version error or out-of-range error.
 	tracer.ctx["output"] = "0x08c379a0000000000000000000000000000000000000000000000000ffffffffffffffff000000000000000000000000000000000000000000000000ffffffffffffffff"
 
 	_, err := tracer.result()

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -515,24 +515,57 @@ func (this *InternalTxTracer) result() (*InternalTxTrace, error) {
 	}
 	if err := this.ctx["error"]; err != nil && err.(error).Error() == errEvmExecutionReverted.Error() {
 		outputHex := this.ctx["output"].(string) // it is already a hex string
-		if len(outputHex) >= 11 && outputHex[2:10] == "08c379a0" {
+		outputHexLength := len(outputHex)
+
+		// outputHexLength should be equal for larger than 138 (10+32*2+32*2) to parse a revert string
+		// outputHex[:10]: "0x08c379a0"
+		// outputHex[10:10+32*2]: a revert string
+		// outputHex[10+32*2:10+32*2+32*2]: the length of a revert string
+		if outputHexLength >= 138 && outputHex[2:10] == "08c379a0" {
 			defaultOffset := 10
 
-			stringOffset, err := strconv.ParseInt(outputHex[defaultOffset:defaultOffset+32*2], 16, 64)
+			// TODO-Klaytn: introduce error handling logic for the case the parsing data is bigger than math.MaxUint64
+			stringOffset, err := strconv.ParseUint(outputHex[defaultOffset:defaultOffset+32*2], 16, 64)
 			if err != nil {
 				logger.Error("failed to parse hex string to get stringOffset",
 					"err", err, "outputHex", outputHex)
 				return nil, err
 			}
-			stringLength, err := strconv.ParseInt(outputHex[defaultOffset+32*2:defaultOffset+32*2+32*2], 16, 64)
+			stringLength, err := strconv.ParseUint(outputHex[defaultOffset+32*2:defaultOffset+32*2+32*2], 16, 64)
 			if err != nil {
 				logger.Error("failed to parse hex string to get stringLength",
 					"err", err, "outputHex", outputHex)
 				return nil, err
 			}
+
+			if stringOffset > uint64(outputHexLength) {
+				stringOffset = 0
+			}
+			if stringLength > uint64(outputHexLength) {
+				stringLength = 0
+			}
+
 			start := defaultOffset + 32*2 + int(stringOffset*2)
 			end := start + int(stringLength*2)
-			asciiInBytes, err := hex.DecodeString(outputHex[start:end])
+
+			if start < 0 {
+				start = 0
+			}
+			if end < 0 {
+				end = 0
+			}
+			// return nothing if end is out of the range
+			if end > outputHexLength {
+				start = outputHexLength
+				end = outputHexLength
+			}
+
+			// left-padding with 0 for hex decoding
+			outputHexSlice := outputHex[start:end]
+			if len(outputHexSlice)%2 == 1 {
+				outputHexSlice = "0" + outputHexSlice
+			}
+			asciiInBytes, err := hex.DecodeString(outputHexSlice)
 			if err != nil {
 				logger.Error("failed to parse hex string to get ASCII representation",
 					"err", err, "outputHex", outputHex)

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -556,8 +556,8 @@ func (this *InternalTxTracer) result() (*InternalTxTrace, error) {
 			}
 			// return nothing if end is out of the range
 			if end > outputHexLength {
-				start = outputHexLength
-				end = outputHexLength
+				start = outputHexLength-1
+				end = outputHexLength-1
 			}
 
 			// left-padding with 0 for hex decoding

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -518,7 +518,7 @@ func (this *InternalTxTracer) result() (*InternalTxTrace, error) {
 		outputHexLength := len(outputHex)
 
 		// outputHexLength should be equal for larger than 138 (10+32*2+32*2) to parse a revert string
-		// outputHex[:10]: "0x08c379a0"
+		// outputHex[:10]: "0x08c379a0" == crypto.Keccak256([]byte("Error(string)"))[:4]
 		// outputHex[10:10+32*2]: a revert string
 		// outputHex[10+32*2:10+32*2+32*2]: the length of a revert string
 		if outputHexLength >= 138 && outputHex[2:10] == "08c379a0" {

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -556,8 +556,8 @@ func (this *InternalTxTracer) result() (*InternalTxTrace, error) {
 			}
 			// return nothing if end is out of the range
 			if end > outputHexLength {
-				start = outputHexLength-1
-				end = outputHexLength-1
+				start = outputHexLength - 1
+				end = outputHexLength - 1
 			}
 
 			// left-padding with 0 for hex decoding


### PR DESCRIPTION
## Proposed changes

`InternalTxTracer.result` is only called by fastCallTracer now. 
(fastCallTracer can be used for debug APIs or chaindatafetcher)

The tracer result parses an error string when a transaction is reverted.
Since current logic doesn't have enough validation logic about slice range or overflow/underflow, the tracer can be panic when an abnormal contract executed. 

This change introduces only small parts of validation for recent invalid cases. 
After v1.9.0 QA, more concrete validation will be introduced later. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
