### PR TITLE
Fix to compare MaxFeePerGas to gasPrice/2

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1142,7 +1142,7 @@ func (args *EthTransactionArgs) setDefaults(ctx context.Context, b Backend) erro
 	} else {
 		// Both maxPriorityFee and maxFee set by caller. Sanity-check their internal relation
 		if isMagma {
-			if args.MaxFeePerGas.ToInt().Cmp(gasPrice) < 0 {
+			if args.MaxFeePerGas.ToInt().Cmp(new(big.Int).Div(gasPrice, common.Big2)) < 0 {
 				return fmt.Errorf("maxFeePerGas (%v) < BaseFee (%v)", args.MaxFeePerGas, gasPrice)
 			}
 		} else {


### PR DESCRIPTION
## Proposed changes
- Occasionally,  sending a transaction results in `"message": "maxFeePerGas (0xcfc72f5c0) < BaseFee (57044206248)"`  while the base fee is increasing

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
