### PR TITLE
Fix homi fundingAddr

### DIFF
--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -497,6 +497,7 @@ func gen(ctx *cli.Context) error {
 
 	privKeys, nodeKeys, nodeAddrs := istcommon.GenerateKeys(cnNum)
 	testPrivKeys, testKeys, testAddrs := istcommon.GenerateKeys(numTestAccs)
+	testAddrs = append(testAddrs, common.HexToAddress(fundingAddr))
 
 	var (
 		genesisJson      *blockchain.Genesis


### PR DESCRIPTION
## Proposed changes

homi's `fundingAddr` flag now actually funds the given address. Before this PR, the flag was not doing anything.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
