### PR TITLE
Remove epoch from reward config cache

### DIFF
--- a/reward/reward_config_cache.go
+++ b/reward/reward_config_cache.go
@@ -59,21 +59,6 @@ func newRewardConfigCache(governanceHelper governanceHelper) *rewardConfigCache 
 }
 
 func (rewardConfigCache *rewardConfigCache) get(blockNumber uint64) (*rewardConfig, error) {
-	var epoch uint64
-	pset, err := rewardConfigCache.governanceHelper.ParamsAt(blockNumber)
-	if err != nil {
-		logger.Error("Couldn't get epoch from governance", "blockNumber", blockNumber, "err", err)
-		return nil, err
-	}
-	epoch = pset.Epoch()
-
-	remainder := blockNumber % epoch
-	if remainder == 0 {
-		blockNumber -= epoch
-	} else {
-		blockNumber -= remainder
-	}
-
 	config, ok := rewardConfigCache.cache.Get(blockNumber)
 	if ok {
 		return config.(*rewardConfig), nil

--- a/reward/reward_config_cache.go
+++ b/reward/reward_config_cache.go
@@ -35,7 +35,6 @@ const (
 )
 
 type rewardConfig struct {
-	blockNum      uint64
 	mintingAmount *big.Int
 	cnRatio       *big.Int
 	pocRatio      *big.Int
@@ -86,7 +85,6 @@ func (rewardConfigCache *rewardConfigCache) newRewardConfig(blockNumber uint64) 
 	}
 
 	rewardConfig := &rewardConfig{
-		blockNum:      blockNumber,
 		mintingAmount: pset.MintingAmountBig(),
 		cnRatio:       big.NewInt(int64(cn)),
 		pocRatio:      big.NewInt(int64(poc)),

--- a/reward/reward_config_cache_test.go
+++ b/reward/reward_config_cache_test.go
@@ -254,7 +254,7 @@ func TestRewardConfigCache_get_exist(t *testing.T) {
 				params.DeferredTxFee: true,
 			},
 			result: rewardConfig{
-				blockNum:      0,
+				blockNum:      1,
 				mintingAmount: big.NewInt(0).SetUint64(9600000000000000000),
 				cnRatio:       big.NewInt(0).SetInt64(34),
 				pocRatio:      big.NewInt(0).SetInt64(54),
@@ -274,7 +274,7 @@ func TestRewardConfigCache_get_exist(t *testing.T) {
 				params.DeferredTxFee: false,
 			},
 			result: rewardConfig{
-				blockNum:      604800,
+				blockNum:      604805,
 				mintingAmount: big.NewInt(0).SetUint64(9600000000000000),
 				cnRatio:       big.NewInt(0).SetInt64(40),
 				pocRatio:      big.NewInt(0).SetInt64(25),
@@ -294,7 +294,7 @@ func TestRewardConfigCache_get_exist(t *testing.T) {
 				params.DeferredTxFee: true,
 			},
 			result: rewardConfig{
-				blockNum:      1209600,
+				blockNum:      1210000,
 				mintingAmount: big.NewInt(0).SetUint64(100000000000000000),
 				cnRatio:       big.NewInt(0).SetInt64(34),
 				pocRatio:      big.NewInt(0).SetInt64(33),
@@ -311,13 +311,6 @@ func TestRewardConfigCache_get_exist(t *testing.T) {
 	for i := 0; i < len(testCases); i++ {
 		blockNumber := testCases[i].blockNumber
 		testGovernance.setTestGovernance(testCases[i].config)
-		epoch := testGovernance.Params().Epoch()
-
-		if blockNumber%epoch == 0 {
-			blockNumber -= epoch
-		} else {
-			blockNumber -= (blockNumber % epoch)
-		}
 		rewardConfig, _ := rewardConfigCache.newRewardConfig(blockNumber)
 		rewardConfigCache.add(blockNumber, rewardConfig)
 	}

--- a/reward/reward_config_cache_test.go
+++ b/reward/reward_config_cache_test.go
@@ -108,7 +108,6 @@ func TestRewardConfigCache_newRewardConfig(t *testing.T) {
 				params.DeferredTxFee: true,
 			},
 			rewardConfig{
-				blockNum:      0,
 				mintingAmount: big.NewInt(0).SetUint64(9600000000000000000),
 				cnRatio:       big.NewInt(0).SetInt64(34),
 				pocRatio:      big.NewInt(0).SetInt64(54),
@@ -127,7 +126,6 @@ func TestRewardConfigCache_newRewardConfig(t *testing.T) {
 				params.DeferredTxFee: false,
 			},
 			rewardConfig{
-				blockNum:      1,
 				mintingAmount: big.NewInt(0).SetInt64(10000),
 				cnRatio:       big.NewInt(0).SetInt64(50),
 				pocRatio:      big.NewInt(0).SetInt64(30),
@@ -146,7 +144,6 @@ func TestRewardConfigCache_newRewardConfig(t *testing.T) {
 				params.DeferredTxFee: true,
 			},
 			rewardConfig{
-				blockNum:      2,
 				mintingAmount: big.NewInt(0).SetInt64(100000000),
 				cnRatio:       big.NewInt(0).SetInt64(10),
 				pocRatio:      big.NewInt(0).SetInt64(35),
@@ -168,7 +165,6 @@ func TestRewardConfigCache_newRewardConfig(t *testing.T) {
 		}
 
 		expectedResult := &testCases[i].result
-		assert.Equal(t, expectedResult.blockNum, rewardConfig.blockNum)
 		assert.Equal(t, expectedResult.mintingAmount, rewardConfig.mintingAmount)
 		assert.Equal(t, expectedResult.cnRatio, rewardConfig.cnRatio)
 		assert.Equal(t, expectedResult.pocRatio, rewardConfig.pocRatio)
@@ -181,7 +177,6 @@ func TestRewardConfigCache_newRewardConfig(t *testing.T) {
 func TestRewardConfigCache_add(t *testing.T) {
 	testCases := []rewardConfig{
 		{
-			blockNum:      1,
 			mintingAmount: big.NewInt(0).SetUint64(9600000000000000000),
 			cnRatio:       big.NewInt(0).SetInt64(34),
 			pocRatio:      big.NewInt(0).SetInt64(54),
@@ -190,7 +185,6 @@ func TestRewardConfigCache_add(t *testing.T) {
 			unitPrice:     big.NewInt(0).SetInt64(25000000000),
 		},
 		{
-			blockNum:      2,
 			mintingAmount: big.NewInt(0).SetInt64(10000),
 			cnRatio:       big.NewInt(0).SetInt64(50),
 			pocRatio:      big.NewInt(0).SetInt64(30),
@@ -199,7 +193,6 @@ func TestRewardConfigCache_add(t *testing.T) {
 			unitPrice:     big.NewInt(0).SetInt64(50000000000),
 		},
 		{
-			blockNum:      3,
 			mintingAmount: big.NewInt(0).SetInt64(100000000),
 			cnRatio:       big.NewInt(0).SetInt64(10),
 			pocRatio:      big.NewInt(0).SetInt64(35),
@@ -220,7 +213,6 @@ func TestRewardConfigCache_add(t *testing.T) {
 
 func TestRewardConfigCache_add_sameNumber(t *testing.T) {
 	rewardConfig := rewardConfig{
-		blockNum:      1,
 		mintingAmount: big.NewInt(0).SetUint64(9600000000000000000),
 		cnRatio:       big.NewInt(0).SetInt64(34),
 		pocRatio:      big.NewInt(0).SetInt64(54),
@@ -254,7 +246,6 @@ func TestRewardConfigCache_get_exist(t *testing.T) {
 				params.DeferredTxFee: true,
 			},
 			result: rewardConfig{
-				blockNum:      1,
 				mintingAmount: big.NewInt(0).SetUint64(9600000000000000000),
 				cnRatio:       big.NewInt(0).SetInt64(34),
 				pocRatio:      big.NewInt(0).SetInt64(54),
@@ -274,7 +265,6 @@ func TestRewardConfigCache_get_exist(t *testing.T) {
 				params.DeferredTxFee: false,
 			},
 			result: rewardConfig{
-				blockNum:      604805,
 				mintingAmount: big.NewInt(0).SetUint64(9600000000000000),
 				cnRatio:       big.NewInt(0).SetInt64(40),
 				pocRatio:      big.NewInt(0).SetInt64(25),
@@ -294,7 +284,6 @@ func TestRewardConfigCache_get_exist(t *testing.T) {
 				params.DeferredTxFee: true,
 			},
 			result: rewardConfig{
-				blockNum:      1210000,
 				mintingAmount: big.NewInt(0).SetUint64(100000000000000000),
 				cnRatio:       big.NewInt(0).SetInt64(34),
 				pocRatio:      big.NewInt(0).SetInt64(33),
@@ -319,7 +308,6 @@ func TestRewardConfigCache_get_exist(t *testing.T) {
 		if err != nil {
 			t.Errorf("error has occurred. err : %v", err)
 		}
-		assert.Equal(t, testCases[i].result.blockNum, rewardConfig.blockNum)
 		assert.Equal(t, testCases[i].result.mintingAmount, rewardConfig.mintingAmount)
 		assert.Equal(t, testCases[i].result.cnRatio, rewardConfig.cnRatio)
 		assert.Equal(t, testCases[i].result.pocRatio, rewardConfig.pocRatio)

--- a/reward/reward_distributor_test.go
+++ b/reward/reward_distributor_test.go
@@ -182,7 +182,6 @@ func TestRewardDistributor_distributeBlockReward(t *testing.T) {
 		{
 			totalTxFee: big.NewInt(0),
 			rewardConfig: &rewardConfig{
-				blockNum:      1,
 				mintingAmount: big.NewInt(0).SetUint64(9600000000000000000),
 				cnRatio:       big.NewInt(0).SetInt64(34),
 				pocRatio:      big.NewInt(0).SetInt64(54),
@@ -197,7 +196,6 @@ func TestRewardDistributor_distributeBlockReward(t *testing.T) {
 		{
 			totalTxFee: big.NewInt(1000000),
 			rewardConfig: &rewardConfig{
-				blockNum:      1,
 				mintingAmount: big.NewInt(0).SetUint64(10000000000),
 				cnRatio:       big.NewInt(0).SetInt64(60),
 				pocRatio:      big.NewInt(0).SetInt64(30),


### PR DESCRIPTION
## Proposed changes
Before the introduction of KIP81 (#1623), reward config cache (rcc) is updated only every epoch (via governance).
However, after the hardfork, reward config can change anytime.
Thus, this PR removes the epoch from rcc, making it store reward config every block.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
