### PR TITLE
Write DeriveShaImpl to post-Kore genesis block

### DIFF
--- a/governance/default.go
+++ b/governance/default.go
@@ -1134,7 +1134,7 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 	if config.IsKoreForkEnabled(common.Big0) &&
 		config.Governance != nil {
 		governanceMap := map[int]interface{}{
-			params.DeriveShaImpl: config.DeriveShaImpl,
+			params.DeriveShaImpl: uint64(config.DeriveShaImpl), // checkValueType expects uint64
 		}
 		if !common.EmptyAddress(config.Governance.GovParamContract) {
 			governanceMap[params.GovParamContract] = config.Governance.GovParamContract

--- a/governance/default.go
+++ b/governance/default.go
@@ -1133,7 +1133,9 @@ func GetGovernanceItemsFromChainConfig(config *params.ChainConfig) GovernanceSet
 	// kore params
 	if config.IsKoreForkEnabled(common.Big0) &&
 		config.Governance != nil {
-		governanceMap := map[int]interface{}{}
+		governanceMap := map[int]interface{}{
+			params.DeriveShaImpl: config.DeriveShaImpl,
+		}
 		if !common.EmptyAddress(config.Governance.GovParamContract) {
 			governanceMap[params.GovParamContract] = config.Governance.GovParamContract
 		}


### PR DESCRIPTION
## Proposed changes

- Genesis blocks with Kore fork enabled, its `block.governanceData` should contain `deriveshaimpl`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #1687

## Further comments