### PR TITLE
[Account] Do not allow to unlock an account if the RPC endpoint is enabled

### DIFF
--- a/accounts/errors.go
+++ b/accounts/errors.go
@@ -45,6 +45,8 @@ var ErrWalletAlreadyOpen = errors.New("wallet already open")
 // secodn time.
 var ErrWalletClosed = errors.New("wallet closed")
 
+var ErrAttemptInsecurelyUnlockAcc = errors.New("Account unlock with HTTP or WebSocket access is forbidden")
+
 // AuthNeededError is returned by backends for signing requests where the user
 // is required to provide further authentication before signing can succeed.
 //

--- a/api/backend.go
+++ b/api/backend.go
@@ -95,7 +95,7 @@ type Backend interface {
 	GetTxLookupInfoAndReceiptInCache(Hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, *types.Receipt)
 }
 
-func GetAPIs(apiBackend Backend) ([]rpc.API, *EthereumAPI) {
+func GetAPIs(apiBackend Backend, insecureUnlockAllow, extRPCEnabled bool) ([]rpc.API, *EthereumAPI) {
 	nonceLock := new(AddrLocker)
 
 	ethAPI := NewEthereumAPI()
@@ -148,7 +148,7 @@ func GetAPIs(apiBackend Backend) ([]rpc.API, *EthereumAPI) {
 		}, {
 			Namespace: "personal",
 			Version:   "1.0",
-			Service:   NewPrivateAccountAPI(apiBackend, nonceLock),
+			Service:   NewPrivateAccountAPI(apiBackend, nonceLock, insecureUnlockAllow, extRPCEnabled),
 			Public:    false,
 		},
 	}, ethAPI

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -41,6 +42,26 @@ const (
 )
 
 var logger = log.NewModuleLogger(log.CMDUtils)
+
+// Fatalf formats a message to standard error and exits the program.
+// The message is also printed to standard output if standard error
+// is redirected to a different file.
+func Fatalf(format string, args ...interface{}) {
+	w := io.MultiWriter(os.Stdout, os.Stderr)
+	if runtime.GOOS == "windows" {
+		// The SameFile check below doesn't work on Windows.
+		// stdout is unlikely to get redirected though, so just print there.
+		w = os.Stdout
+	} else {
+		outf, _ := os.Stdout.Stat()
+		errf, _ := os.Stderr.Stat()
+		if outf != nil && errf != nil && os.SameFile(outf, errf) {
+			w = os.Stderr
+		}
+	}
+	fmt.Fprintf(w, "Fatal: "+format+"\n", args...)
+	os.Exit(1)
+}
 
 func StartNode(stack *node.Node) {
 	if err := stack.Start(); err != nil {

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -268,6 +268,7 @@ var FlagGroups = []FlagGroup{
 			MaxRequestContentLengthFlag,
 			APIFilterGetLogsDeadlineFlag,
 			APIFilterGetLogsMaxItemsFlag,
+			InsecureUnlockAllowedFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -484,6 +484,11 @@ var (
 		Value:  "",
 		EnvVar: "KLAYTN_PASSWORD",
 	}
+	InsecureUnlockAllowedFlag = cli.BoolFlag{
+		Name:   "allow-insecure-unlock",
+		Usage:  "Allow insecure account unlocking when account-related RPCs are exposed by http or websocket",
+		EnvVar: "KLAYTN_INSECUREUNLOCK",
+	}
 
 	VMEnableDebugFlag = cli.BoolFlag{
 		Name:   "vmdebug",
@@ -1692,6 +1697,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(RPCNonEthCompatibleFlag.Name) {
 		rpc.NonEthCompatible = ctx.GlobalBool(RPCNonEthCompatibleFlag.Name)
 	}
+	if ctx.IsSet(InsecureUnlockAllowedFlag.Name) {
+		cfg.InsecureUnlockAllowed = ctx.Bool(InsecureUnlockAllowedFlag.Name)
+	}
 }
 
 func setTxPool(ctx *cli.Context, cfg *blockchain.TxPoolConfig) {
@@ -1985,7 +1993,7 @@ func RegisterCNService(stack *node.Node, cfg *cn.Config) {
 
 	err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 		cfg.WsEndpoint = stack.WSEndpoint()
-		fullNode, err := cn.New(ctx, cfg)
+		fullNode, err := cn.New(ctx, cfg, stack.Config())
 		return fullNode, err
 	})
 	if err != nil {

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -231,6 +231,7 @@ var CommonRPCFlags = []cli.Flag{
 	altsrc.NewIntFlag(utils.RPCWriteTimeoutFlag),
 	altsrc.NewIntFlag(utils.RPCIdleTimeoutFlag),
 	altsrc.NewIntFlag(utils.RPCExecutionTimeoutFlag),
+	altsrc.NewBoolFlag(utils.InsecureUnlockAllowedFlag),
 }
 
 var KCNFlags = []cli.Flag{

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -106,7 +106,7 @@ func newTester(t *testing.T, confOverride func(*cn.Config)) *tester {
 	if confOverride != nil {
 		confOverride(cnConf)
 	}
-	if err = stack.Register(func(ctx *node.ServiceContext) (node.Service, error) { return cn.New(ctx, cnConf) }); err != nil {
+	if err = stack.Register(func(ctx *node.ServiceContext) (node.Service, error) { return cn.New(ctx, cnConf, stack.Config()) }); err != nil {
 		t.Fatalf("failed to register Klaytn protocol: %v", err)
 	}
 	// Start the node and assemble the JavaScript console around it

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -101,6 +101,7 @@ type BackendProtocolManager interface {
 // CN implements the Klaytn consensus node service.
 type CN struct {
 	config      *Config
+	nodeConfig  *node.Config
 	chainConfig *params.ChainConfig
 
 	// Handlers
@@ -200,7 +201,7 @@ func setEngineType(chainConfig *params.ChainConfig) {
 
 // New creates a new CN object (including the
 // initialisation of the common CN object)
-func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
+func New(ctx *node.ServiceContext, config *Config, nodeConfig *node.Config) (*CN, error) {
 	if err := checkSyncMode(config); err != nil {
 		return nil, err
 	}
@@ -232,6 +233,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	cn := &CN{
 		config:            config,
+		nodeConfig:        nodeConfig,
 		chainDB:           chainDB,
 		chainConfig:       chainConfig,
 		eventMux:          ctx.EventMux,
@@ -478,7 +480,7 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 // APIs returns the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *CN) APIs() []rpc.API {
-	apis, ethAPI := api.GetAPIs(s.APIBackend)
+	apis, ethAPI := api.GetAPIs(s.APIBackend, s.nodeConfig.InsecureUnlockAllowed, s.nodeConfig.ExtRPCEnabled())
 
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)

--- a/node/config.go
+++ b/node/config.go
@@ -90,6 +90,9 @@ type Config struct {
 	// scrypt KDF at the expense of security.
 	UseLightweightKDF bool `toml:",omitempty"`
 
+	// InsecureUnlockAllowed allows user to unlock accounts in unsafe http environment.
+	InsecureUnlockAllowed bool `toml:",omitempty"`
+
 	// IPCPath is the requested location to place the IPC endpoint. If the path is
 	// a simple file name, it is placed inside the data directory (or on the root
 	// pipe path on Windows), whereas if it's a resolvable path name (absolute or
@@ -257,6 +260,10 @@ func (c *Config) GRPCEndpoint() string {
 func DefaultGRPCEndpoint() string {
 	config := &Config{GRPCHost: DefaultGRPCHost, GRPCPort: DefaultGRPCPort}
 	return config.GRPCEndpoint()
+}
+
+func (c *Config) ExtRPCEnabled() bool {
+	return c.HTTPHost != "" || c.WSHost != ""
 }
 
 // NodeName returns the devp2p node identifier.

--- a/node/node.go
+++ b/node/node.go
@@ -686,6 +686,11 @@ func (n *Node) RPCHandler() (*rpc.Server, error) {
 	return n.inprocHandler, nil
 }
 
+// Config returns the configuration of node.
+func (n *Node) Config() *Config {
+	return n.config
+}
+
 // Server retrieves the currently running P2P network layer. This method is meant
 // only to inspect fields of the currently running server, life cycle management
 // should be left to this Node entity.

--- a/tests/klay_blockchain_test.go
+++ b/tests/klay_blockchain_test.go
@@ -144,11 +144,12 @@ func createAccount(t *testing.T, numAccounts int, validator *TestAccountType) (*
 func newKlaytnNode(t *testing.T, dir string, validator *TestAccountType) (*node.Node, *cn.CN, error) {
 	var klaytnNode *cn.CN
 
-	fullNode, err := node.New(&node.Config{
+	cfg := &node.Config{
 		DataDir:           dir,
 		UseLightweightKDF: true,
 		P2P:               p2p.Config{PrivateKey: validator.Keys[0], NoListen: true},
-	})
+	}
+	fullNode, err := node.New(cfg)
 	if err != nil {
 		t.Fatalf("failed to create node: %v", err)
 	}
@@ -186,7 +187,7 @@ func newKlaytnNode(t *testing.T, dir string, validator *TestAccountType) (*node.
 	ks := fullNode.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
 	_, _ = ks.ImportECDSA(validator.Keys[0], "") // import a node key
 
-	if err = fullNode.Register(func(ctx *node.ServiceContext) (node.Service, error) { return cn.New(ctx, cnConf) }); err != nil {
+	if err = fullNode.Register(func(ctx *node.ServiceContext) (node.Service, error) { return cn.New(ctx, cnConf, cfg) }); err != nil {
 		return nil, nil, errors.WithMessage(err, "failed to register Klaytn protocol")
 	}
 


### PR DESCRIPTION
## Proposed changes

Unlocking an account is significantly dangerous if the RPC endpoint opens because the barrier is not popped up for the specified duration and results in any value transfer requests being valid and transacted. The idea and code were fetched from the Geth implementation and a slightly modified version is applied in this PR.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
