### PR TITLE
Optimize deriveshaOrig

### DIFF
--- a/storage/statedb/derive_sha.go
+++ b/storage/statedb/derive_sha.go
@@ -21,8 +21,6 @@
 package statedb
 
 import (
-	"bytes"
-
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/rlp"
@@ -33,26 +31,23 @@ type DeriveShaOrig struct{}
 func (d DeriveShaOrig) DeriveSha(list types.DerivableList) common.Hash {
 	trie := NewStackTrie(nil)
 	trie.Reset()
-	keybuf := new(bytes.Buffer)
+	var buf []byte
 
 	// StackTrie requires values to be inserted in increasing
 	// hash order, which is not the order that `list` provides
 	// hashes in. This insertion sequence ensures that the
 	// order is correct.
 	for i := 1; i < list.Len() && i <= 0x7f; i++ {
-		keybuf.Reset()
-		rlp.Encode(keybuf, uint(i))
-		trie.Update(keybuf.Bytes(), list.GetRlp(i))
+		buf = rlp.AppendUint64(buf[:0], uint64(i))
+		trie.Update(buf, list.GetRlp(i))
 	}
 	if list.Len() > 0 {
-		keybuf.Reset()
-		rlp.Encode(keybuf, uint(0))
-		trie.Update(keybuf.Bytes(), list.GetRlp(0))
+		buf = rlp.AppendUint64(buf[:0], 0)
+		trie.Update(buf, list.GetRlp(0))
 	}
 	for i := 0x80; i < list.Len(); i++ {
-		keybuf.Reset()
-		rlp.Encode(keybuf, uint(i))
-		trie.Update(keybuf.Bytes(), list.GetRlp(i))
+		buf = rlp.AppendUint64(buf[:0], uint64(i))
+		trie.Update(buf, list.GetRlp(i))
 	}
 	return trie.Hash()
 }

--- a/tests/tx_root_test.go
+++ b/tests/tx_root_test.go
@@ -35,7 +35,7 @@ func BenchmarkDeriveSha(b *testing.B) {
 		"Concat": types.DeriveShaConcat{},
 	}
 
-	NTS := []int{200}
+	NTS := []int{1000}
 
 	for k, f := range funcs {
 		for _, nt := range NTS {
@@ -105,9 +105,6 @@ func benchDeriveSha(b *testing.B, numTransactions, numValidators int, sha types.
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		sha.DeriveSha(txs)
-		//if testing.Verbose() {
-		//	fmt.Printf("[%d] txhash = %s\n", i, hash.Hex())
-		//}
 	}
 }
 

--- a/tests/tx_root_test.go
+++ b/tests/tx_root_test.go
@@ -18,13 +18,13 @@ package tests
 
 import (
 	"fmt"
-	"github.com/klaytn/klaytn/crypto"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common/profile"
+	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/storage/statedb"
 )
 
@@ -116,7 +116,7 @@ func genTxs(num uint64) (types.Transactions, error) {
 	if err != nil {
 		return nil, err
 	}
-	var addr = crypto.PubkeyToAddress(key.PublicKey)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
 	newTx := func(i uint64) (*types.Transaction, error) {
 		signer := types.NewEIP155Signer(big.NewInt(18))
 		utx := types.NewTransaction(i, addr, new(big.Int), 0, new(big.Int).SetUint64(10000000), nil)


### PR DESCRIPTION
## Proposed changes

This PR contains minor deriveSha optimization.
- AppendUint64 appends the RLP encoding of i to b, and returns the resulting slice. (an rlp integer is known to never require more than 9 bytes total). This function makes encoding more faster by using bit shifting
- change some buffer reseting logic. 

Plus. Added some benchmark testcode.

related Ethereum PR : https://github.com/ethereum/go-ethereum/pull/21728

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
