### PR TITLE
tx_list: bump tx max size to 128KB

### DIFF
--- a/blockchain/tx_list.go
+++ b/blockchain/tx_list.go
@@ -623,11 +623,11 @@ func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) boo
 
 // Discard finds a number of most underpriced transactions, removes them from the
 // priced list and returns them for further removal from the entire pool.
-func (l *txPricedList) Discard(count int, local *accountSet) types.Transactions {
-	drop := make(types.Transactions, 0, count) // Remote underpriced transactions to drop
+func (l *txPricedList) Discard(slots int, local *accountSet) types.Transactions {
+	drop := make(types.Transactions, 0, slots) // Remote underpriced transactions to drop
 	save := make(types.Transactions, 0, 64)    // Local underpriced transactions to keep
 
-	for len(*l.items) > 0 && count > 0 {
+	for len(*l.items) > 0 && slots > 0 {
 		// Discard stale transactions if found during cleanup
 		tx := heap.Pop(l.items).(*types.Transaction)
 		if l.all.Get(tx.Hash()) == nil {
@@ -639,7 +639,7 @@ func (l *txPricedList) Discard(count int, local *accountSet) types.Transactions 
 			save = append(save, tx)
 		} else {
 			drop = append(drop, tx)
-			count--
+			slots -= numSlots(tx)
 		}
 	}
 	for _, tx := range save {

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -883,7 +883,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (bool, error) {
 	// (2) remove an old Tx with the largest nonce from queue to make a room for a new Tx with missing nonce
 	// (3) discard a new Tx if the new Tx does not have a missing nonce
 	// (4) discard underpriced transactions
-	if uint64(pool.all.Slots()+numSlots(tx)) >= pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll {
+	if uint64(pool.all.Slots()+numSlots(tx)) > pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll {
 		// (1) discard a new Tx if there is no room for the account of the Tx
 		from, _ := types.Sender(pool.signer, tx)
 		if pool.queue[from] == nil {

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -54,6 +54,7 @@ const (
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
+	// TODO-klaytn: Change the name to clarify what it means. It means the max length of the transaction.
 	MaxTxDataSize = 4 * txSlotSize // 128KB
 
 	// demoteUnexecutablesFullValidationTxLimit is the number of txs will be fully validated in demoteUnexecutables.

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1736,6 +1736,7 @@ type txLookup struct {
 
 // newTxLookup returns a new txLookup structure.
 func newTxLookup() *txLookup {
+	slotsGauge.Update(int64(0))
 	return &txLookup{
 		all: make(map[common.Hash]*types.Transaction),
 	}

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -1344,11 +1344,11 @@ func TestTransactionAllowedTxSize(t *testing.T) {
 		success      bool   // the expected result whether the addition is succeeded or failed
 		errStr       string
 	}{
-		// Try adding a transaction with maximal allowed size
+		// Try adding a transaction with close to the maximum allowed size
 		{dataSize, 0, true, "failed to add the transaction which size is close to the maximal"},
 		// Try adding a transaction with random allowed size
 		{uint64(rand.Intn(int(dataSize))), 1, true, "failed to add the transaction of random allowed size"},
-		// Try adding a transaction of minimal not allowed size
+		// Try adding a slightly oversize transaction
 		{MaxTxDataSize, 2, false, "expected rejection on slightly oversize transaction"},
 		// Try adding a transaction of random not allowed size
 		{dataSize + 1 + uint64(rand.Intn(int(10*MaxTxDataSize))), 2, false, "expected rejection on oversize transaction"},


### PR DESCRIPTION
## Proposed changes
* it increases tx max size to 128KB
* slot is introduced. For example, if a slot size is 32KB, and the tx size is 96kB, when that tx is inserted into txpool, it adds 96+32-1/32 = 3 slots.
  * dev: 1 is added to the txpool tx count when a tx is inserted
  * PR: tx slot size is added to the txpool tx count(which is actually slots) when a tx is inserted. See numSlots.

## Types of changes
Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
