### PR TITLE
Make ntp server optional

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -28,9 +28,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
-	"github.com/bt51/ntpclient"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/log"
@@ -213,20 +211,6 @@ func ExportAppendChain(blockchain *blockchain.BlockChain, fn string, first uint6
 		return err
 	}
 	logger.Info("Exported blockchain to", "file", fn)
-	return nil
-}
-
-func NtpCheckWithLocal() error {
-	local := time.Now().UTC().Unix()
-	ntp, err := ntpclient.GetNetworkTime("pool.ntp.org", 123)
-	if err != nil {
-		return err
-	}
-	remote := ntp.Unix()
-	if local != remote {
-		return fmt.Errorf("System time is out of sync, local:%x remote:%x", local, remote)
-	}
-	logger.Info("Ntp time check", "local", local, "remote", remote)
 	return nil
 }
 

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -311,6 +311,12 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 // setNodeConfig applies node-related command line flags to the config.
 func (kCfg *KlayConfig) SetNodeConfig(ctx *cli.Context) {
 	cfg := &kCfg.Node
+	// ntp check enable with remote server
+	if ctx.GlobalBool(NtpDisableFlag.Name) {
+		cfg.NtpRemoteServer = ""
+	} else {
+		cfg.NtpRemoteServer = ctx.GlobalString(NtpServerFlag.Name)
+	}
 	SetP2PConfig(ctx, &cfg.P2P)
 	setIPC(ctx, cfg)
 

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -37,6 +37,8 @@ var FlagGroups = []FlagGroup{
 	{
 		Name: "KLAY",
 		Flags: []cli.Flag{
+			NtpDisableFlag,
+			NtpServerFlag,
 			DbTypeFlag,
 			DataDirFlag,
 			KeyStoreDirFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -73,7 +73,7 @@ var (
 	}
 	NtpDisableFlag = cli.BoolFlag{
 		Name:   "ntp.disable",
-		Usage:  "Disable checking if the local time is synchronized with ntp server (default:enable)",
+		Usage:  "Disable checking if the local time is synchronized with ntp server. If this flag is not set, the local time is checked with the time of the server specified by ntp.server.",
 		EnvVar: "KLAYTN_NTP_DISABLE",
 	}
 	NtpServerFlag = cli.StringFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -74,7 +74,7 @@ var (
 	NtpDisableFlag = cli.BoolFlag{
 		Name:   "ntp.disable",
 		Usage:  "Disable checking if the local time is synchronized with ntp server (default:enable)",
-		EnvVar: "KLAYTN_NTP",
+		EnvVar: "KLAYTN_NTP_DISABLE",
 	}
 	NtpServerFlag = cli.StringFlag{
 		Name:   "ntp.server",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -71,6 +71,17 @@ var (
 	ConfFlag = cli.StringFlag{
 		Name: "conf",
 	}
+	NtpDisableFlag = cli.BoolFlag{
+		Name:   "ntp.disable",
+		Usage:  "Disable checking if the local time is synchronized with ntp server (default:enable)",
+		EnvVar: "KLAYTN_NTP",
+	}
+	NtpServerFlag = cli.StringFlag{
+		Name:   "ntp-server",
+		Usage:  "Remote ntp server:port to get the time",
+		Value:  "pool.ntp.org:123",
+		EnvVar: "KLAYTN_NTP_SERVER",
+	}
 	NetworkTypeFlag = cli.StringFlag{
 		Name:   "networktype",
 		Usage:  "Klaytn network type (main-net (mn), service chain-net (scn))",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -77,7 +77,7 @@ var (
 		EnvVar: "KLAYTN_NTP",
 	}
 	NtpServerFlag = cli.StringFlag{
-		Name:   "ntp-server",
+		Name:   "ntp.server",
 		Usage:  "Remote ntp server:port to get the time",
 		Value:  "pool.ntp.org:123",
 		EnvVar: "KLAYTN_NTP_SERVER",

--- a/cmd/utils/nodecmd/defaultcmd.go
+++ b/cmd/utils/nodecmd/defaultcmd.go
@@ -81,7 +81,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	debug.Memsize.Add("node", stack)
 
 	// Ntp time check
-	if err := utils.NtpCheckWithLocal(); err != nil {
+	if err := node.NtpCheckWithLocal(stack); err != nil {
 		log.Fatalf("System time should be synchronized: %v", err)
 	}
 

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -112,6 +112,8 @@ func KsenAppFlags() []cli.Flag {
 // Common flags that configure the node
 var CommonNodeFlags = []cli.Flag{
 	utils.ConfFlag,
+	altsrc.NewBoolFlag(utils.NtpDisableFlag),
+	altsrc.NewStringFlag(utils.NtpServerFlag),
 	altsrc.NewStringFlag(utils.BootnodesFlag),
 	altsrc.NewStringFlag(utils.IdentityFlag),
 	altsrc.NewStringFlag(utils.UnlockedAccountFlag),

--- a/node/config.go
+++ b/node/config.go
@@ -166,6 +166,9 @@ type Config struct {
 	// ephemeral nodes).
 	GRPCPort int `toml:",omitempty"`
 
+	// Ntp server:port to check the synchronization when booting the node
+	NtpRemoteServer string `toml:",omitempty"`
+
 	// Logger is a custom logger to use with the p2p.Server.
 	Logger log.Logger `toml:",omitempty"`
 }

--- a/node/node.go
+++ b/node/node.go
@@ -841,8 +841,8 @@ func NtpCheckWithLocal(n *Node) error {
 	}
 	if !timeIsNear(local, *remote) {
 		errFormat := "System time is out of sync, local:%s remote:%s"
-		return fmt.Errorf(errFormat, local.Format(RFC3339Nano), remote.Format(RFC3339Nano))
+		return fmt.Errorf(errFormat, local.UTC().Format(RFC3339Nano), remote.UTC().Format(RFC3339Nano))
 	}
-	logger.Info("Ntp time check", "local", local, "remote", remote)
+	logger.Info("Ntp time check", "local", local.UTC().Format(RFC3339Nano), "remote", remote.UTC().Format(RFC3339Nano))
 	return nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -806,7 +806,7 @@ func (n *Node) apis() []rpc.API {
 }
 
 func NtpCheckWithLocal(n *Node) error {
-	// ntp check option disabled
+	// Skip check if server is empty (e.g. `ntp.disable` flag)
 	if n.config.NtpRemoteServer == "" {
 		return nil
 	}


### PR DESCRIPTION
## Proposed changes

- This is the follow up #1641 . [reference](https://github.com/klaytn/klaytn/pull/1641#discussion_r998880002)
- The default is checking whether synchronized with remote ntp server (pool.ntp.org:123).
- The ntp time check can be disabled with option `--ntp.disable`
- If you need to specify the ntp server, pass the option `--ntp.server host:port`
- Note
  - Sometimes the node may not boot with an `error` because it cannot synchronize with the remote server `realtime`.
  - You can run it again if the ntp time synchronizes for the local system is on.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

