### PR TITLE
Accept decimal block number for debug_setHead API

### DIFF
--- a/api/api_private_debug.go
+++ b/api/api_private_debug.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
@@ -77,6 +77,10 @@ func (api *PrivateDebugAPI) ChaindbCompact() error {
 }
 
 // SetHead rewinds the head of the blockchain to a previous block.
-func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) {
+func (api *PrivateDebugAPI) SetHead(number rpc.BlockNumber) {
+	if number == rpc.PendingBlockNumber || number == rpc.LatestBlockNumber {
+		logger.Error("Cannot rewind to future")
+		return
+	}
 	api.b.SetHead(uint64(number))
 }

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -514,7 +514,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'setHead',
 			call: 'debug_setHead',
-			params: 1
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'dumpBlock',


### PR DESCRIPTION
## Proposed changes

- Replace `debug_setHead` API argument type from `hexutil.Uint64` to `rpc.BlockNumber`.
- Allows hex and decimal inputs, like other block-number-taking APIs.
- Before this PR
	```
	debug.setHead("0x40") // ok
	debug.setHead(0x40)   // Error: json: cannot unmarshal non-string into Go value of type hexutil.Uint64
	debug.setHead("64")   // Error: json: cannot unmarshal hex string without 0x prefix into Go value of type hexutil.Uint64
	debug.setHead(64)     // Error: json: cannot unmarshal non-string into Go value of type hexutil.Uint64
	```
- After this PR
	```
	debug.setHead("0x40") // ok
	debug.setHead(0x40)   // ok
	debug.setHead("64")   // ok
	debug.setHead(64)     // ok
	```

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
