### PR TITLE
Control by disableUnsafeDebugFlag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             make test-others
-    resource_class: xlarge
+    resource_class: large
 
   test-rpc:
     executor: test-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             make test-others
-    resource_class: large
+    resource_class: xlarge
 
   test-rpc:
     executor: test-executor

--- a/api/backend.go
+++ b/api/backend.go
@@ -139,7 +139,7 @@ func GetAPIs(apiBackend Backend) ([]rpc.API, *EthereumAPI) {
 			Service:   NewPublicDebugAPI(apiBackend),
 			Public:    false,
 		}, {
-			Namespace: "unsafedebug",
+			Namespace: "debug",
 			Version:   "1.0",
 			Service:   NewPrivateDebugAPI(apiBackend),
 			Public:    false,

--- a/api/backend.go
+++ b/api/backend.go
@@ -97,7 +97,7 @@ type Backend interface {
 	GetTxLookupInfoAndReceiptInCache(Hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, *types.Receipt)
 }
 
-func GetAPIs(apiBackend Backend) ([]rpc.API, *EthereumAPI) {
+func GetAPIs(apiBackend Backend, disableUnsafeDebug bool) ([]rpc.API, *EthereumAPI) {
 	nonceLock := new(AddrLocker)
 
 	ethAPI := NewEthereumAPI()
@@ -112,7 +112,7 @@ func GetAPIs(apiBackend Backend) ([]rpc.API, *EthereumAPI) {
 	ethAPI.SetPublicTransactionPoolAPI(publicTransactionPoolAPI)
 	ethAPI.SetPublicAccountAPI(publicAccountAPI)
 
-	return []rpc.API{
+	rpcApi := []rpc.API{
 		{
 			Namespace: "klay",
 			Version:   "1.0",
@@ -139,11 +139,6 @@ func GetAPIs(apiBackend Backend) ([]rpc.API, *EthereumAPI) {
 			Service:   NewPublicDebugAPI(apiBackend),
 			Public:    false,
 		}, {
-			Namespace: "debug",
-			Version:   "1.0",
-			Service:   NewPrivateDebugAPI(apiBackend),
-			Public:    false,
-		}, {
 			Namespace: "klay",
 			Version:   "1.0",
 			Service:   publicAccountAPI,
@@ -154,5 +149,18 @@ func GetAPIs(apiBackend Backend) ([]rpc.API, *EthereumAPI) {
 			Service:   NewPrivateAccountAPI(apiBackend, nonceLock),
 			Public:    false,
 		},
-	}, ethAPI
+	}
+	privateDebugApi := []rpc.API{
+		{
+			Namespace: "debug",
+			Version:   "1.0",
+			Service:   NewPrivateDebugAPI(apiBackend),
+			Public:    false,
+		},
+	}
+	if !disableUnsafeDebug {
+		rpcApi = append(rpcApi, privateDebugApi...)
+	}
+
+	return rpcApi, ethAPI
 }

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -317,6 +317,10 @@ func (kCfg *KlayConfig) SetNodeConfig(ctx *cli.Context) {
 	} else {
 		cfg.NtpRemoteServer = ctx.GlobalString(NtpServerFlag.Name)
 	}
+
+	// disable unsafe debug APIs
+	cfg.DisableUnsafeDebug = ctx.GlobalBool(UnsafeDebugDisableFlag.Name)
+
 	SetP2PConfig(ctx, &cfg.P2P)
 	setIPC(ctx, cfg)
 
@@ -621,6 +625,9 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 	} else {
 		cfg.SnapshotCacheSize = 0 // snapshot disabled
 	}
+
+	// disable unsafe debug APIs
+	cfg.DisableUnsafeDebug = ctx.GlobalBool(UnsafeDebugDisableFlag.Name)
 
 	// Override any default configs for hard coded network.
 	// TODO-Klaytn-Bootnode: Discuss and add `baobab` test network's genesis block

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -255,6 +255,7 @@ var FlagGroups = []FlagGroup{
 			RPCGlobalEthTxFeeCapFlag,
 			RPCConcurrencyLimit,
 			RPCNonEthCompatibleFlag,
+			UnsafeDebugDisableFlag,
 			IPCDisabledFlag,
 			IPCPathFlag,
 			WSEnabledFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -71,6 +71,11 @@ var (
 	ConfFlag = cli.StringFlag{
 		Name: "conf",
 	}
+	UnsafeDebugDisableFlag = cli.BoolFlag{
+		Name:   "unsafe-debug.disable",
+		Usage:  "Disable unsafe debug APIs (traceTransaction, writeXXX, ...).",
+		EnvVar: "KLAYTN_UNSAFE_DEBUG_DISABLE",
+	}
 	NtpDisableFlag = cli.BoolFlag{
 		Name:   "ntp.disable",
 		Usage:  "Disable checking if the local time is synchronized with ntp server. If this flag is not set, the local time is checked with the time of the server specified by ntp.server.",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -71,11 +71,6 @@ var (
 	ConfFlag = cli.StringFlag{
 		Name: "conf",
 	}
-	UnsafeDebugDisableFlag = cli.BoolFlag{
-		Name:   "unsafe-debug.disable",
-		Usage:  "Disable unsafe debug APIs (traceTransaction, writeXXX, ...).",
-		EnvVar: "KLAYTN_UNSAFE_DEBUG_DISABLE",
-	}
 	NtpDisableFlag = cli.BoolFlag{
 		Name:   "ntp.disable",
 		Usage:  "Disable checking if the local time is synchronized with ntp server. If this flag is not set, the local time is checked with the time of the server specified by ntp.server.",
@@ -714,6 +709,11 @@ var (
 		Usage:  "HTTP-RPC server execution timeout (seconds)",
 		Value:  int(rpc.DefaultHTTPTimeouts.ExecutionTimeout / time.Second),
 		EnvVar: "KLAYTN_RPCEXECUTIONTIMEOUT",
+	}
+	UnsafeDebugDisableFlag = cli.BoolFlag{
+		Name:   "rpc.unsafe-debug.disable",
+		Usage:  "Disable unsafe debug APIs (traceTransaction, writeXXX, ...).",
+		EnvVar: "KLAYTN_RPC_UNSAFE_DEBUG_DISABLE",
 	}
 
 	// Network Settings

--- a/cmd/utils/nodecmd/consolecmd_test.go
+++ b/cmd/utils/nodecmd/consolecmd_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 governance:1.0 istanbul:1.0 klay:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 unsafedebug:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 governance:1.0 istanbul:1.0 klay:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0"
 	httpAPIs = "eth:1.0 klay:1.0 net:1.0 rpc:1.0 web3:1.0"
 )
 

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -235,6 +235,7 @@ var CommonRPCFlags = []cli.Flag{
 	altsrc.NewIntFlag(utils.RPCWriteTimeoutFlag),
 	altsrc.NewIntFlag(utils.RPCIdleTimeoutFlag),
 	altsrc.NewIntFlag(utils.RPCExecutionTimeoutFlag),
+	altsrc.NewBoolFlag(utils.UnsafeDebugDisableFlag),
 }
 
 var KCNFlags = []cli.Flag{
@@ -283,7 +284,6 @@ var KENFlags = []cli.Flag{
 	altsrc.NewUint64Flag(utils.TxResendIntervalFlag),
 	altsrc.NewIntFlag(utils.TxResendCountFlag),
 	altsrc.NewBoolFlag(utils.TxResendUseLegacyFlag),
-	altsrc.NewBoolFlag(utils.UnsafeDebugDisableFlag),
 }
 
 var KSCNFlags = []cli.Flag{

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -283,6 +283,7 @@ var KENFlags = []cli.Flag{
 	altsrc.NewUint64Flag(utils.TxResendIntervalFlag),
 	altsrc.NewIntFlag(utils.TxResendCountFlag),
 	altsrc.NewBoolFlag(utils.TxResendUseLegacyFlag),
+	altsrc.NewBoolFlag(utils.UnsafeDebugDisableFlag),
 }
 
 var KSCNFlags = []cli.Flag{

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -23,7 +23,6 @@ package web3ext
 var Modules = map[string]string{
 	"admin":            Admin_JS,
 	"debug":            Debug_JS,
-	"unsafedebug":      UnsafeDebug_JS,
 	"klay":             Klay_JS,
 	"net":              Net_JS,
 	"personal":         Personal_JS,
@@ -547,8 +546,190 @@ web3._extend({
 			params: 0,
 		}),
 		new web3._extend.Method({
+			name: 'printBlock',
+			call: 'debug_printBlock',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'setHead',
+			call: 'debug_setHead',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'startWarmUp',
+			call: 'debug_startWarmUp',
+		}),
+		new web3._extend.Method({
+			name: 'startContractWarmUp',
+			call: 'debug_startContractWarmUp',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'stopWarmUp',
+			call: 'debug_stopWarmUp',
+		}),
+		new web3._extend.Method({
+			name: 'startCollectingTrieStats',
+			call: 'debug_startCollectingTrieStats',
+			params: 1,
+		}),
+		new web3._extend.Method({
+			name: 'chaindbProperty',
+			call: 'debug_chaindbProperty',
+			params: 1,
+			outputFormatter: console.log
+		}),
+		new web3._extend.Method({
+			name: 'chaindbCompact',
+			call: 'debug_chaindbCompact',
+		}),
+		new web3._extend.Method({
+			name: 'metrics',
+			call: 'debug_metrics',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'verbosity',
+			call: 'debug_verbosity',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'verbosityByName',
+			call: 'debug_verbosityByName',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'verbosityByID',
+			call: 'debug_verbosityByID',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'vmodule',
+			call: 'debug_vmodule',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'backtraceAt',
+			call: 'debug_backtraceAt',
+			params: 1,
+		}),
+		new web3._extend.Method({
+			name: 'stacks',
+			call: 'debug_stacks',
+			params: 0,
+			outputFormatter: console.log
+		}),
+		new web3._extend.Method({
+			name: 'freeOSMemory',
+			call: 'debug_freeOSMemory',
+			params: 0,
+		}),
+		new web3._extend.Method({
+			name: 'setGCPercent',
+			call: 'debug_setGCPercent',
+			params: 1,
+		}),
+		new web3._extend.Method({
+			name: 'memStats',
+			call: 'debug_memStats',
+			params: 0,
+		}),
+		new web3._extend.Method({
+			name: 'gcStats',
+			call: 'debug_gcStats',
+			params: 0,
+		}),
+		new web3._extend.Method({
+			name: 'startPProf',
+			call: 'debug_startPProf',
+			params: 2,
+			inputFormatter: [null, null]
+		}),
+		new web3._extend.Method({
+			name: 'stopPProf',
+			call: 'debug_stopPProf',
+			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'isPProfRunning',
+			call: 'debug_isPProfRunning',
+			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'cpuProfile',
+			call: 'debug_cpuProfile',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'startCPUProfile',
+			call: 'debug_startCPUProfile',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'stopCPUProfile',
+			call: 'debug_stopCPUProfile',
+			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'goTrace',
+			call: 'debug_goTrace',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'startGoTrace',
+			call: 'debug_startGoTrace',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'stopGoTrace',
+			call: 'debug_stopGoTrace',
+			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'blockProfile',
+			call: 'debug_blockProfile',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'setBlockProfileRate',
+			call: 'debug_setBlockProfileRate',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'writeBlockProfile',
+			call: 'debug_writeBlockProfile',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'mutexProfile',
+			call: 'debug_mutexProfile',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'setMutexProfileRate',
+			call: 'debug_setMutexProfileRate',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'writeMutexProfile',
+			call: 'debug_writeMutexProfile',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'writeMemProfile',
+			call: 'debug_writeMemProfile',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'traceBlock',
 			call: 'debug_traceBlock',
+			params: 2,
+			inputFormatter: [null, null]
+		}),
+		new web3._extend.Method({
+			name: 'traceBlockFromFile',
+			call: 'debug_traceBlockFromFile',
 			params: 2,
 			inputFormatter: [null, null]
 		}),
@@ -557,6 +738,18 @@ web3._extend({
 			call: 'debug_traceBadBlock',
 			params: 1,
 			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
+			name: 'standardTraceBadBlockToFile',
+			call: 'debug_standardTraceBadBlockToFile',
+			params: 2,
+			inputFormatter: [null, null]
+		}),
+		new web3._extend.Method({
+			name: 'standardTraceBlockToFile',
+			call: 'debug_standardTraceBlockToFile',
+			params: 2,
+			inputFormatter: [null, null]
 		}),
 		new web3._extend.Method({
 			name: 'traceBlockByNumber',
@@ -582,259 +775,20 @@ web3._extend({
 			params: 2,
 			inputFormatter: [null, null]
 		}),
-	],
-	properties: []
-});
-`
-
-const UnsafeDebug_JS = `
-web3._extend({
-	property: 'unsafedebug',
-	methods: [
-		new web3._extend.Method({
-			name: 'printBlock',
-			call: 'unsafedebug_printBlock',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'setHead',
-			call: 'unsafedebug_setHead',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
-		}),
-		new web3._extend.Method({
-			name: 'startWarmUp',
-			call: 'unsafedebug_startWarmUp',
-		}),
-		new web3._extend.Method({
-			name: 'startContractWarmUp',
-			call: 'unsafedebug_startContractWarmUp',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'stopWarmUp',
-			call: 'unsafedebug_stopWarmUp',
-		}),
-		new web3._extend.Method({
-			name: 'startCollectingTrieStats',
-			call: 'unsafedebug_startCollectingTrieStats',
-			params: 1,
-		}),
-		new web3._extend.Method({
-			name: 'chaindbProperty',
-			call: 'unsafedebug_chaindbProperty',
-			params: 1,
-			outputFormatter: console.log
-		}),
-		new web3._extend.Method({
-			name: 'chaindbCompact',
-			call: 'unsafedebug_chaindbCompact',
-		}),
-		new web3._extend.Method({
-			name: 'metrics',
-			call: 'unsafedebug_metrics',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'verbosity',
-			call: 'unsafedebug_verbosity',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'verbosityByName',
-			call: 'unsafedebug_verbosityByName',
-			params: 2
-		}),
-		new web3._extend.Method({
-			name: 'verbosityByID',
-			call: 'unsafedebug_verbosityByID',
-			params: 2
-		}),
-		new web3._extend.Method({
-			name: 'vmodule',
-			call: 'unsafedebug_vmodule',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'backtraceAt',
-			call: 'unsafedebug_backtraceAt',
-			params: 1,
-		}),
-		new web3._extend.Method({
-			name: 'stacks',
-			call: 'unsafedebug_stacks',
-			params: 0,
-			outputFormatter: console.log
-		}),
-		new web3._extend.Method({
-			name: 'freeOSMemory',
-			call: 'unsafedebug_freeOSMemory',
-			params: 0,
-		}),
-		new web3._extend.Method({
-			name: 'setGCPercent',
-			call: 'unsafedebug_setGCPercent',
-			params: 1,
-		}),
-		new web3._extend.Method({
-			name: 'memStats',
-			call: 'unsafedebug_memStats',
-			params: 0,
-		}),
-		new web3._extend.Method({
-			name: 'gcStats',
-			call: 'unsafedebug_gcStats',
-			params: 0,
-		}),
-		new web3._extend.Method({
-			name: 'startPProf',
-			call: 'unsafedebug_startPProf',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-		new web3._extend.Method({
-			name: 'stopPProf',
-			call: 'unsafedebug_stopPProf',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'isPProfRunning',
-			call: 'unsafedebug_isPProfRunning',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'cpuProfile',
-			call: 'unsafedebug_cpuProfile',
-			params: 2
-		}),
-		new web3._extend.Method({
-			name: 'startCPUProfile',
-			call: 'unsafedebug_startCPUProfile',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'stopCPUProfile',
-			call: 'unsafedebug_stopCPUProfile',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'goTrace',
-			call: 'unsafedebug_goTrace',
-			params: 2
-		}),
-		new web3._extend.Method({
-			name: 'startGoTrace',
-			call: 'unsafedebug_startGoTrace',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'stopGoTrace',
-			call: 'unsafedebug_stopGoTrace',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'blockProfile',
-			call: 'unsafedebug_blockProfile',
-			params: 2
-		}),
-		new web3._extend.Method({
-			name: 'setBlockProfileRate',
-			call: 'unsafedebug_setBlockProfileRate',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'writeBlockProfile',
-			call: 'unsafedebug_writeBlockProfile',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'mutexProfile',
-			call: 'unsafedebug_mutexProfile',
-			params: 2
-		}),
-		new web3._extend.Method({
-			name: 'setMutexProfileRate',
-			call: 'unsafedebug_setMutexProfileRate',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'writeMutexProfile',
-			call: 'unsafedebug_writeMutexProfile',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'writeMemProfile',
-			call: 'unsafedebug_writeMemProfile',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'traceBlock',
-			call: 'unsafedebug_traceBlock',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-		new web3._extend.Method({
-			name: 'traceBlockFromFile',
-			call: 'unsafedebug_traceBlockFromFile',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-		new web3._extend.Method({
-			name: 'traceBadBlock',
-			call: 'unsafedebug_traceBadBlock',
-			params: 1,
-			inputFormatter: [null]
-		}),
-		new web3._extend.Method({
-			name: 'standardTraceBadBlockToFile',
-			call: 'unsafedebug_standardTraceBadBlockToFile',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-		new web3._extend.Method({
-			name: 'standardTraceBlockToFile',
-			call: 'unsafedebug_standardTraceBlockToFile',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-		new web3._extend.Method({
-			name: 'traceBlockByNumber',
-			call: 'unsafedebug_traceBlockByNumber',
-			params: 2,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, null]
-		}),
-		new web3._extend.Method({
-			name: 'traceBlockByNumberRange',
-			call: 'unsafedebug_traceBlockByNumberRange',
-			params: 3,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, web3._extend.formatters.inputBlockNumberFormatter, null]
-		}),
-		new web3._extend.Method({
-			name: 'traceBlockByHash',
-			call: 'unsafedebug_traceBlockByHash',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-		new web3._extend.Method({
-			name: 'traceTransaction',
-			call: 'unsafedebug_traceTransaction',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
 		new web3._extend.Method({
 			name: 'preimage',
-			call: 'unsafedebug_preimage',
+			call: 'debug_preimage',
 			params: 1,
 			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
 			name: 'storageRangeAt',
-			call: 'unsafedebug_storageRangeAt',
+			call: 'debug_storageRangeAt',
 			params: 5,
 		}),
 		new web3._extend.Method({
 			name: 'setVMLogTarget',
-			call: 'unsafedebug_setVMLogTarget',
+			call: 'debug_setVMLogTarget',
 			params: 1
 		}),
 	],

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -478,7 +478,7 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 // APIs returns the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *CN) APIs() []rpc.API {
-	apis, ethAPI := api.GetAPIs(s.APIBackend)
+	apis, ethAPI := api.GetAPIs(s.APIBackend, s.config.DisableUnsafeDebug)
 
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -494,9 +494,9 @@ func (s *CN) APIs() []rpc.API {
 
 	var tracerAPI *tracers.API
 	if s.config.DisableUnsafeDebug {
-		tracerAPI = tracers.NewAPI(s.APIBackend)
+		tracerAPI = tracers.NewAPIUnsafeDisabled(s.APIBackend)
 	} else {
-		tracerAPI = tracers.NewUnsafeAPI(s.APIBackend)
+		tracerAPI = tracers.NewAPI(s.APIBackend)
 		apis = append(apis, []rpc.API{
 			{
 				Namespace: "debug",

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -179,6 +179,9 @@ type Config struct {
 	// send-transction variants. The unit is klay.
 	// This is used by eth namespace RPC APIs
 	RPCTxFeeCap float64
+
+	// Disable option for unsafe debug APIs
+	DisableUnsafeDebug bool `toml:",omitempty"`
 }
 
 type configMarshaling struct {

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -98,13 +98,13 @@ type API struct {
 
 // NewAPI creates a new API definition for the tracing methods of the CN service,
 // only allowing predefined tracers.
-func NewAPI(backend Backend) *API {
+func NewAPIUnsafeDisabled(backend Backend) *API {
 	return &API{backend: backend, unsafeTrace: false}
 }
 
 // NewUnsafeAPI creates a new API definition for the tracing methods of the CN service,
 // allowing both predefined tracers and Javascript snippet based tracing.
-func NewUnsafeAPI(backend Backend) *API {
+func NewAPI(backend Backend) *API {
 	return &API{backend: backend, unsafeTrace: true}
 }
 

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -109,23 +109,23 @@ func NewUnsafeAPI(backend Backend) *API {
 }
 
 type chainContext struct {
-	api *API
-	ctx context.Context
+	backend Backend
+	ctx     context.Context
 }
 
 func (context *chainContext) Engine() consensus.Engine {
-	return context.api.backend.Engine()
+	return context.backend.Engine()
 }
 
 func (context *chainContext) GetHeader(hash common.Hash, number uint64) *types.Header {
-	header, err := context.api.backend.HeaderByNumber(context.ctx, rpc.BlockNumber(number))
+	header, err := context.backend.HeaderByNumber(context.ctx, rpc.BlockNumber(number))
 	if err != nil {
 		return nil
 	}
 	if header.Hash() == hash {
 		return header
 	}
-	header, err = context.api.backend.HeaderByHash(context.ctx, hash)
+	header, err = context.backend.HeaderByHash(context.ctx, hash)
 	if err != nil {
 		return nil
 	}
@@ -134,8 +134,8 @@ func (context *chainContext) GetHeader(hash common.Hash, number uint64) *types.H
 
 // chainContext constructs the context reader which is used by the evm for reading
 // the necessary chain context.
-func (api *API) chainContext(ctx context.Context) blockchain.ChainContext {
-	return &chainContext{api: api, ctx: ctx}
+func newChainContext(ctx context.Context, backend Backend) blockchain.ChainContext {
+	return &chainContext{backend: backend, ctx: ctx}
 }
 
 // blockByNumber is the wrapper of the chain access function offered by the backend.
@@ -293,7 +293,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, notifie
 						break
 					}
 
-					vmctx := blockchain.NewEVMContext(msg, task.block.Header(), api.chainContext(localctx), nil)
+					vmctx := blockchain.NewEVMContext(msg, task.block.Header(), newChainContext(localctx, api.backend), nil)
 
 					res, err := api.traceTx(localctx, msg, vmctx, task.statedb, config)
 					if err != nil {
@@ -501,7 +501,7 @@ func (api *API) TraceBlock(ctx context.Context, blob hexutil.Bytes, config *Trac
 // EVM and returns them as a JSON object.
 func (api *API) TraceBlockFromFile(ctx context.Context, file string, config *TraceConfig) ([]*txTraceResult, error) {
 	if !api.unsafeTrace {
-		return nil, errors.New("TraceBlockFromFile is not supported in 'debug' namespace, use 'unsafedebug' namespace instead")
+		return nil, errors.New("TraceBlockFromFile is disabled")
 	}
 	blob, err := ioutil.ReadFile(file)
 	if err != nil {
@@ -531,7 +531,7 @@ func (api *API) TraceBadBlock(ctx context.Context, hash common.Hash, config *Tra
 // to the caller.
 func (api *API) StandardTraceBlockToFile(ctx context.Context, hash common.Hash, config *StdTraceConfig) ([]string, error) {
 	if !api.unsafeTrace {
-		return nil, errors.New("StandardTraceBlockToFile is not supported in 'debug' namespace, use 'unsafedebug' namespace instead")
+		return nil, errors.New("StandardTraceBlockToFile is disabled")
 	}
 	block, err := api.blockByHash(ctx, hash)
 	if err != nil {
@@ -545,7 +545,7 @@ func (api *API) StandardTraceBlockToFile(ctx context.Context, hash common.Hash, 
 // local file system and returns a list of files to the caller.
 func (api *API) StandardTraceBadBlockToFile(ctx context.Context, hash common.Hash, config *StdTraceConfig) ([]string, error) {
 	if !api.unsafeTrace {
-		return nil, errors.New("StandardTraceBadBlockToFile is not supported in 'debug' namespace, use 'unsafedebug' namespace instead")
+		return nil, errors.New("StandardTraceBadBlockToFile is disabled")
 	}
 	blocks, err := api.backend.ChainDB().ReadAllBadBlocks()
 	if err != nil {
@@ -607,7 +607,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 					continue
 				}
 
-				vmctx := blockchain.NewEVMContext(msg, block.Header(), api.chainContext(ctx), nil)
+				vmctx := blockchain.NewEVMContext(msg, block.Header(), newChainContext(ctx, api.backend), nil)
 				res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
 				if err != nil {
 					results[task.index] = &txTraceResult{TxHash: txs[task.index].Hash(), Error: err.Error()}
@@ -631,7 +631,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 			break
 		}
 
-		vmctx := blockchain.NewEVMContext(msg, block.Header(), api.chainContext(ctx), nil)
+		vmctx := blockchain.NewEVMContext(msg, block.Header(), newChainContext(ctx, api.backend), nil)
 		vmenv := vm.NewEVM(vmctx, statedb, api.backend.ChainConfig(), &vm.Config{UseOpcodeComputationCost: true})
 		if _, _, kerr := blockchain.ApplyMessage(vmenv, msg); kerr.ErrTxInvalid != nil {
 			failed = kerr.ErrTxInvalid
@@ -702,7 +702,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		}
 
 		var (
-			vmctx = blockchain.NewEVMContext(msg, block.Header(), api.chainContext(ctx), nil)
+			vmctx = blockchain.NewEVMContext(msg, block.Header(), newChainContext(ctx, api.backend), nil)
 
 			vmConf vm.Config
 			dump   *os.File

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -96,13 +96,13 @@ type API struct {
 	unsafeTrace bool
 }
 
-// NewAPI creates a new API definition for the tracing methods of the CN service,
+// NewAPIUnsafeDisabled creates a new API definition for the tracing methods of the CN service,
 // only allowing predefined tracers.
 func NewAPIUnsafeDisabled(backend Backend) *API {
 	return &API{backend: backend, unsafeTrace: false}
 }
 
-// NewUnsafeAPI creates a new API definition for the tracing methods of the CN service,
+// NewAPI creates a new API definition for the tracing methods of the CN service,
 // allowing both predefined tracers and Javascript snippet based tracing.
 func NewAPI(backend Backend) *API {
 	return &API{backend: backend, unsafeTrace: true}

--- a/node/config.go
+++ b/node/config.go
@@ -169,6 +169,9 @@ type Config struct {
 	// Ntp server:port to check the synchronization when booting the node
 	NtpRemoteServer string `toml:",omitempty"`
 
+	// Disable option for unsafe debug APIs
+	DisableUnsafeDebug bool `toml:",omitempty"`
+
 	// Logger is a custom logger to use with the p2p.Server.
 	Logger log.Logger `toml:",omitempty"`
 }

--- a/node/node.go
+++ b/node/node.go
@@ -796,11 +796,11 @@ func (n *Node) apis() []rpc.API {
 	}
 	debugRpcApi := []rpc.API{
 		{
-			Namespace: "unsafedebug",
+			Namespace: "debug",
 			Version:   "1.0",
 			Service:   debug.Handler,
 		}, {
-			Namespace: "unsafedebug",
+			Namespace: "debug",
 			Version:   "1.0",
 			Service:   NewPublicDebugAPI(n),
 		},

--- a/node/node.go
+++ b/node/node.go
@@ -771,7 +771,7 @@ func (n *Node) ResolvePath(x string) string {
 }
 
 func (n *Node) apis() []rpc.API {
-	return []rpc.API{
+	rpcApi := []rpc.API{
 		{
 			Namespace: "admin",
 			Version:   "1.0",
@@ -781,14 +781,6 @@ func (n *Node) apis() []rpc.API {
 			Version:   "1.0",
 			Service:   NewPublicAdminAPI(n),
 			Public:    true,
-		}, {
-			Namespace: "unsafedebug",
-			Version:   "1.0",
-			Service:   debug.Handler,
-		}, {
-			Namespace: "unsafedebug",
-			Version:   "1.0",
-			Service:   NewPublicDebugAPI(n),
 		}, {
 			// "web3" namespace will be deprecated soon. The same APIs in "web3" are available in "klay" namespace.
 			Namespace: "web3",
@@ -802,6 +794,21 @@ func (n *Node) apis() []rpc.API {
 			Public:    true,
 		},
 	}
+	debugRpcApi := []rpc.API{
+		{
+			Namespace: "unsafedebug",
+			Version:   "1.0",
+			Service:   debug.Handler,
+		}, {
+			Namespace: "unsafedebug",
+			Version:   "1.0",
+			Service:   NewPublicDebugAPI(n),
+		},
+	}
+	if !n.config.DisableUnsafeDebug {
+		rpcApi = append(rpcApi, debugRpcApi...)
+	}
+	return rpcApi
 }
 
 const (

--- a/node/node.go
+++ b/node/node.go
@@ -782,6 +782,10 @@ func (n *Node) apis() []rpc.API {
 			Service:   NewPublicAdminAPI(n),
 			Public:    true,
 		}, {
+			Namespace: "debug",
+			Version:   "1.0",
+			Service:   NewPublicDebugAPI(n),
+		}, {
 			// "web3" namespace will be deprecated soon. The same APIs in "web3" are available in "klay" namespace.
 			Namespace: "web3",
 			Version:   "1.0",
@@ -799,10 +803,6 @@ func (n *Node) apis() []rpc.API {
 			Namespace: "debug",
 			Version:   "1.0",
 			Service:   debug.Handler,
-		}, {
-			Namespace: "debug",
-			Version:   "1.0",
-			Service:   NewPublicDebugAPI(n),
 		},
 	}
 	if !n.config.DisableUnsafeDebug {


### PR DESCRIPTION
## Proposed changes

- This is a follow-up PR to #1672
- This PR introduces the `rpc.unsafe-debug.disable` flag
- If you set the `rpc.unsafe-debug.disable` flag, 
  - can use only a subset of debug APIs. Refer to `Further Comments` for the full list
  - cannot use the [javascript-based tracing](https://ko.docs.klaytn.foundation/dapp/json-rpc/api-references/debug/tracing#javascript-based-tracing) for [VM tracing](https://docs.klaytn.foundation/content/dapp/json-rpc/api-references/debug/tracing) APIs, but only [pre-defined tracers](https://ko.docs.klaytn.foundation/dapp/json-rpc/api-references/debug/tracing#tracing-options) are allowed (e.g., `revertTracer`)
- How to set the flag
  - add ADDITIONAL="--rpc.unsafe-debug.disable" in kxxd.conf file

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

### Why this new flag `rpc.unsafe-debug.disable` is introduced and why some debug APIs are disabled by that flag?
- The debug APIs are for private use in nature, however some public ENs provide debug namespace over RPC for user convenience
- Some debug APIs are vulnerable. Some debug APIs are too heavy/costly. Some debug APIs are meaningless to be provided over RPC.
- Nevertheless, we don't want to discourage public ENs to provide some useful & relatively safe debug APIs (e.g., `debug_traceTransaction`)

### Full list of APIs affected
- debug APIs that are disabled when `rpc.unsafe-debug.disable` flag was set
  - debug_printBlock
  - debug_setHead
  - debug_startWarmUp, debug_startContractWarmUp, debug_stopWarmUp
  - debug_startCollectingTrieStats
  - debug_chaindbProperty, debug_chaindbCompact
  - debug_verbosity, debug_verbosityByName, debug_verbosityByID
  - debug_vmodule, debug_backtraceAt, debug_stacks, debug_freeOSMemory, debug_setGCPercent, debug_memStats, debug_gcStats, debug_startPProf, debug_stopPProf, debug_isPProfRunning, debug_cpuProfile, debug_startCPUProfile, debug_stopCPUProfile
  - debug_goTrace, debug_startGoTrace, debug_stopGoTrace
  - debug_blockProfile, debug_setBlockProfileRate, debug_writeBlockProfile, debug_mutexProfile, debug_setMutexProfileRate, debug_writeMutexProfile, debug_writeMemProfile
  - debug_standardTraceBadBlockToFile, debug_standardTraceBlockToFile
  - debug_preimage
  - debug_storageRangeAt
  - debug_setVMLogTarget

- debug APIs that are NOT disabled even if `rpc.unsafe-debug.disable` flag was set
  - [VM tracing](https://docs.klaytn.foundation/content/dapp/json-rpc/api-references/debug/tracing) APIs, however with limited functionality (only [pre-defined tracers](https://ko.docs.klaytn.foundation/dapp/json-rpc/api-references/debug/tracing#tracing-options) are allowed)
    - debug_traceBadBlock, debug_traceBlock, debug_traceBlockByHash, debug_traceBlockByNumber, debug_traceBlockByNumberRange, debug_traceBlockFromFile, debug_traceTransaction, debug_traceChain
  - debug_dumpBlock, debug_dumpStateTrie, debug_getBlockRlp, debug_getModifiedAccountsByHash, debug_getModifiedAccountsByNumber, debug_getBadBlocks, debug_getModifiedStorageNodesByNumber
  - debug_metrics
 