### PR TITLE
vm: reject the deploy of a bytecode starting with 0xEF

### DIFF
--- a/blockchain/vm/errors.go
+++ b/blockchain/vm/errors.go
@@ -44,4 +44,5 @@ var (
 	ErrExecutionReverted     = errors.New("evm: execution reverted")
 	ErrMaxCodeSizeExceeded   = errors.New("evm: max code size exceeded")
 	ErrInvalidJump           = errors.New("evm: invalid jump destination")
+	ErrInvalidCode           = errors.New("invalid code: must not begin with 0xef")
 )

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -512,6 +512,12 @@ func (evm *EVM) create(caller types.ContractRef, codeAndHash *codeAndHash, gas u
 	if maxCodeSizeExceeded && err == nil {
 		err = ErrMaxCodeSizeExceeded // TODO-Klaytn-Issue615
 	}
+
+	// Reject code starting with 0xEF if EIP-3541 is enabled.
+	if err == nil && len(ret) >= 1 && ret[0] == 0xEF && evm.chainRules.IsKore {
+		err = ErrInvalidCode
+	}
+
 	if evm.vmConfig.Debug && evm.depth == 0 {
 		evm.vmConfig.Tracer.CaptureEnd(ret, gas-contract.Gas, time.Since(start), err)
 	}


### PR DESCRIPTION
## Proposed changes

- This PR rejects the deployement of a bytecode starting with 0xEF
- This is a part of Kore hardfork.

dev
```
>  klay.sendTransaction({"from": "0x74de5a50f1692177532afe5d6d761a098476679d", "input": "0x60ef60005360016000f3"})
"0xd1e9c66e6a44af8a3e5b4b57fbea556c95ad91d4fbe0f14d9356ec60c5e939f9"
> klay.getTransactionReceipt("0xd1e9c66e6a44af8a3e5b4b57fbea556c95ad91d4fbe0f14d9356ec60c5e939f9").status
"0x1"
```
PR
```
>  klay.sendTransaction({"from": "0x74de5a50f1692177532afe5d6d761a098476679d", "input": "0x60ef60005360016000f3"})
"0x1bb669fadb2c61396418f8c7c1fe37c5fb494069562a5ac736b850940b653075"
> klay.getTransactionReceipt("0x1bb669fadb2c61396418f8c7c1fe37c5fb494069562a5ac736b850940b653075").status
"0x0"
> klay.getTransactionReceipt("0x1bb669fadb2c61396418f8c7c1fe37c5fb494069562a5ac736b850940b653075").txError
"0x2"
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #1686 
- https://eips.ethereum.org/EIPS/eip-3541

## Further comments
