### PR TITLE
RewardSpec contains 0s by default

### DIFF
--- a/governance/api_test.go
+++ b/governance/api_test.go
@@ -149,6 +149,9 @@ func TestGetRewards(t *testing.T) {
 				TotalFee: common.Big0,
 				BurntFee: common.Big0,
 				Proposer: minted,
+				Stakers:  common.Big0,
+				Kgf:      common.Big0,
+				Kir:      common.Big0,
 				Rewards: map[common.Address]*big.Int{
 					proposer: minted,
 				},

--- a/reward/reward_distributor_test.go
+++ b/reward/reward_distributor_test.go
@@ -309,6 +309,9 @@ func TestRewardDistributor_GetBlockReward(t *testing.T) {
 				TotalFee: new(big.Int).SetUint64(1000),
 				BurntFee: new(big.Int).SetUint64(500),
 				Proposer: new(big.Int).SetUint64(9.6e18 + 500),
+				Stakers:  new(big.Int).SetUint64(0),
+				Kgf:      new(big.Int).SetUint64(0),
+				Kir:      new(big.Int).SetUint64(0),
 				Rewards: map[common.Address]*big.Int{
 					proposerAddr: new(big.Int).SetUint64(9.6e18 + 500),
 				},
@@ -322,6 +325,9 @@ func TestRewardDistributor_GetBlockReward(t *testing.T) {
 				TotalFee: new(big.Int).SetUint64(1000),
 				BurntFee: new(big.Int).SetUint64(0),
 				Proposer: new(big.Int).SetUint64(9.6e18 + 1000),
+				Stakers:  new(big.Int).SetUint64(0),
+				Kgf:      new(big.Int).SetUint64(0),
+				Kir:      new(big.Int).SetUint64(0),
 				Rewards: map[common.Address]*big.Int{
 					proposerAddr: new(big.Int).SetUint64(9.6e18 + 1000),
 				},
@@ -406,6 +412,9 @@ func TestRewardDistributor_CalcDeferredRewardSimple(t *testing.T) {
 				TotalFee: new(big.Int).SetUint64(1000),
 				BurntFee: new(big.Int).SetUint64(0),
 				Proposer: new(big.Int).SetUint64(9.6e18 + 1000),
+				Stakers:  new(big.Int).SetUint64(0),
+				Kgf:      new(big.Int).SetUint64(0),
+				Kir:      new(big.Int).SetUint64(0),
 				Rewards: map[common.Address]*big.Int{
 					proposerAddr: new(big.Int).SetUint64(9.6e18 + 1000),
 				},
@@ -418,6 +427,9 @@ func TestRewardDistributor_CalcDeferredRewardSimple(t *testing.T) {
 				TotalFee: new(big.Int).SetUint64(1000),
 				BurntFee: new(big.Int).SetUint64(500), // 50% of tx fee burnt
 				Proposer: new(big.Int).SetUint64(9.6e18 + 500),
+				Stakers:  new(big.Int).SetUint64(0),
+				Kgf:      new(big.Int).SetUint64(0),
+				Kir:      new(big.Int).SetUint64(0),
 				Rewards: map[common.Address]*big.Int{
 					proposerAddr: new(big.Int).SetUint64(9.6e18 + 500),
 				},
@@ -467,6 +479,9 @@ func TestRewardDistributor_CalcDeferredRewardSimple_nodeferred(t *testing.T) {
 				TotalFee: new(big.Int).SetUint64(1000),
 				BurntFee: new(big.Int).SetUint64(0),
 				Proposer: new(big.Int).SetUint64(9.6e18 + 1000),
+				Stakers:  new(big.Int).SetUint64(0),
+				Kgf:      new(big.Int).SetUint64(0),
+				Kir:      new(big.Int).SetUint64(0),
 				Rewards: map[common.Address]*big.Int{
 					proposerAddr: new(big.Int).SetUint64(9.6e18 + 1000),
 				},
@@ -480,6 +495,9 @@ func TestRewardDistributor_CalcDeferredRewardSimple_nodeferred(t *testing.T) {
 				TotalFee: new(big.Int).SetUint64(1000),
 				BurntFee: new(big.Int).SetUint64(500),
 				Proposer: new(big.Int).SetUint64(9.6e18 + 500),
+				Stakers:  new(big.Int).SetUint64(0),
+				Kgf:      new(big.Int).SetUint64(0),
+				Kir:      new(big.Int).SetUint64(0),
 				Rewards: map[common.Address]*big.Int{
 					proposerAddr: new(big.Int).SetUint64(9.6e18 + 500),
 				},
@@ -493,6 +511,9 @@ func TestRewardDistributor_CalcDeferredRewardSimple_nodeferred(t *testing.T) {
 				TotalFee: new(big.Int).SetUint64(0),
 				BurntFee: new(big.Int).SetUint64(0),
 				Proposer: new(big.Int).SetUint64(9.6e18),
+				Stakers:  new(big.Int).SetUint64(0),
+				Kgf:      new(big.Int).SetUint64(0),
+				Kir:      new(big.Int).SetUint64(0),
 				Rewards: map[common.Address]*big.Int{
 					proposerAddr: new(big.Int).SetUint64(9.6e18),
 				},


### PR DESCRIPTION
## Proposed changes

- RewardSpec contains 0s by default.
- `klay_getReward` API will explicitly return 0s.
  - Before
	```js
	{
	  burntFee: 0,
	  kgf: null,
	  kir: null,
	  minted: 9600000000000000000,
	  proposer: 9600000000000000000,
	  rewards: {
	    0xbe1d89973bc37019c5dd253db01f31d4ceefc24d: 9600000000000000000
	  },
	  stakers: null,
	  totalFee: 0
	}
	```
  - After
	```js
	{
	  burntFee: 0,
	  kgf: 0,
	  kir: 0,
	  minted: 9600000000000000000,
	  proposer: 9600000000000000000,
	  rewards: {
	    0xbe1d89973bc37019c5dd253db01f31d4ceefc24d: 9600000000000000000
	  },
	  stakers: 0,
	  totalFee: 0
	}
	```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
