### PR TITLE
added basefee metric

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -76,6 +76,7 @@ var (
 	snapshotStorageReadTimer = metrics.NewRegisteredTimer("state/snapshot/storage/reads", nil)
 	snapshotCommitTimer      = metrics.NewRegisteredTimer("state/snapshot/commits", nil)
 
+	blockBaseFee        = metrics.NewRegisteredGauge("chain/basefee", nil)
 	blockInsertTimer    = klaytnmetrics.NewRegisteredHybridTimer("chain/inserts", nil)
 	blockProcessTimer   = klaytnmetrics.NewRegisteredHybridTimer("chain/process", nil)
 	blockExecutionTimer = klaytnmetrics.NewRegisteredHybridTimer("chain/execution", nil)
@@ -2023,6 +2024,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 				"processTxs", processTxsTime, "finalize", processFinalizeTime, "validateState", validateTime,
 				"totalWrite", writeResult.TotalWriteTime, "trieWrite", writeResult.TrieWriteTime)
 
+			if block.Header().BaseFee != nil {
+				blockBaseFee.Update(block.Header().BaseFee.Int64() / int64(params.Ston))
+			}
 			blockProcessTimer.Update(time.Duration(processTxsTime))
 			blockExecutionTimer.Update(time.Duration(processTxsTime) - trieAccess)
 			blockFinalizeTimer.Update(time.Duration(processFinalizeTime))

--- a/work/worker.go
+++ b/work/worker.go
@@ -69,6 +69,7 @@ var (
 	gasLimitReachedTxsGauge = metrics.NewRegisteredGauge("miner/limitreached/gas/txs", nil)
 	strangeErrorTxsCounter  = metrics.NewRegisteredCounter("miner/strangeerror/txs", nil)
 
+	blockBaseFee              = metrics.NewRegisteredGauge("miner/block/mining/basefee", nil)
 	blockMiningTimer          = klaytnmetrics.NewRegisteredHybridTimer("miner/block/mining/time", nil)
 	blockMiningExecuteTxTimer = klaytnmetrics.NewRegisteredHybridTimer("miner/block/execute/time", nil)
 	blockMiningCommitTxTimer  = klaytnmetrics.NewRegisteredHybridTimer("miner/block/commit/time", nil)
@@ -586,6 +587,9 @@ func (self *worker) commitNewWork() {
 			commitTxTime := finishedCommitTx.Sub(tstart)
 			finalizeTime := finishedFinalize.Sub(finishedCommitTx)
 
+			if header.BaseFee != nil {
+				blockBaseFee.Update(header.BaseFee.Int64() / int64(params.Ston))
+			}
 			blockMiningTimer.Update(blockMiningTime)
 			blockMiningCommitTxTimer.Update(commitTxTime)
 			blockMiningExecuteTxTimer.Update(commitTxTime - trieAccess)


### PR DESCRIPTION
## Proposed changes

- Added baseFee metric when mining a block in `commitNewWork( )`.
  - It is for a block producer that do not execute the _insertChain_.
- Added baseFee metric when inserting the block in `insertChain( )`.
  - It is for the other CNs that are not the miner.
- The printed unit is a ston.
- It is tested with grafana server.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

