### PR TITLE
Fix nodecmd tests

### DIFF
--- a/cmd/utils/nodecmd/consolecmd_test.go
+++ b/cmd/utils/nodecmd/consolecmd_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 governance:1.0 istanbul:1.0 klay:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 governance:1.0 istanbul:1.0 klay:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 unsafedebug:1.0 web3:1.0"
 	httpAPIs = "eth:1.0 klay:1.0 net:1.0 rpc:1.0 web3:1.0"
 )
 
@@ -51,7 +51,8 @@ func TestConsoleWelcome(t *testing.T) {
 	klay.SetTemplateFunc("goos", func() string { return runtime.GOOS })
 	klay.SetTemplateFunc("goarch", func() string { return runtime.GOARCH })
 	klay.SetTemplateFunc("gover", runtime.Version)
-	klay.SetTemplateFunc("klayver", func() string { return params.VersionWithCommit(gitCommit) })
+	// TODO: Fix as in testAttachWelcome()
+	klay.SetTemplateFunc("klayver", func() string { return params.VersionWithCommit("") })
 	klay.SetTemplateFunc("niltime", func() string { return time.Unix(0, 0).Format(time.RFC1123) })
 	klay.SetTemplateFunc("apis", func() string { return ipcAPIs })
 
@@ -126,7 +127,10 @@ func testAttachWelcome(t *testing.T, klay *testklay, endpoint, apis string) {
 	attach.SetTemplateFunc("goos", func() string { return runtime.GOOS })
 	attach.SetTemplateFunc("goarch", func() string { return runtime.GOARCH })
 	attach.SetTemplateFunc("gover", runtime.Version)
-	attach.SetTemplateFunc("klayver", func() string { return params.VersionWithCommit(gitCommit) })
+	// The node version uses cmd/utils.gitCommit which is always empty.
+	// TODO: Fix the cmd/utils.DefaultNodeConfig() to use cmd/utils/nodecmd.gitCommit
+	// and then restore "klayver" to use gitCommit.
+	attach.SetTemplateFunc("klayver", func() string { return params.VersionWithCommit("") })
 	attach.SetTemplateFunc("rewardbase", func() string { return klay.Rewardbase })
 	attach.SetTemplateFunc("niltime", func() string { return time.Unix(0, 0).Format(time.RFC1123) })
 	attach.SetTemplateFunc("ipc", func() bool { return strings.HasPrefix(endpoint, "ipc") })

--- a/cmd/utils/nodecmd/genesis_test.go
+++ b/cmd/utils/nodecmd/genesis_test.go
@@ -144,7 +144,7 @@ func TestCustomGenesis(t *testing.T) {
 		for idx, query := range tt.query {
 			klay := runKlay(t,
 				"klay-test", "--datadir", datadir, "--maxconnections", "0", "--port", "0",
-				"--nodiscover", "--nat", "none", "--ipcdisable",
+				"--nodiscover", "--nat", "none", "--ipcdisable", "--ntp.disable",
 				"--exec", query, "--verbosity", "0", "console")
 			klay.ExpectRegexp(tt.result[idx])
 			klay.ExpectExit()


### PR DESCRIPTION
## Proposed changes

- Fix `cmd/utils/nodecmd/consolecmd_test.go` to use correct welcome text
- Fix `cmd/utils/nodecmd/genesis_test.go` to disable ntp during frequent node program invocation.
- As a result, coverage test should pass.

Note that `cmd/utils/nodecmd` tests are disabled in `make test-others`.
To run these tests, type

```bash
env GOPATH=$(go env GOPATH) GO111MODULE=on go run build/ci.go test -p 1 ./cmd/utils/nodecmd/
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments