### PR TITLE
Always use EmptyRootHashOriginal in eth_getProof API

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -397,12 +397,12 @@ type EthStorageResult struct {
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
 // This feature is not supported in Klaytn yet. It just returns account information from state trie.
 func (api *EthereumAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (*EthAccountResult, error) {
-	state, header, err := api.publicKlayAPI.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	state, _, err := api.publicKlayAPI.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
 	}
 	storageTrie := state.StorageTrie(address)
-	storageHash := types.EmptyRootHash(header.Number)
+	storageHash := types.EmptyRootHashOriginal
 	codeHash := state.GetCodeHash(address)
 	storageProof := make([]EthStorageResult, len(storageKeys))
 

--- a/blockchain/types/derive_sha.go
+++ b/blockchain/types/derive_sha.go
@@ -38,8 +38,13 @@ const (
 )
 
 var (
-	// EmptyRootHash is a transaction/receipt root hash when there is no transaction.
+	// EmptyRootHashOriginal is the empty root hash of a state trie,
+	// which is equal to EmptyRootHash with ImplDeriveShaOriginal.
+	EmptyRootHashOriginal = common.HexToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
 	// DeriveSha and EmptyRootHash are populated by derivesha.InitDeriveSha().
+	// DeriveSha is used to calculate TransactionsRoot and ReceiptsRoot.
+	// EmptyRootHash is a transaction/receipt root hash when there is no transaction.
 	DeriveSha     func(list DerivableList, num *big.Int) common.Hash = DeriveShaNone
 	EmptyRootHash func(num *big.Int) common.Hash                     = EmptyRootHashNone
 )

--- a/blockchain/types/derivesha/derive_sha_test.go
+++ b/blockchain/types/derivesha/derive_sha_test.go
@@ -55,6 +55,9 @@ func (e *testGov) ParamsAt(num uint64) (*params.GovParamSet, error) {
 func TestEmptyRoot(t *testing.T) {
 	assert.Equal(t,
 		DeriveShaOrig{}.DeriveSha(types.Transactions{}).Hex(),
+		types.EmptyRootHashOriginal.Hex())
+	assert.Equal(t,
+		DeriveShaOrig{}.DeriveSha(types.Transactions{}).Hex(),
 		"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 	assert.Equal(t,
 		DeriveShaSimple{}.DeriveSha(types.Transactions{}).Hex(),


### PR DESCRIPTION
## Proposed changes

- Fix the wrong usage of `EmptyRootHash`.
- `EmptyRootHash(num)` is the empty TxRoot and ReceiptsRoot. It's not appropriate for `eth_getProof().storageHash`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
