### PR TITLE
Resolve estimate gas api

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1579,7 +1579,14 @@ func EthDoCall(ctx context.Context, b Backend, args EthTransactionArgs, blockNrO
 	if err != nil {
 		return nil, 0, 0, err
 	}
-	st.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.GasPrice()))
+	var balanceBaseFee *big.Int
+	if header.BaseFee != nil {
+		balanceBaseFee = new(big.Int).Mul(baseFee, common.Big2)
+	} else {
+		balanceBaseFee = msg.GasPrice()
+	}
+	// Add gas fee to sender for estimating gasLimit/computing cost or calling a function by insufficient balance sender.
+	st.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), balanceBaseFee))
 
 	// The intrinsicGas is checked again later in the blockchain.ApplyMessage function,
 	// but we check in advance here in order to keep StateTransition.TransactionDb method as unchanged as possible

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -313,9 +313,14 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	if err != nil {
 		return nil, 0, 0, 0, err
 	}
-
+	var balanceBaseFee *big.Int
+	if header.BaseFee != nil {
+		balanceBaseFee = new(big.Int).Mul(baseFee, common.Big2)
+	} else {
+		balanceBaseFee = msg.GasPrice()
+	}
 	// Add gas fee to sender for estimating gasLimit/computing cost or calling a function by insufficient balance sender.
-	state.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.GasPrice()))
+	state.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), balanceBaseFee))
 
 	// The intrinsicGas is checked again later in the blockchain.ApplyMessage function,
 	// but we check in advance here in order to keep StateTransition.TransactionDb method as unchanged as possible


### PR DESCRIPTION
## Proposed changes

- Issue
  - Calling contract view function with 0 gasPrice is failed.
- Resolution
  - Put the (baseFee x 2 x gas) temporary to the from account for any gasPrice.

- Further comments
  - There are two path for the evm to execute contract code (transaction execution, request contract call API).
  - After magma hard fork, the two paths always consume the baseFee per gas.
    - there is no problem in transaction case because it always pay the gas fee.
  - We need to make the view call API case special because of availability (resolution).

- Todo
  - If we implement abstract message type like [https://github.com/ethereum/go-ethereum/blob/master/core/types/transaction.go#L612](url), we can have more flexibility.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

