### PR TITLE
Add GovParamSet.ToChainConfig()-like methods

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -40,7 +40,6 @@ import (
 	"github.com/klaytn/klaytn/consensus/misc"
 	"github.com/klaytn/klaytn/crypto/sha3"
 	"github.com/klaytn/klaytn/networks/rpc"
-	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/rlp"
 )
@@ -202,13 +201,7 @@ func (sb *backend) verifyHeader(chain consensus.ChainReader, header *types.Heade
 			return err
 		}
 
-		kip71 := params.GetDefaultKIP71Config()
-		kip71.LowerBoundBaseFee = pset.LowerBoundBaseFee()
-		kip71.UpperBoundBaseFee = pset.UpperBoundBaseFee()
-		kip71.GasTarget = pset.GasTarget()
-		kip71.BaseFeeDenominator = pset.BaseFeeDenominator()
-		kip71.MaxBlockGasUsedForBaseFee = pset.MaxBlockGasUsedForBaseFee()
-
+		kip71 := pset.ToKIP71Config()
 		if err := misc.VerifyMagmaHeader(parents[len(parents)-1], header, kip71); err != nil {
 			return err
 		}

--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -423,6 +423,94 @@ func (p *GovParamSet) MustGet(key int) interface{} {
 	}
 }
 
+func (p *GovParamSet) ToIstanbulConfig() *IstanbulConfig {
+	var ret IstanbulConfig
+	if _, ok := p.Get(Epoch); ok {
+		ret.Epoch = p.Epoch()
+	}
+	if _, ok := p.Get(Policy); ok {
+		ret.ProposerPolicy = p.Policy()
+	}
+	if _, ok := p.Get(CommitteeSize); ok {
+		ret.SubGroupSize = p.CommitteeSize()
+	}
+
+	return &ret
+}
+
+func (p *GovParamSet) ToRewardConfig() *RewardConfig {
+	var ret RewardConfig
+	if _, ok := p.Get(MintingAmount); ok {
+		ret.MintingAmount = p.MintingAmountBig()
+	}
+	if _, ok := p.Get(Ratio); ok {
+		ret.Ratio = p.Ratio()
+	}
+	if _, ok := p.Get(UseGiniCoeff); ok {
+		ret.UseGiniCoeff = p.UseGiniCoeff()
+	}
+	if _, ok := p.Get(DeferredTxFee); ok {
+		ret.DeferredTxFee = p.DeferredTxFee()
+	}
+	if _, ok := p.Get(StakeUpdateInterval); ok {
+		ret.StakingUpdateInterval = p.StakeUpdateInterval()
+	}
+	if _, ok := p.Get(ProposerRefreshInterval); ok {
+		ret.ProposerUpdateInterval = p.ProposerRefreshInterval()
+	}
+	if _, ok := p.Get(MinimumStake); ok {
+		ret.MinimumStake = p.MinimumStakeBig()
+	}
+
+	return &ret
+}
+
+func (p *GovParamSet) ToKIP71Config() *KIP71Config {
+	var ret KIP71Config
+	if _, ok := p.Get(LowerBoundBaseFee); ok {
+		ret.LowerBoundBaseFee = p.LowerBoundBaseFee()
+	}
+	if _, ok := p.Get(UpperBoundBaseFee); ok {
+		ret.UpperBoundBaseFee = p.UpperBoundBaseFee()
+	}
+	if _, ok := p.Get(GasTarget); ok {
+		ret.GasTarget = p.GasTarget()
+	}
+	if _, ok := p.Get(MaxBlockGasUsedForBaseFee); ok {
+		ret.MaxBlockGasUsedForBaseFee = p.MaxBlockGasUsedForBaseFee()
+	}
+	if _, ok := p.Get(BaseFeeDenominator); ok {
+		ret.BaseFeeDenominator = p.BaseFeeDenominator()
+	}
+
+	return &ret
+}
+
+func (p *GovParamSet) ToGovernanceConfig() *GovernanceConfig {
+	var ret GovernanceConfig
+	if _, ok := p.Get(GoverningNode); ok {
+		ret.GoverningNode = p.GoverningNode()
+	}
+	if _, ok := p.Get(GovernanceMode); ok {
+		ret.GovernanceMode = p.GovernanceModeStr()
+	}
+	ret.Reward = p.ToRewardConfig()
+	ret.KIP71 = p.ToKIP71Config()
+
+	return &ret
+}
+
+func (p *GovParamSet) ToChainConfig() *ChainConfig {
+	var ret ChainConfig
+	if _, ok := p.Get(UnitPrice); ok {
+		ret.UnitPrice = p.UnitPrice()
+	}
+	ret.Istanbul = p.ToIstanbulConfig()
+	ret.Governance = p.ToGovernanceConfig()
+
+	return &ret
+}
+
 // Nominal getters. Shortcut for MustGet() + type assertion.
 
 func (p *GovParamSet) GovernanceModeStr() string {


### PR DESCRIPTION
## Proposed changes

This PR implements the following methods of GovParamSet:
```go
func (p *GovParamSet) ToIstanbulConfig() *IstanbulConfig { }
func (p *GovParamSet) ToRewardConfig() *RewardConfig { }
func (p *GovParamSet) ToKIP71Config() *KIP71Config { }
func (p *GovParamSet) ToGovernanceConfig() *GovernanceConfig { }
func (p *GovParamSet) ToChainConfig() *ChainConfig { }
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
