### PR TITLE
Make tracers test not parallel

### DIFF
--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -242,7 +242,7 @@ func TestCallTracer(t *testing.T) {
 		}
 		file := file // capture range variable
 		t.Run(camel(strings.TrimSuffix(strings.TrimPrefix(file.Name(), "call_tracer_"), ".json")), func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 
 			// Call tracer test found, read if from disk
 			blob, err := ioutil.ReadFile(filepath.Join("testdata", file.Name()))
@@ -353,7 +353,7 @@ func TestInternalCallTracer(t *testing.T) {
 		}
 		file := file // capture range variable
 		t.Run(camel(strings.TrimSuffix(strings.TrimPrefix(file.Name(), "call_tracer_"), ".json")), func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 
 			// Call tracer test found, read if from disk
 			blob, err := ioutil.ReadFile(filepath.Join("testdata", file.Name()))


### PR DESCRIPTION
## Proposed changes

- Tracers unit tests `TestCallTracer` and `TestInternalCallTracer` modifies global state via `fork.SetHardForkBlockNumberConfig()`. Such tests must not run in parallel.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
