### PR TITLE
Make tests independent in staking_manager_test

### DIFF
--- a/reward/staking_manager_test.go
+++ b/reward/staking_manager_test.go
@@ -63,12 +63,7 @@ func generateStakingManagerTestCases() []stakingManagerTestCase {
 	}
 }
 
-func resetStakingManagerForTest() {
-	GetStakingManager().stakingInfoCache = newStakingInfoCache()
-	GetStakingManager().stakingInfoDB = database.NewMemoryDBManager()
-}
-
-func TestStakingManager_NewStakingManager(t *testing.T) {
+func newStakingManagerForTest(t *testing.T) {
 	// test if nil
 	assert.Nil(t, GetStakingManager())
 	assert.Nil(t, GetStakingInfo(123))
@@ -86,6 +81,21 @@ func TestStakingManager_NewStakingManager(t *testing.T) {
 	assert.Equal(t, stGet, stNew)
 }
 
+func resetStakingManagerForTest(t *testing.T) {
+	sm := GetStakingManager()
+	if sm == nil {
+		newStakingManagerForTest(t)
+		sm = GetStakingManager()
+	}
+
+	sm.stakingInfoCache = newStakingInfoCache()
+	sm.stakingInfoDB = database.NewMemoryDBManager()
+}
+
+func TestStakingManager_NewStakingManager(t *testing.T) {
+	newStakingManagerForTest(t)
+}
+
 // Check that appropriate StakingInfo is returned given various blockNum argument.
 func checkGetStakingInfo(t *testing.T) {
 	for _, testcase := range stakingManagerTestCases {
@@ -100,7 +110,7 @@ func checkGetStakingInfo(t *testing.T) {
 // Check that StakinInfo are loaded from cache
 func TestStakingManager_GetFromCache(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
-	resetStakingManagerForTest()
+	resetStakingManagerForTest(t)
 
 	for _, testdata := range stakingManagerTestData {
 		GetStakingManager().stakingInfoCache.add(testdata)
@@ -112,7 +122,7 @@ func TestStakingManager_GetFromCache(t *testing.T) {
 // Check that StakinInfo are loaded from database
 func TestStakingManager_GetFromDB(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
-	resetStakingManagerForTest()
+	resetStakingManagerForTest(t)
 
 	for _, testdata := range stakingManagerTestData {
 		AddStakingInfoToDB(testdata)
@@ -124,7 +134,7 @@ func TestStakingManager_GetFromDB(t *testing.T) {
 // Even if Gini was -1 in the cache, GetStakingInfo returns valid Gini
 func TestStakingManager_FillGiniFromCache(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
-	resetStakingManagerForTest()
+	resetStakingManagerForTest(t)
 
 	for _, testdata := range stakingManagerTestData {
 		// Insert a modified copy of testdata to cache
@@ -140,7 +150,7 @@ func TestStakingManager_FillGiniFromCache(t *testing.T) {
 // Even if Gini was -1 in the DB, GetStakingInfo returns valid Gini
 func TestStakingManager_FillGiniFromDB(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
-	resetStakingManagerForTest()
+	resetStakingManagerForTest(t)
 
 	for _, testdata := range stakingManagerTestData {
 		// Insert a modified copy of testdata to cache


### PR DESCRIPTION
## Proposed changes
- The following functions depend on the behaviour of `TestStakingManager_NewStakingManager`
  - `TestStakingManager_GetFromCache`
  - `TestStakingManager_GetFromDB`
  - `TestStakingManager_FillGiniFromCache`
  - `TestStakingManager_FillGiniFromDB`
- Thus, running a single test fails (e.g., `go test -v -run="TestStakingManager_GetFromCache" .`)
- This PR removes the dependency and  makes the aforementioned functions independently executable

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
