### PR TITLE
[API] `ItemsAt` returns error on future block number

### DIFF
--- a/governance/api.go
+++ b/governance/api.go
@@ -18,6 +18,7 @@ package governance
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 
@@ -163,10 +164,14 @@ func (api *PublicGovernanceAPI) TotalVotingPower() (float64, error) {
 
 func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interface{}, error) {
 	blockNumber := uint64(0)
+	curHeaderNum := api.governance.BlockChain().CurrentHeader().Number.Uint64()
+	numU64 := uint64(num.Int64())
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blockNumber = api.governance.BlockChain().CurrentHeader().Number.Uint64()
+		blockNumber = curHeaderNum
+	} else if curHeaderNum < numU64 {
+		return nil, fmt.Errorf("Error by future block number (Current block number = %d, Given number = %d)", curHeaderNum, numU64)
 	} else {
-		blockNumber = uint64(num.Int64())
+		blockNumber = numU64
 	}
 
 	pset, err := api.governance.ParamsAt(blockNumber)


### PR DESCRIPTION
## Proposed changes

As-Is: Returns the latest gov params
To-Be: Returns an error for the future block number

Considering the programming in service or API query, a definite error can teach the invalid input. For instance, the current block number is 100 and the user input number is 10000. Definitely, the user does not have the intention to query for the latest gov params from the current block 100. 

cc. @blukat29 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
