### PR TITLE
Parameterize DeriveSha with block number

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -397,12 +397,12 @@ type EthStorageResult struct {
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
 // This feature is not supported in Klaytn yet. It just returns account information from state trie.
 func (api *EthereumAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (*EthAccountResult, error) {
-	state, _, err := api.publicKlayAPI.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	state, header, err := api.publicKlayAPI.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
 	}
 	storageTrie := state.StorageTrie(address)
-	storageHash := types.EmptyRootHash
+	storageHash := types.EmptyRootHash(header.Number)
 	codeHash := state.GetCodeHash(address)
 	storageProof := make([]EthStorageResult, len(storageKeys))
 

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -993,7 +993,7 @@ func testInitForEthApi(t *testing.T) (*gomock.Controller, *mock_api.MockBackend,
 	mockCtrl := gomock.NewController(t)
 	mockBackend := mock_api.NewMockBackend(mockCtrl)
 
-	blockchain.InitDeriveSha(types.ImplDeriveShaOriginal)
+	blockchain.InitDeriveSha(dummyChainConfigForEthereumAPITest)
 
 	api := EthereumAPI{
 		publicTransactionPoolAPI: NewPublicTransactionPoolAPI(mockBackend, new(AddrLocker)),

--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -288,12 +288,13 @@ func BenchmarkChainWrite_full_100k_badgerDB(b *testing.B) {
 func makeChainForBench(db database.DBManager, full bool, count uint64) {
 	var hash common.Hash
 	for n := uint64(0); n < count; n++ {
+		num := new(big.Int).SetUint64(n)
 		header := &types.Header{
-			Number:      big.NewInt(int64(n)),
+			Number:      num,
 			ParentHash:  hash,
 			BlockScore:  big.NewInt(1),
-			TxHash:      types.EmptyRootHash,
-			ReceiptHash: types.EmptyRootHash,
+			TxHash:      types.EmptyRootHash(num),
+			ReceiptHash: types.EmptyRootHash(num),
 		}
 		hash = header.Hash()
 

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -67,7 +67,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	}
 	// Header validity is known at this point, check the transactions
 	header := block.Header()
-	if hash := types.DeriveSha(block.Transactions()); hash != header.TxHash {
+	if hash := types.DeriveSha(block.Transactions(), block.Number()); hash != header.TxHash {
 		return fmt.Errorf("transaction root hash mismatch: have %x, want %x", hash, header.TxHash)
 	}
 	baseFee := block.Header().BaseFee
@@ -97,7 +97,7 @@ func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *stat
 		return fmt.Errorf("invalid bloom (remote: %x  local: %x)", header.Bloom, rbloom)
 	}
 	// Tre receipt Trie's root (R = (Tr [[H1, R1], ... [Hn, R1]]))
-	receiptSha := types.DeriveSha(receipts)
+	receiptSha := types.DeriveSha(receipts, block.Number())
 	if receiptSha != header.ReceiptHash {
 		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x)", header.ReceiptHash, receiptSha)
 	}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -241,7 +241,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 	state.EnabledExpensive = db.GetDBConfig().EnableDBPerfMetrics
 
 	// Initialize DeriveSha implementation
-	InitDeriveSha(chainConfig.DeriveShaImpl)
+	InitDeriveSha(chainConfig)
 
 	futureBlocks, _ := lru.New(maxFutureBlocks)
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -240,9 +240,6 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 
 	state.EnabledExpensive = db.GetDBConfig().EnableDBPerfMetrics
 
-	// Initialize DeriveSha implementation
-	InitDeriveSha(chainConfig)
-
 	futureBlocks, _ := lru.New(maxFutureBlocks)
 
 	bc := &BlockChain{

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -664,7 +664,7 @@ func TestFastVsFullChains(t *testing.T) {
 	}
 	// Iterate over all chain data components, and cross reference
 	for i := 0; i < len(blocks); i++ {
-		num, hash := blocks[i].NumberU64(), blocks[i].Hash()
+		bnum, num, hash := blocks[i].Number(), blocks[i].NumberU64(), blocks[i].Hash()
 
 		if ftd, atd := fast.GetTdByHash(hash), archive.GetTdByHash(hash); ftd.Cmp(atd) != 0 {
 			t.Errorf("block #%d [%x]: td mismatch: have %v, want %v", num, hash, ftd, atd)
@@ -674,10 +674,12 @@ func TestFastVsFullChains(t *testing.T) {
 		}
 		if fblock, ablock := fast.GetBlockByHash(hash), archive.GetBlockByHash(hash); fblock.Hash() != ablock.Hash() {
 			t.Errorf("block #%d [%x]: block mismatch: have %v, want %v", num, hash, fblock, ablock)
-		} else if types.DeriveSha(fblock.Transactions()) != types.DeriveSha(ablock.Transactions()) {
+		} else if types.DeriveSha(fblock.Transactions(), bnum) != types.DeriveSha(ablock.Transactions(), bnum) {
 			t.Errorf("block #%d [%x]: transactions mismatch: have %v, want %v", num, hash, fblock.Transactions(), ablock.Transactions())
 		}
-		if freceipts, areceipts := fastDb.ReadReceipts(hash, *fastDb.ReadHeaderNumber(hash)), archiveDb.ReadReceipts(hash, *archiveDb.ReadHeaderNumber(hash)); types.DeriveSha(freceipts) != types.DeriveSha(areceipts) {
+		freceipts := fastDb.ReadReceipts(hash, *fastDb.ReadHeaderNumber(hash))
+		areceipts := archiveDb.ReadReceipts(hash, *archiveDb.ReadHeaderNumber(hash))
+		if types.DeriveSha(freceipts, bnum) != types.DeriveSha(areceipts, bnum) {
 			t.Errorf("block #%d [%x]: receipts mismatch: have %v, want %v", num, hash, freceipts, areceipts)
 		}
 	}

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -204,7 +204,7 @@ func SetupGenesisBlock(db database.DBManager, genesis *Genesis, networkId uint64
 			logger.Info("Writing custom genesis block")
 		}
 		// Initialize DeriveSha implementation
-		InitDeriveSha(genesis.Config.DeriveShaImpl)
+		InitDeriveSha(genesis.Config)
 		block, err := genesis.Commit(common.Hash{}, db)
 		if err != nil {
 			return genesis.Config, common.Hash{}, err
@@ -369,7 +369,7 @@ func (g *Genesis) MustCommit(db database.DBManager) *types.Block {
 	if config == nil {
 		config = params.AllGxhashProtocolChanges
 	}
-	InitDeriveSha(config.DeriveShaImpl)
+	InitDeriveSha(config)
 
 	block, err := g.Commit(common.Hash{}, db)
 	if err != nil {

--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -351,7 +351,7 @@ func genCypressGenesisBlock() *Genesis {
 	genesis := DefaultGenesisBlock()
 	genesis.Config = params.CypressChainConfig.Copy()
 	genesis.Governance = SetGenesisGovernance(genesis)
-	InitDeriveSha(genesis.Config.DeriveShaImpl)
+	InitDeriveSha(genesis.Config)
 	return genesis
 }
 
@@ -359,7 +359,7 @@ func genBaobabGenesisBlock() *Genesis {
 	genesis := DefaultBaobabGenesisBlock()
 	genesis.Config = params.BaobabChainConfig.Copy()
 	genesis.Governance = SetGenesisGovernance(genesis)
-	InitDeriveSha(genesis.Config.DeriveShaImpl)
+	InitDeriveSha(genesis.Config)
 	return genesis
 }
 
@@ -378,6 +378,6 @@ func genCustomGenesisBlock(customChainId uint64) *Genesis {
 	}
 	genesis.Config.SetDefaults()
 	genesis.Governance = SetGenesisGovernance(genesis)
-	InitDeriveSha(genesis.Config.DeriveShaImpl)
+	InitDeriveSha(genesis.Config)
 	return genesis
 }

--- a/blockchain/init_derive_sha.go
+++ b/blockchain/init_derive_sha.go
@@ -18,8 +18,9 @@ package blockchain
 
 import (
 	"github.com/klaytn/klaytn/blockchain/types/derivesha"
+	"github.com/klaytn/klaytn/params"
 )
 
-func InitDeriveSha(deriveShaImpl int) {
-	derivesha.InitDeriveSha(deriveShaImpl)
+func InitDeriveSha(config *params.ChainConfig) {
+	derivesha.InitDeriveSha(config)
 }

--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -144,12 +144,12 @@ func prefixedRlpHash(prefix byte, x interface{}) (h common.Hash) {
 // EmptyBody returns true if there is no additional 'body' to complete the header
 // that is: no transactions.
 func (h *Header) EmptyBody() bool {
-	return h.TxHash == EmptyRootHash
+	return h.TxHash == EmptyRootHash(h.Number)
 }
 
 // EmptyReceipts returns true if there are no receipts for this header/block.
 func (h *Header) EmptyReceipts() bool {
-	return h.ReceiptHash == EmptyRootHash
+	return h.ReceiptHash == EmptyRootHash(h.Number)
 }
 
 // Body is a simple (mutable, non-safe) data container for storing and moving
@@ -198,7 +198,7 @@ func NewBlock(header *Header, txs []*Transaction, receipts []*Receipt) *Block {
 
 	// TODO: panic if len(txs) != len(receipts)
 	if len(txs) == 0 {
-		b.header.TxHash = EmptyRootHash
+		b.header.TxHash = EmptyRootHash(header.Number)
 	} else {
 		b.header.TxHash = DeriveSha(Transactions(txs), header.Number)
 		b.transactions = make(Transactions, len(txs))
@@ -206,7 +206,7 @@ func NewBlock(header *Header, txs []*Transaction, receipts []*Receipt) *Block {
 	}
 
 	if len(receipts) == 0 {
-		b.header.ReceiptHash = EmptyRootHash
+		b.header.ReceiptHash = EmptyRootHash(header.Number)
 	} else {
 		b.header.ReceiptHash = DeriveSha(Receipts(receipts), header.Number)
 		b.header.Bloom = CreateBloom(receipts)

--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -42,9 +42,7 @@ const (
 	Engine_Gxhash
 )
 
-var (
-	EngineType = Engine_IBFT
-)
+var EngineType = Engine_IBFT
 
 //go:generate gencodec -type Header -field-override headerMarshaling -out gen_header_json.go
 
@@ -202,7 +200,7 @@ func NewBlock(header *Header, txs []*Transaction, receipts []*Receipt) *Block {
 	if len(txs) == 0 {
 		b.header.TxHash = EmptyRootHash
 	} else {
-		b.header.TxHash = DeriveSha(Transactions(txs))
+		b.header.TxHash = DeriveSha(Transactions(txs), header.Number)
 		b.transactions = make(Transactions, len(txs))
 		copy(b.transactions, txs)
 	}
@@ -210,7 +208,7 @@ func NewBlock(header *Header, txs []*Transaction, receipts []*Receipt) *Block {
 	if len(receipts) == 0 {
 		b.header.ReceiptHash = EmptyRootHash
 	} else {
-		b.header.ReceiptHash = DeriveSha(Receipts(receipts))
+		b.header.ReceiptHash = DeriveSha(Receipts(receipts), header.Number)
 		b.header.Bloom = CreateBloom(receipts)
 	}
 

--- a/blockchain/types/derive_sha.go
+++ b/blockchain/types/derive_sha.go
@@ -41,10 +41,15 @@ var (
 	// EmptyRootHash is a transaction/receipt root hash when there is no transaction.
 	// DeriveSha and EmptyRootHash are populated by derivesha.InitDeriveSha().
 	DeriveSha     func(list DerivableList, num *big.Int) common.Hash = DeriveShaNone
-	EmptyRootHash common.Hash
+	EmptyRootHash func(num *big.Int) common.Hash                     = EmptyRootHashNone
 )
 
 func DeriveShaNone(list DerivableList, num *big.Int) common.Hash {
+	logger.Crit("DeriveSha not initialized")
+	return common.Hash{}
+}
+
+func EmptyRootHashNone(num *big.Int) common.Hash {
 	logger.Crit("DeriveSha not initialized")
 	return common.Hash{}
 }

--- a/blockchain/types/derive_sha.go
+++ b/blockchain/types/derive_sha.go
@@ -20,7 +20,11 @@
 
 package types
 
-import "github.com/klaytn/klaytn/common"
+import (
+	"math/big"
+
+	"github.com/klaytn/klaytn/common"
+)
 
 type DerivableList interface {
 	Len() int
@@ -36,6 +40,11 @@ const (
 var (
 	// EmptyRootHash is a transaction/receipt root hash when there is no transaction.
 	// DeriveSha and EmptyRootHash are populated by derivesha.InitDeriveSha().
-	DeriveSha     func(list DerivableList) common.Hash
+	DeriveSha     func(list DerivableList, num *big.Int) common.Hash = DeriveShaNone
 	EmptyRootHash common.Hash
 )
+
+func DeriveShaNone(list DerivableList, num *big.Int) common.Hash {
+	logger.Crit("DeriveSha not initialized")
+	return common.Hash{}
+}

--- a/blockchain/types/derivesha/mux.go
+++ b/blockchain/types/derivesha/mux.go
@@ -21,41 +21,53 @@
 package derivesha
 
 import (
+	"math/big"
+
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/params"
 )
-
-// TODO-Klaytn: Make DeriveShaMux state-less
-// As-is: InitDS(type) + DS(list) + ERH
-// To-be: InitDS() + DS(list, type) + ERH(type)
 
 type IDeriveSha interface {
 	DeriveSha(list types.DerivableList) common.Hash
 }
 
 var (
-	deriveShaObj IDeriveSha = nil
-	logger                  = log.NewModuleLogger(log.Blockchain)
+	config     *params.ChainConfig
+	instances  map[int]IDeriveSha
+	emptyRoots map[int]common.Hash
+
+	logger = log.NewModuleLogger(log.Blockchain)
 )
 
-func InitDeriveSha(implType int) {
-	switch implType {
-	case types.ImplDeriveShaOriginal:
-		deriveShaObj = DeriveShaOrig{}
-	case types.ImplDeriveShaSimple:
-		deriveShaObj = DeriveShaSimple{}
-	case types.ImplDeriveShaConcat:
-		deriveShaObj = DeriveShaConcat{}
-	default:
-		logger.Error("Unrecognized deriveShaImpl, falling back to Orig", "impl", implType)
-		deriveShaObj = DeriveShaOrig{}
+func InitDeriveSha(chainConfig *params.ChainConfig) {
+	instances = map[int]IDeriveSha{
+		types.ImplDeriveShaOriginal: DeriveShaOrig{},
+		types.ImplDeriveShaSimple:   DeriveShaSimple{},
+		types.ImplDeriveShaConcat:   DeriveShaConcat{},
 	}
 
+	emptyRoots = make(map[int]common.Hash)
+	for implType, instance := range instances {
+		emptyRoots[implType] = instance.DeriveSha(types.Transactions{})
+	}
+
+	config = chainConfig
 	types.DeriveSha = DeriveShaMux
 	types.EmptyRootHash = DeriveShaMux(types.Transactions{})
 }
 
 func DeriveShaMux(list types.DerivableList) common.Hash {
-	return deriveShaObj.DeriveSha(list)
+	return instances[getType(nil)].DeriveSha(list)
+}
+
+func getType(num *big.Int) int {
+	implType := config.DeriveShaImpl
+	if _, ok := instances[implType]; ok {
+		return implType
+	} else {
+		logger.Error("Unrecognized deriveShaImpl, falling back to Orig", "impl", implType)
+		return types.ImplDeriveShaOriginal
+	}
 }

--- a/blockchain/types/derivesha/mux.go
+++ b/blockchain/types/derivesha/mux.go
@@ -55,11 +55,11 @@ func InitDeriveSha(chainConfig *params.ChainConfig) {
 
 	config = chainConfig
 	types.DeriveSha = DeriveShaMux
-	types.EmptyRootHash = DeriveShaMux(types.Transactions{})
+	types.EmptyRootHash = DeriveShaMux(types.Transactions{}, nil)
 }
 
-func DeriveShaMux(list types.DerivableList) common.Hash {
-	return instances[getType(nil)].DeriveSha(list)
+func DeriveShaMux(list types.DerivableList, num *big.Int) common.Hash {
+	return instances[getType(num)].DeriveSha(list)
 }
 
 func getType(num *big.Int) int {

--- a/blockchain/types/derivesha/mux.go
+++ b/blockchain/types/derivesha/mux.go
@@ -41,7 +41,7 @@ var (
 	logger = log.NewModuleLogger(log.Blockchain)
 )
 
-func InitDeriveSha(chainConfig *params.ChainConfig) {
+func init() {
 	instances = map[int]IDeriveSha{
 		types.ImplDeriveShaOriginal: DeriveShaOrig{},
 		types.ImplDeriveShaSimple:   DeriveShaSimple{},
@@ -52,7 +52,9 @@ func InitDeriveSha(chainConfig *params.ChainConfig) {
 	for implType, instance := range instances {
 		emptyRoots[implType] = instance.DeriveSha(types.Transactions{})
 	}
+}
 
+func InitDeriveSha(chainConfig *params.ChainConfig) {
 	config = chainConfig
 	types.DeriveSha = DeriveShaMux
 	types.EmptyRootHash = EmptyRootHashMux

--- a/blockchain/types/derivesha/mux.go
+++ b/blockchain/types/derivesha/mux.go
@@ -61,14 +61,15 @@ func InitDeriveSha(chainConfig *params.ChainConfig) {
 }
 
 func DeriveShaMux(list types.DerivableList, num *big.Int) common.Hash {
-	return instances[getType(num)].DeriveSha(list)
+	return instances[getType()].DeriveSha(list)
 }
 
 func EmptyRootHashMux(num *big.Int) common.Hash {
-	return emptyRoots[getType(num)]
+	return emptyRoots[getType()]
 }
 
-func getType(num *big.Int) int {
+// TODO: Choose appropriate DeriveShaImpl from governance based on block number
+func getType() int {
 	implType := config.DeriveShaImpl
 	if _, ok := instances[implType]; ok {
 		return implType

--- a/blockchain/types/derivesha/mux.go
+++ b/blockchain/types/derivesha/mux.go
@@ -55,11 +55,15 @@ func InitDeriveSha(chainConfig *params.ChainConfig) {
 
 	config = chainConfig
 	types.DeriveSha = DeriveShaMux
-	types.EmptyRootHash = DeriveShaMux(types.Transactions{}, nil)
+	types.EmptyRootHash = EmptyRootHashMux
 }
 
 func DeriveShaMux(list types.DerivableList, num *big.Int) common.Hash {
 	return instances[getType(num)].DeriveSha(list)
+}
+
+func EmptyRootHashMux(num *big.Int) common.Hash {
+	return emptyRoots[getType(num)]
 }
 
 func getType(num *big.Int) int {

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -159,7 +159,7 @@ func initGenesis(ctx *cli.Context) error {
 		chainDB := stack.OpenDatabase(dbc)
 
 		// Initialize DeriveSha implementation
-		blockchain.InitDeriveSha(genesis.Config.DeriveShaImpl)
+		blockchain.InitDeriveSha(genesis.Config)
 
 		_, hash, err := blockchain.SetupGenesisBlock(chainDB, genesis, params.UnusedNetworkId, false, overwriteGenesis)
 		if err != nil {

--- a/consensus/clique/snapshot_test.go
+++ b/consensus/clique/snapshot_test.go
@@ -402,16 +402,18 @@ func TestClique(t *testing.T) {
 		for j, signer := range signers {
 			copy(genesis.ExtraData[ExtraVanity+j*common.AddressLength:], signer[:])
 		}
-		// Create a pristine blockchain with the genesis injected
-		db := database.NewMemoryDBManager()
-		genesis.Commit(common.Hash{}, db)
-
 		// Assemble a chain of headers from the cast votes
 		config := params.TestChainConfig.Copy()
 		config.Clique = &params.CliqueConfig{
 			Period: 1,
 			Epoch:  tt.epoch,
 		}
+		blockchain.InitDeriveSha(config)
+
+		// Create a pristine blockchain with the genesis injected
+		db := database.NewMemoryDBManager()
+		genesis.Commit(common.Hash{}, db)
+
 		engine := New(config.Clique, db)
 		engine.fakeBlockScore = true
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -331,7 +331,7 @@ func (sb *backend) Verify(proposal istanbul.Proposal) (time.Duration, error) {
 	}
 
 	// check block body
-	txnHash := types.DeriveSha(block.Transactions())
+	txnHash := types.DeriveSha(block.Transactions(), block.Number())
 	if txnHash != block.Header().TxHash {
 		return 0, errMismatchTxhashes
 	}

--- a/datasync/downloader/queue.go
+++ b/datasync/downloader/queue.go
@@ -866,7 +866,7 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction) (int, e
 	defer q.lock.Unlock()
 
 	validate := func(index int, header *types.Header) error {
-		if types.DeriveSha(types.Transactions(txLists[index])) != header.TxHash {
+		if types.DeriveSha(types.Transactions(txLists[index]), header.Number) != header.TxHash {
 			return errInvalidBody
 		}
 		return nil
@@ -886,7 +886,7 @@ func (q *queue) DeliverReceipts(id string, receiptList [][]*types.Receipt) (int,
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	validate := func(index int, header *types.Header) error {
-		if types.DeriveSha(types.Receipts(receiptList[index])) != header.ReceiptHash {
+		if types.DeriveSha(types.Receipts(receiptList[index]), header.Number) != header.ReceiptHash {
 			return errInvalidReceipt
 		}
 		return nil

--- a/datasync/fetcher/fetcher.go
+++ b/datasync/fetcher/fetcher.go
@@ -496,7 +496,7 @@ func (f *Fetcher) loop() {
 						announce.time = task.time
 
 						// If the block is empty (header only), short circuit into the final import queue
-						if header.TxHash == types.EmptyRootHash {
+						if header.EmptyBody() {
 							logger.Trace("Block empty, skipping body retrieval", "peer", announce.origin, "number", header.Number, "hash", header.Hash())
 
 							block := types.NewBlockWithHeader(header)

--- a/datasync/fetcher/fetcher.go
+++ b/datasync/fetcher/fetcher.go
@@ -496,7 +496,7 @@ func (f *Fetcher) loop() {
 						announce.time = task.time
 
 						// If the block is empty (header only), short circuit into the final import queue
-						if header.TxHash == types.DeriveSha(types.Transactions{}) {
+						if header.TxHash == types.EmptyRootHash {
 							logger.Trace("Block empty, skipping body retrieval", "peer", announce.origin, "number", header.Number, "hash", header.Hash())
 
 							block := types.NewBlockWithHeader(header)
@@ -567,7 +567,8 @@ func (f *Fetcher) loop() {
 						}
 
 						if common.EmptyHash(txnHash) {
-							txnHash = types.DeriveSha(types.Transactions(task.transactions[i]))
+							txnHash = types.DeriveSha(
+								types.Transactions(task.transactions[i]), announce.header.Number)
 						}
 
 						if txnHash != announce.header.TxHash {

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -610,7 +610,7 @@ func TestBaoBabGenesisHash(t *testing.T) {
 	baobabHash := params.BaobabGenesisHash
 	genesis := blockchain.DefaultBaobabGenesisBlock()
 	genesis.Governance = blockchain.SetGenesisGovernance(genesis)
-	blockchain.InitDeriveSha(genesis.Config.DeriveShaImpl)
+	blockchain.InitDeriveSha(genesis.Config)
 
 	db := database.NewMemoryDBManager()
 	block, _ := genesis.Commit(common.Hash{}, db)
@@ -623,7 +623,7 @@ func TestCypressGenesisHash(t *testing.T) {
 	cypressHash := params.CypressGenesisHash
 	genesis := blockchain.DefaultGenesisBlock()
 	genesis.Governance = blockchain.SetGenesisGovernance(genesis)
-	blockchain.InitDeriveSha(genesis.Config.DeriveShaImpl)
+	blockchain.InitDeriveSha(genesis.Config)
 
 	db := database.NewMemoryDBManager()
 	block, _ := genesis.Commit(common.Hash{}, db)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -275,6 +275,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	cn.blockchain = bc
 	governance.SetBlockchain(cn.blockchain)
+	blockchain.InitDeriveSha(cn.chainConfig)
 	// Synchronize proposerpolicy & useGiniCoeff
 	if cn.blockchain.Config().Istanbul != nil {
 		cn.blockchain.Config().Istanbul.ProposerPolicy = governance.Params().Policy()

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -998,7 +998,7 @@ func handleReceiptsRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		// Retrieve the requested block's receipts, skipping if unknown to us
 		results := pm.blockchain.GetReceiptsByBlockHash(hash)
 		if results == nil {
-			if header := pm.blockchain.GetHeaderByHash(hash); header == nil || header.ReceiptHash != types.EmptyRootHash {
+			if header := pm.blockchain.GetHeaderByHash(hash); header == nil || !header.EmptyReceipts() {
 				continue
 			}
 		}

--- a/tests/db_write_and_read_test.go
+++ b/tests/db_write_and_read_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/stretchr/testify/assert"
 )
@@ -270,7 +271,9 @@ func testWriteAndReadBlock(t *testing.T, dbManager database.DBManager) {
 	body := generateBody(t)
 	receipts := types.Receipts{generateReceipt(111)}
 
-	blockchain.InitDeriveSha(types.ImplDeriveShaOriginal)
+	blockchain.InitDeriveSha(&params.ChainConfig{
+		DeriveShaImpl: types.ImplDeriveShaOriginal,
+	})
 	block := types.NewBlock(header, body.Transactions, receipts)
 
 	// 1. Before write, nil should be returned.


### PR DESCRIPTION
## Proposed changes

- Add `blockNum` argument to `types.DeriveSha()` and `types.EmptyRootHash()`.
  ```
  As-is: InitDeriveSha(type) + DeriveSha(list) + EmptyRootHash
  To-be: InitDeriveSha(chainConfig) + DeriveSha(list, num) + EmptyRootHash(num)
  ```
- The `num` argument is ignored in this PR.
- Hardfork and/or Governance logic will be added in a later PR
- `blockchain.InitDeriveSha` is relocated from `inside NewBlockChain()` to `cn.New()`
  - This is to feed the up-to-date `chainConfig` which is modified by `governance.UpdateParams()`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

#1687

## Further comments