### PR TITLE
Add rewardConfigCache logic before Kore

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -459,17 +459,10 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 	if err != nil {
 		return nil, err
 	}
-
-	// mimic legacy reward config cache.
-	// if blockNum is multiple of epoch, don't use ParamsAt(blockNum), but use ParamsAt(blockNum - epoch) instead
-	// see https://github.com/klaytn/klaytn/blob/v1.9.1/reward/reward_config_cache.go#L72-L77
-	blockNum := header.Number.Uint64()
-	epoch := pset.Epoch()
-	if !rules.IsKore && blockNum%epoch == 0 {
-		pset, err = sb.governance.ParamsAt(blockNum - epoch)
-		if err != nil {
-			return nil, err
-		}
+	rewardParamNum := reward.CalcRewardParamBlock(header.Number.Uint64(), pset.Epoch(), rules)
+	rewardParamSet, err := sb.governance.ParamsAt(rewardParamNum)
+	if err != nil {
+		return nil, err
 	}
 
 	// If sb.chain is nil, it means backend is not initialized yet.
@@ -496,9 +489,9 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 			logger.Trace(logMsg, "header.Number", header.Number.Uint64(), "node address", sb.address, "rewardbase", header.Rewardbase)
 		}
 
-		rewardSpec, err = reward.CalcDeferredReward(header, rules, pset)
+		rewardSpec, err = reward.CalcDeferredReward(header, rules, rewardParamSet)
 	} else {
-		rewardSpec, err = reward.CalcDeferredRewardSimple(header, rules, pset)
+		rewardSpec, err = reward.CalcDeferredRewardSimple(header, rules, rewardParamSet)
 	}
 
 	if err != nil {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -462,7 +462,7 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 
 	// mimic legacy reward config cache.
 	// if blockNum is multiple of epoch, don't use ParamsAt(blockNum), but use ParamsAt(blockNum - epoch) instead
-	// see https://github.com/klaytn/klaytn/blob/eabdabed10f7c57ee8809f93dbc0ff67ae9f26bf/reward/reward_config_cache.go#L72-L77
+	// see https://github.com/klaytn/klaytn/blob/v1.9.1/reward/reward_config_cache.go#L72-L77
 	blockNum := header.Number.Uint64()
 	epoch := pset.Epoch()
 	if !rules.IsKore && blockNum%epoch == 0 {

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -63,6 +63,7 @@ type (
 
 type (
 	minimumStake           *big.Int
+	mintimgAmount          *big.Int
 	stakingUpdateInterval  uint64
 	proposerUpdateInterval uint64
 	proposerPolicy         uint64
@@ -147,6 +148,8 @@ func newBlockChain(n int, items ...interface{}) (*blockchain.BlockChain, *backen
 			genesis.Config.Governance.Reward.StakingUpdateInterval = uint64(v)
 		case proposerUpdateInterval:
 			genesis.Config.Governance.Reward.ProposerUpdateInterval = uint64(v)
+		case mintimgAmount:
+			genesis.Config.Governance.Reward.MintingAmount = v
 		case governanceMode:
 			genesis.Config.Governance.GovernanceMode = string(v)
 		case *ecdsa.PrivateKey:
@@ -653,6 +656,86 @@ func TestWriteCommittedSeals(t *testing.T) {
 	err = writeCommittedSeals(h, [][]byte{unexpectedCommittedSeal})
 	if err != errInvalidCommittedSeals {
 		t.Errorf("error mismatch: have %v, want %v", err, errInvalidCommittedSeals)
+	}
+}
+
+func TestRewardDistribution(t *testing.T) {
+	type vote = map[string]interface{}
+	type expected = map[int]uint64
+	type testcase struct {
+		length   int // total number of blocks to simulate
+		votes    map[int]vote
+		expected expected
+	}
+
+	mintAmount := uint64(1)
+	koreBlock := uint64(9)
+	testEpoch := 3
+
+	testcases := []testcase{
+		{
+			12,
+			map[int]vote{
+				1: {"reward.mintingamount": "2"}, // activated at block 7 (activation is before-Kore)
+				4: {"reward.mintingamount": "3"}, // activated at block 9 (activation is after-Kore)
+			},
+			map[int]uint64{
+				1:  1,
+				2:  2,
+				3:  3,
+				4:  4,
+				5:  5,
+				6:  6,
+				7:  8, // 2 is minted from now
+				8:  10,
+				9:  13, // 3 is minted from now
+				10: 16,
+				11: 19,
+				12: 22,
+				13: 25,
+			},
+		},
+	}
+
+	var configItems []interface{}
+	configItems = append(configItems, epoch(testEpoch))
+	configItems = append(configItems, mintimgAmount(new(big.Int).SetUint64(mintAmount)))
+	configItems = append(configItems, istanbulCompatibleBlock(new(big.Int).SetUint64(0)))
+	configItems = append(configItems, LondonCompatibleBlock(new(big.Int).SetUint64(0)))
+	configItems = append(configItems, EthTxTypeCompatibleBlock(new(big.Int).SetUint64(0)))
+	configItems = append(configItems, magmaCompatibleBlock(new(big.Int).SetUint64(0)))
+	configItems = append(configItems, koreCompatibleBlock(new(big.Int).SetUint64(koreBlock)))
+	configItems = append(configItems, blockPeriod(0)) // set block period to 0 to prevent creating future block
+
+	chain, engine := newBlockChain(1, configItems...)
+	assert.Equal(t, uint64(testEpoch), engine.governance.Params().Epoch())
+	assert.Equal(t, mintAmount, engine.governance.Params().MintingAmountBig().Uint64())
+
+	var previousBlock, currentBlock *types.Block = nil, chain.Genesis()
+
+	for _, tc := range testcases {
+		// Place a vote if a vote is scheduled in upcoming block
+		// Note that we're building (head+1)'th block here.
+		for num := 0; num <= tc.length; num++ {
+			for k, v := range tc.votes[num+1] {
+				ok := engine.governance.AddVote(k, v)
+				assert.True(t, ok)
+			}
+
+			// Create a block
+			previousBlock = currentBlock
+			currentBlock = makeBlockWithSeal(chain, engine, previousBlock)
+			_, err := chain.InsertChain(types.Blocks{currentBlock})
+			assert.NoError(t, err)
+
+			// check balance
+			addr := currentBlock.Rewardbase()
+			state, err := chain.State()
+			assert.NoError(t, err)
+			bal := state.GetBalance(addr)
+
+			assert.Equal(t, tc.expected[num+1], bal.Uint64(), "wrong at block %d", num+1)
+		}
 	}
 }
 

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -63,7 +63,7 @@ type (
 
 type (
 	minimumStake           *big.Int
-	mintimgAmount          *big.Int
+	mintingAmount          *big.Int
 	stakingUpdateInterval  uint64
 	proposerUpdateInterval uint64
 	proposerPolicy         uint64
@@ -148,7 +148,7 @@ func newBlockChain(n int, items ...interface{}) (*blockchain.BlockChain, *backen
 			genesis.Config.Governance.Reward.StakingUpdateInterval = uint64(v)
 		case proposerUpdateInterval:
 			genesis.Config.Governance.Reward.ProposerUpdateInterval = uint64(v)
-		case mintimgAmount:
+		case mintingAmount:
 			genesis.Config.Governance.Reward.MintingAmount = v
 		case governanceMode:
 			genesis.Config.Governance.GovernanceMode = string(v)
@@ -699,7 +699,7 @@ func TestRewardDistribution(t *testing.T) {
 
 	var configItems []interface{}
 	configItems = append(configItems, epoch(testEpoch))
-	configItems = append(configItems, mintimgAmount(new(big.Int).SetUint64(mintAmount)))
+	configItems = append(configItems, mintingAmount(new(big.Int).SetUint64(mintAmount)))
 	configItems = append(configItems, istanbulCompatibleBlock(new(big.Int).SetUint64(0)))
 	configItems = append(configItems, LondonCompatibleBlock(new(big.Int).SetUint64(0)))
 	configItems = append(configItems, EthTxTypeCompatibleBlock(new(big.Int).SetUint64(0)))

--- a/governance/api.go
+++ b/governance/api.go
@@ -112,6 +112,17 @@ func (api *GovernanceKlayAPI) GetRewards(num *rpc.BlockNumber) (*reward.RewardSp
 		return nil, err
 	}
 
+	// mimic legacy reward config cache.
+	// if num is multiple of epoch, don't use ParamsAt(num), but use ParamsAt(num - epoch) instead
+	// see https://github.com/klaytn/klaytn/blob/eabdabed10f7c57ee8809f93dbc0ff67ae9f26bf/reward/reward_config_cache.go#L72-L77
+	epoch := pset.Epoch()
+	if !rules.IsKore && blockNumber%epoch == 0 {
+		pset, err = api.governance.ParamsAt(blockNumber - epoch)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return reward.GetBlockReward(header, rules, pset)
 }
 

--- a/governance/api.go
+++ b/governance/api.go
@@ -114,7 +114,7 @@ func (api *GovernanceKlayAPI) GetRewards(num *rpc.BlockNumber) (*reward.RewardSp
 
 	// mimic legacy reward config cache.
 	// if num is multiple of epoch, don't use ParamsAt(num), but use ParamsAt(num - epoch) instead
-	// see https://github.com/klaytn/klaytn/blob/eabdabed10f7c57ee8809f93dbc0ff67ae9f26bf/reward/reward_config_cache.go#L72-L77
+	// see https://github.com/klaytn/klaytn/blob/v1.9.1/reward/reward_config_cache.go#L72-L77
 	epoch := pset.Epoch()
 	if !rules.IsKore && blockNumber%epoch == 0 {
 		pset, err = api.governance.ParamsAt(blockNumber - epoch)

--- a/governance/api_test.go
+++ b/governance/api_test.go
@@ -1,13 +1,30 @@
 package governance
 
 import (
+	"math/big"
 	"testing"
 
-	"github.com/docker/docker/pkg/testutil/assert"
+	"github.com/klaytn/klaytn/blockchain/state"
+	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus"
+	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/storage/database"
+	"github.com/stretchr/testify/assert"
 )
+
+type testBlockChain struct {
+	num    uint64
+	config *params.ChainConfig
+}
+
+func newTestBlockchain(config *params.ChainConfig) *testBlockChain {
+	return &testBlockChain{
+		config: config,
+	}
+}
 
 func newTestGovernanceApi() *PublicGovernanceAPI {
 	config := params.CypressChainConfig
@@ -35,4 +52,131 @@ func TestLowerBoundFeeSet(t *testing.T) {
 	invalidLowerBoundBaseFee := curUpperBoundBaseFee + 100
 	_, err := govApi.Vote("kip71.lowerboundbasefee", invalidLowerBoundBaseFee)
 	assert.Equal(t, err, errInvalidLowerBound)
+}
+
+func TestGetRewards(t *testing.T) {
+	type expected = map[int]uint64
+	type strMap = map[string]interface{}
+	type override struct {
+		num    int
+		strMap strMap
+	}
+	type testcase struct {
+		length   int // total number of blocks to simulate
+		override []override
+		expected expected
+	}
+
+	var (
+		mintAmount = uint64(1)
+		koreBlock  = uint64(9)
+		epoch      = 3
+		latestNum  = rpc.BlockNumber(-1)
+		proposer   = common.HexToAddress("0x0000000000000000000000000000000000000000")
+		config     = getTestConfig()
+	)
+
+	testcases := []testcase{
+		{
+			12,
+			[]override{
+				{
+					3,
+					strMap{
+						"reward.mintingamount": "2",
+					},
+				},
+				{
+					6,
+					strMap{
+						"reward.mintingamount": "3",
+					},
+				},
+			},
+			map[int]uint64{
+				1:  1,
+				2:  1,
+				3:  1,
+				4:  1,
+				5:  1,
+				6:  1,
+				7:  2, // 2 is minted from now
+				8:  2,
+				9:  3, // 3 is minted from now
+				10: 3,
+				11: 3,
+				12: 3,
+				13: 3,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		config.Governance.Reward.MintingAmount = new(big.Int).SetUint64(mintAmount)
+		config.Istanbul.Epoch = uint64(epoch)
+		config.KoreCompatibleBlock = new(big.Int).SetUint64(koreBlock)
+
+		bc := newTestBlockchain(config)
+
+		dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
+
+		e := NewMixedEngine(config, dbm)
+		e.SetBlockchain(bc)
+		e.UpdateParams()
+
+		// write initial gov items and overrides to database
+		pset, _ := params.NewGovParamSetChainConfig(config)
+		gset := NewGovernanceSet()
+		gset.Import(pset.StrMap())
+		e.headerGov.WriteGovernance(0, NewGovernanceSet(), gset)
+		for _, o := range tc.override {
+			override := NewGovernanceSet()
+			override.Import(o.strMap)
+			e.headerGov.WriteGovernance(uint64(o.num), gset, override)
+		}
+
+		govKlayApi := NewGovernanceKlayAPI(e, bc)
+
+		for num := 1; num <= tc.length; num++ {
+			bc.SetBlockNum(uint64(num))
+
+			rewardSpec, err := govKlayApi.GetRewards(&latestNum)
+			assert.Nil(t, err)
+
+			minted := new(big.Int).SetUint64(tc.expected[num])
+			expectedRewardSpec := &reward.RewardSpec{
+				Minted:   minted,
+				TotalFee: common.Big0,
+				BurntFee: common.Big0,
+				Proposer: minted,
+				Rewards: map[common.Address]*big.Int{
+					proposer: minted,
+				},
+			}
+			assert.Equal(t, expectedRewardSpec, rewardSpec, "wrong at block %d", num)
+		}
+	}
+}
+
+func (bc *testBlockChain) Engine() consensus.Engine                    { return nil }
+func (bc *testBlockChain) GetHeader(common.Hash, uint64) *types.Header { return nil }
+func (bc *testBlockChain) GetHeaderByNumber(val uint64) *types.Header {
+	return &types.Header{
+		Number: new(big.Int).SetUint64(val),
+	}
+}
+func (bc *testBlockChain) GetBlockByNumber(num uint64) *types.Block         { return nil }
+func (bc *testBlockChain) StateAt(root common.Hash) (*state.StateDB, error) { return nil, nil }
+func (bc *testBlockChain) Config() *params.ChainConfig {
+	return bc.config
+}
+
+func (bc *testBlockChain) CurrentHeader() *types.Header {
+	return &types.Header{
+		Number: new(big.Int).SetUint64(bc.num),
+	}
+}
+
+func (bc *testBlockChain) SetBlockNum(num uint64) {
+	bc.num = num
 }

--- a/reward/reward_distributor.go
+++ b/reward/reward_distributor.go
@@ -153,6 +153,15 @@ func IsRewardSimple(pset *params.GovParamSet) bool {
 	return pset.Policy() != uint64(istanbul.WeightedRandom)
 }
 
+// CalcRewardParamBlock returns the block number with which governance parameters must be fetched
+// This mimics the legacy reward config cache before Kore
+func CalcRewardParamBlock(num, epoch uint64, rules params.Rules) uint64 {
+	if !rules.IsKore && num%epoch == 0 {
+		return num - epoch
+	}
+	return num
+}
+
 // GetBlockReward returns the actual reward amounts paid in this block
 // Used in klay_getReward RPC API
 func GetBlockReward(header *types.Header, rules params.Rules, pset *params.GovParamSet) (*RewardSpec, error) {


### PR DESCRIPTION
## Proposed changes

### Problem
- Before Kore, when `blockNum % epoch = 0`,  reward distributor used parameters at `blockNum - epoch` https://github.com/klaytn/klaytn/blob/8664bc88319567f560bc5244131672d554e55293/reward/reward_config_cache.go#L72-L77
- However, after Kore, `blockNum` is used
- This introduces a discrepancy between pre-Kore and Kore

For example, at block 106444800 where [KGP-3](https://govforum.klaytn.foundation/c/proposal/5) is applied, old parameters (106444800 - epoch) are used.
```
> kir="0x3d803a7375a8ee5996f52a8d6725637a89f5bbf8"
> N=106444800
> klay.getBalance(kir, N+1) - klay.getBalance(kir, N)
640050148302389200
> klay.getBalance(kir, N) - klay.getBalance(kir, N-1)
1152361217533149200
```

After Kore, this will no longer be the case.

### Solution (This PR)
This PR fixes this problem by using old parameters for such blocks before Kore hardfork.
closes #1728.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
