### PR TITLE
fixed string() for magma block's header

### DIFF
--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -377,23 +377,35 @@ Transactions:
 }
 
 func (h *Header) String() string {
-	return fmt.Sprintf(`Header(%x):
-[
-	ParentHash:       %x
-	Rewardbase:       %x
-	Root:             %x
-	TxSha:            %x
-	ReceiptSha:       %x
-	Bloom:            %x
-	BlockScore:       %v
-	Number:           %v
-	GasUsed:          %v
-	Time:             %v
-	TimeFoS:          %v
-	Extra:            %s
-	Governance:       %x
-	Vote:             %x
-]`, h.Hash(), h.ParentHash, h.Rewardbase, h.Root, h.TxHash, h.ReceiptHash, h.Bloom, h.BlockScore, h.Number, h.GasUsed, h.Time, h.TimeFoS, h.Extra, h.Governance, h.Vote)
+	prefix := `Header(%x):
+	[`
+	strBaseHeader := `
+		ParentHash:       %x
+		Rewardbase:       %x
+		Root:             %x
+		TxSha:            %x
+		ReceiptSha:       %x
+		Bloom:            %x
+		BlockScore:       %v
+		Number:           %v
+		GasUsed:          %v
+		Time:             %v
+		TimeFoS:          %v
+		Extra:            %s
+		Governance:       %x
+		Vote:             %x
+	`
+	suffix := `
+	]`
+	strHeader := ""
+	if h.BaseFee != nil {
+		strBaseHeader = strBaseHeader + `	BaseFee:          %x
+		`
+		strHeader = fmt.Sprintf(prefix+strBaseHeader+suffix, h.Hash(), h.ParentHash, h.Rewardbase, h.Root, h.TxHash, h.ReceiptHash, h.Bloom, h.BlockScore, h.Number, h.GasUsed, h.Time, h.TimeFoS, h.Extra, h.Governance, h.Vote, h.BaseFee)
+	} else {
+		strHeader = fmt.Sprintf(prefix+strBaseHeader+suffix, h.Hash(), h.ParentHash, h.Rewardbase, h.Root, h.TxHash, h.ReceiptHash, h.Bloom, h.BlockScore, h.Number, h.GasUsed, h.Time, h.TimeFoS, h.Extra, h.Governance, h.Vote)
+	}
+	return strHeader
 }
 
 type Blocks []*Block


### PR DESCRIPTION
## Proposed changes

- New feature for printing the string of the magma hard forked block header with klaytn client.
- It is tested with klaytn client.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

