### PR TITLE
First commit of stateb-pruning to convert to version 1.10

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -408,7 +408,7 @@ func (api *EthereumAPI) GetProof(ctx context.Context, address common.Address, st
 
 	// if we have a storageTrie, (which means the account exists), we can update the storagehash
 	if storageTrie != nil {
-		storageHash = storageTrie.Hash()
+		storageHash = storageTrie.Hash().ToHash()
 	} else {
 		// no storageTrie means the account does not exist, so the codeHash is the hash of an empty bytearray.
 		codeHash = crypto.Keccak256Hash(nil)
@@ -465,10 +465,10 @@ func (api *EthereumAPI) GetHeaderByHash(ctx context.Context, hash common.Hash) m
 }
 
 // GetBlockByNumber returns the requested canonical block.
-// * When blockNr is -1 the chain head is returned.
-// * When blockNr is -2 the pending chain head is returned.
-// * When fullTx is true all transactions in the block are returned, otherwise
-//   only the transaction hash is returned.
+//   - When blockNr is -1 the chain head is returned.
+//   - When blockNr is -2 the pending chain head is returned.
+//   - When fullTx is true all transactions in the block are returned, otherwise
+//     only the transaction hash is returned.
 func (api *EthereumAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	// Klaytn backend returns error when there is no matched block but
 	// Ethereum returns it as nil without error, so we should return is as nil when there is no matched block.
@@ -553,11 +553,11 @@ func (api *EthereumAPI) GetStorageAt(ctx context.Context, address common.Address
 // OverrideAccount in go-ethereum has been renamed to EthOverrideAccount.
 // OverrideAccount is defined in go-ethereum's internal package, so OverrideAccount is redefined here as EthOverrideAccount.
 type EthOverrideAccount struct {
-	Nonce     *hexutil.Uint64              `json:"nonce"`
-	Code      *hexutil.Bytes               `json:"code"`
-	Balance   **hexutil.Big                `json:"balance"`
-	State     *map[common.Hash]common.Hash `json:"state"`
-	StateDiff *map[common.Hash]common.Hash `json:"stateDiff"`
+	Nonce     *hexutil.Uint64                    `json:"nonce"`
+	Code      *hexutil.Bytes                     `json:"code"`
+	Balance   **hexutil.Big                      `json:"balance"`
+	State     *map[common.ExtHash]common.ExtHash `json:"state"`
+	StateDiff *map[common.ExtHash]common.ExtHash `json:"stateDiff"`
 }
 
 // EthStateOverride is the collection of overridden accounts.

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -223,7 +223,7 @@ func (s *PublicBlockChainAPI) GetStorageAt(ctx context.Context, address common.A
 	if err != nil {
 		return nil, err
 	}
-	res := state.GetState(address, common.HexToHash(key))
+	res := state.GetState(address, common.HexToExtHash(key))
 	return res[:], state.Error()
 }
 

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -103,7 +103,7 @@ func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *stat
 	}
 	// Validate the state root against the received state root and throw
 	// an error if they don't match.
-	if root := statedb.IntermediateRoot(true); header.Root != root {
+	if root := statedb.IntermediateRoot(true).ToHash(); header.Root != root {
 		return fmt.Errorf("invalid merkle root (remote: %x local: %x)", header.Root, root)
 	}
 	return nil

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -285,13 +285,13 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 	}
 	// Make sure the state associated with the block is available
 	head := bc.CurrentBlock()
-	if _, err := state.New(head.Root(), bc.stateCache, bc.snaps); err != nil {
+	if _, err := state.New(head.Root().ToRootExtHash(), bc.stateCache, bc.snaps); err != nil {
 		// Head state is missing, before the state recovery, find out the
 		// disk layer point of snapshot(if it's enabled). Make sure the
 		// rewound point is lower than disk layer.
 		var diskRoot common.Hash
 		if bc.cacheConfig.SnapshotCacheSize > 0 {
-			diskRoot = bc.db.ReadSnapshotRoot()
+			diskRoot = bc.db.ReadSnapshotRoot().ToHash()
 		}
 		if diskRoot != (common.Hash{}) {
 			logger.Warn("Head state missing, repairing", "number", head.Number(), "hash", head.Hash(), "snaproot", diskRoot)
@@ -341,7 +341,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 			logger.Warn("Enabling snapshot recovery", "chainhead", head.NumberU64(), "diskbase", *layer)
 			recover = true
 		}
-		bc.snaps, _ = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotCacheSize, head.Root(), bc.cacheConfig.SnapshotAsyncGen, true, recover)
+		bc.snaps, _ = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotCacheSize, head.Root().ToRootExtHash(), bc.cacheConfig.SnapshotAsyncGen, true, recover)
 	}
 
 	for i := 1; i <= bc.cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker; i++ {
@@ -381,7 +381,7 @@ func (bc *BlockChain) prefetchTxWorker(index int) {
 		snaps = bc.snaps
 	}
 	for followup := range bc.prefetchTxCh {
-		stateDB, err := state.NewForPrefetching(bc.CurrentBlock().Root(), bc.stateCache, snaps)
+		stateDB, err := state.NewForPrefetching(bc.CurrentBlock().Root().ToRootExtHash(), bc.stateCache, snaps)
 		if err != nil {
 			logger.Debug("failed to retrieve stateDB for prefetchTxWorker", "err", err)
 			continue
@@ -413,7 +413,7 @@ func (bc *BlockChain) SetCanonicalBlock(blockNum uint64) {
 	}
 	// Make sure the state associated with the block is available
 	head := bc.CurrentBlock()
-	if _, err := state.New(head.Root(), bc.stateCache, bc.snaps); err != nil {
+	if _, err := state.New(head.Root().ToRootExtHash(), bc.stateCache, bc.snaps); err != nil {
 		// Dangling block without a state associated, init from scratch
 		logger.Warn("Head state missing, repairing chain",
 			"number", head.NumberU64(), "hash", head.Hash().String())
@@ -544,7 +544,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 					if root != (common.Hash{}) && !beyondRoot && newHeadBlock.Root() == root {
 						beyondRoot, rootNumber = true, newHeadBlock.NumberU64()
 					}
-					if _, err := state.New(newHeadBlock.Root(), bc.stateCache, bc.snaps); err != nil {
+					if _, err := state.New(newHeadBlock.Root().ToRootExtHash(), bc.stateCache, bc.snaps); err != nil {
 						// Rewound state missing, rolled back to the parent block, reset to genesis
 						logger.Trace("Block state missing, rewinding further", "number", newHeadBlock.NumberU64(), "hash", newHeadBlock.Hash())
 						parent := bc.GetBlock(newHeadBlock.ParentHash(), newHeadBlock.NumberU64()-1)
@@ -636,7 +636,7 @@ func (bc *BlockChain) FastSyncCommitHead(hash common.Hash) error {
 	if block == nil {
 		return fmt.Errorf("non existent block [%x…]", hash[:4])
 	}
-	if _, err := statedb.NewSecureTrie(block.Root(), bc.stateCache.TrieDB()); err != nil {
+	if _, err := statedb.NewSecureTrie(block.Root().ToRootExtHash(), bc.stateCache.TrieDB()); err != nil {
 		return err
 	}
 	// If all checks out, manually set the head block
@@ -648,7 +648,7 @@ func (bc *BlockChain) FastSyncCommitHead(hash common.Hash) error {
 	// Destroy any existing state snapshot and regenerate it in the background,
 	// also resuming the normal maintenance of any previously paused snapshot.
 	if bc.snaps != nil {
-		bc.snaps.Rebuild(block.Root())
+		bc.snaps.Rebuild(block.Root().ToRootExtHash())
 	}
 	logger.Info("Committed new head block", "number", block.Number(), "hash", hash)
 	return nil
@@ -683,29 +683,31 @@ func (bc *BlockChain) State() (*state.StateDB, error) {
 
 // StateAt returns a new mutable state based on a particular point in time.
 func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
-	return state.New(root, bc.stateCache, bc.snaps)
+	return state.New(root.ToRootExtHash(), bc.stateCache, bc.snaps)
 }
 
 // StateAtWithPersistent returns a new mutable state based on a particular point in time with persistent trie nodes.
 func (bc *BlockChain) StateAtWithPersistent(root common.Hash) (*state.StateDB, error) {
-	exist := bc.stateCache.TrieDB().DoesExistNodeInPersistent(root)
+	tmpRoot := root.ToRootExtHash()
+	exist := bc.stateCache.TrieDB().DoesExistNodeInPersistent(tmpRoot)
 	if !exist {
 		return nil, ErrNotExistNode
 	}
-	return state.New(root, bc.stateCache, bc.snaps)
+	return state.New(tmpRoot, bc.stateCache, bc.snaps)
 }
 
 // StateAtWithGCLock returns a new mutable state based on a particular point in time with read lock of the state nodes.
 func (bc *BlockChain) StateAtWithGCLock(root common.Hash) (*state.StateDB, error) {
 	bc.RLockGCCachedNode()
 
-	exist := bc.stateCache.TrieDB().DoesExistCachedNode(root)
+	tmpRoot := root.ToRootExtHash()
+	exist := bc.stateCache.TrieDB().DoesExistCachedNode(tmpRoot)
 	if !exist {
 		bc.RUnlockGCCachedNode()
 		return nil, ErrNotExistNode
 	}
 
-	stateDB, err := state.New(root, bc.stateCache, bc.snaps)
+	stateDB, err := state.New(tmpRoot, bc.stateCache, bc.snaps)
 	if err != nil {
 		bc.RUnlockGCCachedNode()
 		return nil, err
@@ -758,7 +760,7 @@ func (bc *BlockChain) ResetWithGenesisBlock(genesis *types.Block) error {
 func (bc *BlockChain) repair(head **types.Block) error {
 	for {
 		// Abort if we've rewound to a head block that does have associated state
-		if _, err := state.New((*head).Root(), bc.stateCache, bc.snaps); err == nil {
+		if _, err := state.New((*head).Root().ToRootExtHash(), bc.stateCache, bc.snaps); err == nil {
 			logger.Info("Rewound blockchain to past state", "number", (*head).Number(), "hash", (*head).Hash())
 			return nil
 		} else {
@@ -853,7 +855,7 @@ func (bc *BlockChain) HasBlock(hash common.Hash, number uint64) bool {
 
 // HasState checks if state trie is fully present in the database or not.
 func (bc *BlockChain) HasState(hash common.Hash) bool {
-	_, err := bc.stateCache.OpenTrie(hash)
+	_, err := bc.stateCache.OpenTrie(hash.ToRootExtHash())
 	return err == nil
 }
 
@@ -977,12 +979,12 @@ func (bc *BlockChain) GetLogsByHash(hash common.Hash) [][]*types.Log {
 // TrieNode retrieves a blob of data associated with a trie node
 // either from ephemeral in-memory cache, or from persistent storage.
 func (bc *BlockChain) TrieNode(hash common.Hash) ([]byte, error) {
-	return bc.stateCache.TrieDB().Node(hash)
+	return bc.stateCache.TrieDB().Node(hash.ToRootExtHash())
 }
 
 // ContractCode retrieves a blob of data associated with a contract hash
 // either from ephemeral in-memory cache, or from persistent storage.
-func (bc *BlockChain) ContractCode(hash common.Hash) ([]byte, error) {
+func (bc *BlockChain) ContractCode(hash common.ExtHash) ([]byte, error) {
 	return bc.stateCache.ContractCode(hash)
 }
 
@@ -991,9 +993,9 @@ func (bc *BlockChain) ContractCode(hash common.Hash) ([]byte, error) {
 //
 // If the code doesn't exist in the in-memory cache, check the storage with
 // new code scheme.
-func (bc *BlockChain) ContractCodeWithPrefix(hash common.Hash) ([]byte, error) {
+func (bc *BlockChain) ContractCodeWithPrefix(hash common.ExtHash) ([]byte, error) {
 	type codeReader interface {
-		ContractCodeWithPrefix(codeHash common.Hash) ([]byte, error)
+		ContractCodeWithPrefix(codeHash common.ExtHash) ([]byte, error)
 	}
 	return bc.stateCache.(codeReader).ContractCodeWithPrefix(hash)
 }
@@ -1001,6 +1003,7 @@ func (bc *BlockChain) ContractCodeWithPrefix(hash common.Hash) ([]byte, error) {
 // Stop stops the blockchain service. If any imports are currently in progress
 // it will abort them using the procInterrupt.
 func (bc *BlockChain) Stop() {
+	var tmpSnapBase common.ExtHash
 	if !atomic.CompareAndSwapInt32(&bc.running, 0, 1) {
 		return
 	}
@@ -1020,9 +1023,10 @@ func (bc *BlockChain) Stop() {
 	var snapBase common.Hash
 	if bc.snaps != nil {
 		var err error
-		if snapBase, err = bc.snaps.Journal(bc.CurrentBlock().Root()); err != nil {
+		if tmpSnapBase, err = bc.snaps.Journal(bc.CurrentBlock().Root().ToRootExtHash()); err != nil {
 			logger.Error("Failed to journal state snapshot", "err", err)
 		}
+		snapBase = tmpSnapBase.ToHash()
 	}
 
 	triedb := bc.stateCache.TrieDB()
@@ -1035,17 +1039,17 @@ func (bc *BlockChain) Stop() {
 		}
 
 		logger.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
-		if err := triedb.Commit(recent.Root(), true, number); err != nil {
+		if err := triedb.Commit(recent.Root().ToRootExtHash(), true, number); err != nil {
 			logger.Error("Failed to commit recent state trie", "err", err)
 		}
 		if snapBase != (common.Hash{}) {
-			logger.Info("Writing snapshot state to disk", "root", snapBase)
-			if err := triedb.Commit(snapBase, true, number); err != nil {
+			logger.Info("Writing snapshot state to disk", "root", tmpSnapBase)
+			if err := triedb.Commit(tmpSnapBase, true, number); err != nil {
 				logger.Error("Failed to commit recent state trie", "err", err)
 			}
 		}
 		for !bc.triegc.Empty() {
-			triedb.Dereference(bc.triegc.PopItem().(common.Hash))
+			triedb.Dereference(bc.triegc.PopItem().(common.Hash).ToRootExtHash())
 		}
 		if size, _, _ := triedb.Size(); size != 0 {
 			logger.Error("Dangling trie nodes after full cleanup")
@@ -1298,11 +1302,11 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 			return err
 		}
 
-		bc.checkStartStateMigration(block.NumberU64(), root)
+		bc.checkStartStateMigration(block.NumberU64(), root.ToHash())
 		bc.lastCommittedBlock = block.NumberU64()
 	} else {
 		// Full but not archive node, do proper garbage collection
-		trieDB.Reference(root, common.Hash{}) // metadata reference to keep trie alive
+		trieDB.Reference(root, common.InitExtHash()) // metadata reference to keep trie alive
 
 		// If we exceeded our memory allowance, flush matured singleton nodes to disk
 		var (
@@ -1323,11 +1327,11 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 
 		if isCommitTrieRequired(bc, block.NumberU64()) {
 			logger.Trace("Commit the state trie into the disk", "blocknum", block.NumberU64())
-			if err := trieDB.Commit(block.Header().Root, true, block.NumberU64()); err != nil {
+			if err := trieDB.Commit(block.Header().Root.ToRootExtHash(), true, block.NumberU64()); err != nil {
 				return err
 			}
 
-			if bc.checkStartStateMigration(block.NumberU64(), root) {
+			if bc.checkStartStateMigration(block.NumberU64(), root.ToHash()) {
 				// flush referenced trie nodes out to new stateTrieDB
 				if err := trieDB.Cap(0); err != nil {
 					logger.Error("Error from trieDB.Cap by state migration", "err", err)
@@ -1337,7 +1341,7 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 			bc.lastCommittedBlock = block.NumberU64()
 		}
 
-		bc.chBlock <- gcBlock{root, block.NumberU64()}
+		bc.chBlock <- gcBlock{root.ToHash(), block.NumberU64()}
 	}
 	return nil
 }
@@ -1384,7 +1388,7 @@ func (bc *BlockChain) gcCachedNodeLoop() {
 						bc.triegc.Push(root, number)
 						break
 					}
-					trieDB.Dereference(root.(common.Hash))
+					trieDB.Dereference(root.(common.Hash).ToRootExtHash())
 					cnt++
 				}
 				logger.Debug("GC cached node", "currentBlk", blkNum, "chosenBlk", chosen, "deferenceCnt", cnt)
@@ -1818,7 +1822,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 						}
 					}()
 
-					throwaway, err := state.NewForPrefetching(parent.Root(), bc.stateCache, snaps)
+					throwaway, err := state.NewForPrefetching(parent.Root().ToRootExtHash(), bc.stateCache, snaps)
 					if throwaway == nil || err != nil {
 						logger.Warn("failed to get StateDB for prefetcher", "err", err,
 							"parentBlockNum", parent.NumberU64(), "currBlockNum", bc.CurrentBlock().NumberU64())
@@ -1929,6 +1933,10 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		}
 
 		// Validate the state using the default validator
+		ethanNum := block.NumberU64()
+		fmt.Printf("blockNum = %d\n", ethanNum)
+		common.SetBlockNum(uint32(ethanNum))
+		database.DeleteStateDBProcNum(ethanNum)
 		err = bc.validator.ValidateState(block, parent, stateDB, receipts, usedGas)
 		if err != nil {
 			bc.reportBlock(block, receipts, err)

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -209,7 +209,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		return nil, nil
 	}
 	for i := 0; i < n; i++ {
-		statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil)
+		statedb, err := state.New(parent.Root().ToRootExtHash(), state.NewDatabase(db), nil)
 		if err != nil {
 			panic(err)
 		}
@@ -230,7 +230,7 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 	}
 
 	header := &types.Header{
-		Root:       state.IntermediateRoot(true),
+		Root:       state.IntermediateRoot(true).ToHash(),
 		ParentHash: parent.Hash(),
 		BlockScore: engine.CalcBlockScore(chain, time.Uint64(), &types.Header{
 			Number:     parent.Number(),

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -148,7 +148,7 @@ func findBlockWithState(db database.DBManager) *types.Block {
 	}
 
 	startBlock := headBlock
-	for _, err := state.New(headBlock.Root(), state.NewDatabase(db), nil); err != nil; {
+	for _, err := state.New(headBlock.Root().ToRootExtHash(), state.NewDatabase(db), nil); err != nil; {
 		if headBlock.NumberU64() == 0 {
 			logger.Crit("failed to find state from the head block to the genesis block",
 				"headBlockNum", headBlock.NumberU64(),
@@ -298,7 +298,7 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 	if db == nil {
 		db = database.NewMemoryDBManager()
 	}
-	stateDB, _ := state.New(baseStateRoot, state.NewDatabase(db), nil)
+	stateDB, _ := state.New(baseStateRoot.InitExtHash(), state.NewDatabase(db), nil)
 	for addr, account := range g.Alloc {
 		if len(account.Code) != 0 {
 			originalCode := stateDB.GetCode(addr)
@@ -311,7 +311,7 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 			}
 		}
 		for key, value := range account.Storage {
-			stateDB.SetState(addr, key, value)
+			stateDB.SetState(addr, key.ToRootExtHash(), value.ToRootExtHash())
 		}
 		stateDB.AddBalance(addr, account.Balance)
 		stateDB.SetNonce(addr, account.Nonce)
@@ -326,7 +326,7 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 		Governance: g.Governance,
 		GasUsed:    g.GasUsed,
 		BlockScore: g.BlockScore,
-		Root:       root,
+		Root:       root.ToHash(),
 	}
 	if g.BlockScore == nil {
 		head.BlockScore = params.GenesisBlockScore

--- a/blockchain/state/iterator.go
+++ b/blockchain/state/iterator.go
@@ -45,14 +45,14 @@ type NodeIterator struct {
 	stateIt statedb.NodeIterator // Primary iterator for the global state trie
 	dataIt  statedb.NodeIterator // Secondary iterator for the data trie of a contract
 
-	accountHash common.Hash // Hash of the node containing the account
-	codeHash    common.Hash // Hash of the contract source code
-	Code        []byte      // Source code associated with a contract
+	accountHash common.ExtHash // Hash of the node containing the account
+	codeHash    common.ExtHash // Hash of the contract source code
+	Code        []byte         // Source code associated with a contract
 
 	Type   string
-	Hash   common.Hash // Hash of the current entry being iterated (nil if not standalone)
-	Parent common.Hash // Hash of the first full ancestor node (nil if current is the root)
-	Path   []byte      // the hex-encoded path to the current node.
+	Hash   common.ExtHash // Hash of the current entry being iterated (nil if not standalone)
+	Parent common.ExtHash // Hash of the first full ancestor node (nil if current is the root)
+	Path   []byte         // the hex-encoded path to the current node.
 
 	Error error // Failure set in case of an internal error in the iteratord
 }
@@ -119,6 +119,7 @@ func (it *NodeIterator) step() error {
 	}
 	// Otherwise we've reached an account node, initiate data iteration
 
+	/* oldHash2ExtHash : ExtHash only version code.
 	serializer := account.NewAccountSerializer()
 	if err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob()), serializer); err != nil {
 		return err
@@ -135,10 +136,10 @@ func (it *NodeIterator) step() error {
 			it.dataIt = nil
 		}
 
-		if codeHash := pa.GetCodeHash(); !bytes.Equal(codeHash, emptyCodeHash) {
-			it.codeHash = common.BytesToHash(codeHash)
+		if codeHash := pa.GetCodeHash(); !bytes.Equal(codeHash[:common.HashLength], emptyCodeHash) {
+			it.codeHash = common.BytesToExtHash(codeHash)
 			// addrHash := common.BytesToHash(it.stateIt.LeafKey())
-			it.Code, err = it.state.db.ContractCode(common.BytesToHash(codeHash))
+			it.Code, err = it.state.db.ContractCode(common.BytesToExtHash(codeHash))
 			if err != nil {
 				return fmt.Errorf("code %x: %v", codeHash, err)
 			}
@@ -146,13 +147,57 @@ func (it *NodeIterator) step() error {
 	}
 	it.accountHash = it.stateIt.Parent()
 	return nil
+	*/
+
+	// <-- Code that reads the hash version of the DB and converts it to the ExtHash version for processing
+	serializer := account.NewAccountSerializer()
+	serializerLH := account.NewAccountLHSerializer()
+	err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob()), serializerLH)
+	if err != nil {
+		if errLH := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob()), serializer); errLH != nil {
+			fmt.Printf("Err : %s\n", err.Error())
+			return errLH
+		}
+	} else {
+		serializer = serializerLH.Copy()
+	}
+	obj := serializer.GetAccount()
+
+	if pa := account.GetProgramAccount(obj); pa != nil {
+		dataTrie, err := it.state.db.OpenStorageTrie(pa.GetStorageRoot())
+		if err != nil {
+			return err
+		}
+		it.dataIt = dataTrie.NodeIterator(nil)
+		if !it.dataIt.Next(true) {
+			it.dataIt = nil
+		}
+
+		if codeHash := pa.GetCodeHash(); !bytes.Equal(codeHash[:common.HashLength], emptyCodeHash) {
+			codeHashLen := len(codeHash)
+			if codeHashLen == common.HashLength {
+				it.codeHash = common.BytesLegacyToExtHash(codeHash)
+			} else if codeHashLen == common.ExtHashLength {
+				it.codeHash = common.BytesToRootExtHash(codeHash)
+			} else {
+				panic(fmt.Sprintf("code hash len error : %x", codeHash))
+			}
+			it.Code, err = it.state.db.ContractCode(common.BytesToRootExtHash(it.codeHash.Bytes()))
+			if err != nil {
+				return fmt.Errorf("code %x/%x: %v", codeHash, it.codeHash, err)
+			}
+		}
+	}
+	it.accountHash = it.stateIt.Parent()
+	return nil
+	// -->
 }
 
 // retrieve pulls and caches the current state entry the iterator is traversing.
 // The method returns whether there are any more data left for inspection.
 func (it *NodeIterator) retrieve() bool {
 	// Clear out any previously set values
-	it.Hash = common.Hash{}
+	it.Hash = common.InitExtHash()
 	it.Path = []byte{}
 
 	// If the iteration's done, return no available data
@@ -169,7 +214,7 @@ func (it *NodeIterator) retrieve() bool {
 
 		it.Hash, it.Parent, it.Path = it.dataIt.Hash(), it.dataIt.Parent(), it.dataIt.Path()
 
-		if it.Parent == (common.Hash{}) {
+		if it.Parent.ToHash() == (common.Hash{}) {
 			it.Parent = it.accountHash
 		}
 	case it.Code != nil:
@@ -187,7 +232,7 @@ func (it *NodeIterator) retrieve() bool {
 }
 
 // CheckStateConsistencyParallel checks the consistency of all state/storage trie of given two state databases in parallel.
-func CheckStateConsistencyParallel(oldDB Database, newDB Database, root common.Hash, quitCh chan struct{}) error {
+func CheckStateConsistencyParallel(oldDB Database, newDB Database, root common.ExtHash, quitCh chan struct{}) error {
 	// Check if the tries can be called
 	_, err := oldDB.OpenTrie(root)
 	if err != nil {
@@ -247,7 +292,7 @@ func CheckStateConsistencyParallel(oldDB Database, newDB Database, root common.H
 
 // concurrentIterator checks the consistency of all state/storage trie of given two state database
 // and pass the result via the channel.
-func concurrentIterator(oldDB Database, newDB Database, root common.Hash, quit chan struct{}, resultCh chan struct{}, finishCh chan error) (resultErr error) {
+func concurrentIterator(oldDB Database, newDB Database, root common.ExtHash, quit chan struct{}, resultCh chan struct{}, finishCh chan error) (resultErr error) {
 	defer func() {
 		finishCh <- resultErr
 	}()
@@ -324,7 +369,7 @@ func concurrentIterator(oldDB Database, newDB Database, root common.Hash, quit c
 }
 
 // CheckStateConsistency checks the consistency of all state/storage trie of given two state database.
-func CheckStateConsistency(oldDB Database, newDB Database, root common.Hash, mapSize int, quit chan struct{}) error {
+func CheckStateConsistency(oldDB Database, newDB Database, root common.ExtHash, mapSize int, quit chan struct{}) error {
 	// Create and iterate a state trie rooted in a sub-node
 	oldState, err := New(root, oldDB, nil)
 	if err != nil {
@@ -340,7 +385,7 @@ func CheckStateConsistency(oldDB Database, newDB Database, root common.Hash, map
 	newIt := NewNodeIterator(newState)
 
 	cnt := 0
-	nodes := make(map[common.Hash]struct{}, mapSize)
+	nodes := make(map[common.ExtHash]struct{}, mapSize)
 
 	lastTime := time.Now()
 	report := func() {
@@ -392,7 +437,7 @@ func CheckStateConsistency(oldDB Database, newDB Database, root common.Hash, map
 			}
 		}
 
-		if !common.EmptyHash(oldIt.Hash) {
+		if !common.EmptyHash(oldIt.Hash.ToHash()) {
 			nodes[oldIt.Hash] = struct{}{}
 		}
 

--- a/blockchain/state/journal.go
+++ b/blockchain/state/journal.go
@@ -114,7 +114,7 @@ type (
 	}
 	storageChange struct {
 		account       *common.Address
-		key, prevalue common.Hash
+		key, prevalue common.ExtHash
 	}
 	codeChange struct {
 		account            *common.Address
@@ -129,7 +129,7 @@ type (
 		txhash common.Hash
 	}
 	addPreimageChange struct {
-		hash common.Hash
+		hash common.ExtHash
 	}
 	touchChange struct {
 		account   *common.Address
@@ -204,7 +204,7 @@ func (ch nonceChange) dirtied() *common.Address {
 }
 
 func (ch codeChange) revert(s *StateDB) {
-	s.getStateObject(*ch.account).setCode(common.BytesToHash(ch.prevhash), ch.prevcode)
+	s.getStateObject(*ch.account).setCode(common.BytesToExtHash(ch.prevhash), ch.prevcode)
 }
 
 func (ch codeChange) dirtied() *common.Address {

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -53,8 +54,20 @@ var (
 
 	logger = log.NewModuleLogger(log.BlockchainState)
 
+	errNotExistingAddress = fmt.Errorf("there is no account corresponding to the given address")
+	errNotContractAddress = fmt.Errorf("given address is not a contract address")
+
 	// TODO-Klaytn EnabledExpensive and DBConfig.EnableDBPerfMetrics will be merged
 	EnabledExpensive = false
+
+	midAccountCnt  = uint64(0)
+	midStorageCnt  = uint64(0)
+	codeCnt        = uint64(0)
+	leafAccountCnt = uint64(0)
+	leafStorageCnt = uint64(0)
+	unknownCnt     = uint64(0)
+	mutex          = &sync.Mutex{}
+	once           sync.Once
 )
 
 // StateDBs within the Klaytn protocol are used to cache stateObjects from Merkle Patricia Trie
@@ -65,9 +78,9 @@ type StateDB struct {
 
 	snaps         *snapshot.Tree
 	snap          snapshot.Snapshot
-	snapDestructs map[common.Hash]struct{}
-	snapAccounts  map[common.Hash][]byte
-	snapStorage   map[common.Hash]map[common.Hash][]byte
+	snapDestructs map[common.ExtHash]struct{}
+	snapAccounts  map[common.ExtHash][]byte
+	snapStorage   map[common.ExtHash]map[common.ExtHash][]byte
 
 	// This map holds 'live' objects, which will get modified while processing a state transition.
 	stateObjects             map[common.Address]*stateObject
@@ -89,7 +102,7 @@ type StateDB struct {
 	logs         map[common.Hash][]*types.Log
 	logSize      uint
 
-	preimages map[common.Hash][]byte
+	preimages map[common.ExtHash][]byte
 
 	// Per-transaction access list
 	accessList *accessList
@@ -117,7 +130,7 @@ type StateDB struct {
 }
 
 // Create a new state from a given trie.
-func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) {
+func New(root common.ExtHash, db Database, snaps *snapshot.Tree) (*StateDB, error) {
 	tr, err := db.OpenTrie(root)
 	if err != nil {
 		return nil, err
@@ -130,22 +143,22 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		stateObjectsDirtyStorage: make(map[common.Address]struct{}),
 		stateObjectsDirty:        make(map[common.Address]struct{}),
 		logs:                     make(map[common.Hash][]*types.Log),
-		preimages:                make(map[common.Hash][]byte),
+		preimages:                make(map[common.ExtHash][]byte),
 		journal:                  newJournal(),
 		accessList:               newAccessList(),
 	}
 	if sdb.snaps != nil {
 		if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap != nil {
-			sdb.snapDestructs = make(map[common.Hash]struct{})
-			sdb.snapAccounts = make(map[common.Hash][]byte)
-			sdb.snapStorage = make(map[common.Hash]map[common.Hash][]byte)
+			sdb.snapDestructs = make(map[common.ExtHash]struct{})
+			sdb.snapAccounts = make(map[common.ExtHash][]byte)
+			sdb.snapStorage = make(map[common.ExtHash]map[common.ExtHash][]byte)
 		}
 	}
 	return sdb, nil
 }
 
 // Create a new state from a given trie with prefetching
-func NewForPrefetching(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) {
+func NewForPrefetching(root common.ExtHash, db Database, snaps *snapshot.Tree) (*StateDB, error) {
 	tr, err := db.OpenTrieForPrefetching(root)
 	if err != nil {
 		return nil, err
@@ -158,15 +171,15 @@ func NewForPrefetching(root common.Hash, db Database, snaps *snapshot.Tree) (*St
 		stateObjectsDirtyStorage: make(map[common.Address]struct{}),
 		stateObjectsDirty:        make(map[common.Address]struct{}),
 		logs:                     make(map[common.Hash][]*types.Log),
-		preimages:                make(map[common.Hash][]byte),
+		preimages:                make(map[common.ExtHash][]byte),
 		journal:                  newJournal(),
 		prefetching:              true,
 	}
 	if sdb.snaps != nil {
 		if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap != nil {
-			sdb.snapDestructs = make(map[common.Hash]struct{})
-			sdb.snapAccounts = make(map[common.Hash][]byte)
-			sdb.snapStorage = make(map[common.Hash]map[common.Hash][]byte)
+			sdb.snapDestructs = make(map[common.ExtHash]struct{})
+			sdb.snapAccounts = make(map[common.ExtHash][]byte)
+			sdb.snapStorage = make(map[common.ExtHash]map[common.ExtHash][]byte)
 		}
 	}
 	return sdb, nil
@@ -195,7 +208,7 @@ func (self *StateDB) Error() error {
 
 // Reset clears out all ephemeral state objects from the state db, but keeps
 // the underlying state trie to avoid reloading data for the next operations.
-func (self *StateDB) Reset(root common.Hash) error {
+func (self *StateDB) Reset(root common.ExtHash) error {
 	tr, err := self.db.OpenTrie(root)
 	if err != nil {
 		return err
@@ -208,7 +221,7 @@ func (self *StateDB) Reset(root common.Hash) error {
 	self.txIndex = 0
 	self.logs = make(map[common.Hash][]*types.Log)
 	self.logSize = 0
-	self.preimages = make(map[common.Hash][]byte)
+	self.preimages = make(map[common.ExtHash][]byte)
 	self.clearJournalAndRefund()
 	self.accessList = newAccessList()
 	return nil
@@ -238,7 +251,7 @@ func (self *StateDB) Logs() []*types.Log {
 }
 
 // AddPreimage records a SHA3 preimage seen by the VM.
-func (self *StateDB) AddPreimage(hash common.Hash, preimage []byte) {
+func (self *StateDB) AddPreimage(hash common.ExtHash, preimage []byte) {
 	if _, ok := self.preimages[hash]; !ok {
 		self.journal.append(addPreimageChange{hash: hash})
 		pi := make([]byte, len(preimage))
@@ -248,7 +261,7 @@ func (self *StateDB) AddPreimage(hash common.Hash, preimage []byte) {
 }
 
 // Preimages returns a list of SHA3 preimages that have been submitted.
-func (self *StateDB) Preimages() map[common.Hash][]byte {
+func (self *StateDB) Preimages() map[common.ExtHash][]byte {
 	return self.preimages
 }
 
@@ -343,25 +356,25 @@ func (self *StateDB) GetCodeHash(addr common.Address) common.Hash {
 	if stateObject == nil {
 		return common.BytesToHash(emptyCodeHash)
 	}
-	return common.BytesToHash(stateObject.CodeHash())
+	return common.BytesToHash(stateObject.CodeHash()[:common.HashLength])
 }
 
 // GetState retrieves a value from the given account's storage trie.
-func (self *StateDB) GetState(addr common.Address, hash common.Hash) common.Hash {
+func (self *StateDB) GetState(addr common.Address, hash common.ExtHash) common.ExtHash {
 	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		return stateObject.GetState(self.db, hash)
 	}
-	return common.Hash{}
+	return common.InitExtHash()
 }
 
 // GetCommittedState retrieves a value from the given account's committed storage trie.
-func (self *StateDB) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
+func (self *StateDB) GetCommittedState(addr common.Address, hash common.ExtHash) common.ExtHash {
 	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		return stateObject.GetCommittedState(self.db, hash)
 	}
-	return common.Hash{}
+	return common.InitExtHash()
 }
 
 // IsContractAvailable returns true if the account corresponding to the given address implements ProgramAccount.
@@ -484,13 +497,13 @@ func (self *StateDB) SetNonce(addr common.Address, nonce uint64) {
 func (self *StateDB) SetCode(addr common.Address, code []byte) error {
 	stateObject := self.GetOrNewSmartContract(addr)
 	if stateObject != nil {
-		return stateObject.SetCode(crypto.Keccak256Hash(code), code)
+		return stateObject.SetCode(crypto.Keccak256Hash(code).ToRootExtHash(), code)
 	}
 
 	return nil
 }
 
-func (self *StateDB) SetState(addr common.Address, key, value common.Hash) {
+func (self *StateDB) SetState(addr common.Address, key, value common.ExtHash) {
 	stateObject := self.GetOrNewSmartContract(addr)
 	if stateObject != nil {
 		stateObject.SetState(self.db, key, value)
@@ -499,7 +512,7 @@ func (self *StateDB) SetState(addr common.Address, key, value common.Hash) {
 
 // SetStorage replaces the entire storage for the specified account with given
 // storage. This function should only be used for debugging.
-func (self *StateDB) SetStorage(addr common.Address, storage map[common.Hash]common.Hash) {
+func (self *StateDB) SetStorage(addr common.Address, storage map[common.ExtHash]common.ExtHash) {
 	stateObject := self.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetStorage(storage)
@@ -615,7 +628,7 @@ func (self *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		if EnabledExpensive {
 			defer func(start time.Time) { self.SnapshotAccountReads += time.Since(start) }(time.Now())
 		}
-		if acc, err = self.snap.Account(crypto.Keccak256Hash(addr.Bytes())); err == nil {
+		if acc, err = self.snap.Account(crypto.Keccak256Hash(addr.Bytes()).ToRootExtHash()); err == nil {
 			if acc == nil {
 				return nil
 			}
@@ -634,12 +647,29 @@ func (self *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 			self.setError(err)
 			return nil
 		}
+		/* oldHash2ExtHash : ExtHash only version code.
 		serializer := account.NewAccountSerializer()
 		if err := rlp.DecodeBytes(enc, serializer); err != nil {
 			logger.Error("Failed to decode state object", "addr", addr, "err", err)
 			return nil
 		}
 		acc = serializer.GetAccount()
+		*/
+
+		// <-- Code that reads the hash version of the DB and converts it to the ExtHash version for processing
+		serializer := account.NewAccountSerializer()
+		serializerLH := account.NewAccountLHSerializer()
+		if errLH := rlp.DecodeBytes(enc, serializerLH); errLH != nil {
+			err := rlp.DecodeBytes(enc, serializer)
+			if err != nil {
+				logger.Error("Failed to decode state object", "addr", addr, "err", err)
+				return nil
+			}
+		} else {
+			serializer = serializerLH.Copy()
+		}
+		acc = serializer.GetAccount()
+		// -->
 	}
 	// Insert into the live set.
 	obj := newObject(self, addr, acc)
@@ -743,8 +773,8 @@ func (self *StateDB) createObjectWithMap(addr common.Address, accountType accoun
 // CreateAccount is called during the EVM CREATE operation. The situation might arise that
 // a contract does the following:
 //
-//   1. sends funds to sha(account ++ (nonce + 1))
-//   2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
+//  1. sends funds to sha(account ++ (nonce + 1))
+//  2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
 //
 // Carrying over the balance ensures that Ether doesn't disappear.
 func (self *StateDB) CreateAccount(addr common.Address) {
@@ -782,19 +812,19 @@ func (self *StateDB) CreateSmartContractAccountWithKey(addr common.Address, huma
 	}
 }
 
-func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common.Hash) bool) {
+func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common.ExtHash) bool) {
 	so := db.getStateObject(addr)
 	if so == nil {
 		return
 	}
 	it := statedb.NewIterator(so.getStorageTrie(db.db).NodeIterator(nil))
 	for it.Next() {
-		key := common.BytesToHash(db.trie.GetKey(it.Key))
+		key := common.BytesToExtHash(db.trie.GetKey(it.Key))
 		if value, dirty := so.dirtyStorage[key]; dirty {
 			cb(key, value)
 			continue
 		}
-		cb(key, common.BytesToHash(it.Value))
+		cb(key, common.BytesToExtHash(it.Value))
 	}
 }
 
@@ -810,7 +840,7 @@ func (self *StateDB) Copy() *StateDB {
 		refund:            self.refund,
 		logs:              make(map[common.Hash][]*types.Log, len(self.logs)),
 		logSize:           self.logSize,
-		preimages:         make(map[common.Hash][]byte),
+		preimages:         make(map[common.ExtHash][]byte),
 		journal:           newJournal(),
 	}
 	// Copy the dirty states, logs, and preimages
@@ -855,17 +885,17 @@ func (self *StateDB) Copy() *StateDB {
 		state.snaps = self.snaps
 		state.snap = self.snap
 		// deep copy needed
-		state.snapDestructs = make(map[common.Hash]struct{})
+		state.snapDestructs = make(map[common.ExtHash]struct{})
 		for k, v := range self.snapDestructs {
 			state.snapDestructs[k] = v
 		}
-		state.snapAccounts = make(map[common.Hash][]byte)
+		state.snapAccounts = make(map[common.ExtHash][]byte)
 		for k, v := range self.snapAccounts {
 			state.snapAccounts[k] = v
 		}
-		state.snapStorage = make(map[common.Hash]map[common.Hash][]byte)
+		state.snapStorage = make(map[common.ExtHash]map[common.ExtHash][]byte)
 		for k, v := range self.snapStorage {
-			temp := make(map[common.Hash][]byte)
+			temp := make(map[common.ExtHash][]byte)
 			for kk, vv := range v {
 				temp[kk] = vv
 			}
@@ -968,13 +998,13 @@ func (stateDB *StateDB) Finalise(deleteEmptyObjects bool, setStorageRoot bool) {
 // IntermediateRoot computes the current root hash of the state statedb.
 // It is called in between transactions to get the root hash that
 // goes into transaction receipts.
-func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.ExtHash {
 	s.Finalise(deleteEmptyObjects, true)
 	// Track the amount of time wasted on hashing the account trie
 	if EnabledExpensive {
 		defer func(start time.Time) { s.AccountHashes += time.Since(start) }(time.Now())
 	}
-	return s.trie.Hash()
+	return s.trie.RootHash()
 }
 
 // Prepare sets the current transaction hash and index and block hash which is
@@ -992,9 +1022,9 @@ func (s *StateDB) clearJournalAndRefund() {
 }
 
 // Commit writes the state to the underlying in-memory trie database.
-func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) {
+func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.ExtHash, err error) {
 	if s.dbErr != nil {
-		return common.Hash{}, fmt.Errorf("commit aborted due to earlier error: %v", s.dbErr)
+		return common.InitExtHash(), fmt.Errorf("commit aborted due to earlier error: %v", s.dbErr)
 	}
 
 	defer s.clearJournalAndRefund()
@@ -1017,12 +1047,12 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) 
 			if stateObject.IsProgramAccount() {
 				// Write any contract code associated with the state object.
 				if stateObject.code != nil && stateObject.dirtyCode {
-					s.db.TrieDB().DiskDB().WriteCode(common.BytesToHash(stateObject.CodeHash()), stateObject.code)
+					s.db.TrieDB().DiskDB().WriteCode(common.BytesToRootExtHash(stateObject.CodeHash()), stateObject.code)
 					stateObject.dirtyCode = false
 				}
 				// Write any storage changes in the state object to its storage trie.
 				if err := stateObject.CommitStorageTrie(s.db); err != nil {
-					return common.Hash{}, err
+					return common.InitExtHash(), err
 				}
 			}
 			// Update the object in the main account trie.
@@ -1040,7 +1070,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) 
 	if EnabledExpensive {
 		defer func(start time.Time) { s.AccountCommits += time.Since(start) }(time.Now())
 	}
-	root, err = s.trie.Commit(func(_ [][]byte, _ []byte, leaf []byte, parent common.Hash, parentDepth int) error {
+	root, err = s.trie.Commit(func(_ [][]byte, _ []byte, leaf []byte, parent common.ExtHash, parentDepth int) error {
 		serializer := account.NewAccountSerializer()
 		if err := rlp.DecodeBytes(leaf, serializer); err != nil {
 			logger.Warn("RLP decode failed", "err", err, "leaf", string(leaf))
@@ -1048,12 +1078,16 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) 
 		}
 		acc := serializer.GetAccount()
 		if pa := account.GetProgramAccount(acc); pa != nil {
-			if pa.GetStorageRoot() != emptyState {
+			if pa.GetStorageRoot().ToHash() != emptyState {
 				s.db.TrieDB().Reference(pa.GetStorageRoot(), parent)
+			}
+			code := common.BytesToRootExtHash(pa.GetCodeHash())
+			if code.ToHash() != emptyCode {
+				s.db.TrieDB().Reference(code, parent)
 			}
 		}
 		return nil
-	})
+	}, true)
 
 	// If snapshotting is enabled, update the snapshot tree with this new version
 	if s.snap != nil {
@@ -1084,22 +1118,17 @@ func (s *StateDB) GetTxHash() common.Hash {
 	return s.thash
 }
 
-var (
-	errNotExistingAddress = fmt.Errorf("there is no account corresponding to the given address")
-	errNotContractAddress = fmt.Errorf("given address is not a contract address")
-)
-
-func (s *StateDB) GetContractStorageRoot(contractAddr common.Address) (common.Hash, error) {
+func (s *StateDB) GetContractStorageRoot(contractAddr common.Address) (common.ExtHash, error) {
 	acc := s.GetAccount(contractAddr)
 	if acc == nil {
-		return common.Hash{}, errNotExistingAddress
+		return common.InitExtHash(), errNotExistingAddress
 	}
 	if acc.Type() != account.SmartContractAccountType {
-		return common.Hash{}, errNotContractAddress
+		return common.InitExtHash(), errNotContractAddress
 	}
 	contract, true := acc.(*account.SmartContractAccount)
 	if !true {
-		return common.Hash{}, errNotContractAddress
+		return common.InitExtHash(), errNotContractAddress
 	}
 	return contract.GetStorageRoot(), nil
 }

--- a/blockchain/state/sync.go
+++ b/blockchain/state/sync.go
@@ -34,16 +34,16 @@ import (
 // LRU cache is mendatory when state syncing and block processing are executed simultaneously
 func NewStateSync(root common.Hash, database statedb.StateTrieReadDB, bloom *statedb.SyncBloom, lruCache *lru.Cache, onLeaf func(paths [][]byte, leaf []byte) error) *statedb.TrieSync {
 	// Register the storage slot callback if the external callback is specified.
-	var onSlot func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash, parentDepth int) error
+	var onSlot func(paths [][]byte, hexpath []byte, leaf []byte, parent common.ExtHash, parentDepth int) error
 	if onLeaf != nil {
-		onSlot = func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash, parentDepth int) error {
+		onSlot = func(paths [][]byte, hexpath []byte, leaf []byte, parent common.ExtHash, parentDepth int) error {
 			return onLeaf(paths, leaf)
 		}
 	}
 	// Register the account callback to connect the state trie and the storage
 	// trie belongs to the contract.
 	var syncer *statedb.TrieSync
-	onAccount := func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash, parentDepth int) error {
+	onAccount := func(paths [][]byte, hexpath []byte, leaf []byte, parent common.ExtHash, parentDepth int) error {
 		if onLeaf != nil {
 			if err := onLeaf(paths, leaf); err != nil {
 				return err
@@ -56,10 +56,10 @@ func NewStateSync(root common.Hash, database statedb.StateTrieReadDB, bloom *sta
 		obj := serializer.GetAccount()
 		if pa := account.GetProgramAccount(obj); pa != nil {
 			syncer.AddSubTrie(pa.GetStorageRoot(), hexpath, parentDepth+1, parent, onSlot)
-			syncer.AddCodeEntry(common.BytesToHash(pa.GetCodeHash()), hexpath, parentDepth+1, parent)
+			syncer.AddCodeEntry(common.BytesToRootExtHash(pa.GetCodeHash()), hexpath, parentDepth+1, parent)
 		}
 		return nil
 	}
-	syncer = statedb.NewTrieSync(root, database, onAccount, bloom, lruCache)
+	syncer = statedb.NewTrieSync(root.ToExtHash(), database, onAccount, bloom, lruCache)
 	return syncer
 }

--- a/blockchain/types/account/account.go
+++ b/blockchain/types/account/account.go
@@ -110,12 +110,12 @@ type Account interface {
 type ProgramAccount interface {
 	Account
 
-	GetStorageRoot() common.Hash
+	GetStorageRoot() common.ExtHash
 	GetCodeHash() []byte
 	GetCodeFormat() params.CodeFormat
 	GetVmVersion() params.VmVersion
 
-	SetStorageRoot(h common.Hash)
+	SetStorageRoot(h common.ExtHash)
 	SetCodeHash(h []byte)
 	SetCodeInfo(codeInfo params.CodeInfo)
 }

--- a/blockchain/types/account/account_legacy_hash.go
+++ b/blockchain/types/account/account_legacy_hash.go
@@ -1,0 +1,340 @@
+// Copyright 2019 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package account
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/klaytn/klaytn/blockchain/types/accountkey"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/rlp"
+)
+
+// all code decode for legacy hash ( 32 byte hash )
+
+//account.go
+//
+// NewAccountWithType creates an Account object with the given type.
+func NewAccountLHWithType(t AccountType) (Account, error) {
+	switch t {
+	case LegacyAccountType:
+		return newLegacyAccountLH(), nil
+	case ExternallyOwnedAccountType:
+		//return newExternallyOwnedAccountLH(), nil
+		return newExternallyOwnedAccount(), nil
+		// or panic()?
+	case SmartContractAccountType:
+		return newSmartContractAccountLH(), nil
+	}
+
+	return nil, ErrUndefinedAccountType
+}
+
+// Account is the Klaytn consensus representation of accounts.
+// These objects are stored in the main account trie.
+type AccountLH interface {
+	Type() AccountType
+
+	GetNonce() uint64
+	GetBalance() *big.Int
+	GetHumanReadable() bool
+
+	SetNonce(n uint64)
+	SetBalance(b *big.Int)
+	SetHumanReadable(b bool)
+
+	// UpdateKey updates the account's key with the given key.
+	UpdateKey(newKey accountkey.AccountKey, currentBlockNumber uint64) error
+
+	// Empty returns whether the account is considered empty.
+	// The "empty" account may be defined differently depending on the actual account type.
+	// An example of an empty account could be described as the one that satisfies the following conditions:
+	// - nonce is zero
+	// - balance is zero
+	// - codeHash is the same as emptyCodeHash
+	Empty() bool
+
+	// Equal returns true if all the attributes are exactly same. Otherwise, returns false.
+	Equal(Account) bool
+
+	// DeepCopy copies all the attributes.
+	DeepCopy() Account
+
+	// String returns all attributes of this object as a string.
+	String() string
+}
+
+//account_serializer.go
+//
+// AccountSerializer serializes an Account object using RLP/JSON.
+type AccountLHSerializer struct {
+	accType AccountType
+	account AccountLH
+}
+
+// accountJSON is an internal data structure for JSON serialization.
+type accountLHJSON struct {
+	AccType AccountType     `json:"accType"`
+	Account json.RawMessage `json:"account"`
+}
+
+// NewAccountSerializer creates a new AccountSerializer object with default values.
+// This returned object will be used for decoding.
+func NewAccountLHSerializer() *AccountLHSerializer {
+	return &AccountLHSerializer{}
+}
+
+func (ser *AccountLHSerializer) DecodeRLP(s *rlp.Stream) error {
+	if err := s.Decode(&ser.accType); err != nil {
+		// fallback to decoding a LegacyAccount object.
+		acc := newLegacyAccountLH()
+		if err := s.Decode(acc); err != nil {
+			return err
+		}
+		ser.accType = LegacyAccountType
+		ser.account = acc
+		return nil
+	}
+
+	var err error
+	ser.account, err = NewAccountLHWithType(ser.accType)
+	if err != nil {
+		return err
+	}
+
+	return s.Decode(ser.account)
+}
+
+func (ser *AccountLHSerializer) Copy() (eser *AccountSerializer) {
+	return &AccountSerializer{
+		accType: ser.accType,
+		account: ser.account.DeepCopy(),
+	}
+	/*
+		        switch eser.accType {
+		        case LegacyAccountType:
+				eser.account = ser.account.DeepCopy()
+		        case ExternallyOwnedAccountType:
+				eser.account = ser.account.DeepCopy()
+		        case SmartContractAccountType:
+				eser.account = ser.account.DeepCopy()
+		        }*/
+}
+
+/*
+// account_common.go
+//
+// AccountCommon represents the common data structure of a Klaytn account.
+type AccountLHCommon struct {
+        nonce         uint64
+        balance       *big.Int
+        humanReadable bool
+        key           accountkey.AccountKey
+}
+
+// accountCommonSerializable is an internal data structure for RLP serialization.
+// This object is required due to AccountKey.
+// AccountKey is an interface and it requires to use AccountKeySerializer for serialization.
+type accountLHCommonSerializable struct {
+        Nonce         uint64
+        Balance       *big.Int
+        HumanReadable bool
+        Key           *accountkey.AccountKeySerializer
+}
+
+// newAccountCommon creates an AccountCommon object with default values.
+func newAccountLHCommon() *AccountLHCommon {
+        return &AccountLHCommon{
+                nonce:         0,
+                balance:       new(big.Int),
+                humanReadable: false,
+                key:           accountkey.NewAccountKeyLegacy(),
+        }
+}
+
+func (e *AccountLHCommon) DecodeRLP(s *rlp.Stream) error {
+        serialized := newAccountLHCommonSerializable()
+
+        if err := s.Decode(serialized); err != nil {
+                return err
+        }
+        e.fromSerializable(serialized)
+        return nil
+}
+
+func newAccountLHCommonSerializable() *accountLHCommonSerializable {
+        return &accountLHCommonSerializable{
+                Balance: new(big.Int),
+                Key:     accountkey.NewAccountKeySerializer(),
+        }
+}
+
+// fromSerializable updates its values from the given accountCommonSerializable object.
+func (e *AccountLHCommon) fromSerializable(o *accountLHCommonSerializable) {
+        e.nonce = o.Nonce
+        e.balance = o.Balance
+        e.humanReadable = o.HumanReadable
+        e.key = o.Key.GetKey()
+}
+*/
+
+// legacy_account.go
+//
+// LegacyAccount is the Klaytn consensus representation of legacy accounts.
+// These objects are stored in the main account trie.
+type LegacyAccountLH struct {
+	Nonce    uint64
+	Balance  *big.Int
+	Root     common.Hash // merkle root of the storage trie
+	CodeHash []byte
+}
+
+// newLegacyAccount returns a LegacyAccount object whose all
+// attributes are initialized.
+// This object is used when an account is created.
+// Refer to StateDB.createObject().
+func newLegacyAccountLH() *LegacyAccountLH {
+	logger.CritWithStack("Legacy account is deprecated.")
+	return &LegacyAccountLH{
+		0, new(big.Int), common.Hash{}, emptyCodeHash,
+	}
+}
+
+func (a *LegacyAccountLH) DeepCopy() Account {
+	return &LegacyAccount{
+		Nonce:    a.Nonce,
+		Balance:  a.Balance,
+		Root:     common.BytesLegacyToExtHash(a.Root.Bytes()),
+		CodeHash: a.CodeHash,
+	}
+}
+
+func (a *LegacyAccountLH) Type() AccountType       { return 0 }
+func (a *LegacyAccountLH) GetNonce() uint64        { return 0 }
+func (a *LegacyAccountLH) GetBalance() *big.Int    { return big.NewInt(0) }
+func (a *LegacyAccountLH) GetHumanReadable() bool  { return false }
+func (a *LegacyAccountLH) SetNonce(n uint64)       { return }
+func (a *LegacyAccountLH) SetBalance(b *big.Int)   { return }
+func (a *LegacyAccountLH) SetHumanReadable(b bool) { return }
+func (a *LegacyAccountLH) UpdateKey(newKey accountkey.AccountKey, currentBlockNumber uint64) error {
+	return nil
+}
+func (a *LegacyAccountLH) Empty() bool        { return false }
+func (a *LegacyAccountLH) Equal(Account) bool { return false }
+
+//func (a *LegacyAccountLH) DeepCopy() Account { return nil }
+func (a *LegacyAccountLH) String() string { return "Not Implemented" }
+
+// externally_owned_account.go
+//
+// ExternallyOwnedAccount represents a Klaytn account used by a user.
+/*type ExternallyOwnedAccountLH struct {
+        *AccountLHCommon
+}
+
+// newExternallyOwnedAccount creates an ExternallyOwnedAccount object with default values.
+func newExternallyOwnedAccountLH() *ExternallyOwnedAccountLH {
+        return &ExternallyOwnedAccountLH{
+                newAccountLHCommon(),
+        }
+}*/
+
+// smart_contract_account.go
+//
+// SmartContractAccount represents a smart contract account containing
+// storage root and code hash.
+type SmartContractAccountLH struct {
+	//aaa *AccountLHCommon
+	*AccountCommon
+	storageRoot common.Hash // merkle root of the storage trie
+	codeHash    []byte
+	codeInfo    params.CodeInfo // consists of two information, vmVersion and codeFormat
+}
+
+// smartContractAccountSerializable is an internal data structure for RLP serialization.
+// This structure inherits accountCommonSerializable.
+type smartContractAccountLHSerializable struct {
+	//aaa CommonSerializable *accountLHCommonSerializable
+	CommonSerializable *accountCommonSerializable
+	StorageRoot        common.Hash
+	CodeHash           []byte
+	CodeInfo           params.CodeInfo
+}
+
+func newSmartContractAccountLH() *SmartContractAccountLH {
+	return &SmartContractAccountLH{
+		//aaa newAccountLHCommon(),
+		newAccountCommon(),
+		//common.InitExtHash(),
+		common.Hash{},
+		emptyCodeHash,
+		params.CodeInfo(0),
+	}
+}
+func (sca *SmartContractAccountLH) fromSerializable(o *smartContractAccountLHSerializable) {
+	//aaa sca.AccountLHCommon.fromSerializable(o.CommonSerializable)
+	sca.AccountCommon.fromSerializable(o.CommonSerializable)
+	sca.storageRoot = o.StorageRoot
+	sca.codeHash = o.CodeHash
+	sca.codeInfo = o.CodeInfo
+}
+
+func (sca *SmartContractAccountLH) DecodeRLP(s *rlp.Stream) error {
+	serialized := &smartContractAccountLHSerializable{
+		//aaa newAccountLHCommonSerializable(),
+		newAccountCommonSerializable(),
+		//common.InitExtHash(),
+		common.Hash{},
+		[]byte{},
+		params.CodeInfo(0),
+	}
+
+	if err := s.Decode(serialized); err != nil {
+		return err
+	}
+
+	sca.fromSerializable(serialized)
+
+	return nil
+}
+
+func (a *SmartContractAccountLH) DeepCopy() Account {
+	return &SmartContractAccount{
+		AccountCommon: a.AccountCommon.DeepCopy(),
+		storageRoot:   common.BytesLegacyToExtHash(a.storageRoot.Bytes()),
+		codeHash:      a.codeHash,
+		codeInfo:      a.codeInfo,
+	}
+}
+
+func (a *SmartContractAccountLH) Type() AccountType       { return 0 }
+func (a *SmartContractAccountLH) GetNonce() uint64        { return 0 }
+func (a *SmartContractAccountLH) GetBalance() *big.Int    { return big.NewInt(0) }
+func (a *SmartContractAccountLH) GetHumanReadable() bool  { return false }
+func (a *SmartContractAccountLH) SetNonce(n uint64)       { return }
+func (a *SmartContractAccountLH) SetBalance(b *big.Int)   { return }
+func (a *SmartContractAccountLH) SetHumanReadable(b bool) { return }
+func (a *SmartContractAccountLH) UpdateKey(newKey accountkey.AccountKey, currentBlockNumber uint64) error {
+	return nil
+}
+func (a *SmartContractAccountLH) Empty() bool        { return false }
+func (a *SmartContractAccountLH) Equal(Account) bool { return false }
+
+//func (a *SmartContractAccountLH) DeepCopy() Account { return nil }
+func (a *SmartContractAccountLH) String() string { return "Not implemented" }

--- a/blockchain/types/account/legacy_account.go
+++ b/blockchain/types/account/legacy_account.go
@@ -31,7 +31,7 @@ import (
 type LegacyAccount struct {
 	Nonce    uint64
 	Balance  *big.Int
-	Root     common.Hash // merkle root of the storage trie
+	Root     common.ExtHash // merkle root of the storage trie
 	CodeHash []byte
 }
 
@@ -48,7 +48,7 @@ func newEmptyLegacyAccount() *LegacyAccount {
 func newLegacyAccount() *LegacyAccount {
 	logger.CritWithStack("Legacy account is deprecated.")
 	return &LegacyAccount{
-		0, new(big.Int), common.Hash{}, emptyCodeHash,
+		0, new(big.Int), common.InitExtHash(), emptyCodeHash,
 	}
 }
 
@@ -63,7 +63,7 @@ func newLegacyAccountWithMap(values map[AccountValueKeyType]interface{}) *Legacy
 		acc.Balance.Set(v)
 	}
 
-	if v, ok := values[AccountValueKeyStorageRoot].(common.Hash); ok {
+	if v, ok := values[AccountValueKeyStorageRoot].(common.ExtHash); ok {
 		acc.Root = v
 	}
 
@@ -91,7 +91,7 @@ func (a *LegacyAccount) GetHumanReadable() bool {
 	return false
 }
 
-func (a *LegacyAccount) GetStorageRoot() common.Hash {
+func (a *LegacyAccount) GetStorageRoot() common.ExtHash {
 	return a.Root
 }
 
@@ -113,7 +113,7 @@ func (a *LegacyAccount) SetHumanReadable(b bool) {
 		"callstack", stack.Caller(0).String())
 }
 
-func (a *LegacyAccount) SetStorageRoot(h common.Hash) {
+func (a *LegacyAccount) SetStorageRoot(h common.ExtHash) {
 	a.Root = h
 }
 

--- a/blockchain/types/account/smart_contract_account.go
+++ b/blockchain/types/account/smart_contract_account.go
@@ -34,7 +34,7 @@ import (
 // storage root and code hash.
 type SmartContractAccount struct {
 	*AccountCommon
-	storageRoot common.Hash // merkle root of the storage trie
+	storageRoot common.ExtHash // merkle root of the storage trie
 	codeHash    []byte
 	codeInfo    params.CodeInfo // consists of two information, vmVersion and codeFormat
 }
@@ -43,7 +43,7 @@ type SmartContractAccount struct {
 // This structure inherits accountCommonSerializable.
 type smartContractAccountSerializable struct {
 	CommonSerializable *accountCommonSerializable
-	StorageRoot        common.Hash
+	StorageRoot        common.ExtHash
 	CodeHash           []byte
 	CodeInfo           params.CodeInfo
 }
@@ -53,7 +53,7 @@ type smartContractAccountSerializableJSON struct {
 	Balance       *hexutil.Big                     `json:"balance"`
 	HumanReadable bool                             `json:"humanReadable"`
 	Key           *accountkey.AccountKeySerializer `json:"key"`
-	StorageRoot   common.Hash                      `json:"storageRoot"`
+	StorageRoot   common.ExtHash                   `json:"storageRoot"`
 	CodeHash      []byte                           `json:"codeHash"`
 	CodeFormat    params.CodeFormat                `json:"codeFormat"`
 	VmVersion     params.VmVersion                 `json:"vmVersion"`
@@ -62,7 +62,7 @@ type smartContractAccountSerializableJSON struct {
 func newSmartContractAccount() *SmartContractAccount {
 	return &SmartContractAccount{
 		newAccountCommon(),
-		common.Hash{},
+		common.InitExtHash(),
 		emptyCodeHash,
 		params.CodeInfo(0),
 	}
@@ -71,12 +71,12 @@ func newSmartContractAccount() *SmartContractAccount {
 func newSmartContractAccountWithMap(values map[AccountValueKeyType]interface{}) *SmartContractAccount {
 	sca := &SmartContractAccount{
 		newAccountCommonWithMap(values),
-		common.Hash{},
+		common.InitExtHash(),
 		emptyCodeHash,
 		params.CodeInfo(0),
 	}
 
-	if v, ok := values[AccountValueKeyStorageRoot].(common.Hash); ok {
+	if v, ok := values[AccountValueKeyStorageRoot].(common.ExtHash); ok {
 		sca.storageRoot = v
 	}
 
@@ -120,7 +120,7 @@ func (sca *SmartContractAccount) EncodeRLP(w io.Writer) error {
 func (sca *SmartContractAccount) DecodeRLP(s *rlp.Stream) error {
 	serialized := &smartContractAccountSerializable{
 		newAccountCommonSerializable(),
-		common.Hash{},
+		common.InitExtHash(),
 		[]byte{},
 		params.CodeInfo(0),
 	}
@@ -169,7 +169,7 @@ func (sca *SmartContractAccount) Type() AccountType {
 	return SmartContractAccountType
 }
 
-func (sca *SmartContractAccount) GetStorageRoot() common.Hash {
+func (sca *SmartContractAccount) GetStorageRoot() common.ExtHash {
 	return sca.storageRoot
 }
 
@@ -185,7 +185,7 @@ func (sca *SmartContractAccount) GetVmVersion() params.VmVersion {
 	return sca.codeInfo.GetVmVersion()
 }
 
-func (sca *SmartContractAccount) SetStorageRoot(h common.Hash) {
+func (sca *SmartContractAccount) SetStorageRoot(h common.ExtHash) {
 	sca.storageRoot = h
 }
 

--- a/blockchain/vm/gas_table.go
+++ b/blockchain/vm/gas_table.go
@@ -100,13 +100,13 @@ var (
 func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	var (
 		y, x    = stack.Back(1), stack.Back(0)
-		current = evm.StateDB.GetState(contract.Address(), common.BigToHash(x))
+		current = evm.StateDB.GetState(contract.Address(), common.BigToRootExtHash(x))
 	)
 	// This checks for 3 scenario's and calculates gas accordingly
 	// 1. From a zero-value address to a non-zero value         (NEW VALUE)
 	// 2. From a non-zero value address to a zero-value address (DELETE)
 	// 3. From a non-zero to a non-zero                         (CHANGE)
-	isOldEmpty := common.EmptyHash(current)
+	isOldEmpty := common.EmptyHash(current.ToHash())
 	isNewEmpty := common.EmptyHash(common.BigToHash(y))
 	if isOldEmpty && !isNewEmpty {
 		// 0 => non 0
@@ -121,19 +121,19 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	}
 }
 
-// 0. If *gasleft* is less than or equal to 2300, fail the current call.
-// 1. If current value equals new value (this is a no-op), SLOAD_GAS is deducted.
-// 2. If current value does not equal new value:
-//   2.1. If original value equals current value (this storage slot has not been changed by the current execution context):
+//  0. If *gasleft* is less than or equal to 2300, fail the current call.
+//  1. If current value equals new value (this is a no-op), SLOAD_GAS is deducted.
+//  2. If current value does not equal new value:
+//     2.1. If original value equals current value (this storage slot has not been changed by the current execution context):
 //     2.1.1. If original value is 0, SSTORE_SET_GAS (20K) gas is deducted.
 //     2.1.2. Otherwise, SSTORE_RESET_GAS gas is deducted. If new value is 0, add SSTORE_CLEARS_SCHEDULE to refund counter.
-//   2.2. If original value does not equal current value (this storage slot is dirty), SLOAD_GAS gas is deducted. Apply both of the following clauses:
+//     2.2. If original value does not equal current value (this storage slot is dirty), SLOAD_GAS gas is deducted. Apply both of the following clauses:
 //     2.2.1. If original value is not 0:
-//       2.2.1.1. If current value is 0 (also means that new value is not 0), subtract SSTORE_CLEARS_SCHEDULE gas from refund counter.
-//       2.2.1.2. If new value is 0 (also means that current value is not 0), add SSTORE_CLEARS_SCHEDULE gas to refund counter.
+//     2.2.1.1. If current value is 0 (also means that new value is not 0), subtract SSTORE_CLEARS_SCHEDULE gas from refund counter.
+//     2.2.1.2. If new value is 0 (also means that current value is not 0), add SSTORE_CLEARS_SCHEDULE gas to refund counter.
 //     2.2.2. If original value equals new value (this storage slot is reset):
-//       2.2.2.1. If original value is 0, add SSTORE_SET_GAS - SLOAD_GAS to refund counter.
-//       2.2.2.2. Otherwise, add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter.
+//     2.2.2.1. If original value is 0, add SSTORE_SET_GAS - SLOAD_GAS to refund counter.
+//     2.2.2.2. Otherwise, add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter.
 func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	// If we fail the minimum gas availability invariant, fail (0)
 	if contract.Gas <= params.SstoreSentryGasEIP2200 {
@@ -142,14 +142,14 @@ func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
 	var (
 		y, x    = stack.Back(1), stack.Back(0)
-		current = evm.StateDB.GetState(contract.Address(), common.BigToHash(x))
+		current = evm.StateDB.GetState(contract.Address(), common.BigToRootExtHash(x)).ToHash()
 	)
-	value := common.BigToHash(y)
+	value := common.BigToRootExtHash(y).ToHash()
 
 	if current == value { // noop (1)
 		return params.SloadGasEIP2200, nil
 	}
-	original := evm.StateDB.GetCommittedState(contract.Address(), common.BigToHash(x))
+	original := evm.StateDB.GetCommittedState(contract.Address(), common.BigToRootExtHash(x)).ToHash()
 	if original == current {
 		if original == (common.Hash{}) { // create slot (2.1.1)
 			return params.SstoreSetGasEIP2200, nil

--- a/blockchain/vm/interface.go
+++ b/blockchain/vm/interface.go
@@ -54,9 +54,9 @@ type StateDB interface {
 	SubRefund(uint64)
 	GetRefund() uint64
 
-	GetCommittedState(common.Address, common.Hash) common.Hash
-	GetState(common.Address, common.Hash) common.Hash
-	SetState(common.Address, common.Hash, common.Hash)
+	GetCommittedState(common.Address, common.ExtHash) common.ExtHash
+	GetState(common.Address, common.ExtHash) common.ExtHash
+	SetState(common.Address, common.ExtHash, common.ExtHash)
 
 	Suicide(common.Address) bool
 	HasSuicided(common.Address) bool
@@ -85,14 +85,14 @@ type StateDB interface {
 	Snapshot() int
 
 	AddLog(*types.Log)
-	AddPreimage(common.Hash, []byte)
+	AddPreimage(common.ExtHash, []byte)
 
 	// IsProgramAccount returns true if the account implements ProgramAccount.
 	IsProgramAccount(address common.Address) bool
 	IsContractAvailable(address common.Address) bool
 	IsValidCodeFormat(addr common.Address) bool
 
-	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool)
+	ForEachStorage(common.Address, func(common.ExtHash, common.ExtHash) bool)
 
 	GetTxHash() common.Hash
 

--- a/blockchain/vm/operations_acl.go
+++ b/blockchain/vm/operations_acl.go
@@ -34,15 +34,15 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		// Gas sentry honoured, do the actual gas calculation based on the stored value
 		var (
 			y, x    = stack.Back(1), stack.Peek()
-			slot    = common.BigToHash(x)
-			current = evm.StateDB.GetState(contract.Address(), slot)
+			slot    = common.BigToRootExtHash(x)
+			current = evm.StateDB.GetState(contract.Address(), slot).ToHash()
 			cost    = uint64(0)
 		)
 		// Check slot presence in the access list
-		if addrPresent, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {
+		if addrPresent, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot.ToHash()); !slotPresent {
 			cost = params.ColdSloadCostEIP2929
 			// If the caller cannot afford the cost, this change will be rolled back
-			evm.StateDB.AddSlotToAccessList(contract.Address(), slot)
+			evm.StateDB.AddSlotToAccessList(contract.Address(), slot.ToHash())
 			if !addrPresent {
 				// Once we're done with YOLOv2 and schedule this for mainnet, might
 				// be good to remove this panic here, which is just really a
@@ -50,14 +50,14 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 				panic("impossible case: address was not present in access list during sstore op")
 			}
 		}
-		value := common.BigToHash(y)
+		value := common.BigToRootExtHash(y).ToHash()
 
 		if current == value { // noop (1)
 			// EIP 2200 original clause:
 			//		return params.SloadGasEIP2200, nil
 			return cost + params.WarmStorageReadCostEIP2929, nil // SLOAD_GAS
 		}
-		original := evm.StateDB.GetCommittedState(contract.Address(), common.BigToHash(x))
+		original := evm.StateDB.GetCommittedState(contract.Address(), common.BigToRootExtHash(x)).ToHash()
 		if original == current {
 			if original == (common.Hash{}) { // create slot (2.1.1)
 				return cost + params.SstoreSetGasEIP2200, nil

--- a/common/exthash_filter.go
+++ b/common/exthash_filter.go
@@ -1,0 +1,304 @@
+package common
+
+import (
+	"errors"
+)
+
+type rlpDS struct {
+	kind   uint8
+	data   []byte
+	length int
+}
+
+func RlpPaddingFilter(src []byte) (reRlp []byte, err error) {
+	if len(src) <= 32 {
+		return src, err
+	}
+
+	obj, err := rlpDecodeStructure(src)
+	if err != nil {
+		return src, nil
+	}
+
+	for _, v := range obj {
+		reRlp = append(reRlp, v.data...)
+	}
+	//fmt.Printf("\n")
+
+	return reRlp, err
+}
+
+func rlpCheckHeader(src []byte) (err error) {
+	var totalLen int
+
+	strLen := len(src)
+
+	switch {
+	case src[0] == 0x80:
+		totalLen, err = 1, nil
+	case src[0] < 0x80:
+		_, _, totalLen, err = parseHeader(src, 1)
+	case src[0] < 0xb8:
+		_, _, totalLen, err = parseHeader(src, 2)
+	case src[0] < 0xc0:
+		_, _, totalLen, err = parseHeader(src, 3)
+	case src[0] < 0xf8:
+		_, _, totalLen, err = parseHeader(src, 4)
+	default:
+		_, _, totalLen, err = parseHeader(src, 5)
+	}
+	if strLen != totalLen {
+		err = errors.New("rlp decode length error at simple RLP CheckHeader")
+	}
+	return err
+}
+
+func rlpDecodeStructure(src []byte) (reObj []rlpDS, err error) {
+	var obj rlpDS
+
+	tmpLen := 0
+	for i := 0; i < len(src); {
+		switch {
+		case src[i] == 0x80:
+			obj.kind = 0
+			obj.data, obj.length, tmpLen, err = src[i:i+1], 1, 1, nil
+		case src[i] < 0x80:
+			obj.kind = 1
+			obj.data, obj.length, tmpLen, err = rule1parse(src[i:])
+		case src[i] < 0xb8:
+			obj.kind = 2
+			obj.data, obj.length, tmpLen, err = rule2parse(src[i:])
+		case src[i] < 0xc0:
+			obj.kind = 2
+			obj.data, obj.length, tmpLen, err = rule3parse(src[i:])
+		case src[i] < 0xf8:
+			obj.kind = 3
+			obj.data, obj.length, tmpLen, err = rule4parse(src[i:])
+		default:
+			obj.kind = 3
+			obj.data, obj.length, tmpLen, err = rule5parse(src[i:])
+		}
+		if err != nil {
+			break
+		}
+
+		reObj = append(reObj, obj)
+		i += tmpLen
+	}
+	return reObj, err
+}
+
+func rule1parse(src []byte) (reStr []byte, reLen, totalLen int, err error) {
+	totalLen = 0
+	srcLen := len(src)
+	for ; totalLen < srcLen && src[totalLen] < 0x80; totalLen += 1 {
+	}
+
+	tmpStr := src[:totalLen]
+	reLen = len(tmpStr)
+
+	reStr = append(reStr, tmpStr[:]...)
+	reLen = len(tmpStr)
+	return reStr, reLen, totalLen, err
+}
+
+func rule2parse(src []byte) (reStr []byte, reLen int, totalLen int, err error) {
+
+	dataIdx, _, totalLen, err := parseHeader(src, 2)
+	if err != nil {
+		return reStr, reLen, totalLen, err
+	}
+
+	tmpStr := ExtPaddingFilter(src[dataIdx:totalLen])
+	reStr, reLen = makepacket(tmpStr, 2)
+
+	return reStr, reLen, totalLen, err
+}
+
+//reLen : padding 제거된후 전체 길이
+//totalLen : 원래 전체 길이
+func rule3parse(src []byte) (reStr []byte, reLen, totalLen int, err error) {
+
+	dataIdx, _, totalLen, err := parseHeader(src, 3)
+	if err != nil {
+		return reStr, reLen, totalLen, err
+	}
+
+	tmpStr := ExtPaddingFilter(src[dataIdx:totalLen])
+	reStr, reLen = makepacket(tmpStr, 3)
+
+	return reStr, reLen, totalLen, err
+}
+
+func rule4parse(src []byte) (reStr []byte, reLen, totalLen int, err error) {
+	var tmpPacket, tmpReStr []byte
+	var packetList [][]byte
+	var tmpPacketLen int
+
+	dataIdx, _, totalLen, err := parseHeader(src, 4)
+	if err != nil {
+		return reStr, reLen, totalLen, err
+	}
+
+	tmpReLen, tmpTotalLen := int(0), int(0)
+	for i := dataIdx; i < totalLen; {
+		switch {
+		case src[i] == 0x80:
+			tmpReStr, tmpReLen, tmpTotalLen, err = src[i:i+1], 1, 1, nil
+		case src[i] < 0x80:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule1parse(src[i:])
+		case src[i] < 0xb8:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule2parse(src[i:])
+		case src[i] < 0xc0:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule3parse(src[i:])
+		case src[i] < 0xf8:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule4parse(src[i:])
+		default:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule5parse(src[i:])
+		}
+		if err != nil || i+tmpTotalLen > totalLen {
+			return src[:totalLen], totalLen, totalLen, nil
+		}
+
+		packetList = append(packetList, tmpReStr)
+		tmpPacket = append(tmpPacket, tmpReStr[:]...)
+		tmpPacketLen += tmpReLen
+		i += tmpTotalLen
+	}
+	reStr, reLen = makepacket(tmpPacket, 4)
+
+	return reStr, reLen, totalLen, err
+}
+
+func rule5parse(src []byte) (reStr []byte, reLen, totalLen int, err error) {
+	var tmpPacket, tmpReStr []byte
+	//var packetList [][]byte
+	var tmpPacketLen int
+
+	dataIdx, _, totalLen, err := parseHeader(src, 5)
+	if err != nil {
+		return reStr, reLen, totalLen, err
+	}
+
+	for i := dataIdx; i < totalLen; {
+		tmpReLen, tmpTotalLen := int(0), int(0)
+		switch {
+		case src[i] == 0x80:
+			tmpReStr, tmpReLen, tmpTotalLen, err = src[i:i+1], 1, 1, nil
+		case src[i] < 0x80:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule1parse(src[i:])
+		case src[i] < 0xb8:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule2parse(src[i:])
+		case src[i] < 0xc0:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule3parse(src[i:])
+		case src[i] < 0xf8:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule4parse(src[i:])
+		default:
+			tmpReStr, tmpReLen, tmpTotalLen, err = rule5parse(src[i:])
+		}
+		if err != nil || i+tmpTotalLen > totalLen {
+			return src[:totalLen], totalLen, totalLen, nil
+		}
+
+		tmpPacket = append(tmpPacket, tmpReStr[:]...)
+		tmpPacketLen += tmpReLen
+		i += tmpTotalLen
+	}
+	reStr, reLen = makepacket(tmpPacket, 5)
+
+	return reStr, reLen, totalLen, err
+}
+
+func parseHeader(src []byte, flag int) (dataIdx, dataLen, totalLen int, err error) {
+	var hexIdx int
+	srcLen := len(src)
+	if srcLen < 1 {
+		err = errors.New("rlp decode length too small - 1... at simple RLP Decoder")
+		return dataIdx, dataLen, totalLen, err
+	}
+
+	switch {
+	case flag == 2 || flag == 4:
+		if flag == 2 {
+			hexIdx = 0x80
+		} else {
+			hexIdx = 0xc0
+		}
+
+		dataLen = int(src[0]) - hexIdx
+		totalLen = dataLen + 1
+		dataIdx = 1
+	case flag == 3 || flag == 5:
+		if flag == 3 {
+			hexIdx = 0xb7
+		} else {
+			hexIdx = 0xf7
+		}
+
+		if srcLen < int(src[0])-hexIdx {
+			err = errors.New("rlp decode length too small - 2... at simple RLP Decoder")
+			return dataIdx, dataLen, totalLen, err
+		}
+		i := 1
+		for ; i < srcLen && i <= int(src[0])-hexIdx; i += 1 {
+			dataLen *= 0x100
+			dataLen += int(src[i])
+		}
+		totalLen = dataLen + i
+		dataIdx = i
+	}
+	if totalLen > srcLen || dataLen > srcLen || dataLen <= 0 || dataIdx == totalLen {
+		err = errors.New("rlp decode length error at simple RLP Decoder")
+	} else if (hexIdx == 0x80 && dataLen >= 55) || (hexIdx == 0xb7 && dataLen < 55) || (hexIdx == 0xc0 && dataLen >= 55) || (hexIdx == 0xf7 && dataLen < 55) {
+		err = errors.New("rlp decode length error at simple RLP Decoder")
+	}
+	return dataIdx, dataLen, totalLen, err
+}
+
+func makepacket(data []byte, flag int) (packet []byte, packetLen int) {
+	var tmpByte byte
+	var procData []byte
+	var tmpHeader []byte
+
+	if tmpData, err := RlpPaddingFilter(data); err == nil {
+		procData = tmpData
+	} else {
+		procData = data
+	}
+	dataLen := len(procData)
+
+	if dataLen <= 55 {
+		if flag == 2 {
+			tmpByte = uint8(0x80 + dataLen)
+		} else { //4
+			tmpByte = uint8(0xc0 + dataLen)
+		}
+		packet = append(packet, tmpByte)
+		packet = append(packet, procData[:dataLen]...)
+	} else {
+		div := 0xffffff
+		dlen := dataLen
+		for ; div >= 0; div /= 0x100 {
+			if dlen > div && div > 0 {
+				tmpByte = uint8(dlen / div)
+				tmpHeader = append(tmpHeader, tmpByte)
+				div %= (div + 1)
+			} else if div == 0 {
+				tmpByte = uint8(dlen)
+				tmpHeader = append(tmpHeader, tmpByte)
+				break
+			}
+		}
+		tmpHeaderLen := len(tmpHeader)
+		if flag == 3 {
+			tmpByte = uint8(0xb7 + tmpHeaderLen)
+		} else { //5
+			tmpByte = uint8(0xf7 + tmpHeaderLen)
+		}
+		packet = append(packet, tmpByte)
+		packet = append(packet, tmpHeader...)
+		packet = append(packet, procData[:dataLen]...)
+	}
+	packetLen = len(packet)
+	return packet, packetLen
+}

--- a/common/exthash_filter_test.go
+++ b/common/exthash_filter_test.go
@@ -1,0 +1,140 @@
+// Modifications Copyright 2018 The klaytn Authors
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from common/types_test.go (2018/06/04).
+// Modified and improved for the klaytn development.
+
+package common
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestFiltersCase1(t *testing.T) {
+
+	srcStr, answer := []byte("f8729e20fb89cf6444214fbeec19fa56fb55644b3d95cd60b2db025a0a9a3d0bcfb85101f84e02808005f848a302a10241648c5a079203f35708ba25630dee558dcffd6cc0a03d2d8903c595455154b8a302a102748fe1aa2f0670f02a82934c2e0fbe691455a845fcdbf053ffa14b38a8f93a9f"), []byte("f8729e20fb89cf6444214fbeec19fa56fb55644b3d95cd60b2db025a0a9a3d0bcfb85101f84e02808005f848a302a10241648c5a079203f35708ba25630dee558dcffd6cc0a03d2d8903c595455154b8a302a102748fe1aa2f0670f02a82934c2e0fbe691455a845fcdbf053ffa14b38a8f93a9f")
+
+	dst := make([]byte, hex.DecodedLen(len(srcStr)))
+	n, _ := hex.Decode(dst, srcStr)
+
+	reAns := make([]byte, hex.DecodedLen(len(answer)))
+	n2, _ := hex.Decode(reAns, answer)
+
+	reStr, _ := RlpPaddingFilter(dst[:n])
+
+	if !bytes.Equal(reAns[:n2], reStr) {
+		t.Errorf("Expected %x got %x", reAns[:n2], reStr)
+	}
+}
+
+func TestFiltersCase3(t *testing.T) {
+
+	srcStr, answer := []byte("f8729e3aa21f22bb1d06ffd3052056f424f5a75c897909bf19054f5c5faef94ba4b85101f84e02808005f848a302a10284d9016c570bd864eaa2621c482acf9a8109a8bbd315369029b6433a6d591a6fa302a102748fe1aa2f0670f02a82934c2e0fbe691455a845fcdbf053ffa14b38a8f93a9f"), []byte("f8729e3aa21f22bb1d06ffd3052056f424f5a75c897909bf19054f5c5faef94ba4b85101f84e02808005f848a302a10284d9016c570bd864eaa2621c482acf9a8109a8bbd315369029b6433a6d591a6fa302a102748fe1aa2f0670f02a82934c2e0fbe691455a845fcdbf053ffa14b38a8f93a9f")
+	dst := make([]byte, hex.DecodedLen(len(srcStr)))
+	n, _ := hex.Decode(dst, srcStr)
+
+	reAns := make([]byte, hex.DecodedLen(len(answer)))
+	n2, _ := hex.Decode(reAns, answer)
+
+	reStr, _ := RlpPaddingFilter(dst[:n])
+
+	if !bytes.Equal(reAns[:n2], reStr) {
+		t.Errorf("Expected %x got %x", reAns[:n2], reStr)
+	}
+}
+
+func TestFiltersCase4(t *testing.T) {
+
+	srcStr, answer := []byte("f8729e379923746b521cba3a25830d3c5c7c4eca96f39c4eb50d055302c6adc5bbb85101f84e02808005f848a302a1021bf80c2bb3766fe0ad90dd3838a6d37fc4e8d99ee5ca2756daf0c8a1a02ea7c7a302a102748fe1aa2f0670f02a82934c2e0fbe691455a845fcdbf053ffa14b38a8f93a9f"), []byte("f8729e379923746b521cba3a25830d3c5c7c4eca96f39c4eb50d055302c6adc5bbb85101f84e02808005f848a302a1021bf80c2bb3766fe0ad90dd3838a6d37fc4e8d99ee5ca2756daf0c8a1a02ea7c7a302a102748fe1aa2f0670f02a82934c2e0fbe691455a845fcdbf053ffa14b38a8f93a9f")
+	dst := make([]byte, hex.DecodedLen(len(srcStr)))
+	n, _ := hex.Decode(dst, srcStr)
+
+	reAns := make([]byte, hex.DecodedLen(len(answer)))
+	n2, _ := hex.Decode(reAns, answer)
+
+	reStr, _ := RlpPaddingFilter(dst[:n])
+
+	if !bytes.Equal(reAns[:n2], reStr) {
+		t.Errorf("Expected %x got %x", reAns[:n2], reStr)
+	}
+}
+
+func TestFiltersCase5(t *testing.T) {
+
+	srcStr, answer := []byte("f8729e207ed723a0db1f98bfdf6ad39825aad0f8411ec118542883c9ca7b2b9f41b85101f84e02808005f848a302a103c73a7767c4294627455a4ad454fd5b0ec5cf4dbf9db0c1bd4ae3895ae754e3a8a302a102748fe1aa2f0670f02a82934c2e0fbe691455a845fcdbf053ffa14b38a8f93a9f"), []byte("f8729e207ed723a0db1f98bfdf6ad39825aad0f8411ec118542883c9ca7b2b9f41b85101f84e02808005f848a302a103c73a7767c4294627455a4ad454fd5b0ec5cf4dbf9db0c1bd4ae3895ae754e3a8a302a102748fe1aa2f0670f02a82934c2e0fbe691455a845fcdbf053ffa14b38a8f93a9f")
+	dst := make([]byte, hex.DecodedLen(len(srcStr)))
+	n, _ := hex.Decode(dst, srcStr)
+
+	reAns := make([]byte, hex.DecodedLen(len(answer)))
+	n2, _ := hex.Decode(reAns, answer)
+
+	reStr, _ := RlpPaddingFilter(dst[:n])
+
+	if !bytes.Equal(reAns[:n2], reStr) {
+		t.Errorf("Expected %x got %x", reAns[:n2], reStr)
+	}
+}
+
+func TestFiltersCase6(t *testing.T) {
+
+	srcStr, answer := []byte("03c73a7767c4294627455a4ad454fd5b0ec5cf4dbf9db0c1bd4ae3895ae754e3a8"), []byte("03c73a7767c4294627455a4ad454fd5b0ec5cf4dbf9db0c1bd4ae3895ae754e3a8")
+	dst := make([]byte, hex.DecodedLen(len(srcStr)))
+	n, _ := hex.Decode(dst, srcStr)
+
+	reAns := make([]byte, hex.DecodedLen(len(answer)))
+	n2, _ := hex.Decode(reAns, answer)
+
+	reStr, _ := RlpPaddingFilter(dst[:n])
+
+	if !bytes.Equal(reAns[:n2], reStr) {
+		t.Errorf("Expected %x got %x", reAns[:n2], reStr)
+	}
+}
+
+func TestFiltersCase8(t *testing.T) {
+
+	srcStr, answer := []byte("f8999e20cc9ef35b62b1335a9af34451a1c57fc07256f4df842497856bd6d808d9b87801f87501808004f86f02f86ce301a103d65fabd61151c76536b7a93f4c2731fd817f6c30f54e0d03b80631733847d121e301a103ef5bb9400ef6dfd55ec1924b3f9302064d132513af1852287aef7cfe850eb522e301a1024f450f9d909824f3a5726d586234398851d325006f0500bcc2f78dfbd92ccb72"), []byte("f8999e20cc9ef35b62b1335a9af34451a1c57fc07256f4df842497856bd6d808d9b87801f87501808004f86f02f86ce301a103d65fabd61151c76536b7a93f4c2731fd817f6c30f54e0d03b80631733847d121e301a103ef5bb9400ef6dfd55ec1924b3f9302064d132513af1852287aef7cfe850eb522e301a1024f450f9d909824f3a5726d586234398851d325006f0500bcc2f78dfbd92ccb72")
+	dst := make([]byte, hex.DecodedLen(len(srcStr)))
+	n, _ := hex.Decode(dst, srcStr)
+
+	reAns := make([]byte, hex.DecodedLen(len(answer)))
+	n2, _ := hex.Decode(reAns, answer)
+
+	reStr, _ := RlpPaddingFilter(dst[:n])
+
+	if !bytes.Equal(reAns[:n2], reStr) {
+		t.Errorf("Expected %x got %x", reAns[:n2], reStr)
+	}
+}
+
+func TestFiltersCase9(t *testing.T) {
+
+	srcStr, answer := []byte("03d65fabd61151c76536b7a93f4c2731fd817f6c30f54e0d03b80631733847d121"), []byte("03d65fabd61151c76536b7a93f4c2731fd817f6c30f54e0d03b80631733847d121")
+	dst := make([]byte, hex.DecodedLen(len(srcStr)))
+	n, _ := hex.Decode(dst, srcStr)
+
+	reAns := make([]byte, hex.DecodedLen(len(answer)))
+	n2, _ := hex.Decode(reAns, answer)
+
+	reStr, _ := RlpPaddingFilter(dst[:n])
+
+	if !bytes.Equal(reAns[:n2], reStr) {
+		t.Errorf("Expected %x got %x", reAns[:n2], reStr)
+	}
+}

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -572,7 +572,7 @@ func (c *Clique) Prepare(chain consensus.ChainReader, header *types.Header) erro
 // Finalize implements consensus.Engine and returns the final block.
 func (c *Clique) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt) (*types.Block, error) {
 	// No block rewards in PoA, so the state remains as is
-	header.Root = state.IntermediateRoot(true)
+	header.Root = state.IntermediateRoot(true).ToHash()
 
 	// Assemble and return the final block for sealing
 	return types.NewBlock(header, txs, receipts), nil

--- a/consensus/gxhash/consensus.go
+++ b/consensus/gxhash/consensus.go
@@ -398,7 +398,7 @@ func (gxhash *Gxhash) Prepare(chain consensus.ChainReader, header *types.Header)
 func (gxhash *Gxhash) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt) (*types.Block, error) {
 	// Accumulate any block rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header)
-	header.Root = state.IntermediateRoot(true)
+	header.Root = state.IntermediateRoot(true).ToHash()
 
 	// Header seems complete, assemble into a block and return
 	return types.NewBlock(header, txs, receipts), nil

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -505,7 +505,7 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 
 	reward.DistributeBlockReward(state, rewardSpec.Rewards)
 
-	header.Root = state.IntermediateRoot(true)
+	header.Root = state.IntermediateRoot(true).ToHash()
 
 	// Assemble and return the final block for sealing
 	return types.NewBlock(header, txs, receipts), nil

--- a/datasync/downloader/statesync.go
+++ b/datasync/downloader/statesync.go
@@ -457,13 +457,13 @@ func (s *stateSync) fillTasks(n int, req *stateReq) (nodes []common.Hash, paths 
 	if fill := n - (len(s.trieTasks) + len(s.codeTasks)); fill > 0 {
 		nodes, paths, codes := s.sched.Missing(fill)
 		for i, hash := range nodes {
-			s.trieTasks[hash] = &trieTask{
+			s.trieTasks[hash.ToHash()] = &trieTask{
 				path:     paths[i],
 				attempts: make(map[string]struct{}),
 			}
 		}
 		for _, hash := range codes {
-			s.codeTasks[hash] = &codeTask{
+			s.codeTasks[hash.ToHash()] = &codeTask{
 				attempts: make(map[string]struct{}),
 			}
 		}
@@ -592,7 +592,7 @@ func (s *stateSync) processNodeData(blob []byte) (common.Hash, error) {
 	s.keccak.Write(blob)
 	s.keccak.Sum(res.Hash[:0])
 	err := s.sched.Process(res)
-	return res.Hash, err
+	return res.Hash.ToHash(), err
 }
 
 // updateStats bumps the various state sync progress counters and displays a log

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/robertkrimen/otto v0.0.0-20180506084358-03d472dc43ab
 	github.com/rs/cors v1.7.0
 	github.com/satori/go.uuid v1.2.0
+	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 // indirect
 	github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570
 	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -325,7 +325,7 @@ func (api *PublicDebugAPI) DumpStateTrie(ctx context.Context, blockNrOrHash rpc.
 	}
 
 	db := state.NewDatabaseWithExistingCache(api.cn.chainDB, api.cn.blockchain.StateCache().TrieDB().TrieNodeCache())
-	stateDB, err := state.New(block.Root(), db, nil)
+	stateDB, err := state.New(block.Root().ToExtHash(), db, nil)
 	if err != nil {
 		return DumpStateTrieResult{}, err
 	}
@@ -496,11 +496,11 @@ func (api *PublicDebugAPI) GetModifiedAccountsByHash(startHash common.Hash, endH
 func (api *PublicDebugAPI) getModifiedAccounts(startBlock, endBlock *types.Block) ([]common.Address, error) {
 	trieDB := api.cn.blockchain.StateCache().TrieDB()
 
-	oldTrie, err := statedb.NewSecureTrie(startBlock.Root(), trieDB)
+	oldTrie, err := statedb.NewSecureTrie(startBlock.Root().ToExtHash(), trieDB)
 	if err != nil {
 		return nil, err
 	}
-	newTrie, err := statedb.NewSecureTrie(endBlock.Root(), trieDB)
+	newTrie, err := statedb.NewSecureTrie(endBlock.Root().ToExtHash(), trieDB)
 	if err != nil {
 		return nil, err
 	}
@@ -574,11 +574,11 @@ func (api *PublicDebugAPI) getModifiedStorageNodes(contractAddr common.Address, 
 	}
 
 	trieDB := api.cn.blockchain.StateCache().TrieDB()
-	oldTrie, err := statedb.NewSecureTrie(startBlockRoot, trieDB)
+	oldTrie, err := statedb.NewSecureTrie(startBlockRoot.ToExtHash(), trieDB)
 	if err != nil {
 		return 0, err
 	}
-	newTrie, err := statedb.NewSecureTrie(endBlockRoot, trieDB)
+	newTrie, err := statedb.NewSecureTrie(endBlockRoot.ToExtHash(), trieDB)
 	if err != nil {
 		return 0, err
 	}

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -935,7 +935,7 @@ func handleNodeDataRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	}
 	// Gather state data until the fetch or network limits is reached
 	var (
-		hash  common.Hash
+		hash  common.ExtHash
 		bytes int
 		data  [][]byte
 	)
@@ -948,7 +948,7 @@ func handleNodeDataRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		}
 		// Retrieve the requested state entry, stopping if enough was found
 		// TODO-Klaytn-Snapsync now the code and trienode is mixed in the protocol level, separate these two types.
-		entry, err := pm.blockchain.TrieNode(hash)
+		entry, err := pm.blockchain.TrieNode(hash.ToHash())
 		if len(entry) == 0 || err != nil {
 			// Read the contract code with prefix only to save unnecessary lookups.
 			entry, err = pm.blockchain.ContractCodeWithPrefix(hash)

--- a/node/cn/snap/handler.go
+++ b/node/cn/snap/handler.go
@@ -65,8 +65,8 @@ type Handler func(peer *Peer) error
 type SnapshotReader interface {
 	StateCache() state.Database
 	Snapshots() *snapshot.Tree
-	ContractCode(hash common.Hash) ([]byte, error)
-	ContractCodeWithPrefix(hash common.Hash) ([]byte, error)
+	ContractCode(hash common.ExtHash) ([]byte, error)
+	ContractCodeWithPrefix(hash common.ExtHash) ([]byte, error)
 }
 
 type SnapshotDownloader interface {
@@ -234,11 +234,11 @@ func ServiceGetAccountRangeQuery(chain SnapshotReader, req *GetAccountRangePacke
 	}
 	// TODO-Klaytn-SnapSync investigate the cache pollution
 	// Retrieve the requested state and bail out if non existent
-	tr, err := statedb.NewTrie(req.Root, chain.StateCache().TrieDB())
+	tr, err := statedb.NewTrie(req.Root.ToRootExtHash(), chain.StateCache().TrieDB())
 	if err != nil {
 		return nil, nil
 	}
-	it, err := chain.Snapshots().AccountIterator(req.Root, req.Origin)
+	it, err := chain.Snapshots().AccountIterator(req.Root.ToRootExtHash(), req.Origin.ToRootExtHash())
 	if err != nil {
 		return nil, nil
 	}
@@ -246,7 +246,7 @@ func ServiceGetAccountRangeQuery(chain SnapshotReader, req *GetAccountRangePacke
 	var (
 		accounts []*AccountData
 		size     uint64
-		last     common.Hash
+		last     common.ExtHash
 	)
 	for it.Next() {
 		hash, account := it.Hash(), common.CopyBytes(it.Account())
@@ -257,7 +257,7 @@ func ServiceGetAccountRangeQuery(chain SnapshotReader, req *GetAccountRangePacke
 		// Assemble the reply item
 		size += uint64(common.HashLength + len(account))
 		accounts = append(accounts, &AccountData{
-			Hash: hash,
+			Hash: hash.ToHash(),
 			Body: account,
 		})
 		// If we've exceeded the request threshold, abort
@@ -277,7 +277,7 @@ func ServiceGetAccountRangeQuery(chain SnapshotReader, req *GetAccountRangePacke
 		logger.Warn("Failed to prove account range", "origin", req.Origin, "err", err)
 		return nil, nil
 	}
-	if last != (common.Hash{}) {
+	if last.ToHash() != (common.Hash{}) {
 		if err := tr.Prove(last[:], 0, proof); err != nil {
 			logger.Warn("Failed to prove account range", "last", last, "err", err)
 			return nil, nil
@@ -324,14 +324,14 @@ func ServiceGetStorageRangesQuery(chain SnapshotReader, req *GetStorageRangesPac
 			limit, req.Limit = common.BytesToHash(req.Limit), nil
 		}
 		// Retrieve the requested state and bail out if non existent
-		it, err := chain.Snapshots().StorageIterator(req.Root, accountHash, origin)
+		it, err := chain.Snapshots().StorageIterator(req.Root.ToRootExtHash(), accountHash.ToRootExtHash(), origin.ToRootExtHash())
 		if err != nil {
 			return nil, nil
 		}
 		// Iterate over the requested range and pile slots up
 		var (
 			storage []*StorageData
-			last    common.Hash
+			last    common.ExtHash
 			abort   bool
 		)
 		for it.Next() {
@@ -347,7 +347,7 @@ func ServiceGetStorageRangesQuery(chain SnapshotReader, req *GetStorageRangesPac
 			// Assemble the reply item
 			size += uint64(common.HashLength + len(slot))
 			storage = append(storage, &StorageData{
-				Hash: hash,
+				Hash: hash.ToHash(),
 				Body: slot,
 			})
 			// If we've exceeded the request threshold, abort
@@ -364,7 +364,7 @@ func ServiceGetStorageRangesQuery(chain SnapshotReader, req *GetStorageRangesPac
 		if origin != (common.Hash{}) || abort {
 			// Request started at a non-zero hash or was capped prematurely, add
 			// the endpoint Merkle proofs
-			accTrie, err := statedb.NewTrie(req.Root, chain.StateCache().TrieDB())
+			accTrie, err := statedb.NewTrie(req.Root.ToRootExtHash(), chain.StateCache().TrieDB())
 			if err != nil {
 				return nil, nil
 			}
@@ -387,7 +387,7 @@ func ServiceGetStorageRangesQuery(chain SnapshotReader, req *GetStorageRangesPac
 				logger.Warn("Failed to prove storage range", "origin", req.Origin, "err", err)
 				return nil, nil
 			}
-			if last != (common.Hash{}) {
+			if last.ToHash() != (common.Hash{}) {
 				if err := stTrie.Prove(last[:], 0, proof); err != nil {
 					logger.Warn("Failed to prove storage range", "last", last, "err", err)
 					return nil, nil
@@ -424,7 +424,7 @@ func ServiceGetByteCodesQuery(chain SnapshotReader, req *GetByteCodesPacket) [][
 			// Peers should not request the empty code, but if they do, at
 			// least sent them back a correct response without db lookups
 			codes = append(codes, []byte{})
-		} else if blob, err := chain.ContractCode(hash); err == nil {
+		} else if blob, err := chain.ContractCode(hash.ToExtHash()); err == nil {
 			codes = append(codes, blob)
 			bytes += uint64(len(blob))
 		}
@@ -444,12 +444,12 @@ func ServiceGetTrieNodesQuery(chain SnapshotReader, req *GetTrieNodesPacket, sta
 	// Make sure we have the state associated with the request
 	triedb := chain.StateCache().TrieDB()
 
-	accTrie, err := statedb.NewSecureTrie(req.Root, triedb)
+	accTrie, err := statedb.NewSecureTrie(req.Root.ToRootExtHash(), triedb)
 	if err != nil {
 		// We don't have the requested state available, bail out
 		return nil, nil
 	}
-	snap := chain.Snapshots().Snapshot(req.Root)
+	snap := chain.Snapshots().Snapshot(req.Root.ToRootExtHash())
 	if snap == nil {
 		// We don't have the requested state snapshotted yet, bail out.
 		// In reality we could still serve using the account and storage
@@ -481,7 +481,7 @@ func ServiceGetTrieNodesQuery(chain SnapshotReader, req *GetTrieNodesPacket, sta
 
 		default:
 			// Storage slots requested, open the storage trie and retrieve from there
-			acc, err := snap.Account(common.BytesToHash(pathset[0]))
+			acc, err := snap.Account(common.BytesToExtHash(pathset[0]))
 			loads++ // always account database reads, even for failures
 			if err != nil || acc == nil {
 				break

--- a/node/cn/snap/handler_test.go
+++ b/node/cn/snap/handler_test.go
@@ -81,7 +81,7 @@ func (r *testSnapshotReader) Snapshots() *snapshot.Tree {
 	return r.snap
 }
 
-func (r *testSnapshotReader) ContractCode(hash common.Hash) ([]byte, error) {
+func (r *testSnapshotReader) ContractCode(hash common.ExtHash) ([]byte, error) {
 	return r.db.ContractCode(hash)
 }
 

--- a/node/cn/snap/nodeset.go
+++ b/node/cn/snap/nodeset.go
@@ -47,7 +47,7 @@ func NewNodeSet() *NodeSet {
 	}
 }
 
-func (db *NodeSet) ReadCachedTrieNode(hash common.Hash) ([]byte, error) {
+func (db *NodeSet) ReadCachedTrieNode(hash common.ExtHash) ([]byte, error) {
 	return db.Get(hash.Bytes())
 }
 

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -254,8 +254,8 @@ func (api *API) TraceChain(ctx context.Context, start, end rpc.BlockNumber, conf
 // traceChain configures a new tracer according to the provided configuration, and
 // executes all the transactions contained within.
 // The traceChain operates in two modes: subscription mode and rpc mode
-//  - if notifier and sub is not nil, it works as a subscription mode and returns nothing
-//  - if those parameters are nil, it works as a rpc mode and returns the block trace results, so it can pass the result through rpc-call
+//   - if notifier and sub is not nil, it works as a subscription mode and returns nothing
+//   - if those parameters are nil, it works as a rpc mode and returns the block trace results, so it can pass the result through rpc-call
 func (api *API) traceChain(start, end *types.Block, config *TraceConfig, notifier *rpc.Notifier, sub *rpc.Subscription) (map[uint64]*blockTraceResult, error) {
 	// Prepare all the states for tracing. Note this procedure can take very
 	// long time. Timeout mechanism is necessary.
@@ -375,11 +375,11 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, notifie
 			}
 			if trieDb := statedb.Database().TrieDB(); trieDb != nil {
 				// Hold the reference for tracer, will be released at the final stage
-				trieDb.Reference(block.Root(), common.Hash{})
+				trieDb.Reference(block.Root().ToRootExtHash(), common.InitExtHash())
 
 				// Release the parent state because it's already held by the tracer
 				if !common.EmptyHash(parent) {
-					trieDb.Dereference(parent)
+					trieDb.Dereference(parent.ToRootExtHash())
 				}
 				// Prefer disk if the trie db memory grows too much
 				s1, s2, s3 := trieDb.Size()
@@ -427,7 +427,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, notifie
 
 			// Dereference any parent tries held in memory by this task
 			if res.statedb.Database().TrieDB() != nil {
-				res.statedb.Database().TrieDB().Dereference(res.rootref)
+				res.statedb.Database().TrieDB().Dereference(res.rootref.ToRootExtHash())
 			}
 			if notifier != nil {
 				// Stream completed traces to the user, aborting on the first error

--- a/node/cn/tracers/tracer.go
+++ b/node/cn/tracers/tracer.go
@@ -227,7 +227,7 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 		hash := popSlice(ctx)
 		addr := popSlice(ctx)
 
-		state := dw.db.GetState(common.BytesToAddress(addr), common.BytesToHash(hash))
+		state := dw.db.GetState(common.BytesToAddress(addr), common.BytesToExtHash(hash))
 
 		ptr := ctx.PushFixedBuffer(len(state))
 		copy(makeSlice(ptr, uint(len(state))), state[:])

--- a/snapshot/disklayer.go
+++ b/snapshot/disklayer.go
@@ -40,8 +40,8 @@ type diskLayer struct {
 	triedb *statedb.Database  // Trie node cache for reconstruction purposes
 	cache  *fastcache.Cache   // Cache to avoid hitting the disk for direct access
 
-	root  common.Hash // Root hash of the base snapshot
-	stale bool        // Signals that the layer became stale (state progressed)
+	root  common.ExtHash // Root hash of the base snapshot
+	stale bool           // Signals that the layer became stale (state progressed)
 
 	genMarker  []byte                    // Marker for the state that's indexed during initial layer generation
 	genPending chan struct{}             // Notification channel when generation is done (test synchronicity)
@@ -51,7 +51,7 @@ type diskLayer struct {
 }
 
 // Root returns  root hash for which this snapshot was made.
-func (dl *diskLayer) Root() common.Hash {
+func (dl *diskLayer) Root() common.ExtHash {
 	return dl.root
 }
 
@@ -71,7 +71,7 @@ func (dl *diskLayer) Stale() bool {
 
 // Account directly retrieves the account associated with a particular hash in
 // the snapshot slim data format.
-func (dl *diskLayer) Account(hash common.Hash) (account.Account, error) {
+func (dl *diskLayer) Account(hash common.ExtHash) (account.Account, error) {
 	data, err := dl.AccountRLP(hash)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func (dl *diskLayer) Account(hash common.Hash) (account.Account, error) {
 
 // AccountRLP directly retrieves the account RLP associated with a particular
 // hash in the snapshot slim data format.
-func (dl *diskLayer) AccountRLP(hash common.Hash) ([]byte, error) {
+func (dl *diskLayer) AccountRLP(hash common.ExtHash) ([]byte, error) {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
@@ -126,7 +126,7 @@ func (dl *diskLayer) AccountRLP(hash common.Hash) ([]byte, error) {
 
 // Storage directly retrieves the storage data associated with a particular hash,
 // within a particular account.
-func (dl *diskLayer) Storage(accountHash, storageHash common.Hash) ([]byte, error) {
+func (dl *diskLayer) Storage(accountHash, storageHash common.ExtHash) ([]byte, error) {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
@@ -167,6 +167,6 @@ func (dl *diskLayer) Storage(accountHash, storageHash common.Hash) ([]byte, erro
 // Update creates a new layer on top of the existing snapshot diff tree with
 // the specified data items. Note, the maps are retained by the method to avoid
 // copying everything.
-func (dl *diskLayer) Update(blockHash common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer {
+func (dl *diskLayer) Update(blockHash common.ExtHash, destructs map[common.ExtHash]struct{}, accounts map[common.ExtHash][]byte, storage map[common.ExtHash]map[common.ExtHash][]byte) *diffLayer {
 	return newDiffLayer(dl, blockHash, destructs, accounts, storage)
 }

--- a/snapshot/iterator.go
+++ b/snapshot/iterator.go
@@ -43,7 +43,7 @@ type Iterator interface {
 
 	// Hash returns the hash of the account or storage slot the iterator is
 	// currently at.
-	Hash() common.Hash
+	Hash() common.ExtHash
 
 	// Release releases associated resources. Release should always succeed and
 	// can be called multiple times without causing error.
@@ -78,15 +78,15 @@ type diffAccountIterator struct {
 	// explicitly tracked since the referenced diff layer might go stale after
 	// the iterator was positioned and we don't want to fail accessing the old
 	// hash as long as the iterator is not touched any more.
-	curHash common.Hash
+	curHash common.ExtHash
 
-	layer *diffLayer    // Live layer to retrieve values from
-	keys  []common.Hash // Keys left in the layer to iterate
-	fail  error         // Any failures encountered (stale)
+	layer *diffLayer       // Live layer to retrieve values from
+	keys  []common.ExtHash // Keys left in the layer to iterate
+	fail  error            // Any failures encountered (stale)
 }
 
 // AccountIterator creates an account iterator over a single diff layer.
-func (dl *diffLayer) AccountIterator(seek common.Hash) AccountIterator {
+func (dl *diffLayer) AccountIterator(seek common.ExtHash) AccountIterator {
 	// Seek out the requested starting account
 	hashes := dl.AccountList()
 	index := sort.Search(len(hashes), func(i int) bool {
@@ -130,7 +130,7 @@ func (it *diffAccountIterator) Error() error {
 }
 
 // Hash returns the hash of the account the iterator is currently at.
-func (it *diffAccountIterator) Hash() common.Hash {
+func (it *diffAccountIterator) Hash() common.ExtHash {
 	return it.curHash
 }
 
@@ -170,7 +170,7 @@ type diskAccountIterator struct {
 }
 
 // AccountIterator creates an account iterator over a disk layer.
-func (dl *diskLayer) AccountIterator(seek common.Hash) AccountIterator {
+func (dl *diskLayer) AccountIterator(seek common.ExtHash) AccountIterator {
 	pos := common.TrimRightZeroes(seek[:])
 	return &diskAccountIterator{
 		layer: dl,
@@ -211,8 +211,8 @@ func (it *diskAccountIterator) Error() error {
 }
 
 // Hash returns the hash of the account the iterator is currently at.
-func (it *diskAccountIterator) Hash() common.Hash {
-	return common.BytesToHash(it.it.Key()) // The prefix will be truncated
+func (it *diskAccountIterator) Hash() common.ExtHash {
+	return common.BytesToExtHash(it.it.Key()) // The prefix will be truncated
 }
 
 // Account returns the RLP encoded slim account the iterator is currently at.
@@ -237,12 +237,12 @@ type diffStorageIterator struct {
 	// explicitly tracked since the referenced diff layer might go stale after
 	// the iterator was positioned and we don't want to fail accessing the old
 	// hash as long as the iterator is not touched any more.
-	curHash common.Hash
-	account common.Hash
+	curHash common.ExtHash
+	account common.ExtHash
 
-	layer *diffLayer    // Live layer to retrieve values from
-	keys  []common.Hash // Keys left in the layer to iterate
-	fail  error         // Any failures encountered (stale)
+	layer *diffLayer       // Live layer to retrieve values from
+	keys  []common.ExtHash // Keys left in the layer to iterate
+	fail  error            // Any failures encountered (stale)
 }
 
 // StorageIterator creates a storage iterator over a single diff layer.
@@ -250,7 +250,7 @@ type diffStorageIterator struct {
 // "destructed" returned. If it's true then it means the whole storage is
 // destructed in this layer(maybe recreated too), don't bother deeper layer
 // for storage retrieval.
-func (dl *diffLayer) StorageIterator(account common.Hash, seek common.Hash) (StorageIterator, bool) {
+func (dl *diffLayer) StorageIterator(account common.ExtHash, seek common.ExtHash) (StorageIterator, bool) {
 	// Create the storage for this account even it's marked
 	// as destructed. The iterator is for the new one which
 	// just has the same address as the deleted one.
@@ -297,7 +297,7 @@ func (it *diffStorageIterator) Error() error {
 }
 
 // Hash returns the hash of the storage slot the iterator is currently at.
-func (it *diffStorageIterator) Hash() common.Hash {
+func (it *diffStorageIterator) Hash() common.ExtHash {
 	return it.curHash
 }
 
@@ -334,7 +334,7 @@ func (it *diffStorageIterator) Release() {}
 // contained within a disk layer.
 type diskStorageIterator struct {
 	layer   *diskLayer
-	account common.Hash
+	account common.ExtHash
 	it      database.Iterator
 }
 
@@ -342,7 +342,7 @@ type diskStorageIterator struct {
 // If the whole storage is destructed, then all entries in the disk
 // layer are deleted already. So the "destructed" flag returned here
 // is always false.
-func (dl *diskLayer) StorageIterator(account common.Hash, seek common.Hash) (StorageIterator, bool) {
+func (dl *diskLayer) StorageIterator(account common.ExtHash, seek common.ExtHash) (StorageIterator, bool) {
 	pos := common.TrimRightZeroes(seek[:])
 	return &diskStorageIterator{
 		layer:   dl,
@@ -384,8 +384,8 @@ func (it *diskStorageIterator) Error() error {
 }
 
 // Hash returns the hash of the storage slot the iterator is currently at.
-func (it *diskStorageIterator) Hash() common.Hash {
-	return common.BytesToHash(it.it.Key()) // The prefix will be truncated
+func (it *diskStorageIterator) Hash() common.ExtHash {
+	return common.BytesToExtHash(it.it.Key()) // The prefix will be truncated
 }
 
 // Slot returns the raw storage slot content the iterator is currently at.

--- a/snapshot/iterator_binary.go
+++ b/snapshot/iterator_binary.go
@@ -35,8 +35,8 @@ type binaryIterator struct {
 	aDone           bool
 	bDone           bool
 	accountIterator bool
-	k               common.Hash
-	account         common.Hash
+	k               common.ExtHash
+	account         common.ExtHash
 	fail            error
 }
 
@@ -47,8 +47,8 @@ func (dl *diffLayer) initBinaryAccountIterator() Iterator {
 	parent, ok := dl.parent.(*diffLayer)
 	if !ok {
 		l := &binaryIterator{
-			a:               dl.AccountIterator(common.Hash{}),
-			b:               dl.Parent().AccountIterator(common.Hash{}),
+			a:               dl.AccountIterator(common.InitExtHash()),
+			b:               dl.Parent().AccountIterator(common.InitExtHash()),
 			accountIterator: true,
 		}
 		l.aDone = !l.a.Next()
@@ -56,7 +56,7 @@ func (dl *diffLayer) initBinaryAccountIterator() Iterator {
 		return l
 	}
 	l := &binaryIterator{
-		a:               dl.AccountIterator(common.Hash{}),
+		a:               dl.AccountIterator(common.InitExtHash()),
 		b:               parent.initBinaryAccountIterator(),
 		accountIterator: true,
 	}
@@ -68,12 +68,12 @@ func (dl *diffLayer) initBinaryAccountIterator() Iterator {
 // initBinaryStorageIterator creates a simplistic iterator to step over all the
 // storage slots in a slow, but easily verifiable way. Note this function is used
 // for initialization, use `newBinaryStorageIterator` as the API.
-func (dl *diffLayer) initBinaryStorageIterator(account common.Hash) Iterator {
+func (dl *diffLayer) initBinaryStorageIterator(account common.ExtHash) Iterator {
 	parent, ok := dl.parent.(*diffLayer)
 	if !ok {
 		// If the storage in this layer is already destructed, discard all
 		// deeper layers but still return an valid single-branch iterator.
-		a, destructed := dl.StorageIterator(account, common.Hash{})
+		a, destructed := dl.StorageIterator(account, common.InitExtHash())
 		if destructed {
 			l := &binaryIterator{
 				a:       a,
@@ -85,7 +85,7 @@ func (dl *diffLayer) initBinaryStorageIterator(account common.Hash) Iterator {
 		}
 		// The parent is disk layer, don't need to take care "destructed"
 		// anymore.
-		b, _ := dl.Parent().StorageIterator(account, common.Hash{})
+		b, _ := dl.Parent().StorageIterator(account, common.InitExtHash())
 		l := &binaryIterator{
 			a:       a,
 			b:       b,
@@ -97,7 +97,7 @@ func (dl *diffLayer) initBinaryStorageIterator(account common.Hash) Iterator {
 	}
 	// If the storage in this layer is already destructed, discard all
 	// deeper layers but still return an valid single-branch iterator.
-	a, destructed := dl.StorageIterator(account, common.Hash{})
+	a, destructed := dl.StorageIterator(account, common.InitExtHash())
 	if destructed {
 		l := &binaryIterator{
 			a:       a,
@@ -157,7 +157,7 @@ func (it *binaryIterator) Error() error {
 }
 
 // Hash returns the hash of the account the iterator is currently at.
-func (it *binaryIterator) Hash() common.Hash {
+func (it *binaryIterator) Hash() common.ExtHash {
 	return it.k
 }
 
@@ -211,7 +211,7 @@ func (dl *diffLayer) newBinaryAccountIterator() AccountIterator {
 
 // newBinaryStorageIterator creates a simplistic account iterator to step over
 // all the storage slots in a slow, but easily verifiable way.
-func (dl *diffLayer) newBinaryStorageIterator(account common.Hash) StorageIterator {
+func (dl *diffLayer) newBinaryStorageIterator(account common.ExtHash) StorageIterator {
 	iter := dl.initBinaryStorageIterator(account)
 	return iter.(StorageIterator)
 }

--- a/snapshot/iterator_fast.go
+++ b/snapshot/iterator_fast.go
@@ -67,8 +67,8 @@ func (its weightedIterators) Swap(i, j int) {
 // fastIterator is a more optimized multi-layer iterator which maintains a
 // direct mapping of all iterators leading down to the bottom layer.
 type fastIterator struct {
-	tree *Tree       // Snapshot tree to reinitialize stale sub-iterators with
-	root common.Hash // Root hash to reinitialize stale sub-iterators through
+	tree *Tree          // Snapshot tree to reinitialize stale sub-iterators with
+	root common.ExtHash // Root hash to reinitialize stale sub-iterators through
 
 	curAccount []byte
 	curSlot    []byte
@@ -82,7 +82,7 @@ type fastIterator struct {
 // newFastIterator creates a new hierarchical account or storage iterator with one
 // element per diff layer. The returned combo iterator can be used to walk over
 // the entire snapshot diff stack simultaneously.
-func newFastIterator(tree *Tree, root common.Hash, account common.Hash, seek common.Hash, accountIterator bool) (*fastIterator, error) {
+func newFastIterator(tree *Tree, root common.ExtHash, account common.ExtHash, seek common.ExtHash, accountIterator bool) (*fastIterator, error) {
 	snap := tree.Snapshot(root)
 	if snap == nil {
 		return nil, fmt.Errorf("unknown snapshot: %x", root)
@@ -123,7 +123,7 @@ func newFastIterator(tree *Tree, root common.Hash, account common.Hash, seek com
 // which it prepares the stack for step-by-step iteration.
 func (fi *fastIterator) init() {
 	// Track which account hashes are iterators positioned on
-	positioned := make(map[common.Hash]int)
+	positioned := make(map[common.ExtHash]int)
 
 	// Position all iterators and track how many remain live
 	for i := 0; i < len(fi.iterators); i++ {
@@ -306,7 +306,7 @@ func (fi *fastIterator) Error() error {
 }
 
 // Hash returns the current key
-func (fi *fastIterator) Hash() common.Hash {
+func (fi *fastIterator) Hash() common.ExtHash {
 	return fi.iterators[0].it.Hash()
 }
 
@@ -334,7 +334,7 @@ func (fi *fastIterator) Release() {
 // Debug is a convencience helper during testing
 func (fi *fastIterator) Debug() {
 	for _, it := range fi.iterators {
-		fmt.Printf("[p=%v v=%v] ", it.priority, it.it.Hash()[0])
+		fmt.Printf("[p=%v v=%v] ", it.priority, it.it.Hash().Bytes()[0])
 	}
 	fmt.Println()
 }
@@ -342,13 +342,13 @@ func (fi *fastIterator) Debug() {
 // newFastAccountIterator creates a new hierarchical account iterator with one
 // element per diff layer. The returned combo iterator can be used to walk over
 // the entire snapshot diff stack simultaneously.
-func newFastAccountIterator(tree *Tree, root common.Hash, seek common.Hash) (AccountIterator, error) {
-	return newFastIterator(tree, root, common.Hash{}, seek, true)
+func newFastAccountIterator(tree *Tree, root common.ExtHash, seek common.ExtHash) (AccountIterator, error) {
+	return newFastIterator(tree, root, common.InitExtHash(), seek, true)
 }
 
 // newFastStorageIterator creates a new hierarchical storage iterator with one
 // element per diff layer. The returned combo iterator can be used to walk over
 // the entire snapshot diff stack simultaneously.
-func newFastStorageIterator(tree *Tree, root common.Hash, account common.Hash, seek common.Hash) (StorageIterator, error) {
+func newFastStorageIterator(tree *Tree, root common.ExtHash, account common.ExtHash, seek common.ExtHash) (StorageIterator, error) {
 	return newFastIterator(tree, root, account, seek, false)
 }

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -114,19 +114,19 @@ var (
 // Snapshot represents the functionality supported by a snapshot storage layer.
 type Snapshot interface {
 	// Root returns the root hash for which this snapshot was made.
-	Root() common.Hash
+	Root() common.ExtHash
 
 	// Account directly retrieves the account associated with a particular hash in
 	// the snapshot slim data format.
-	Account(hash common.Hash) (account.Account, error)
+	Account(hash common.ExtHash) (account.Account, error)
 
 	// AccountRLP directly retrieves the account RLP associated with a particular
 	// hash in the snapshot slim data format.
-	AccountRLP(hash common.Hash) ([]byte, error)
+	AccountRLP(hash common.ExtHash) ([]byte, error)
 
 	// Storage directly retrieves the storage data associated with a particular hash,
 	// within a particular account.
-	Storage(accountHash, storageHash common.Hash) ([]byte, error)
+	Storage(accountHash, storageHash common.ExtHash) ([]byte, error)
 }
 
 // snapshot is the internal version of the snapshot data layer that supports some
@@ -145,22 +145,22 @@ type snapshot interface {
 	// the specified data items.
 	//
 	// Note, the maps are retained by the method to avoid copying everything.
-	Update(blockRoot common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer
+	Update(blockRoot common.ExtHash, destructs map[common.ExtHash]struct{}, accounts map[common.ExtHash][]byte, storage map[common.ExtHash]map[common.ExtHash][]byte) *diffLayer
 
 	// Journal commits an entire diff hierarchy to disk into a single journal entry.
 	// This is meant to be used during shutdown to persist the snapshot without
 	// flattening everything down (bad for reorgs).
-	Journal(buffer *bytes.Buffer) (common.Hash, error)
+	Journal(buffer *bytes.Buffer) (common.ExtHash, error)
 
 	// Stale return whether this layer has become stale (was flattened across) or
 	// if it's still live.
 	Stale() bool
 
 	// AccountIterator creates an account iterator over an arbitrary layer.
-	AccountIterator(seek common.Hash) AccountIterator
+	AccountIterator(seek common.ExtHash) AccountIterator
 
 	// StorageIterator creates a storage iterator over an arbitrary layer.
-	StorageIterator(account common.Hash, seek common.Hash) (StorageIterator, bool)
+	StorageIterator(account common.ExtHash, seek common.ExtHash) (StorageIterator, bool)
 }
 
 // Tree is an Ethereum state snapshot tree. It consists of one persistent base
@@ -173,10 +173,10 @@ type snapshot interface {
 // storage data to avoid expensive multi-level trie lookups; and to allow sorted,
 // cheap iteration of the account/storage tries for sync aid.
 type Tree struct {
-	diskdb database.DBManager       // Persistent database to store the snapshot
-	triedb *statedb.Database        // In-memory cache to access the trie through
-	cache  int                      // Megabytes permitted to use for read caches
-	layers map[common.Hash]snapshot // Collection of all known layers
+	diskdb database.DBManager          // Persistent database to store the snapshot
+	triedb *statedb.Database           // In-memory cache to access the trie through
+	cache  int                         // Megabytes permitted to use for read caches
+	layers map[common.ExtHash]snapshot // Collection of all known layers
 	lock   sync.RWMutex
 
 	// Test hooks
@@ -194,17 +194,17 @@ type Tree struct {
 // If the memory layers in the journal do not match the disk layer (e.g. there is
 // a gap) or the journal is missing, there are two repair cases:
 //
-// - if the 'recovery' parameter is true, all memory diff-layers will be discarded.
-//   This case happens when the snapshot is 'ahead' of the state trie.
-// - otherwise, the entire snapshot is considered invalid and will be recreated on
-//   a background thread.
-func New(diskdb database.DBManager, triedb *statedb.Database, cache int, root common.Hash, async bool, rebuild bool, recovery bool) (*Tree, error) {
+//   - if the 'recovery' parameter is true, all memory diff-layers will be discarded.
+//     This case happens when the snapshot is 'ahead' of the state trie.
+//   - otherwise, the entire snapshot is considered invalid and will be recreated on
+//     a background thread.
+func New(diskdb database.DBManager, triedb *statedb.Database, cache int, root common.ExtHash, async bool, rebuild bool, recovery bool) (*Tree, error) {
 	// Create a new, empty snapshot tree
 	snap := &Tree{
 		diskdb: diskdb,
 		triedb: triedb,
 		cache:  cache,
-		layers: make(map[common.Hash]snapshot),
+		layers: make(map[common.ExtHash]snapshot),
 	}
 	if !async {
 		defer snap.waitBuild()
@@ -284,7 +284,7 @@ func (t *Tree) Disable() {
 			panic(fmt.Sprintf("unknown layer type: %T", layer))
 		}
 	}
-	t.layers = map[common.Hash]snapshot{}
+	t.layers = map[common.ExtHash]snapshot{}
 
 	// Delete all snapshot liveness information from the database
 	batch := t.diskdb.NewSnapshotDBBatch()
@@ -303,7 +303,7 @@ func (t *Tree) Disable() {
 
 // Snapshot retrieves a snapshot belonging to the given block root, or nil if no
 // snapshot is maintained for that block.
-func (t *Tree) Snapshot(blockRoot common.Hash) Snapshot {
+func (t *Tree) Snapshot(blockRoot common.ExtHash) Snapshot {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
@@ -313,7 +313,7 @@ func (t *Tree) Snapshot(blockRoot common.Hash) Snapshot {
 // Snapshots returns all visited layers from the topmost layer with specific
 // root and traverses downward. The layer amount is limited by the given number.
 // If nodisk is set, then disk layer is excluded.
-func (t *Tree) Snapshots(root common.Hash, limits int, nodisk bool) []Snapshot {
+func (t *Tree) Snapshots(root common.ExtHash, limits int, nodisk bool) []Snapshot {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
@@ -345,7 +345,7 @@ func (t *Tree) Snapshots(root common.Hash, limits int, nodisk bool) []Snapshot {
 
 // Update adds a new snapshot into the tree, if that can be linked to an existing
 // old parent. It is disallowed to insert a disk layer (the origin of all).
-func (t *Tree) Update(blockRoot common.Hash, parentRoot common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error {
+func (t *Tree) Update(blockRoot common.ExtHash, parentRoot common.ExtHash, destructs map[common.ExtHash]struct{}, accounts map[common.ExtHash][]byte, storage map[common.ExtHash]map[common.ExtHash][]byte) error {
 	// Reject noop updates to avoid self-loops in the snapshot tree. This is a
 	// special case that can only happen for Clique networks where empty blocks
 	// don't modify the state (0 block subsidy).
@@ -379,7 +379,7 @@ func (t *Tree) Update(blockRoot common.Hash, parentRoot common.Hash, destructs m
 // which may or may not overflow and cascade to disk. Since this last layer's
 // survival is only known *after* capping, we need to omit it from the count if
 // we want to ensure that *at least* the requested number of diff layers remain.
-func (t *Tree) Cap(root common.Hash, layers int) error {
+func (t *Tree) Cap(root common.ExtHash, layers int) error {
 	// Retrieve the head snapshot to cap from
 	snap := t.Snapshot(root)
 	if snap == nil {
@@ -410,21 +410,21 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 		diff.lock.RUnlock()
 
 		// Replace the entire snapshot tree with the flat base
-		t.layers = map[common.Hash]snapshot{base.root: base}
+		t.layers = map[common.ExtHash]snapshot{base.root: base}
 		return nil
 	}
 	persisted := t.cap(diff, layers)
 
 	// Remove any layer that is stale or links into a stale layer
-	children := make(map[common.Hash][]common.Hash)
+	children := make(map[common.ExtHash][]common.ExtHash)
 	for root, snap := range t.layers {
 		if diff, ok := snap.(*diffLayer); ok {
 			parent := diff.parent.Root()
 			children[parent] = append(children[parent], root)
 		}
 	}
-	var remove func(root common.Hash)
-	remove = func(root common.Hash) {
+	var remove func(root common.ExtHash)
+	remove = func(root common.ExtHash) {
 		delete(t.layers, root)
 		for _, child := range children[root] {
 			remove(child)
@@ -438,8 +438,8 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 	}
 	// If the disk layer was modified, regenerate all the cumulative blooms
 	if persisted != nil {
-		var rebloom func(root common.Hash)
-		rebloom = func(root common.Hash) {
+		var rebloom func(root common.ExtHash)
+		rebloom = func(root common.ExtHash) {
 			if diff, ok := t.layers[root].(*diffLayer); ok {
 				diff.rebloom(persisted)
 			}
@@ -610,11 +610,11 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 			continue
 		}
 		// Generation might be mid-account, track that case too
-		midAccount := base.genMarker != nil && bytes.Equal(accountHash[:], base.genMarker[:common.HashLength])
+		midAccount := base.genMarker != nil && bytes.Equal(accountHash[:], base.genMarker[:common.ExtHashLength])
 
 		for storageHash, data := range storage {
 			// Skip any slot not covered yet by the snapshot
-			if midAccount && bytes.Compare(storageHash[:], base.genMarker[common.HashLength:]) > 0 {
+			if midAccount && bytes.Compare(storageHash[:], base.genMarker[common.ExtHashLength:]) > 0 {
 				continue
 			}
 			if len(data) > 0 {
@@ -668,11 +668,11 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 //
 // The method returns the root hash of the base layer that needs to be persisted
 // to disk as a trie too to allow continuing any pending generation op.
-func (t *Tree) Journal(root common.Hash) (common.Hash, error) {
+func (t *Tree) Journal(root common.ExtHash) (common.ExtHash, error) {
 	// Retrieve the head snapshot to journal from var snap snapshot
 	snap := t.Snapshot(root)
 	if snap == nil {
-		return common.Hash{}, fmt.Errorf("snapshot [%#x] missing", root)
+		return common.InitExtHash(), fmt.Errorf("snapshot [%#x] missing", root)
 	}
 	// Run the journaling
 	t.lock.Lock()
@@ -681,21 +681,21 @@ func (t *Tree) Journal(root common.Hash) (common.Hash, error) {
 	// Firstly write out the metadata of journal
 	journal := new(bytes.Buffer)
 	if err := rlp.Encode(journal, journalVersion); err != nil {
-		return common.Hash{}, err
+		return common.InitExtHash(), err
 	}
 	diskroot := t.diskRoot()
-	if diskroot == (common.Hash{}) {
-		return common.Hash{}, errors.New("invalid disk root")
+	if diskroot.ToHash() == (common.Hash{}) {
+		return common.InitExtHash(), errors.New("invalid disk root")
 	}
 	// Secondly write out the disk layer root, ensure the
 	// diff journal is continuous with disk.
 	if err := rlp.Encode(journal, diskroot); err != nil {
-		return common.Hash{}, err
+		return common.InitExtHash(), err
 	}
 	// Finally write out the journal of each layer in reverse order.
 	base, err := snap.(snapshot).Journal(journal)
 	if err != nil {
-		return common.Hash{}, err
+		return common.InitExtHash(), err
 	}
 	// Store the journal into the database and return
 	t.diskdb.WriteSnapshotJournal(journal.Bytes())
@@ -705,7 +705,7 @@ func (t *Tree) Journal(root common.Hash) (common.Hash, error) {
 // Rebuild wipes all available snapshot data from the persistent database and
 // discard all caches and diff layers. Afterwards, it starts a new snapshot
 // generator with the given root hash.
-func (t *Tree) Rebuild(root common.Hash) {
+func (t *Tree) Rebuild(root common.ExtHash) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
@@ -742,14 +742,14 @@ func (t *Tree) Rebuild(root common.Hash) {
 	// Start generating a new snapshot from scratch on a background thread. The
 	// generator will run a wiper first if there's not one running right now.
 	logger.Info("Rebuilding state snapshot")
-	t.layers = map[common.Hash]snapshot{
+	t.layers = map[common.ExtHash]snapshot{
 		root: generateSnapshot(t.diskdb, t.triedb, t.cache, root),
 	}
 }
 
 // AccountIterator creates a new account iterator for the specified root hash and
 // seeks to a starting account hash.
-func (t *Tree) AccountIterator(root common.Hash, seek common.Hash) (AccountIterator, error) {
+func (t *Tree) AccountIterator(root common.ExtHash, seek common.ExtHash) (AccountIterator, error) {
 	ok, err := t.generating()
 	if err != nil {
 		return nil, err
@@ -762,7 +762,7 @@ func (t *Tree) AccountIterator(root common.Hash, seek common.Hash) (AccountItera
 
 // StorageIterator creates a new storage iterator for the specified root hash and
 // account. The iterator will be move to the specific start position.
-func (t *Tree) StorageIterator(root common.Hash, account common.Hash, seek common.Hash) (StorageIterator, error) {
+func (t *Tree) StorageIterator(root common.ExtHash, account common.ExtHash, seek common.ExtHash) (StorageIterator, error) {
 	ok, err := t.generating()
 	if err != nil {
 		return nil, err
@@ -775,23 +775,23 @@ func (t *Tree) StorageIterator(root common.Hash, account common.Hash, seek commo
 
 // Verify iterates the whole state(all the accounts as well as the corresponding storages)
 // with the specific root and compares the re-computed hash with the original one.
-func (t *Tree) Verify(root common.Hash) error {
-	acctIt, err := t.AccountIterator(root, common.Hash{})
+func (t *Tree) Verify(root common.ExtHash) error {
+	acctIt, err := t.AccountIterator(root, common.InitExtHash())
 	if err != nil {
 		return err
 	}
 	defer acctIt.Release()
 
-	got, err := generateTrieRoot(acctIt, common.Hash{}, trieGenerate, func(accountHash, codeHash common.Hash, stat *generateStats) (common.Hash, error) {
-		storageIt, err := t.StorageIterator(root, accountHash, common.Hash{})
+	got, err := generateTrieRoot(acctIt, common.InitExtHash(), trieGenerate, func(accountHash, codeHash common.ExtHash, stat *generateStats) (common.ExtHash, error) {
+		storageIt, err := t.StorageIterator(root, accountHash, common.InitExtHash())
 		if err != nil {
-			return common.Hash{}, err
+			return common.InitExtHash(), err
 		}
 		defer storageIt.Release()
 
 		hash, err := generateTrieRoot(storageIt, accountHash, trieGenerate, nil, stat, false)
 		if err != nil {
-			return common.Hash{}, err
+			return common.InitExtHash(), err
 		}
 		return hash, nil
 	}, newGenerateStats(), true)
@@ -827,10 +827,10 @@ func (t *Tree) disklayer() *diskLayer {
 
 // diskRoot is a internal helper function to return the disk layer root.
 // The lock of snapTree is assumed to be held already.
-func (t *Tree) diskRoot() common.Hash {
+func (t *Tree) diskRoot() common.ExtHash {
 	disklayer := t.disklayer()
 	if disklayer == nil {
-		return common.Hash{}
+		return common.InitExtHash()
 	}
 	return disklayer.Root()
 }
@@ -851,7 +851,7 @@ func (t *Tree) generating() (bool, error) {
 }
 
 // diskRoot is a external helper function to return the disk layer root.
-func (t *Tree) DiskRoot() common.Hash {
+func (t *Tree) DiskRoot() common.ExtHash {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 

--- a/snapshot/sort.go
+++ b/snapshot/sort.go
@@ -27,7 +27,7 @@ import (
 )
 
 // hashes is a helper to implement sort.Interface.
-type hashes []common.Hash
+type hashes []common.ExtHash
 
 // Len is the number of elements in the collection.
 func (hs hashes) Len() int { return len(hs) }

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -181,17 +181,17 @@ func TxLookupKey(hash common.Hash) []byte {
 }
 
 // AccountSnapshotKey = SnapshotAccountPrefix + hash
-func AccountSnapshotKey(hash common.Hash) []byte {
+func AccountSnapshotKey(hash common.ExtHash) []byte {
 	return append(SnapshotAccountPrefix, hash.Bytes()...)
 }
 
 // StorageSnapshotKey = SnapshotStoragePrefix + account hash + storage hash
-func StorageSnapshotKey(accountHash, storageHash common.Hash) []byte {
+func StorageSnapshotKey(accountHash, storageHash common.ExtHash) []byte {
 	return append(append(SnapshotStoragePrefix, accountHash.Bytes()...), storageHash.Bytes()...)
 }
 
 // StorageSnapshotsKey = SnapshotStoragePrefix + account hash + storage hash
-func StorageSnapshotsKey(accountHash common.Hash) []byte {
+func StorageSnapshotsKey(accountHash common.ExtHash) []byte {
 	return append(SnapshotStoragePrefix, accountHash.Bytes()...)
 }
 
@@ -205,7 +205,7 @@ func preimageKey(hash common.Hash) []byte {
 }
 
 // CodeKey = codePrefix + hash
-func CodeKey(hash common.Hash) []byte {
+func CodeKey(hash common.ExtHash) []byte {
 	return append(codePrefix, hash.Bytes()...)
 }
 

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -96,9 +96,9 @@ type DatabaseReader interface {
 type Database struct {
 	diskDB database.DBManager // Persistent storage for matured trie nodes
 
-	nodes  map[common.Hash]*cachedNode // Data and references relationships of a trie node
-	oldest common.Hash                 // Oldest tracked node, flush-list head
-	newest common.Hash                 // Newest tracked node, flush-list tail
+	nodes  map[common.ExtHash]*cachedNode // Data and references relationships of a node
+	oldest common.ExtHash                 // Oldest tracked node, flush-list head
+	newest common.ExtHash                 // Newest tracked node, flush-list tail
 
 	preimages map[common.Hash][]byte // Preimages of nodes from the secure trie
 
@@ -180,11 +180,11 @@ type cachedNode struct {
 	// TODO-Klaytn: need to change data type of this if we increase the code size limit
 	size uint16 // Byte size of the useful cached data
 
-	parents  uint64                 // Number of live nodes referencing this one
-	children map[common.Hash]uint64 // External children referenced by this node
+	parents  uint64                    // Number of live nodes referencing this one
+	children map[common.ExtHash]uint64 // External children referenced by this node
 
-	flushPrev common.Hash // Previous node in the flush-list
-	flushNext common.Hash // Next node in the flush-list
+	flushPrev common.ExtHash // Previous node in the flush-list
+	flushNext common.ExtHash // Next node in the flush-list
 }
 
 // rlp returns the raw rlp encoded blob of the cached trie node, either directly
@@ -202,7 +202,7 @@ func (n *cachedNode) rlp() []byte {
 
 // obj returns the decoded and expanded trie node, either directly from the cache,
 // or by regenerating it from the rlp encoded blob.
-func (n *cachedNode) obj(hash common.Hash) node {
+func (n *cachedNode) obj(hash common.ExtHash) node {
 	if node, ok := n.node.(rawNode); ok {
 		return mustDecodeNode(hash[:], node)
 	}
@@ -211,8 +211,8 @@ func (n *cachedNode) obj(hash common.Hash) node {
 
 // childs returns all the tracked children of this node, both the implicit ones
 // from inside the node as well as the explicit ones from outside the node.
-func (n *cachedNode) childs() []common.Hash {
-	children := make([]common.Hash, 0, 16)
+func (n *cachedNode) childs() []common.ExtHash {
+	children := make([]common.ExtHash, 0, 16)
 	for child := range n.children {
 		children = append(children, child)
 	}
@@ -224,7 +224,7 @@ func (n *cachedNode) childs() []common.Hash {
 
 // gatherChildren traverses the node hierarchy of a collapsed database node and
 // retrieves all the hashnode children.
-func gatherChildren(n node, children *[]common.Hash) {
+func gatherChildren(n node, children *[]common.ExtHash) {
 	switch n := n.(type) {
 	case *rawShortNode:
 		gatherChildren(n.Val, children)
@@ -234,7 +234,7 @@ func gatherChildren(n node, children *[]common.Hash) {
 			gatherChildren(n[i], children)
 		}
 	case hashNode:
-		*children = append(*children, common.BytesToHash(n))
+		*children = append(*children, common.BytesToExtHash(n))
 
 	case valueNode, nil, rawNode:
 
@@ -322,7 +322,7 @@ func NewDatabaseWithNewCache(diskDB database.DBManager, cacheConfig *TrieNodeCac
 
 	return &Database{
 		diskDB:              diskDB,
-		nodes:               map[common.Hash]*cachedNode{{}: {}},
+		nodes:               map[common.ExtHash]*cachedNode{common.InitExtHash(): {}},
 		preimages:           make(map[common.Hash][]byte),
 		trieNodeCache:       trieNodeCache,
 		trieNodeCacheConfig: cacheConfig,
@@ -335,7 +335,7 @@ func NewDatabaseWithNewCache(diskDB database.DBManager, cacheConfig *TrieNodeCac
 func NewDatabaseWithExistingCache(diskDB database.DBManager, cache TrieNodeCache) *Database {
 	return &Database{
 		diskDB:        diskDB,
-		nodes:         map[common.Hash]*cachedNode{{}: {}},
+		nodes:         map[common.ExtHash]*cachedNode{common.InitExtHash(): {}},
 		preimages:     make(map[common.Hash][]byte),
 		trieNodeCache: cache,
 	}
@@ -389,10 +389,10 @@ func (db *Database) RUnlockGCCachedNode() {
 }
 
 // NodeChildren retrieves the children of the given hash trie
-func (db *Database) NodeChildren(hash common.Hash) ([]common.Hash, error) {
-	childrenHash := make([]common.Hash, 0, 16)
+func (db *Database) NodeChildren(hash common.ExtHash) ([]common.ExtHash, error) {
+	childrenHash := make([]common.ExtHash, 0, 16)
 
-	if (hash == common.Hash{}) {
+	if (hash.ToHash() == common.Hash{}) {
 		return childrenHash, ErrZeroHashNode
 	}
 
@@ -417,7 +417,7 @@ func (db *Database) NodeChildren(hash common.Hash) ([]common.Hash, error) {
 	for _, child := range children {
 		n, ok := child.(hashNode)
 		if ok {
-			hash := common.BytesToHash(n)
+			hash := common.BytesToExtHash(n)
 			childrenHash = append(childrenHash, hash)
 		}
 	}
@@ -429,7 +429,7 @@ func (db *Database) NodeChildren(hash common.Hash) ([]common.Hash, error) {
 // The blob size must be specified to allow proper size tracking.
 // All nodes inserted by this function will be reference tracked
 // and in theory should only used for **trie nodes** insertion.
-func (db *Database) insert(hash common.Hash, lenEncoded uint16, node node) {
+func (db *Database) insert(hash common.ExtHash, lenEncoded uint16, node node) {
 	// If the node's already cached, skip
 	if _, ok := db.nodes[hash]; ok {
 		return
@@ -448,18 +448,18 @@ func (db *Database) insert(hash common.Hash, lenEncoded uint16, node node) {
 	db.nodes[hash] = entry
 
 	// Update the flush-list endpoints
-	if db.oldest == (common.Hash{}) {
+	if db.oldest.ToHash() == (common.Hash{}) {
 		db.oldest, db.newest = hash, hash
 	} else {
 		if _, ok := db.nodes[db.newest]; !ok {
 			missingNewest := db.newest
 			db.newest = db.getLastNodeHashInFlushList()
-			db.nodes[db.newest].flushNext = common.Hash{}
+			db.nodes[db.newest].flushNext = common.InitExtHash()
 			logger.Error("Found a newest node for missingNewest", "oldNewest", missingNewest, "newNewest", db.newest)
 		}
 		db.nodes[db.newest].flushNext, db.newest = hash, hash
 	}
-	db.nodesSize += common.StorageSize(common.HashLength + entry.size)
+	db.nodesSize += common.StorageSize(common.ExtHashLength + entry.size)
 }
 
 // insertPreimage writes a new trie node pre-image to the memory database if it's
@@ -475,7 +475,7 @@ func (db *Database) insertPreimage(hash common.Hash, preimage []byte) {
 }
 
 // getCachedNode finds an encoded node in the trie node cache if enabled.
-func (db *Database) getCachedNode(hash common.Hash) []byte {
+func (db *Database) getCachedNode(hash common.ExtHash) []byte {
 	if db.trieNodeCache != nil {
 		if enc := db.trieNodeCache.Get(hash[:]); enc != nil {
 			memcacheCleanHitMeter.Mark(1)
@@ -497,7 +497,7 @@ func (db *Database) setCachedNode(hash, enc []byte) {
 
 // node retrieves a cached trie node from memory, or returns nil if node can be
 // found in the memory cache.
-func (db *Database) node(hash common.Hash) (n node, fromDB bool) {
+func (db *Database) node(hash common.ExtHash) (n node, fromDB bool) {
 	// Retrieve the node from the trie node cache if available
 	if enc := db.getCachedNode(hash); enc != nil {
 		if dec, err := decodeNode(hash[:], enc); err == nil {
@@ -526,8 +526,8 @@ func (db *Database) node(hash common.Hash) (n node, fromDB bool) {
 
 // Node retrieves an encoded cached trie node from memory. If it cannot be found
 // cached, the method queries the persistent database for the content.
-func (db *Database) Node(hash common.Hash) ([]byte, error) {
-	if (hash == common.Hash{}) {
+func (db *Database) Node(hash common.ExtHash) ([]byte, error) {
+	if (hash.ToHash() == common.Hash{}) {
 		return nil, ErrZeroHashNode
 	}
 	// Retrieve the node from the trie node cache if available
@@ -553,8 +553,8 @@ func (db *Database) Node(hash common.Hash) ([]byte, error) {
 
 // NodeFromOld retrieves an encoded cached trie node from memory. If it cannot be found
 // cached, the method queries the old persistent database for the content.
-func (db *Database) NodeFromOld(hash common.Hash) ([]byte, error) {
-	if (hash == common.Hash{}) {
+func (db *Database) NodeFromOld(hash common.ExtHash) ([]byte, error) {
+	if (hash.ToHash() == common.Hash{}) {
 		return nil, ErrZeroHashNode
 	}
 	// Retrieve the node from the trie node cache if available
@@ -579,7 +579,7 @@ func (db *Database) NodeFromOld(hash common.Hash) ([]byte, error) {
 }
 
 // DoesExistCachedNode returns if the node exists on cached trie node in memory.
-func (db *Database) DoesExistCachedNode(hash common.Hash) bool {
+func (db *Database) DoesExistCachedNode(hash common.ExtHash) bool {
 	// Retrieve the node from cache if available
 	db.lock.RLock()
 	_, ok := db.nodes[hash]
@@ -588,7 +588,7 @@ func (db *Database) DoesExistCachedNode(hash common.Hash) bool {
 }
 
 // DoesExistNodeInPersistent returns if the node exists on the persistent database or its cache.
-func (db *Database) DoesExistNodeInPersistent(hash common.Hash) bool {
+func (db *Database) DoesExistNodeInPersistent(hash common.ExtHash) bool {
 	// Retrieve the node from DB cache if available
 	if enc := db.getCachedNode(hash); enc != nil {
 		return true
@@ -630,13 +630,13 @@ func secureKey(hash common.Hash) []byte {
 // Nodes retrieves the hashes of all the nodes cached within the memory database.
 // This method is extremely expensive and should only be used to validate internal
 // states in test code.
-func (db *Database) Nodes() []common.Hash {
+func (db *Database) Nodes() []common.ExtHash {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
-	hashes := make([]common.Hash, 0, len(db.nodes))
+	var hashes = make([]common.ExtHash, 0, len(db.nodes))
 	for hash := range db.nodes {
-		if hash != (common.Hash{}) { // Special case for "root" references/nodes
+		if hash.ToHash() != (common.Hash{}) { // Special case for "root" references/nodes
 			hashes = append(hashes, hash)
 		}
 	}
@@ -647,7 +647,7 @@ func (db *Database) Nodes() []common.Hash {
 // This function is used to add reference between internal trie node
 // and external node(e.g. storage trie root), all internal trie nodes
 // are referenced together by database itself.
-func (db *Database) Reference(child common.Hash, parent common.Hash) {
+func (db *Database) Reference(child common.ExtHash, parent common.ExtHash) {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
@@ -655,7 +655,7 @@ func (db *Database) Reference(child common.Hash, parent common.Hash) {
 }
 
 // reference is the private locked version of Reference.
-func (db *Database) reference(child common.Hash, parent common.Hash) {
+func (db *Database) reference(child common.ExtHash, parent common.ExtHash) {
 	// If the node does not exist, it's a node pulled from disk, skip
 	node, ok := db.nodes[child]
 	if !ok {
@@ -663,8 +663,8 @@ func (db *Database) reference(child common.Hash, parent common.Hash) {
 	}
 	// If the reference already exists, only duplicate for roots
 	if db.nodes[parent].children == nil {
-		db.nodes[parent].children = make(map[common.Hash]uint64)
-	} else if _, ok = db.nodes[parent].children[child]; ok && parent != (common.Hash{}) {
+		db.nodes[parent].children = make(map[common.ExtHash]uint64)
+	} else if _, ok = db.nodes[parent].children[child]; ok && parent.ToHash() != (common.Hash{}) {
 		return
 	}
 	node.parents++
@@ -672,9 +672,9 @@ func (db *Database) reference(child common.Hash, parent common.Hash) {
 }
 
 // Dereference removes an existing reference from a root node.
-func (db *Database) Dereference(root common.Hash) {
+func (db *Database) Dereference(root common.ExtHash) {
 	// Sanity check to ensure that the meta-root is not removed
-	if common.EmptyHash(root) {
+	if common.EmptyHash(root.ToHash()) {
 		logger.Error("Attempted to dereference the trie cache meta root")
 		return
 	}
@@ -686,7 +686,7 @@ func (db *Database) Dereference(root common.Hash) {
 	defer db.lock.Unlock()
 
 	nodes, storage, start := len(db.nodes), db.nodesSize, time.Now()
-	db.dereference(root, common.Hash{})
+	db.dereference(root, common.InitExtHash())
 
 	db.gcnodes += uint64(nodes - len(db.nodes))
 	db.gcsize += storage - db.nodesSize
@@ -701,7 +701,7 @@ func (db *Database) Dereference(root common.Hash) {
 }
 
 // dereference is the private locked version of Dereference.
-func (db *Database) dereference(child common.Hash, parent common.Hash) {
+func (db *Database) dereference(child common.ExtHash, parent common.ExtHash) {
 	// Dereference the parent-child
 	node := db.nodes[parent]
 
@@ -732,7 +732,7 @@ func (db *Database) dereference(child common.Hash, parent common.Hash) {
 			db.dereference(hash, child)
 		}
 		delete(db.nodes, child)
-		db.nodesSize -= common.StorageSize(common.HashLength + int(node.size))
+		db.nodesSize -= common.StorageSize(common.ExtHashLength + int(node.size))
 	}
 }
 
@@ -765,7 +765,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	// Keep committing nodes from the flush-list until we're below allowance
 	oldest := db.oldest
 	batch := db.diskDB.NewBatch(database.StateTrieDB)
-	for size > limit && oldest != (common.Hash{}) {
+	for size > limit && oldest.ToHash() != (common.Hash{}) {
 		// Fetch the oldest referenced node and push into the batch
 		node := db.nodes[oldest]
 		enc := node.rlp()
@@ -781,7 +781,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 		// is the total size, including both the useful cached data (hash -> blob), as
 		// well as the flushlist metadata (2*hash). When flushing items from the cache,
 		// we need to reduce both.
-		size -= common.StorageSize(3*common.HashLength + int(node.size))
+		size -= common.StorageSize(3*common.ExtHashLength + int(node.size))
 		oldest = node.flushNext
 	}
 	// Flush out any remainder data from the last batch
@@ -806,12 +806,12 @@ func (db *Database) Cap(limit common.StorageSize) error {
 		delete(db.nodes, db.oldest)
 		db.oldest = node.flushNext
 
-		db.nodesSize -= common.StorageSize(common.HashLength + int(node.size))
+		db.nodesSize -= common.StorageSize(common.ExtHashLength + int(node.size))
 	}
-	if db.oldest != (common.Hash{}) {
-		db.nodes[db.oldest].flushPrev = common.Hash{}
+	if db.oldest.ToHash() != (common.Hash{}) {
+		db.nodes[db.oldest].flushPrev = common.InitExtHash()
 	} else {
-		db.newest = common.Hash{}
+		db.newest = common.InitExtHash()
 	}
 	db.flushnodes += uint64(nodes - len(db.nodes))
 	db.flushsize += nodeSize - db.nodesSize
@@ -867,7 +867,7 @@ type commitResult struct {
 	val []byte
 }
 
-func (db *Database) writeBatchNodes(node common.Hash) error {
+func (db *Database) writeBatchNodes(node common.ExtHash) error {
 	rootNode, ok := db.nodes[node]
 	if !ok {
 		return nil
@@ -919,7 +919,7 @@ func (db *Database) writeBatchNodes(node common.Hash) error {
 	return nil
 }
 
-func (db *Database) concurrentCommit(hash common.Hash, resultCh chan<- commitResult, childIndex int) {
+func (db *Database) concurrentCommit(hash common.ExtHash, resultCh chan<- commitResult, childIndex int) {
 	logger.Trace("concurrentCommit start", "childIndex", childIndex)
 	defer logger.Trace("concurrentCommit end", "childIndex", childIndex)
 	db.commit(hash, resultCh)
@@ -930,7 +930,7 @@ func (db *Database) concurrentCommit(hash common.Hash, resultCh chan<- commitRes
 // to disk, forcefully tearing down all references in both directions.
 //
 // As a side effect, all pre-images accumulated up to this point are also written.
-func (db *Database) Commit(node common.Hash, report bool, blockNum uint64) error {
+func (db *Database) Commit(node common.ExtHash, report bool, blockNum uint64) error {
 	// Create a database batch to flush persistent data out. It is important that
 	// outside code doesn't see an inconsistent state (referenced data removed from
 	// memory cache during commit but not yet in persistent database). This is ensured
@@ -984,7 +984,7 @@ func (db *Database) Commit(node common.Hash, report bool, blockNum uint64) error
 }
 
 // commit iteratively encodes nodes from parents to child nodes.
-func (db *Database) commit(hash common.Hash, resultCh chan<- commitResult) {
+func (db *Database) commit(hash common.ExtHash, resultCh chan<- commitResult) {
 	node, ok := db.nodes[hash]
 	if !ok {
 		return
@@ -1004,7 +1004,7 @@ func (db *Database) commit(hash common.Hash, resultCh chan<- commitResult) {
 // persisted trie is removed from the cache. The reason behind the two-phase
 // commit is to ensure consistent data availability while moving from memory
 // to disk.
-func (db *Database) uncache(hash common.Hash) {
+func (db *Database) uncache(hash common.ExtHash) {
 	// If the node does not exists, we're done on this path
 	node, ok := db.nodes[hash]
 	if !ok {
@@ -1017,7 +1017,7 @@ func (db *Database) uncache(hash common.Hash) {
 		db.uncache(child)
 	}
 	delete(db.nodes, hash)
-	db.nodesSize -= common.StorageSize(common.HashLength + int(node.size))
+	db.nodesSize -= common.StorageSize(common.ExtHashLength + int(node.size))
 }
 
 // Size returns the current database size of the memory cache in front of the
@@ -1041,9 +1041,9 @@ func (db *Database) Size() (common.StorageSize, common.StorageSize, common.Stora
 // This method is extremely CPU and memory intensive, only use when must.
 func (db *Database) verifyIntegrity() {
 	// Iterate over all the cached nodes and accumulate them into a set
-	reachable := map[common.Hash]struct{}{{}: {}}
+	reachable := map[common.ExtHash]struct{}{common.InitExtHash(): {}}
 
-	for child := range db.nodes[common.Hash{}].children {
+	for child := range db.nodes[common.InitExtHash()].children {
 		db.accumulate(child, reachable)
 	}
 	// Find any unreachable but cached nodes
@@ -1061,7 +1061,7 @@ func (db *Database) verifyIntegrity() {
 
 // accumulate iterates over the trie defined by hash and accumulates all the
 // cached children found in memory.
-func (db *Database) accumulate(hash common.Hash, reachable map[common.Hash]struct{}) {
+func (db *Database) accumulate(hash common.ExtHash, reachable map[common.ExtHash]struct{}) {
 	// Mark the node reachable if present in the memory cache
 	node, ok := db.nodes[hash]
 	if !ok {
@@ -1075,29 +1075,29 @@ func (db *Database) accumulate(hash common.Hash, reachable map[common.Hash]struc
 	}
 }
 
-func (db *Database) removeNodeInFlushList(hash common.Hash) {
+func (db *Database) removeNodeInFlushList(hash common.ExtHash) {
 	node, ok := db.nodes[hash]
 	if !ok {
 		return
 	}
 
 	if hash == db.oldest && hash == db.newest {
-		db.oldest = common.Hash{}
-		db.newest = common.Hash{}
+		db.oldest = common.InitExtHash()
+		db.newest = common.InitExtHash()
 	} else if hash == db.oldest {
 		db.oldest = node.flushNext
-		db.nodes[node.flushNext].flushPrev = common.Hash{}
+		db.nodes[node.flushNext].flushPrev = common.InitExtHash()
 	} else if hash == db.newest {
 		db.newest = node.flushPrev
-		db.nodes[node.flushPrev].flushNext = common.Hash{}
+		db.nodes[node.flushPrev].flushNext = common.InitExtHash()
 	} else {
 		db.nodes[node.flushPrev].flushNext = node.flushNext
 		db.nodes[node.flushNext].flushPrev = node.flushPrev
 	}
 }
 
-func (db *Database) getLastNodeHashInFlushList() common.Hash {
-	var lastNodeHash common.Hash
+func (db *Database) getLastNodeHashInFlushList() common.ExtHash {
+	lastNodeHash := common.InitExtHash()
 	nodeHash := db.oldest
 	for {
 		if _, ok := db.nodes[nodeHash]; ok {
@@ -1107,7 +1107,7 @@ func (db *Database) getLastNodeHashInFlushList() common.Hash {
 			break
 		}
 
-		if db.nodes[nodeHash].flushNext != (common.Hash{}) {
+		if db.nodes[nodeHash].flushNext.ToHash() != (common.Hash{}) {
 			nodeHash = db.nodes[nodeHash].flushNext
 		} else {
 			logger.Debug("found last noode in map of flush list")
@@ -1188,7 +1188,7 @@ type NodeInfo struct {
 }
 
 // CollectChildrenStats collects the depth of the trie recursively
-func (db *Database) CollectChildrenStats(node common.Hash, depth int, resultCh chan<- NodeInfo) {
+func (db *Database) CollectChildrenStats(node common.ExtHash, depth int, resultCh chan<- NodeInfo) {
 	n, _ := db.node(node)
 	if n == nil {
 		return

--- a/storage/statedb/errors.go
+++ b/storage/statedb/errors.go
@@ -31,8 +31,8 @@ import (
 // in the case where a trie node is not present in the local database. It contains
 // information necessary for retrieving the missing node.
 type MissingNodeError struct {
-	NodeHash common.Hash // hash of the missing node
-	Path     []byte      // hex-encoded path to the missing node
+	NodeHash common.ExtHash // hash of the missing node
+	Path     []byte         // hex-encoded path to the missing node
 }
 
 func (err *MissingNodeError) Error() string {

--- a/storage/statedb/hasher.go
+++ b/storage/statedb/hasher.go
@@ -21,7 +21,9 @@
 package statedb
 
 import (
+	"fmt"
 	"hash"
+	"reflect"
 	"sync"
 
 	"github.com/klaytn/klaytn/common"
@@ -93,29 +95,55 @@ func (h *hasher) hash(n node, db *Database, force bool) (node, node) {
 	}
 	// Trie not processed yet or needs storage, walk the children
 	collapsed, cached := h.hashChildren(n, db)
-	hashed, lenEncoded := h.store(collapsed, db, force)
+	hashed, lenEncoded, extHashed := h.store(collapsed, db, force, false)
 	// Cache the hash of the node for later reuse and remove
 	// the dirty flag in commit mode. It's fine to assign these values directly
 	// without copying the node first because hashChildren copies it.
-	cachedHash, _ := hashed.(hashNode)
+	extCachedHash := extHashed.Bytes()
+	cachedHash, ok := hashed.(hashNode)
+	if extHashed.ToHash() == (common.Hash{}) && ok {
+		extCachedHash = common.BytesToExtHash(cachedHash.Bytes()).Bytes()
+	}
 	switch cn := cached.(type) {
 	case *shortNode:
-		cn.flags.hash = cachedHash
+		if ok {
+			cn.flags.hash = extCachedHash
+			n.(*shortNode).flags.hash = extCachedHash
+		} else {
+			cn.flags.hash = cachedHash
+			n.(*shortNode).flags.hash = cachedHash
+		}
 		cn.flags.lenEncoded = lenEncoded
 		if db != nil {
 			cn.flags.dirty = false
 		}
 	case *fullNode:
-		cn.flags.hash = cachedHash
+		if ok {
+			cn.flags.hash = extCachedHash
+			n.(*fullNode).flags.hash = extCachedHash
+		} else {
+			cn.flags.hash = cachedHash
+			n.(*fullNode).flags.hash = cachedHash
+		}
 		cn.flags.lenEncoded = lenEncoded
 		if db != nil {
 			cn.flags.dirty = false
 		}
 	}
-	return hashed, cached
+
+	switch hashed.(type) {
+	case *shortNode:
+		return hashed, cached
+	case hashNode:
+		return toHashNode(extCachedHash), cached
+	case valueNode:
+		return valueNode(extCachedHash), cached
+	default:
+		panic(fmt.Sprintf("node process not defind : node type = %v", reflect.TypeOf(hashed)))
+	}
 }
 
-func (h *hasher) hashRoot(n node, db *Database, force bool) (node, node) {
+func (h *hasher) hashRoot(n node, db *Database, force bool, extRootFlag bool) (node, node) {
 	// If we're not storing the node, just hashing, use available cached data
 	if hash, dirty := n.cache(); hash != nil {
 		if db == nil {
@@ -132,26 +160,56 @@ func (h *hasher) hashRoot(n node, db *Database, force bool) (node, node) {
 	}
 	// Trie not processed yet or needs storage, walk the children
 	collapsed, cached := h.hashChildrenFromRoot(n, db)
-	hashed, lenEncoded := h.store(collapsed, db, force)
+	hashed, lenEncoded, extHashed := h.store(collapsed, db, force, extRootFlag)
 	// Cache the hash of the node for later reuse and remove
 	// the dirty flag in commit mode. It's fine to assign these values directly
 	// without copying the node first because hashChildren copies it.
-	cachedHash, _ := hashed.(hashNode)
+	extCachedHash := extHashed.Bytes()
+	cachedHash, ok := hashed.(hashNode)
+	if extHashed.ToHash() == (common.Hash{}) && ok {
+		if extRootFlag {
+			extCachedHash = common.BytesToRootExtHash(cachedHash.Bytes()).Bytes()
+		} else {
+			extCachedHash = common.BytesToExtHash(cachedHash.Bytes()).Bytes()
+		}
+	}
 	switch cn := cached.(type) {
 	case *shortNode:
-		cn.flags.hash = cachedHash
+		if ok {
+			cn.flags.hash = extCachedHash
+			n.(*shortNode).flags.hash = extCachedHash
+		} else {
+			cn.flags.hash = cachedHash
+			n.(*shortNode).flags.hash = cachedHash
+		}
 		cn.flags.lenEncoded = lenEncoded
 		if db != nil {
 			cn.flags.dirty = false
 		}
 	case *fullNode:
-		cn.flags.hash = cachedHash
+		if ok {
+			cn.flags.hash = extCachedHash
+			n.(*fullNode).flags.hash = extCachedHash
+		} else {
+			cn.flags.hash = cachedHash
+			n.(*fullNode).flags.hash = cachedHash
+		}
 		cn.flags.lenEncoded = lenEncoded
 		if db != nil {
 			cn.flags.dirty = false
 		}
 	}
-	return hashed, cached
+
+	switch hashed.(type) {
+	case *shortNode:
+		return hashed, cached
+	case hashNode:
+		return toHashNode(extCachedHash), cached
+	case valueNode:
+		return valueNode(extCachedHash), cached
+	default:
+		panic(fmt.Sprintf("node process not defind : node type = %v", reflect.TypeOf(hashed)))
+	}
 }
 
 // hashChildren replaces the children of a node with their hashes if the encoded
@@ -243,10 +301,12 @@ func (h *hasher) hashChildrenFromRoot(original node, db *Database) (node, node) 
 // store hashes the node n and if we have a storage layer specified, it writes
 // the key/value pair to it and tracks any node->child references as well as any
 // node->external trie references.
-func (h *hasher) store(n node, db *Database, force bool) (node, uint16) {
+func (h *hasher) store(n node, db *Database, force, rootFlag bool) (node, uint16, common.ExtHash) {
+	var tmpHash common.ExtHash
+
 	// Don't store hashes or empty nodes.
 	if _, isHash := n.(hashNode); n == nil || isHash {
-		return n, 0
+		return n, 0, tmpHash
 	}
 	hash, _ := n.cache()
 	lenEncoded := n.lenEncoded()
@@ -260,17 +320,21 @@ func (h *hasher) store(n node, db *Database, force bool) (node, uint16) {
 		lenEncoded = uint16(len(h.tmp))
 	}
 	if lenEncoded < 32 && !force {
-		return n, lenEncoded // Nodes smaller than 32 bytes are stored inside their parent
+		return n, lenEncoded, tmpHash // Nodes smaller than 32 bytes are stored inside their parent
 	}
 	if hash == nil {
 		hash = h.makeHashNode(h.tmp)
 	}
 	if db != nil {
 		// We are pooling the trie nodes into an intermediate memory cache
-		hash := common.BytesToHash(hash)
+		if rootFlag {
+			tmpHash = common.BytesToRootExtHash(hash)
+		} else {
+			tmpHash = common.BytesToExtHash(hash)
+		}
 
 		db.lock.Lock()
-		db.insert(hash, lenEncoded, n)
+		db.insert(tmpHash, lenEncoded, n)
 		db.lock.Unlock()
 
 		// Track external references from account->storage trie
@@ -278,24 +342,33 @@ func (h *hasher) store(n node, db *Database, force bool) (node, uint16) {
 			switch n := n.(type) {
 			case *shortNode:
 				if child, ok := n.Val.(valueNode); ok {
-					h.onleaf(nil, nil, child, hash, 0)
+					h.onleaf(nil, nil, child, tmpHash, 0)
 				}
+				n.flags.hash = toHashNode(tmpHash.Bytes())
 			case *fullNode:
 				for i := 0; i < 16; i++ {
 					if child, ok := n.Children[i].(valueNode); ok {
-						h.onleaf(nil, nil, child, hash, 0)
+						h.onleaf(nil, nil, child, tmpHash, 0)
 					}
 				}
+				n.flags.hash = toHashNode(tmpHash[:])
 			}
 		}
 	}
-	return hash, lenEncoded
+	return hash, lenEncoded, tmpHash
 }
 
 func (h *hasher) makeHashNode(data []byte) hashNode {
 	n := make(hashNode, h.sha.Size())
 	h.sha.Reset()
-	h.sha.Write(data)
+	tmpData, err := common.RlpPaddingFilter(data)
+	if err == nil {
+		h.sha.Write(tmpData)
+	} else {
+		//tmpData = rlp.ExtPaddingFilter(data)
+		tmpData = common.ExtPaddingFilter(data)
+		h.sha.Write(tmpData)
+	}
 	h.sha.Read(n)
 	return n
 }

--- a/storage/statedb/iterator.go
+++ b/storage/statedb/iterator.go
@@ -71,10 +71,10 @@ type NodeIterator interface {
 	Error() error
 
 	// Hash returns the hash of the current node.
-	Hash() common.Hash
+	Hash() common.ExtHash
 	// Parent returns the hash of the parent of the current node. The hash may be the one
 	// grandparent if the immediate parent is an internal node with no hash.
-	Parent() common.Hash
+	Parent() common.ExtHash
 	// Path returns the hex-encoded path to the current node.
 	// Callers must not retain references to the return value after calling Next.
 	// For leaf nodes, the last element of the path is the 'terminator symbol' 0x10.
@@ -118,11 +118,11 @@ type NodeIterator interface {
 // nodeIteratorState represents the iteration state at one particular node of the
 // trie, which can be resumed at a later invocation.
 type nodeIteratorState struct {
-	hash    common.Hash // Hash of the node being iterated (nil if not standalone)
-	node    node        // Trie node being iterated
-	parent  common.Hash // Hash of the first full ancestor node (nil if current is the root)
-	index   int         // Child to be processed next
-	pathlen int         // Length of the path to this node
+	hash    common.ExtHash // Hash of the node being iterated (nil if not standalone)
+	node    node           // Trie node being iterated
+	parent  common.ExtHash // Hash of the first full ancestor node (nil if current is the root)
+	index   int            // Child to be processed next
+	pathlen int            // Length of the path to this node
 }
 
 type nodeIterator struct {
@@ -148,7 +148,7 @@ func (e seekError) Error() string {
 }
 
 func newNodeIterator(trie *Trie, start []byte) NodeIterator {
-	if trie.Hash() == emptyState {
+	if trie.Hash().ToHash() == emptyState {
 		return new(nodeIterator)
 	}
 	it := &nodeIterator{trie: trie}
@@ -156,16 +156,16 @@ func newNodeIterator(trie *Trie, start []byte) NodeIterator {
 	return it
 }
 
-func (it *nodeIterator) Hash() common.Hash {
+func (it *nodeIterator) Hash() common.ExtHash {
 	if len(it.stack) == 0 {
-		return common.Hash{}
+		return common.InitExtHash()
 	}
 	return it.stack[len(it.stack)-1].hash
 }
 
-func (it *nodeIterator) Parent() common.Hash {
+func (it *nodeIterator) Parent() common.ExtHash {
 	if len(it.stack) == 0 {
-		return common.Hash{}
+		return common.InitExtHash()
 	}
 	return it.stack[len(it.stack)-1].parent
 }
@@ -203,7 +203,7 @@ func (it *nodeIterator) LeafProof() [][]byte {
 			for i, item := range it.stack[:len(it.stack)-1] {
 				// Gather nodes that end up as hash nodes (or the root)
 				node, _ := hasher.hashChildren(item.node, nil)
-				hashed, _ := hasher.store(node, nil, false)
+				hashed, _, _ := hasher.store(node, nil, false, false)
 				if _, ok := hashed.(hashNode); ok || i == 0 {
 					enc, _ := rlp.EncodeToBytes(node)
 					proofs = append(proofs, enc)
@@ -280,7 +280,7 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 		// Initialize the iterator if we've just started.
 		root := it.trie.Hash()
 		state := &nodeIteratorState{node: it.trie.root, index: -1}
-		if root != emptyRoot {
+		if root.ToHash() != emptyRoot.ToHash() {
 			state.hash = root
 		}
 		err := state.resolve(it, nil)
@@ -295,7 +295,7 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 	for len(it.stack) > 0 {
 		parent := it.stack[len(it.stack)-1]
 		ancestor := parent.hash
-		if (ancestor == common.Hash{}) {
+		if (ancestor.ToHash() == common.Hash{}) {
 			ancestor = parent.parent
 		}
 		state, path, ok := it.nextChild(parent, ancestor)
@@ -313,7 +313,7 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 
 func (it *nodeIterator) resolveHash(hash hashNode, path []byte) (node, error) {
 	if it.resolver != nil {
-		hash := common.BytesToHash(hash)
+		hash := common.BytesToExtHash(hash)
 		enc, _ := it.resolver.ReadCachedTrieNode(hash)
 		if enc != nil {
 			if resolved, err := decodeNode(hash[:], enc); err == nil {
@@ -331,12 +331,12 @@ func (st *nodeIteratorState) resolve(it *nodeIterator, path []byte) error {
 			return err
 		}
 		st.node = resolved
-		st.hash = common.BytesToHash(hash)
+		st.hash = common.BytesToExtHash(hash)
 	}
 	return nil
 }
 
-func (it *nodeIterator) nextChild(parent *nodeIteratorState, ancestor common.Hash) (*nodeIteratorState, []byte, bool) {
+func (it *nodeIterator) nextChild(parent *nodeIteratorState, ancestor common.ExtHash) (*nodeIteratorState, []byte, bool) {
 	switch node := parent.node.(type) {
 	case *fullNode:
 		// Full node, move to the first non-nil child.
@@ -345,7 +345,7 @@ func (it *nodeIterator) nextChild(parent *nodeIteratorState, ancestor common.Has
 			if child != nil {
 				hash, _ := child.cache()
 				state := &nodeIteratorState{
-					hash:    common.BytesToHash(hash),
+					hash:    common.BytesToExtHash(hash),
 					node:    child,
 					parent:  ancestor,
 					index:   -1,
@@ -361,7 +361,7 @@ func (it *nodeIterator) nextChild(parent *nodeIteratorState, ancestor common.Has
 		if parent.index < 0 {
 			hash, _ := node.Val.cache()
 			state := &nodeIteratorState{
-				hash:    common.BytesToHash(hash),
+				hash:    common.BytesToExtHash(hash),
 				node:    node.Val,
 				parent:  ancestor,
 				index:   -1,
@@ -424,11 +424,11 @@ func NewDifferenceIterator(a, b NodeIterator) (NodeIterator, *int) {
 	return it, &it.count
 }
 
-func (it *differenceIterator) Hash() common.Hash {
+func (it *differenceIterator) Hash() common.ExtHash {
 	return it.b.Hash()
 }
 
-func (it *differenceIterator) Parent() common.Hash {
+func (it *differenceIterator) Parent() common.ExtHash {
 	return it.b.Parent()
 }
 
@@ -484,7 +484,7 @@ func (it *differenceIterator) Next(bool) bool {
 			return true
 		case 0:
 			// a and b are identical; skip this whole subtree if the nodes have hashes
-			hasHash := it.a.Hash() == common.Hash{}
+			hasHash := it.a.Hash().ToHash() == common.Hash{}
 			if !it.b.Next(hasHash) {
 				return false
 			}
@@ -535,11 +535,11 @@ func NewUnionIterator(iters []NodeIterator) (NodeIterator, *int) {
 	return ui, &ui.count
 }
 
-func (it *unionIterator) Hash() common.Hash {
+func (it *unionIterator) Hash() common.ExtHash {
 	return (*it.items)[0].Hash()
 }
 
-func (it *unionIterator) Parent() common.Hash {
+func (it *unionIterator) Parent() common.ExtHash {
 	return (*it.items)[0].Parent()
 }
 
@@ -594,7 +594,7 @@ func (it *unionIterator) Next(descend bool) bool {
 	for len(*it.items) > 0 && ((!descend && bytes.HasPrefix((*it.items)[0].Path(), least.Path())) || compareNodes(least, (*it.items)[0]) == 0) {
 		skipped := heap.Pop(it.items).(NodeIterator)
 		// Skip the whole subtree if the nodes have hashes; otherwise just skip this node
-		if skipped.Next(skipped.Hash() == common.Hash{}) {
+		if skipped.Next(skipped.Hash().ToHash() == common.Hash{}) {
 			it.count += 1
 			// If there are more elements, push the iterator back on the heap
 			heap.Push(it.items, skipped)

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -210,7 +210,7 @@ func (mr *MockBlockChainMockRecorder) Config() *gomock.Call {
 }
 
 // ContractCode mocks base method
-func (m *MockBlockChain) ContractCode(arg0 common.Hash) ([]byte, error) {
+func (m *MockBlockChain) ContractCode(arg0 common.ExtHash) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContractCode", arg0)
 	ret0, _ := ret[0].([]byte)

--- a/work/work.go
+++ b/work/work.go
@@ -247,8 +247,8 @@ type BlockChain interface {
 
 	InsertChain(chain types.Blocks) (int, error)
 	TrieNode(hash common.Hash) ([]byte, error)
-	ContractCode(hash common.Hash) ([]byte, error)
-	ContractCodeWithPrefix(hash common.Hash) ([]byte, error)
+	ContractCode(hash common.ExtHash) ([]byte, error)
+	ContractCodeWithPrefix(hash common.ExtHash) ([]byte, error)
 	Config() *params.ChainConfig
 	State() (*state.StateDB, error)
 	Rollback(chain []common.Hash)


### PR DESCRIPTION
## Proposed changes

Firt commit to Statedb-pruning
- The key element is the addition of Extended Hash (ExtHash).
- ExtHash removes hash duplication by adding an additional 8 bytes to the existing 32-byte hash.
- Stores only the latest 86400 block of statedb and deletes past data.
- Header, Body, and Reciepts also erased past data, but it seems to have some problems.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
