### PR TITLE
increased protocol message max size

### DIFF
--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -53,7 +53,7 @@ var ProtocolVersions = []uint{klay65, klay64, klay63, klay62}
 // ProtocolLengths are the number of implemented message corresponding to different protocol versions.
 var ProtocolLengths = []uint64{21, 19, 17, 8}
 
-const ProtocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a protocol message
+const ProtocolMaxMsgSize = 12 * 1024 * 1024 // Maximum cap on the size of a protocol message
 
 // Klaytn protocol message codes
 // TODO-Klaytn-Issue751 Protocol message should be refactored. Present code is not used.

--- a/node/sc/protocol.go
+++ b/node/sc/protocol.go
@@ -26,7 +26,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 )
 
-const ProtocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a protocol message
+const ProtocolMaxMsgSize = 12 * 1024 * 1024 // Maximum cap on the size of a protocol message
 
 const (
 	// Protocol messages belonging to servicechain/1


### PR DESCRIPTION
## Proposed changes

- There is a case where the size of a protocol message is greater than max (10MB)
  - https://baobab.klaytnfinder.io/block/97148983
- This PR increase the max size a bit (2MB).

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

