### PR TITLE
[API] Makes consistent formatting for RPC API

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -550,7 +550,7 @@ func RpcOutputBlock(b *types.Block, td *big.Int, inclTx bool, fullTx bool, isEna
 		"logsBloom":        head.Bloom,
 		"stateRoot":        head.Root,
 		"reward":           head.Rewardbase,
-		"blockscore":       (*hexutil.Big)(head.BlockScore),
+		"blockScore":       (*hexutil.Big)(head.BlockScore),
 		"totalBlockScore":  (*hexutil.Big)(td),
 		"extraData":        hexutil.Bytes(head.Extra),
 		"governanceData":   hexutil.Bytes(head.Governance),

--- a/node/cn/filters/api.go
+++ b/node/cn/filters/api.go
@@ -225,11 +225,8 @@ func RPCMarshalHeader(head *types.Header, isEnabledEthTxTypeFork bool) map[strin
 		"timestampFoS":     hexutil.Uint(head.TimeFoS),
 		"extraData":        hexutil.Bytes(head.Extra),
 		"governanceData":   hexutil.Bytes(head.Governance),
+		"voteData":         hexutil.Bytes(head.Vote),
 		"hash":             head.Hash(),
-	}
-
-	if len(head.Vote) != 0 {
-		result["voteData"] = hexutil.Bytes(head.Vote)
 	}
 
 	if isEnabledEthTxTypeFork {


### PR DESCRIPTION
## Proposed changes

The JSON marshaling for the RPC outputs between `getHeader()` and `getBlock()` was slightly different.
For the `getHeader`, the header had a typo `blockscore` (not a camelCase) and did not include the bytes array of `Vote` field, but `getBlock` unconditionally contains it.
This PR makes the format the same as each other so that developers are not annoyed by inconsistency.
Creating a new function that has one fixed format and returns filled contents of it seems much better, but not pushing such a work for now.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
