### PR TITLE
Disable VM Standard Tracing APIs in debug namespace

### DIFF
--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -530,6 +530,9 @@ func (api *API) TraceBadBlock(ctx context.Context, hash common.Hash, config *Tra
 // execution of EVM to the local file system and returns a list of files
 // to the caller.
 func (api *API) StandardTraceBlockToFile(ctx context.Context, hash common.Hash, config *StdTraceConfig) ([]string, error) {
+	if !api.unsafeTrace {
+		return nil, errors.New("StandardTraceBlockToFile is not supported in 'debug' namespace, use 'unsafedebug' namespace instead")
+	}
 	block, err := api.blockByHash(ctx, hash)
 	if err != nil {
 		return nil, fmt.Errorf("block %#x not found", hash)
@@ -541,6 +544,9 @@ func (api *API) StandardTraceBlockToFile(ctx context.Context, hash common.Hash, 
 // execution of EVM against a block pulled from the pool of bad ones to the
 // local file system and returns a list of files to the caller.
 func (api *API) StandardTraceBadBlockToFile(ctx context.Context, hash common.Hash, config *StdTraceConfig) ([]string, error) {
+	if !api.unsafeTrace {
+		return nil, errors.New("StandardTraceBadBlockToFile is not supported in 'debug' namespace, use 'unsafedebug' namespace instead")
+	}
 	blocks, err := api.backend.ChainDB().ReadAllBadBlocks()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Proposed changes

- VM Standard Tracing APIs (`standardTraceBlockToFile`, `standardTraceBadBlockToFile`) write results in local file
- The `debug` namespace is to provided developer-friendly APIs over RPC in public ENs, and it is meaningless to provide VM Standard Tracing APIs over RPC (because they write results in local file)
- This PR disables VM Standard Tracing APIs in `debug` namespace (however they still remain in the `unsafedebug` namespace).

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #1672 

## Further comments

None
