### PR TITLE
Fix genesis block bug with KIP71 parameters

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -330,16 +330,14 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 	if g.BlockScore == nil {
 		head.BlockScore = params.GenesisBlockScore
 	}
-
-	if g.Config.IsMagmaForkEnabled(common.Big0) {
-		if g.Config != nil &&
-			g.Config.Governance != nil &&
-			g.Config.Governance.KIP71 != nil {
+	if g.Config != nil && g.Config.IsMagmaForkEnabled(common.Big0) {
+		if g.Config.Governance != nil && g.Config.Governance.KIP71 != nil {
 			head.BaseFee = new(big.Int).SetUint64(g.Config.Governance.KIP71.LowerBoundBaseFee)
 		} else {
 			head.BaseFee = new(big.Int).SetUint64(params.DefaultLowerBoundBaseFee)
 		}
 	}
+
 	stateDB.Commit(false)
 	stateDB.Database().TrieDB().Commit(root, true, g.Number)
 

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -330,7 +330,7 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 	if g.BlockScore == nil {
 		head.BlockScore = params.GenesisBlockScore
 	}
-	// TODO-klaytn should set genesis block's base fee
+
 	if g.Config.IsMagmaForkEnabled(common.Big0) {
 		if g.Config != nil &&
 			g.Config.Governance != nil &&

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -331,8 +331,14 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 		head.BlockScore = params.GenesisBlockScore
 	}
 	// TODO-klaytn should set genesis block's base fee
-	if g.Config != nil && g.Config.IsMagmaForkEnabled(common.Big0) {
-		head.BaseFee = new(big.Int).SetUint64(params.DefaultLowerBoundBaseFee)
+	if g.Config.IsMagmaForkEnabled(common.Big0) {
+		if g.Config != nil &&
+			g.Config.Governance != nil &&
+			g.Config.Governance.KIP71 != nil {
+			head.BaseFee = new(big.Int).SetUint64(g.Config.Governance.KIP71.LowerBoundBaseFee)
+		} else {
+			head.BaseFee = new(big.Int).SetUint64(params.DefaultLowerBoundBaseFee)
+		}
 	}
 	stateDB.Commit(false)
 	stateDB.Database().TrieDB().Commit(root, true, g.Number)

--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -376,7 +376,7 @@ func genCustomGenesisBlock(customChainId uint64) *Genesis {
 			},
 		},
 	}
-	genesis.Config.SetDefaults()
+	genesis.Config.SetDefaultsForGenesis()
 	genesis.Governance = SetGenesisGovernance(genesis)
 	InitDeriveSha(genesis.Config)
 	return genesis

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -107,7 +107,7 @@ func initGenesis(ctx *cli.Context) error {
 	}
 
 	// Update undefined config with default values
-	genesis.Config.SetDefaults()
+	genesis.Config.SetDefaultsForGenesis()
 
 	// Validate config values
 	if err := ValidateGenesisConfig(genesis); err != nil {

--- a/governance/contract.go
+++ b/governance/contract.go
@@ -118,10 +118,11 @@ func (e *ContractEngine) contractAddrAt(num uint64) (common.Address, error) {
 		return common.Address{}, errParamsAtFail
 	}
 
+	// this happens when GovParamContract has not been voted
 	param, ok := headerParams.Get(params.GovParamContract)
 	if !ok {
 		logger.Error("Could not find GovParam contract address")
-		return common.Address{}, errGovParamNotExist
+		return common.Address{}, nil
 	}
 
 	addr, ok := param.(common.Address)

--- a/governance/default.go
+++ b/governance/default.go
@@ -1101,7 +1101,6 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 			params.StakeUpdateInterval:     governance.Reward.StakingUpdateInterval,
 			params.ProposerRefreshInterval: governance.Reward.ProposerUpdateInterval,
 		}
-
 		appendGovSet(governanceMap)
 	}
 
@@ -1112,7 +1111,6 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 			params.Policy:        istanbul.ProposerPolicy,
 			params.CommitteeSize: istanbul.SubGroupSize,
 		}
-
 		appendGovSet(istanbulMap)
 	}
 
@@ -1127,7 +1125,6 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 			params.MaxBlockGasUsedForBaseFee: kip71.MaxBlockGasUsedForBaseFee,
 			params.BaseFeeDenominator:        kip71.BaseFeeDenominator,
 		}
-
 		appendGovSet(governanceMap)
 	}
 
@@ -1138,7 +1135,6 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 			params.GovParamContract: config.Governance.GovParamContract,
 			params.Kip82Ratio:       config.Governance.Reward.Kip82Ratio,
 		}
-
 		appendGovSet(governanceMap)
 	}
 

--- a/governance/default.go
+++ b/governance/default.go
@@ -1136,6 +1136,7 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 		config.Governance != nil {
 		governanceMap := map[int]interface{}{
 			params.GovParamContract: config.Governance.GovParamContract,
+			params.Kip82Ratio:       config.Governance.Reward.Kip82Ratio,
 		}
 
 		appendToReturn(governanceMap)

--- a/governance/default.go
+++ b/governance/default.go
@@ -1236,7 +1236,7 @@ func (gov *Governance) ParamsAt(num uint64) (*params.GovParamSet, error) {
 		logger.Error("NewGovParamSetStrMap failed", "num", num, "err", err)
 		return nil, err
 	}
-	return params.NewGovParamSetMerged(gov.initialParams, pset), nil
+	return pset, nil
 }
 
 func (gov *Governance) UpdateParams() error {
@@ -1246,6 +1246,6 @@ func (gov *Governance) UpdateParams() error {
 		return err
 	}
 
-	gov.currentParams = params.NewGovParamSetMerged(gov.initialParams, pset)
+	gov.currentParams = pset
 	return nil
 }

--- a/governance/default.go
+++ b/governance/default.go
@@ -1135,7 +1135,8 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 		if !common.EmptyAddress(config.Governance.GovParamContract) {
 			governanceMap[params.GovParamContract] = config.Governance.GovParamContract
 		}
-		if config.Governance.Reward.Kip82Ratio != "" {
+		if config.Governance.Reward != nil &&
+			config.Governance.Reward.Kip82Ratio != "" {
 			governanceMap[params.Kip82Ratio] = config.Governance.Reward.Kip82Ratio
 		}
 		appendGovSet(governanceMap)

--- a/governance/default.go
+++ b/governance/default.go
@@ -1134,9 +1134,8 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 	// kore params
 	if config.IsKoreForkEnabled(common.Big0) &&
 		config.Governance != nil {
-		governance := config.Governance
 		governanceMap := map[int]interface{}{
-			params.GovParamContract: governance.GovParamContract,
+			params.GovParamContract: config.Governance.GovParamContract,
 		}
 
 		appendToReturn(governanceMap)

--- a/governance/default.go
+++ b/governance/default.go
@@ -1075,12 +1075,12 @@ func (gov *Governance) GetTxPool() txPool {
 // GetGovernanceItemsFromChainConfig returns governance set
 // that is effective at the genesis block
 func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet {
-	g := NewGovernanceSet()
+	govSet := NewGovernanceSet()
 
-	// append to the return value `g`
-	appendToReturn := func(govmap map[int]interface{}) {
+	// append to the return value `govSet`
+	appendGovSet := func(govmap map[int]interface{}) {
 		for k, v := range govmap {
-			if err := g.SetValue(k, v); err != nil {
+			if err := govSet.SetValue(k, v); err != nil {
 				writeFailLog(k, err)
 			}
 		}
@@ -1102,7 +1102,7 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 			params.ProposerRefreshInterval: governance.Reward.ProposerUpdateInterval,
 		}
 
-		appendToReturn(governanceMap)
+		appendGovSet(governanceMap)
 	}
 
 	if config.Istanbul != nil {
@@ -1113,7 +1113,7 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 			params.CommitteeSize: istanbul.SubGroupSize,
 		}
 
-		appendToReturn(istanbulMap)
+		appendGovSet(istanbulMap)
 	}
 
 	// magma params
@@ -1128,7 +1128,7 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 			params.BaseFeeDenominator:        kip71.BaseFeeDenominator,
 		}
 
-		appendToReturn(governanceMap)
+		appendGovSet(governanceMap)
 	}
 
 	// kore params
@@ -1139,10 +1139,10 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 			params.Kip82Ratio:       config.Governance.Reward.Kip82Ratio,
 		}
 
-		appendToReturn(governanceMap)
+		appendGovSet(governanceMap)
 	}
 
-	return g
+	return govSet
 }
 
 func writeFailLog(key int, err error) {

--- a/governance/default.go
+++ b/governance/default.go
@@ -1131,8 +1131,9 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 	// kore params
 	if config.IsKoreForkEnabled(common.Big0) &&
 		config.Governance != nil {
-		governanceMap := map[int]interface{}{
-			params.GovParamContract: config.Governance.GovParamContract,
+		governanceMap := map[int]interface{}{}
+		if !common.EmptyAddress(config.Governance.GovParamContract) {
+			governanceMap[params.GovParamContract] = config.Governance.GovParamContract
 		}
 		if config.Governance.Reward.Kip82Ratio != "" {
 			governanceMap[params.Kip82Ratio] = config.Governance.Reward.Kip82Ratio

--- a/governance/default.go
+++ b/governance/default.go
@@ -1133,7 +1133,9 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 		config.Governance != nil {
 		governanceMap := map[int]interface{}{
 			params.GovParamContract: config.Governance.GovParamContract,
-			params.Kip82Ratio:       config.Governance.Reward.Kip82Ratio,
+		}
+		if config.Governance.Reward.Kip82Ratio != "" {
+			governanceMap[params.Kip82Ratio] = config.Governance.Reward.Kip82Ratio
 		}
 		appendGovSet(governanceMap)
 	}

--- a/governance/mixed_test.go
+++ b/governance/mixed_test.go
@@ -51,8 +51,8 @@ func newTestMixedEngineNoContractEngine(t *testing.T, config *params.ChainConfig
 }
 
 // Without ContractGov, Check that
-// - From a fresh MixedEngine instance, Params() and ParamsAt(0) returns the
-//   initial config value.
+//   - From a fresh MixedEngine instance, Params() and ParamsAt(0) returns the
+//     initial config value.
 func TestMixedEngine_Header_New(t *testing.T) {
 	valueA := uint64(0x11)
 
@@ -172,15 +172,19 @@ func TestMixedEngine_Params(t *testing.T) {
 
 // TestMixedEngine_ParamsAt tests if ParamsAt() returns correct values
 // given headerBlock and contractBlock;
-//     at headerBlock, params are inserted to DB via WriteGovernance()
-//     at contractBlock, params are inserted to GovParam via SetParamIn() contract call.
+//
+//	at headerBlock, params are inserted to DB via WriteGovernance()
+//	at contractBlock, params are inserted to GovParam via SetParamIn() contract call.
+//
 // valueA is set in ChainConfig
 // valueB is set in DB
 // valueC is set in GovParam contract
 //
-//  chainConfig     headerBlock    contractBlock       now
+//	chainConfig     headerBlock    contractBlock       now
+//
 // Block |---------------|--------------|---------------|
-//            valueA          valueB         valueC
+//
+// ............valueA          valueB         valueC
 func TestMixedEngine_ParamsAt(t *testing.T) {
 	var (
 		name        = "kip71.gastarget"
@@ -201,7 +205,8 @@ func TestMixedEngine_ParamsAt(t *testing.T) {
 	// write to headerGov
 	headerBlock := sim.BlockChain().CurrentHeader().Number.Uint64()
 	e.headerGov.db.WriteGovernance(map[string]interface{}{
-		name: valueB,
+		name:                          valueB,
+		"governance.govparamcontract": config.Governance.GovParamContract,
 	}, headerBlock)
 	err := e.UpdateParams()
 	assert.Nil(t, err)

--- a/governance/mixed_test.go
+++ b/governance/mixed_test.go
@@ -202,7 +202,8 @@ func TestMixedEngine_ParamsAt(t *testing.T) {
 
 	e, owner, sim, contract := newTestMixedEngine(t, config)
 
-	// write to headerGov
+	// write minimal params for test to headerGov
+	// note that mainnet will have all parameters in the headerGov db
 	headerBlock := sim.BlockChain().CurrentHeader().Number.Uint64()
 	e.headerGov.db.WriteGovernance(map[string]interface{}{
 		name:                          valueB,

--- a/params/config.go
+++ b/params/config.go
@@ -415,7 +415,7 @@ func (c *ChainConfig) SetDefaultsForGenesis() {
 	}
 
 	if c.Governance.Reward == nil {
-		c.Governance.Reward = GetDefaultRewardConfig()
+		c.Governance.Reward = GetDefaultRewardConfigForGenesis()
 		logger.Warn("Override the default governance reward config to the chain config", "reward",
 			c.Governance.Reward)
 	}
@@ -533,7 +533,7 @@ func GetDefaultGovernanceConfigForGenesis() *GovernanceConfig {
 	gov := &GovernanceConfig{
 		GovernanceMode: DefaultGovernanceMode,
 		GoverningNode:  common.HexToAddress(DefaultGoverningNode),
-		Reward:         GetDefaultRewardConfig(),
+		Reward:         GetDefaultRewardConfigForGenesis(),
 	}
 	return gov
 }
@@ -554,6 +554,18 @@ func GetDefaultIstanbulConfig() *IstanbulConfig {
 		Epoch:          DefaultEpoch,
 		ProposerPolicy: DefaultProposerPolicy,
 		SubGroupSize:   DefaultSubGroupSize,
+	}
+}
+
+func GetDefaultRewardConfigForGenesis() *RewardConfig {
+	return &RewardConfig{
+		MintingAmount:          DefaultMintingAmount,
+		Ratio:                  DefaultRatio,
+		UseGiniCoeff:           DefaultUseGiniCoeff,
+		DeferredTxFee:          DefaultDefferedTxFee,
+		StakingUpdateInterval:  DefaultStakeUpdateInterval,
+		ProposerUpdateInterval: DefaultProposerRefreshInterval,
+		MinimumStake:           DefaultMinimumStake,
 	}
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -443,6 +443,9 @@ func (c *ChainConfig) SetDefaults() {
 	if c.Governance.KIP71 == nil {
 		c.Governance.KIP71 = GetDefaultKIP71Config()
 	}
+	if c.Governance.Reward.Kip82Ratio == "" {
+		c.Governance.Reward.Kip82Ratio = DefaultKip82Ratio
+	}
 }
 
 // isForkIncompatible returns true if a fork scheduled at s1 cannot be rescheduled to

--- a/params/config.go
+++ b/params/config.go
@@ -400,15 +400,17 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	return nil
 }
 
-// SetDefaults fills undefined chain config with default values.
-func (c *ChainConfig) SetDefaults() {
+// SetDefaultsForGenesis fills undefined chain config with default values.
+// Only used for generating genesis.
+// Empty values from genesis.json will be left out from genesis.
+func (c *ChainConfig) SetDefaultsForGenesis() {
 	if c.Clique == nil && c.Istanbul == nil {
 		c.Istanbul = GetDefaultIstanbulConfig()
 		logger.Warn("Override the default Istanbul config to the chain config")
 	}
 
 	if c.Governance == nil {
-		c.Governance = GetDefaultGovernanceConfig()
+		c.Governance = GetDefaultGovernanceConfigForGenesis()
 		logger.Warn("Override the default governance config to the chain config")
 	}
 
@@ -416,10 +418,6 @@ func (c *ChainConfig) SetDefaults() {
 		c.Governance.Reward = GetDefaultRewardConfig()
 		logger.Warn("Override the default governance reward config to the chain config", "reward",
 			c.Governance.Reward)
-	}
-
-	if c.Governance.KIP71 == nil {
-		c.Governance.KIP71 = GetDefaultKIP71Config()
 	}
 
 	// StakingUpdateInterval must be nonzero because it is used as denominator
@@ -434,6 +432,16 @@ func (c *ChainConfig) SetDefaults() {
 		c.Governance.Reward.ProposerUpdateInterval = ProposerUpdateInterval()
 		logger.Warn("Override the default proposer update interval to the chain config", "interval",
 			c.Governance.Reward.ProposerUpdateInterval)
+	}
+}
+
+// SetDefaults fills undefined chain config with default values
+// so that nil pointer does not exist in the chain config
+func (c *ChainConfig) SetDefaults() {
+	c.SetDefaultsForGenesis()
+
+	if c.Governance.KIP71 == nil {
+		c.Governance.KIP71 = GetDefaultKIP71Config()
 	}
 }
 
@@ -518,6 +526,16 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsMagma:    c.IsMagmaForkEnabled(num),
 		IsKore:     c.IsKoreForkEnabled(num),
 	}
+}
+
+// cypress genesis config
+func GetDefaultGovernanceConfigForGenesis() *GovernanceConfig {
+	gov := &GovernanceConfig{
+		GovernanceMode: DefaultGovernanceMode,
+		GoverningNode:  common.HexToAddress(DefaultGoverningNode),
+		Reward:         GetDefaultRewardConfig(),
+	}
+	return gov
 }
 
 func GetDefaultGovernanceConfig() *GovernanceConfig {

--- a/params/governance_paramset.go
+++ b/params/governance_paramset.go
@@ -524,6 +524,9 @@ func (p *GovParamSet) ToGovernanceConfig() *GovernanceConfig {
 	if _, ok := p.Get(GovernanceMode); ok {
 		ret.GovernanceMode = p.GovernanceModeStr()
 	}
+	if _, ok := p.Get(GovParamContract); ok {
+		ret.GovParamContract = p.GovParamContract()
+	}
 	ret.Reward = p.ToRewardConfig()
 	ret.KIP71 = p.ToKIP71Config()
 

--- a/reward/reward_distributor.go
+++ b/reward/reward_distributor.go
@@ -57,7 +57,7 @@ type rewardConfig struct {
 	// values calculated from block header
 	totalFee *big.Int
 
-	// values from ChainConfig
+	// values from GovParamSet
 	mintingAmount *big.Int
 	minimumStake  *big.Int
 	deferredTxFee bool
@@ -99,24 +99,15 @@ func DistributeBlockReward(b BalanceAdder, rewards map[common.Address]*big.Int) 
 	}
 }
 
-func NewRewardConfig(header *types.Header, config *params.ChainConfig) (*rewardConfig, error) {
-	if config.Governance == nil {
-		return nil, errors.New("no config.Governance")
-	}
-	if config.Governance.Reward == nil {
-		return nil, errors.New("no config.Governance.Reward")
-	}
-
-	rules := config.Rules(header.Number)
-
-	cnRatio, kgfRatio, kirRatio, totalRatio, err := parseRewardRatio(config.Governance.Reward.Ratio)
+func NewRewardConfig(header *types.Header, rules params.Rules, pset *params.GovParamSet) (*rewardConfig, error) {
+	cnRatio, kgfRatio, kirRatio, totalRatio, err := parseRewardRatio(pset.Ratio())
 	if err != nil {
 		return nil, err
 	}
 
 	var cnProposerRatio, cnStakingRatio, cnTotalRatio int64
 	if rules.IsKore {
-		cnProposerRatio, cnStakingRatio, cnTotalRatio, err = parseRewardKip82Ratio(config.Governance.Reward.Kip82Ratio)
+		cnProposerRatio, cnStakingRatio, cnTotalRatio, err = parseRewardKip82Ratio(pset.Kip82Ratio())
 		if err != nil {
 			return nil, err
 		}
@@ -127,12 +118,12 @@ func NewRewardConfig(header *types.Header, config *params.ChainConfig) (*rewardC
 		rules: rules,
 
 		// values calculated from block header
-		totalFee: GetTotalTxFee(header, config),
+		totalFee: GetTotalTxFee(header, rules, pset),
 
-		// values from ChainConfig
-		mintingAmount: new(big.Int).Set(config.Governance.Reward.MintingAmount),
-		minimumStake:  new(big.Int).Set(config.Governance.Reward.MinimumStake),
-		deferredTxFee: config.Governance.Reward.DeferredTxFee,
+		// values from GovParamSet
+		mintingAmount: new(big.Int).Set(pset.MintingAmountBig()),
+		minimumStake:  new(big.Int).Set(pset.MinimumStakeBig()),
+		deferredTxFee: pset.DeferredTxFee(),
 
 		// parsed ratio
 		cnRatio:    big.NewInt(cnRatio),
@@ -147,39 +138,34 @@ func NewRewardConfig(header *types.Header, config *params.ChainConfig) (*rewardC
 	}, nil
 }
 
-func GetTotalTxFee(header *types.Header, config *params.ChainConfig) *big.Int {
+func GetTotalTxFee(header *types.Header, rules params.Rules, pset *params.GovParamSet) *big.Int {
 	totalFee := new(big.Int).SetUint64(header.GasUsed)
-	if config.IsMagmaForkEnabled(header.Number) {
+	if rules.IsMagma {
 		totalFee = totalFee.Mul(totalFee, header.BaseFee)
 	} else {
-		totalFee = totalFee.Mul(totalFee, new(big.Int).SetUint64(config.UnitPrice))
+		totalFee = totalFee.Mul(totalFee, new(big.Int).SetUint64(pset.UnitPrice()))
 	}
 	return totalFee
 }
 
 // config.Istanbul must have been set
-func IsRewardSimple(config *params.ChainConfig) bool {
-	policy := config.Istanbul.ProposerPolicy
-	return policy != uint64(istanbul.WeightedRandom)
+func IsRewardSimple(pset *params.GovParamSet) bool {
+	return pset.Policy() != uint64(istanbul.WeightedRandom)
 }
 
 // GetBlockReward returns the actual reward amounts paid in this block
 // Used in klay_getReward RPC API
-func GetBlockReward(header *types.Header, config *params.ChainConfig) (*RewardSpec, error) {
+func GetBlockReward(header *types.Header, rules params.Rules, pset *params.GovParamSet) (*RewardSpec, error) {
 	var spec *RewardSpec
 	var err error
 
-	if config.Istanbul == nil {
-		return nil, errors.New("no IstanbulConfig")
-	}
-
-	if IsRewardSimple(config) {
-		spec, err = CalcDeferredRewardSimple(header, config)
+	if IsRewardSimple(pset) {
+		spec, err = CalcDeferredRewardSimple(header, rules, pset)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		spec, err = CalcDeferredReward(header, config)
+		spec, err = CalcDeferredReward(header, rules, pset)
 		if err != nil {
 			return nil, err
 		}
@@ -188,8 +174,8 @@ func GetBlockReward(header *types.Header, config *params.ChainConfig) (*RewardSp
 	// Compensate the difference between CalcDeferredReward() and actual payment.
 	// If not DeferredTxFee, CalcDeferredReward() assumes 0 total_fee, but
 	// some non-zero fee already has been paid to the proposer.
-	if !config.Governance.Reward.DeferredTxFee {
-		blockFee := GetTotalTxFee(header, config)
+	if !pset.DeferredTxFee() {
+		blockFee := GetTotalTxFee(header, rules, pset)
 		spec.Proposer = spec.Proposer.Add(spec.Proposer, spec.TotalFee)
 		spec.TotalFee = spec.TotalFee.Add(spec.TotalFee, blockFee)
 		incrementRewardsMap(spec.Rewards, header.Rewardbase, blockFee)
@@ -203,8 +189,8 @@ func GetBlockReward(header *types.Header, config *params.ChainConfig) (*RewardSp
 // MintKLAY has been superseded because we need to split reward distribution
 // logic into (1) calculation, and (2) actual distribution.
 // CalcDeferredRewardSimple does the former and DistributeBlockReward does the latter
-func CalcDeferredRewardSimple(header *types.Header, config *params.ChainConfig) (*RewardSpec, error) {
-	rc, err := NewRewardConfig(header, config)
+func CalcDeferredRewardSimple(header *types.Header, rules params.Rules, pset *params.GovParamSet) (*RewardSpec, error) {
+	rc, err := NewRewardConfig(header, rules, pset)
 	if err != nil {
 		return nil, err
 	}
@@ -262,12 +248,12 @@ func CalcDeferredRewardSimple(header *types.Header, config *params.ChainConfig) 
 
 // CalcDeferredReward calculates the deferred rewards,
 // which are determined at the end of block processing.
-func CalcDeferredReward(header *types.Header, config *params.ChainConfig) (*RewardSpec, error) {
+func CalcDeferredReward(header *types.Header, rules params.Rules, pset *params.GovParamSet) (*RewardSpec, error) {
 	defer func(start time.Time) {
 		CalcDeferredRewardTimer = time.Since(start)
 	}(time.Now())
 
-	rc, err := NewRewardConfig(header, config)
+	rc, err := NewRewardConfig(header, rules, pset)
 	if err != nil {
 		return nil, err
 	}

--- a/reward/reward_distributor_test.go
+++ b/reward/reward_distributor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/params"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (governance *testGovernance) Params() *params.GovParamSet {
@@ -103,23 +104,19 @@ func newTestBalanceAdder() *testBalanceAdder {
 }
 
 func getTestConfig() *params.ChainConfig {
-	return &params.ChainConfig{
-		MagmaCompatibleBlock: big.NewInt(0),
-		KoreCompatibleBlock:  big.NewInt(0),
-		UnitPrice:            1,
-		Governance: &params.GovernanceConfig{
-			Reward: &params.RewardConfig{
-				MintingAmount: minted,
-				Ratio:         "34/54/12",
-				Kip82Ratio:    "20/80",
-				DeferredTxFee: true,
-				MinimumStake:  big.NewInt(0).SetUint64(minStaking),
-			},
-		},
-		Istanbul: &params.IstanbulConfig{
-			ProposerPolicy: 2,
-		},
-	}
+	config := &params.ChainConfig{}
+	config.SetDefaults() // To use GovParamSet without having parse errors
+
+	config.MagmaCompatibleBlock = big.NewInt(0)
+	config.KoreCompatibleBlock = big.NewInt(0)
+	config.UnitPrice = 1
+	config.Governance.Reward.MintingAmount = minted
+	config.Governance.Reward.Ratio = "34/54/12"
+	config.Governance.Reward.Kip82Ratio = "20/80"
+	config.Governance.Reward.DeferredTxFee = true
+	config.Governance.Reward.MinimumStake = big.NewInt(0).SetUint64(minStaking)
+	config.Istanbul.ProposerPolicy = 2
+	return config
 }
 
 func (balanceAdder *testBalanceAdder) AddBalance(addr common.Address, v *big.Int) {
@@ -231,7 +228,11 @@ func TestRewardDistributor_GetTotalTxFee(t *testing.T) {
 			config.MagmaCompatibleBlock = big.NewInt(0)
 		}
 
-		result := GetTotalTxFee(header, config)
+		rules := config.Rules(header.Number)
+		pset, err := params.NewGovParamSetChainConfig(config)
+		require.Nil(t, err)
+
+		result := GetTotalTxFee(header, rules, pset)
 		assert.Equal(t, testCase.expectedTotalTxFee.Uint64(), result.Uint64())
 	}
 }
@@ -252,17 +253,22 @@ func TestRewardDistributor_getBurnAmountMagma(t *testing.T) {
 		{12936418927364923, big.NewInt(0), big.NewInt(0)},
 	}
 
-	header := &types.Header{
-		Number: big.NewInt(1),
-	}
-	config := &params.ChainConfig{}
-	config.MagmaCompatibleBlock = big.NewInt(0)
+	var (
+		header = &types.Header{
+			Number: big.NewInt(1),
+		}
+		rules = params.Rules{
+			IsMagma: true,
+		}
+		pset, _ = params.NewGovParamSetIntMap(map[int]interface{}{
+			params.UnitPrice: 0, // unused value because Magma
+		})
+	)
 
 	for _, testCase := range testCases {
 		header.GasUsed = testCase.gasUsed
 		header.BaseFee = testCase.baseFee
-
-		txFee := GetTotalTxFee(header, config)
+		txFee := GetTotalTxFee(header, rules, pset)
 		burnedTxFee := getBurnAmountMagma(txFee)
 		// expectedTotalTxFee = GetTotalTxFee / 2 = BurnedTxFee
 		assert.Equal(t, testCase.expectedTotalTxFee.Uint64(), burnedTxFee.Uint64())
@@ -280,11 +286,14 @@ func TestRewardDistributor_GetBlockReward(t *testing.T) {
 			BaseFee:    big.NewInt(1),
 			Rewardbase: proposerAddr,
 		}
-
 		stakingInfo = genStakingInfo(5, nil, map[int]uint64{
 			0: minStaking + 4,
 			1: minStaking + 3,
 		})
+		rules = params.Rules{
+			IsMagma: true,
+			IsKore:  true,
+		}
 	)
 
 	testcases := []struct {
@@ -368,8 +377,12 @@ func TestRewardDistributor_GetBlockReward(t *testing.T) {
 			config = noDeferred(config)
 		}
 		config.Istanbul.ProposerPolicy = uint64(tc.policy)
-		spec, err := GetBlockReward(header, config)
-		assert.Nil(t, err, "testcases[%d] failed", i)
+
+		pset, err := params.NewGovParamSetChainConfig(config)
+		require.Nil(t, err)
+
+		spec, err := GetBlockReward(header, rules, pset)
+		require.Nil(t, err, "testcases[%d] failed", i)
 		assert.Equal(t, tc.expected, spec, "testcases[%d] failed", i)
 	}
 }
@@ -418,8 +431,12 @@ func TestRewardDistributor_CalcDeferredRewardSimple(t *testing.T) {
 			config = noMagma(config)
 		}
 
-		spec, err := CalcDeferredRewardSimple(header, config)
-		assert.Nil(t, err, "testcases[%d] failed", i)
+		rules := config.Rules(header.Number)
+		pset, err := params.NewGovParamSetChainConfig(config)
+		require.Nil(t, err)
+
+		spec, err := CalcDeferredRewardSimple(header, rules, pset)
+		require.Nil(t, err, "testcases[%d] failed", i)
 		assert.Equal(t, tc.expected, spec, "testcases[%d] failed", i)
 	}
 }
@@ -492,8 +509,12 @@ func TestRewardDistributor_CalcDeferredRewardSimple_nodeferred(t *testing.T) {
 			config = noKore(config)
 		}
 
-		spec, err := CalcDeferredRewardSimple(header, config)
-		assert.Nil(t, err, "testcases[%d] failed", i)
+		rules := config.Rules(header.Number)
+		pset, err := params.NewGovParamSetChainConfig(config)
+		require.Nil(t, err)
+
+		spec, err := CalcDeferredRewardSimple(header, rules, pset)
+		require.Nil(t, err, "testcases[%d] failed", i)
 		assert.Equal(t, tc.expected, spec, "testcases[%d] failed", i)
 	}
 }
@@ -658,8 +679,12 @@ func TestRewardDistributor_CalcDeferredReward(t *testing.T) {
 			config = noMagma(config)
 		}
 
-		spec, err := CalcDeferredReward(header, config)
-		assert.Nil(t, err, "failed tc: %s", tc.desc)
+		rules := config.Rules(header.Number)
+		pset, err := params.NewGovParamSetChainConfig(config)
+		require.Nil(t, err)
+
+		spec, err := CalcDeferredReward(header, rules, pset)
+		require.Nil(t, err, "failed tc: %s", tc.desc)
 		assert.Equal(t, tc.expected, spec, "failed tc: %s", tc.desc)
 	}
 }
@@ -675,7 +700,9 @@ func TestRewardDistributor_CalcDeferredReward_StakingInfos(t *testing.T) {
 			BaseFee:    big.NewInt(1),
 			Rewardbase: proposerAddr,
 		}
-		config = getTestConfig()
+		config  = getTestConfig()
+		rules   = config.Rules(header.Number)
+		pset, _ = params.NewGovParamSetChainConfig(config)
 	)
 
 	testcases := []struct {
@@ -767,8 +794,8 @@ func TestRewardDistributor_CalcDeferredReward_StakingInfos(t *testing.T) {
 		} else {
 			SetTestStakingManagerWithStakingInfoCache(tc.stakingInfo)
 		}
-		spec, err := CalcDeferredReward(header, config)
-		assert.Nil(t, err, "testcases[%d] failed", i)
+		spec, err := CalcDeferredReward(header, rules, pset)
+		require.Nil(t, err, "testcases[%d] failed", i)
 		assert.Equal(t, tc.expected, spec, "testcases[%d] failed: %s", i, tc.desc)
 	}
 }
@@ -843,8 +870,12 @@ func TestRewardDistributor_CalcDeferredReward_Remainings(t *testing.T) {
 	SetTestStakingManagerWithStakingInfoCache(stakingInfo)
 
 	for _, tc := range testcases {
-		spec, err := CalcDeferredReward(header, tc.config)
-		assert.Nil(t, err, "failed tc: %s", tc.desc)
+		rules := tc.config.Rules(header.Number)
+		pset, err := params.NewGovParamSetChainConfig(tc.config)
+		require.Nil(t, err)
+
+		spec, err := CalcDeferredReward(header, rules, pset)
+		require.Nil(t, err, "failed tc: %s", tc.desc)
 		assert.Equal(t, tc.expected, spec, "failed tc: %s", tc.desc)
 	}
 }
@@ -943,8 +974,12 @@ func TestRewardDistributor_calcDeferredFee(t *testing.T) {
 			config = noMagma(config)
 		}
 
-		rc, err := NewRewardConfig(header, config)
-		assert.Nil(t, err)
+		rules := config.Rules(header.Number)
+		pset, err := params.NewGovParamSetChainConfig(config)
+		require.Nil(t, err)
+
+		rc, err := NewRewardConfig(header, rules, pset)
+		require.Nil(t, err)
 
 		total, reward, burnt := calcDeferredFee(rc)
 		actual := &Result{
@@ -957,15 +992,23 @@ func TestRewardDistributor_calcDeferredFee(t *testing.T) {
 }
 
 func TestRewardDistributor_calcDeferredFee_nodeferred(t *testing.T) {
-	header := &types.Header{
-		Number:     big.NewInt(1),
-		GasUsed:    1000,
-		BaseFee:    big.NewInt(1),
-		Rewardbase: proposerAddr,
-	}
+	var (
+		header = &types.Header{
+			Number:     big.NewInt(1),
+			GasUsed:    1000,
+			BaseFee:    big.NewInt(1),
+			Rewardbase: proposerAddr,
+		}
+		rules = params.Rules{
+			IsMagma: true,
+		}
+	)
 
-	rc, err := NewRewardConfig(header, noDeferred(getTestConfig()))
-	assert.Nil(t, err)
+	pset, err := params.NewGovParamSetChainConfig(noDeferred(getTestConfig()))
+	require.Nil(t, err)
+
+	rc, err := NewRewardConfig(header, rules, pset)
+	require.Nil(t, err)
 
 	total, reward, burnt := calcDeferredFee(rc)
 	assert.Equal(t, uint64(0), total.Uint64())
@@ -1042,8 +1085,13 @@ func TestRewardDistributor_calcSplit(t *testing.T) {
 		if !tc.isKore {
 			config = noKore(config)
 		}
-		rc, err := NewRewardConfig(header, config)
-		assert.Nil(t, err)
+
+		rules := config.Rules(header.Number)
+		pset, err := params.NewGovParamSetChainConfig(config)
+		require.Nil(t, err)
+
+		rc, err := NewRewardConfig(header, rules, pset)
+		require.Nil(t, err)
 
 		fee := new(big.Int).SetUint64(tc.fee)
 		proposer, stakers, kgf, kir, remaining := calcSplit(rc, minted, fee)
@@ -1173,7 +1221,7 @@ func TestRewardDistributor_calcShares(t *testing.T) {
 	}
 }
 
-func benchSetup() (*types.Header, *params.ChainConfig) {
+func benchSetup() (*types.Header, params.Rules, *params.GovParamSet) {
 	// in the worst case, distribute stake shares among N
 	amounts := make(map[int]uint64)
 	N := 50
@@ -1190,17 +1238,22 @@ func benchSetup() (*types.Header, *params.ChainConfig) {
 	header.BaseFee = big.NewInt(30000000000)
 	header.Number = big.NewInt(0)
 	header.Rewardbase = intToAddress(rewardBaseAddr)
-	return header, config
+
+	rules := config.Rules(header.Number)
+	pset, _ := params.NewGovParamSetChainConfig(config)
+
+	return header, rules, pset
 }
 
 func Benchmark_CalcDeferredReward(b *testing.B) {
 	oldStakingManager := GetStakingManager()
 	defer SetTestStakingManager(oldStakingManager)
 
-	header, config := benchSetup()
+	header, rules, pset := benchSetup()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		CalcDeferredReward(header, config)
+		CalcDeferredReward(header, rules, pset)
 	}
 }
 

--- a/tests/klay_test_blockchain_test.go
+++ b/tests/klay_test_blockchain_test.go
@@ -315,8 +315,14 @@ func (bcdata *BCData) GenABlockWithTxpool(accountMap *AccountMap, txpool *blockc
 	prof.Profile("main_insert_blockchain", time.Now().Sub(start))
 
 	// Apply reward
+	config := bcdata.bc.Config()
+	rules := config.Rules(bcdata.bc.CurrentHeader().Number)
+	pset, err := params.NewGovParamSetChainConfig(config)
+	if err != nil {
+		return err
+	}
 	start = time.Now()
-	spec, err := reward.CalcDeferredRewardSimple(header, bcdata.bc.Config())
+	spec, err := reward.CalcDeferredRewardSimple(header, rules, pset)
 	if err != nil {
 		return err
 	}
@@ -382,8 +388,14 @@ func (bcdata *BCData) GenABlockWithTransactions(accountMap *AccountMap, transact
 	prof.Profile("main_insert_blockchain", time.Now().Sub(start))
 
 	// Apply reward
+	config := bcdata.bc.Config()
+	rules := config.Rules(bcdata.bc.CurrentHeader().Number)
+	pset, err := params.NewGovParamSetChainConfig(config)
+	if err != nil {
+		return err
+	}
 	start = time.Now()
-	spec, err := reward.CalcDeferredRewardSimple(bcdata.bc.CurrentHeader(), bcdata.bc.Config())
+	spec, err := reward.CalcDeferredRewardSimple(bcdata.bc.CurrentHeader(), rules, pset)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed changes
This PR
- inserts the KIP71 parameters from `genesis.json` to the genesis block
- adds missing params in ToChainConfig()
- handles empty GovParam address in headergov
- changes Reward functions to receive `Rules` and `GovParamSet`
- close #1375

### 1. Inserting the KIP71 parameters from `genesis.json` to the genesis block

If nodes were created as follows, it will be problematic:
```
homi setup local --cn-num 1 --governance
# ...
cat homi-output/scripts/genesis.json
...
    "magmaCompatibleBlock": 0,
...
    "kip71": {
        "lowerboundbasefee": 0,
        "upperboundbasefee": 0,
        "gastarget": 0,
        "maxblockgasusedforbasefee": 0,
        "basefeedenominator": 0
    }
...
```

Output:
```
ERROR[11/21,17:59:48 +09] [51|work/worker.go:539]  Failed to prepare header for mining       err="invalid baseFee: have 25000000000, want 0, parentBaseFee 25000000000, parentGasUsed 0"
```

This is because the genesis block's baseFee contains the default LowerBoundBaseFee.

To address this issue, following logic needs to be updated:
- ToBlock(): Respect `genesis.json` lowerboundbasefee instead of default
- GetGovernanceItemsFromChainConfig(): returns magma or kore parameters if the genesis block is magma or kore, resp.

SetDefaults() must ignore new parameters (magma, kore, and so on) if they're not present in `genesis.json`.
So we rename SetDefaults() -> SetDefaultsForGenesis(), and introduce SetDefaults() for ChainConfig initialization in `node/cn/backend`.


### 2. Adding missing params in ToChainConfig()

GovParamContract was missing

### 3. Handling empty GovParam address from headergov

If GovParam address has not been voted, it could be empty even after Kore hardfork.
So, we regard this situation ContractEngine-disabled.

- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.

### 4. Changing Reward functions to receive `Rules` and `GovParamSet`
If `governance = "null"` in `genesis.json`, kip82ratio was missing when the node starts.
It could result in `Crit` when trying to parse an empty kip82ratio with `parseRewardKip82Ratio`.
To avoid this situation, we make sure it falls back to the default kip82 ratio by using ParamsAt() in `Finalize()`, and change the parameters of Reward functions as well.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
