### PR TITLE
[Verification] Added parent header nil check

### DIFF
--- a/consensus/misc/kip71.go
+++ b/consensus/misc/kip71.go
@@ -7,12 +7,13 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/math"
+	"github.com/klaytn/klaytn/consensus"
 	"github.com/klaytn/klaytn/params"
 )
 
 func VerifyMagmaHeader(parentHeader, header *types.Header, kip71Config *params.KIP71Config) error {
 	if parentHeader == nil {
-		return ErrUnknownAncestor
+		return consensus.ErrUnknownAncestor
 	}
 	if header.BaseFee == nil {
 		return fmt.Errorf("header is missing baseFee")

--- a/consensus/misc/kip71.go
+++ b/consensus/misc/kip71.go
@@ -12,7 +12,7 @@ import (
 
 func VerifyMagmaHeader(parentHeader, header *types.Header, kip71Config *params.KIP71Config) error {
 	if parentHeader == nil {
-		return fmt.Errorf("parent header is empty. (header number = %v)", header.Number)
+		return ErrUnknownAncestor
 	}
 	if header.BaseFee == nil {
 		return fmt.Errorf("header is missing baseFee")

--- a/consensus/misc/kip71.go
+++ b/consensus/misc/kip71.go
@@ -11,6 +11,9 @@ import (
 )
 
 func VerifyMagmaHeader(parentHeader, header *types.Header, kip71Config *params.KIP71Config) error {
+	if parentHeader == nil {
+		return fmt.Errorf("parent header is empty. (header number = %v)", header.Number)
+	}
 	if header.BaseFee == nil {
 		return fmt.Errorf("header is missing baseFee")
 	}


### PR DESCRIPTION
## Proposed changes

An attacker can launch a DoS attack on victim CNs, PNs and ENs. This kind of DoS attack forces the victim process to exit, leading to reachable panic. This attack is pretty simple as it does not require tricky code modification. I do not describe how this attack can be reproduced. Attached below is a panic path. 

```
INFO[08/25,11:46:12 +09] [28] Downloader queue stats                    receiptTasks=0 blockTasks=0 stakingInfoTasks=0 itemSize=721.28B throttle=8192
DEBUG[08/25,11:46:12 +09] [28] Inserting downloaded chain                items=53 firstnum=1 firsthash=fb4687…e7644c lastnum=53 lasthash=a12a32…d9f651
DEBUG[08/25,11:46:12 +09] [28] Processing full sync content terminated   elapsed=110.460464ms
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1a0 pc=0x10d377c]

goroutine 1132 [running]:
github.com/klaytn/klaytn/consensus/misc.nextBlockBaseFee(0x0, 0xc011825ff0, 0xc0116820a0, 0xc0116820c0)
    klaytn/victim/klaytn/consensus/misc/kip71.go:58 +0x9c
github.com/klaytn/klaytn/consensus/misc.NextMagmaBlockBaseFee(0xc000159680?, 0xc011825ff0)
    klaytn/victim/klaytn/consensus/misc/kip71.go:52 +0x105
github.com/klaytn/klaytn/consensus/misc.VerifyMagmaHeader(0x0, 0xc01168e000, 0x1a270c2?)
    klaytn/victim/klaytn/consensus/misc/kip71.go:23 +0x3e
github.com/klaytn/klaytn/consensus/istanbul/backend.(*backend).verifyHeader(0xc00099e000, {0x1d452d8, 0xc00013c000}, 0xc01168e000, {0xc00012ea18, 0x1, 0x1})
    klaytn/consensus/istanbul/backend/engine.go:224 +0x389
github.com/klaytn/klaytn/consensus/istanbul/backend.(*backend).VerifyHeader(0xc011adbb00?, {0x1d452d8, 0xc00013c000}, 0xc01168e000, 0xd0?)
    klaytn/consensus/istanbul/backend/engine.go:182 +0x179
github.com/klaytn/klaytn/blockchain.(*BlockChain).insertChain(0xc00013c000, {0xc011af8c40?, 0x35, 0x35})
    klaytn/blockchain/blockchain.go:1887 +0x14b7
github.com/klaytn/klaytn/blockchain.(*BlockChain).InsertChain(0xc011c006c0?, {0xc011af8c40?, 0x70c19b4fa9d8db4d?, 0xc0003f68c0?})
    klaytn/blockchain/blockchain.go:1752 +0x25
github.com/klaytn/klaytn/datasync/downloader.(*Downloader).importBlockResults(0xc0000005a0, {0xc011af8380, 0x35, 0x0?})
    klaytn/datasync/downloader/downloader.go:1586 +0x50a
github.com/klaytn/klaytn/datasync/downloader.(*Downloader).processFullSyncContent(0xc0000005a0)
    klaytn/datasync/downloader/downloader.go:1560 +0x139
github.com/klaytn/klaytn/datasync/downloader.(*Downloader).spawnSync.func1()
    klaytn/datasync/downloader/downloader.go:556 +0x70
created by github.com/klaytn/klaytn/datasync/downloader.(*Downloader).spawnSync
    klaytn/datasync/downloader/downloader.go:556 +0x127
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
