### PR TITLE
Fix TestGovernance_Engines timing bug

### DIFF
--- a/tests/gov_contract_test.go
+++ b/tests/gov_contract_test.go
@@ -86,6 +86,10 @@ func TestGovernance_Engines(t *testing.T) {
 	go func() {
 		deployGovParamTx_constructor(t, node, owner, chainId)
 
+		// Give some time for txpool to recognize the contract, because otherwise
+		// the txpool may reject the setParam tx with 'not a program account'
+		time.Sleep(2 * time.Second)
+
 		deployGovParamTx_setParamIn(t, node, owner, chainId, contractAddr, paramName, paramBytes)
 
 		node.Governance().AddVote("governance.govparamcontract", contractAddr)

--- a/tests/klay_blockchain_test.go
+++ b/tests/klay_blockchain_test.go
@@ -294,7 +294,9 @@ func deployContractDeployTx(t *testing.T, txpool work.TxPool, chainId *big.Int, 
 	require.Nil(t, err)
 
 	err = txpool.AddLocal(tx)
-	require.True(t, err == nil || err == blockchain.ErrAlreadyNonceExistInPool)
+	if err != nil && err != blockchain.ErrAlreadyNonceExistInPool {
+		t.Fatal(err)
+	}
 
 	contractAddr := crypto.CreateAddress(sender.Addr, sender.Nonce)
 	sender.AddNonce()
@@ -322,7 +324,9 @@ func deployContractExecutionTx(t *testing.T, txpool work.TxPool, chainId *big.In
 	require.Nil(t, err)
 
 	err = txpool.AddLocal(tx)
-	require.True(t, err == nil || err == blockchain.ErrAlreadyNonceExistInPool)
+	if err != nil && err != blockchain.ErrAlreadyNonceExistInPool {
+		t.Fatal(err)
+	}
 
 	sender.AddNonce()
 	return tx


### PR DESCRIPTION
## Proposed changes

- Fix the occasional nightly-coverage error of `tests/gov_contract_test.go:TestGovernance_Engines`
- Cause of the error
  - The test deploys a contract and then immediately calls the contract.
  - The txpool is somehow holding the statedb before contract is deployed.
  - The contract call tx is rejected at `txpool.AddLocal()` with 'not a program account' error.
- Why this test only breaks in coverage?
  - Perhaps coverage instrumentation made the program slow?
- How to reproduce the error:
  - Comment gov_contract_test.go line 91
  - Add `time.Sleep(time.Second * 10)` in line 109 (simulate a slowdown)
  - Run `go test -run=TestGovernance_Engines`.
  - After 60 seconds, it should fail with 'test taking too long; something must be wrong'.
- How to check that it's fixed
  - Uncomment gov_contract_test.go line 91
  - Test passes now.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
