### PR TITLE
changed the ntp url to ntp pool

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -218,7 +218,7 @@ func ExportAppendChain(blockchain *blockchain.BlockChain, fn string, first uint6
 
 func NtpCheckWithLocal() error {
 	local := time.Now().UTC().Unix()
-	ntp, err := ntpclient.GetNetworkTime("time.nist.gov", 123)
+	ntp, err := ntpclient.GetNetworkTime("pool.ntp.org", 123)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

- NTP url is changed for the unstable time server, `time.nist.gov`
- `pool.ntp.org` has about 4600 time servers.
- This url is default and will be updated by optionally passing after toml configuration PR.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

