### PR TITLE
added snapshot generation asynchronously flag

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -129,7 +129,8 @@ type CacheConfig struct {
 	TriesInMemory        uint64                       // Maximum number of recent state tries according to its block number
 	SenderTxHashIndexing bool                         // Enables saving senderTxHash to txHash mapping information to database and cache
 	TrieNodeCacheConfig  *statedb.TrieNodeCacheConfig // Configures trie node cache
-	SnapshotCacheSize    int                          // Memory allowance (MB) to use for caching snapshot entries in memory
+	SnapshotCacheSize    int                          // Memory allowance (MB) to use for caching snapshot entries in memoryd
+	SnapshotGenAsync     bool                         // Enables snapshot data generation asynchronously
 }
 
 // gcBlock is used for priority queue for GC.
@@ -230,6 +231,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 			TriesInMemory:       DefaultTriesInMemory,
 			TrieNodeCacheConfig: statedb.GetEmptyTrieNodeCacheConfig(),
 			SnapshotCacheSize:   512,
+			SnapshotGenAsync:    true,
 		}
 	}
 
@@ -344,7 +346,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 			logger.Warn("Enabling snapshot recovery", "chainhead", head.NumberU64(), "diskbase", *layer)
 			recover = true
 		}
-		bc.snaps, _ = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotCacheSize, head.Root(), false, true, recover)
+		bc.snaps, _ = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotCacheSize, head.Root(), bc.cacheConfig.SnapshotGenAsync, true, recover)
 	}
 
 	for i := 1; i <= bc.cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker; i++ {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -129,8 +129,8 @@ type CacheConfig struct {
 	TriesInMemory        uint64                       // Maximum number of recent state tries according to its block number
 	SenderTxHashIndexing bool                         // Enables saving senderTxHash to txHash mapping information to database and cache
 	TrieNodeCacheConfig  *statedb.TrieNodeCacheConfig // Configures trie node cache
-	SnapshotCacheSize    int                          // Memory allowance (MB) to use for caching snapshot entries in memoryd
-	SnapshotGenAsync     bool                         // Enables snapshot data generation asynchronously
+	SnapshotCacheSize    int                          // Memory allowance (MB) to use for caching snapshot entries in memory
+	SnapshotAsyncGen     bool                         // Enables snapshot data generation asynchronously
 }
 
 // gcBlock is used for priority queue for GC.
@@ -231,7 +231,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 			TriesInMemory:       DefaultTriesInMemory,
 			TrieNodeCacheConfig: statedb.GetEmptyTrieNodeCacheConfig(),
 			SnapshotCacheSize:   512,
-			SnapshotGenAsync:    true,
+			SnapshotAsyncGen:    true,
 		}
 	}
 
@@ -346,7 +346,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 			logger.Warn("Enabling snapshot recovery", "chainhead", head.NumberU64(), "diskbase", *layer)
 			recover = true
 		}
-		bc.snaps, _ = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotCacheSize, head.Root(), bc.cacheConfig.SnapshotGenAsync, true, recover)
+		bc.snaps, _ = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotCacheSize, head.Root(), bc.cacheConfig.SnapshotAsyncGen, true, recover)
 	}
 
 	for i := 1; i <= bc.cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker; i++ {

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -178,6 +178,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			TriesInMemory:       DefaultTriesInMemory,
 			TrieNodeCacheConfig: statedb.GetEmptyTrieNodeCacheConfig(),
 			SnapshotCacheSize:   512,
+			SnapshotGenAsync:    true,
 		}
 		blockchain, _ := NewBlockChain(db, cacheConfig, config, engine, vm.Config{})
 		defer blockchain.Stop()

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -178,7 +178,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			TriesInMemory:       DefaultTriesInMemory,
 			TrieNodeCacheConfig: statedb.GetEmptyTrieNodeCacheConfig(),
 			SnapshotCacheSize:   512,
-			SnapshotGenAsync:    true,
+			SnapshotAsyncGen:    true,
 		}
 		blockchain, _ := NewBlockChain(db, cacheConfig, config, engine, vm.Config{})
 		defer blockchain.Stop()

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -609,6 +609,7 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 			logger.Crit("State snapshot should not be used with --start-block-num", "num", cfg.StartBlockNumber)
 		}
 		logger.Info("State snapshot is enabled", "cache-size (MB)", cfg.SnapshotCacheSize)
+		cfg.SnapshotAsyncGen = ctx.GlobalBool(SnapshotAsyncGen.Name)
 	} else {
 		cfg.SnapshotCacheSize = 0 // snapshot disabled
 	}

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -312,6 +312,7 @@ var FlagGroups = []FlagGroup{
 			KESNodeTypeServiceFlag,
 			SnapshotFlag,
 			SnapshotCacheSizeFlag,
+			SnapshotGenAsync,
 		},
 	},
 }

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -312,7 +312,7 @@ var FlagGroups = []FlagGroup{
 			KESNodeTypeServiceFlag,
 			SnapshotFlag,
 			SnapshotCacheSizeFlag,
-			SnapshotGenAsync,
+			SnapshotAsyncGen,
 		},
 	},
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -317,8 +317,8 @@ var (
 		Value:  512,
 		EnvVar: "KLAYTN_SNAPSHOT_CACHE_SIZE",
 	}
-	SnapshotGenAsync = cli.BoolTFlag{
-		Name:   "snapshot.gen.async",
+	SnapshotAsyncGen = cli.BoolTFlag{
+		Name:   "snapshot.async-gen",
 		Usage:  "Enables snapshot data generation in background",
 		EnvVar: "KLAYTN_SNAPSHOT_BACKGROUND_GENERATION",
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -317,6 +317,11 @@ var (
 		Value:  512,
 		EnvVar: "KLAYTN_SNAPSHOT_CACHE_SIZE",
 	}
+	SnapshotGenAsync = cli.BoolTFlag{
+		Name:   "snapshot.gen.async",
+		Usage:  "Enables snapshot data generation in background",
+		EnvVar: "KLAYTN_SNAPSHOT_BACKGROUND_GENERATION",
+	}
 	TrieMemoryCacheSizeFlag = cli.IntFlag{
 		Name:   "state.cache-size",
 		Usage:  "Size of in-memory cache of the global state (in MiB) to flush matured singleton trie nodes to disk",

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -202,7 +202,7 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewUint64Flag(utils.OpcodeComputationCostLimitFlag),
 	altsrc.NewBoolFlag(utils.SnapshotFlag),
 	altsrc.NewIntFlag(utils.SnapshotCacheSizeFlag),
-	altsrc.NewBoolTFlag(utils.SnapshotGenAsync),
+	altsrc.NewBoolTFlag(utils.SnapshotAsyncGen),
 }
 
 // Common RPC flags

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -202,6 +202,7 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewUint64Flag(utils.OpcodeComputationCostLimitFlag),
 	altsrc.NewBoolFlag(utils.SnapshotFlag),
 	altsrc.NewIntFlag(utils.SnapshotCacheSizeFlag),
+	altsrc.NewBoolTFlag(utils.SnapshotGenAsync),
 }
 
 // Common RPC flags

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -263,7 +263,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		cacheConfig = &blockchain.CacheConfig{
 			ArchiveMode: config.NoPruning, CacheSize: config.TrieCacheSize,
 			BlockInterval: config.TrieBlockInterval, TriesInMemory: config.TriesInMemory,
-			TrieNodeCacheConfig: &config.TrieNodeCacheConfig, SenderTxHashIndexing: config.SenderTxHashIndexing, SnapshotCacheSize: config.SnapshotCacheSize, SnapshotGenAsync: config.SnapshotGenAsync,
+			TrieNodeCacheConfig: &config.TrieNodeCacheConfig, SenderTxHashIndexing: config.SenderTxHashIndexing, SnapshotCacheSize: config.SnapshotCacheSize, SnapshotAsyncGen: config.SnapshotAsyncGen,
 		}
 	)
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -263,7 +263,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		cacheConfig = &blockchain.CacheConfig{
 			ArchiveMode: config.NoPruning, CacheSize: config.TrieCacheSize,
 			BlockInterval: config.TrieBlockInterval, TriesInMemory: config.TriesInMemory,
-			TrieNodeCacheConfig: &config.TrieNodeCacheConfig, SenderTxHashIndexing: config.SenderTxHashIndexing, SnapshotCacheSize: config.SnapshotCacheSize,
+			TrieNodeCacheConfig: &config.TrieNodeCacheConfig, SenderTxHashIndexing: config.SenderTxHashIndexing, SnapshotCacheSize: config.SnapshotCacheSize, SnapshotGenAsync: config.SnapshotGenAsync,
 		}
 	)
 

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -124,6 +124,7 @@ type Config struct {
 	ParallelDBWrite      bool
 	TrieNodeCacheConfig  statedb.TrieNodeCacheConfig
 	SnapshotCacheSize    int
+	SnapshotGenAsync     bool
 
 	// Mining-related options
 	ServiceChainSigner common.Address `toml:",omitempty"`

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -124,7 +124,7 @@ type Config struct {
 	ParallelDBWrite      bool
 	TrieNodeCacheConfig  statedb.TrieNodeCacheConfig
 	SnapshotCacheSize    int
-	SnapshotGenAsync     bool
+	SnapshotAsyncGen     bool
 
 	// Mining-related options
 	ServiceChainSigner common.Address `toml:",omitempty"`


### PR DESCRIPTION
## Proposed changes

When `--snapshot` flag is set, the snapshot layer is generated after stopping block processing. This PR added a snapshot generation flag in order to generate snapshot data in a background while block processing normally. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

