### PR TITLE
disable datadog tracer when DD_DATADOG_ENABLED os flag is not set

### DIFF
--- a/networks/rpc/http_datadog.go
+++ b/networks/rpc/http_datadog.go
@@ -26,11 +26,13 @@ type DatadogTracer struct {
 }
 
 func newDatadogTracer() *DatadogTracer {
-	if v := os.Getenv("DD_TRACE_ENABLED"); v != "" {
-		ddTraceEnabled, err := strconv.ParseBool(v)
-		if err != nil || ddTraceEnabled == false {
-			return nil
-		}
+	v := os.Getenv("DD_TRACE_ENABLED")
+	if v == "" {
+		return nil
+	}
+
+	if ddTraceEnabled, err := strconv.ParseBool(v); ddTraceEnabled == false || err != nil {
+		return nil
 	}
 
 	headers := strings.Split(os.Getenv("DD_TRACE_HEADER_TAGS"), ",")


### PR DESCRIPTION
## Proposed changes

- disable datadog tracer when DD_DATADOG_ENABLED os environment flag is not set

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
