### PR TITLE
Add block number parameter to governance.chainConfigAt() API

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -313,6 +313,12 @@ web3._extend({
 			call: 'governance_getStakingInfo',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'chainConfigAt',
+			call: 'governance_chainConfigAt',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		})
 	],
 	properties: [

--- a/governance/api.go
+++ b/governance/api.go
@@ -245,7 +245,29 @@ func (api *PublicGovernanceAPI) MyVotingPower() (float64, error) {
 }
 
 func (api *PublicGovernanceAPI) ChainConfig() *params.ChainConfig {
-	return nil
+	num := rpc.LatestBlockNumber
+	return api.chainConfigAt(&num)
+}
+
+func (api *PublicGovernanceAPI) ChainConfigAt(num *rpc.BlockNumber) *params.ChainConfig {
+	return api.chainConfigAt(num)
+}
+
+func (api *PublicGovernanceAPI) chainConfigAt(num *rpc.BlockNumber) *params.ChainConfig {
+	var blocknum uint64
+	if num == nil || *num == rpc.LatestBlockNumber {
+		blocknum = api.governance.BlockChain().CurrentHeader().Number.Uint64()
+	} else if *num == rpc.PendingBlockNumber {
+		blocknum = api.governance.BlockChain().CurrentHeader().Number.Uint64() + 1
+	} else {
+		blocknum = num.Uint64()
+	}
+
+	pset, err := api.governance.ParamsAt(blocknum)
+	if err != nil {
+		return nil
+	}
+	return pset.ToChainConfig()
 }
 
 func (api *PublicGovernanceAPI) NodeAddress() common.Address {

--- a/governance/api.go
+++ b/governance/api.go
@@ -255,10 +255,8 @@ func (api *PublicGovernanceAPI) ChainConfigAt(num *rpc.BlockNumber) *params.Chai
 
 func (api *PublicGovernanceAPI) chainConfigAt(num *rpc.BlockNumber) *params.ChainConfig {
 	var blocknum uint64
-	if num == nil || *num == rpc.LatestBlockNumber {
+	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
 		blocknum = api.governance.BlockChain().CurrentHeader().Number.Uint64()
-	} else if *num == rpc.PendingBlockNumber {
-		blocknum = api.governance.BlockChain().CurrentHeader().Number.Uint64() + 1
 	} else {
 		blocknum = num.Uint64()
 	}

--- a/governance/api.go
+++ b/governance/api.go
@@ -245,7 +245,7 @@ func (api *PublicGovernanceAPI) MyVotingPower() (float64, error) {
 }
 
 func (api *PublicGovernanceAPI) ChainConfig() *params.ChainConfig {
-	return api.governance.InitialChainConfig()
+	return nil
 }
 
 func (api *PublicGovernanceAPI) NodeAddress() common.Address {

--- a/governance/contract_test.go
+++ b/governance/contract_test.go
@@ -191,7 +191,7 @@ func prepareContractEngine(t *testing.T, bc *blockchain.BlockChain, addr common.
 	dbm.WriteGovernance(map[string]interface{}{
 		"governance.govparamcontract": addr,
 	}, 0)
-	gov := NewGovernance(bc.Config(), dbm)
+	gov := NewGovernance(dbm)
 	pset, err := gov.ParamsAt(0)
 	require.Nil(t, err)
 	require.Equal(t, addr, pset.GovParamContract())
@@ -208,13 +208,17 @@ func prepareContractEngine(t *testing.T, bc *blockchain.BlockChain, addr common.
 // TestContractEngine_Params tests if Params() returns the parameters required
 // for generating the next block. That is,
 //
-//     start          setparam       activation-1       end
+//	start          setparam       activation-1       end
+//
 // Block |---------------|---------------|---------------|
-//               ^               ^               ^
-//               t0              t1              t2
+//
+//	^               ^               ^
+//	t0              t1              t2
+//
 // At num = activation - 2, Params() = prev
 // At num = activation - 1, Params() = next
-//    because next is for generating "activation" block
+//
+//	because next is for generating "activation" block
 func TestContractEngine_Params(t *testing.T) {
 	initialParam := map[string][]byte{
 		"istanbul.committeesize": {0xa},
@@ -262,10 +266,13 @@ func TestContractEngine_Params(t *testing.T) {
 // TestContractEngine_ParamsAt tests if ParamsAt(num) returns the parameters
 // required for generating the "num" block. That is,
 //
-//     start          setparam       activation         end
+//	start          setparam       activation         end
+//
 // Block |---------------|---------------|---------------|
-//               ^               ^               ^
-//               t0              t1              t2
+//
+//	^               ^               ^
+//	t0              t1              t2
+//
 // ParamsAt(activation - 1) = prev
 // ParamsAt(activation)     = next
 func TestContractEngine_ParamsAt(t *testing.T) {

--- a/governance/default.go
+++ b/governance/default.go
@@ -817,8 +817,7 @@ func (g *Governance) searchCache(num uint64) (uint64, bool) {
 }
 
 func (g *Governance) ReadGovernance(num uint64) (uint64, map[string]interface{}, error) {
-	// if num is zero, epochWithFallback() will Crit
-	// so epoch should be set to any value greater than zero
+	// epochWithFallback() falls back to Default before initializeCache()
 	epoch := g.epochWithFallback()
 	blockNum := CalcGovernanceInfoBlock(num, epoch)
 

--- a/governance/default.go
+++ b/governance/default.go
@@ -819,11 +819,7 @@ func (g *Governance) searchCache(num uint64) (uint64, bool) {
 func (g *Governance) ReadGovernance(num uint64) (uint64, map[string]interface{}, error) {
 	// if num is zero, epochWithFallback() will Crit
 	// so epoch should be set to any value greater than zero
-	epoch := uint64(1)
-	if num != 0 {
-		epoch = g.epochWithFallback()
-	}
-
+	epoch := g.epochWithFallback()
 	blockNum := CalcGovernanceInfoBlock(num, epoch)
 
 	// Check cache first
@@ -1186,9 +1182,8 @@ func (gov *Governance) epochWithFallback() uint64 {
 		return v.(uint64)
 	}
 
-	// We shouldn't reach here because Governance is only relevant with Istanbul engine.
-	logger.Crit("Failed to read governance. ChainConfig.Istanbul == nil")
-	return params.DefaultEpoch // unreachable. just satisfying compiler.
+	// now that gov.ChainConfig is gone, we return default instead of gov.ChainConfig.Epoch
+	return params.DefaultEpoch
 }
 
 func (gov *Governance) Params() *params.GovParamSet {

--- a/governance/default.go
+++ b/governance/default.go
@@ -817,7 +817,13 @@ func (g *Governance) searchCache(num uint64) (uint64, bool) {
 }
 
 func (g *Governance) ReadGovernance(num uint64) (uint64, map[string]interface{}, error) {
-	epoch := g.epochWithFallback()
+	// if num is zero, epochWithFallback() will Crit
+	// so epoch should be set to any value greater than zero
+	epoch := uint64(1)
+	if num != 0 {
+		epoch = g.epochWithFallback()
+	}
+
 	blockNum := CalcGovernanceInfoBlock(num, epoch)
 
 	// Check cache first
@@ -1180,10 +1186,9 @@ func (gov *Governance) epochWithFallback() uint64 {
 		return v.(uint64)
 	}
 
-	// if epoch does not exist, treat epoch as 1
-	// this could be the case when parameter has not been set
-	// that is, when ReadGovernance() is called from initializeCache()
-	return 1
+	// We shouldn't reach here because Governance is only relevant with Istanbul engine.
+	logger.Crit("Failed to read governance. ChainConfig.Istanbul == nil")
+	return params.DefaultEpoch // unreachable. just satisfying compiler.
 }
 
 func (gov *Governance) Params() *params.GovParamSet {

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -697,7 +697,7 @@ func TestGovernance_initializeCache(t *testing.T) {
 		gov.itemCache.Purge()
 
 		// 2. call initializeCache
-		err := gov.initializeCache()
+		err := gov.initializeCache(config)
 
 		// 3. check the affected values with expected results
 		assert.NoError(t, err)
@@ -759,7 +759,6 @@ func TestGovernance_ReadGovernanceState(t *testing.T) {
 	gov.ReadGovernanceState()
 
 	assert.Equal(t, bn, gov.lastGovernanceStateBlock)
-	assert.Equal(t, config, gov.ChainConfig)
 	assert.Equal(t, gjson.VoteMap, gov.voteMap.items)
 	assert.Equal(t, gjson.NodeAddress, gov.nodeAddress.Load())
 	assert.Equal(t, gjson.GovernanceVotes, gov.GovernanceVotes.items)

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -79,8 +79,6 @@ type HeaderEngine interface {
 		istanbul.ValidatorSet, []GovernanceVote, []GovernanceTallyItem)
 
 	// Get internal fields
-	ChainId() uint64
-	InitialChainConfig() *params.ChainConfig
 	GetVoteMapCopy() map[string]VoteStatus
 	GetGovernanceTalliesCopy() []GovernanceTallyItem
 	CurrentSetCopy() map[string]interface{}

--- a/governance/mixed.go
+++ b/governance/mixed.go
@@ -99,7 +99,7 @@ func newMixedEngine(config *params.ChainConfig, db database.DBManager, doInit bo
 	if doInit {
 		e.headerGov = NewGovernanceInitialize(config, db)
 	} else {
-		e.headerGov = NewGovernance(config, db)
+		e.headerGov = NewGovernance(db)
 	}
 
 	e.contractGov = NewContractEngine(e.headerGov)
@@ -312,14 +312,6 @@ func (e *MixedEngine) HandleGovernanceVote(
 	istanbul.ValidatorSet, []GovernanceVote, []GovernanceTallyItem,
 ) {
 	return e.headerGov.HandleGovernanceVote(valset, votes, tally, header, proposer, self, writable)
-}
-
-func (e *MixedEngine) ChainId() uint64 {
-	return e.headerGov.ChainId()
-}
-
-func (e *MixedEngine) InitialChainConfig() *params.ChainConfig {
-	return e.headerGov.InitialChainConfig()
 }
 
 func (e *MixedEngine) GetVoteMapCopy() map[string]VoteStatus {


### PR DESCRIPTION
## Proposed changes

This PR
- introduces `governance.chainConfigAt(num)`
- changes the semantic of `governance.chainConfig` to return the latest chainConfig
- At num=0, ReadGovernance uses DefaultEpoch because istanbul.epoch might not exist at program startup
- Remove unused methods
- closes #1615

Before:
```js
> governance.chainConfig
{
  chainId: 1001,
  deriveShaImpl: 2,
  governance: {
    governanceMode: "single",
...
}
```

After:
```js
> governance.chainConfig // returns the latest
{
  chainId: 1001,
  deriveShaImpl: 0,
  governance: {
    governanceMode: "single",
...
}

> governance.chainConfig() // latest block
{
  chainId: 1001,
  deriveShaImpl: 0,
  governance: {
    governanceMode: "single",
...
}

> governance.chainConfig(0) // specified block
{
  chainId: 1001,
  deriveShaImpl: 2,
  governance: {
    governanceMode: "single",
...
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

#1615

## Further comments
