### PR TITLE
Revive chainConfig in Governance

### DIFF
--- a/governance/contract_test.go
+++ b/governance/contract_test.go
@@ -191,7 +191,7 @@ func prepareContractEngine(t *testing.T, bc *blockchain.BlockChain, addr common.
 	dbm.WriteGovernance(map[string]interface{}{
 		"governance.govparamcontract": addr,
 	}, 0)
-	gov := NewGovernance(dbm)
+	gov := NewGovernance(bc.Config(), dbm)
 	pset, err := gov.ParamsAt(0)
 	require.Nil(t, err)
 	require.Equal(t, addr, pset.GovParamContract())
@@ -212,8 +212,8 @@ func prepareContractEngine(t *testing.T, bc *blockchain.BlockChain, addr common.
 //
 // Block |---------------|---------------|---------------|
 //
-//	^               ^               ^
-//	t0              t1              t2
+// ..............^               ^               ^
+// ..............t0              t1              t2
 //
 // At num = activation - 2, Params() = prev
 // At num = activation - 1, Params() = next
@@ -270,8 +270,8 @@ func TestContractEngine_Params(t *testing.T) {
 //
 // Block |---------------|---------------|---------------|
 //
-//	^               ^               ^
-//	t0              t1              t2
+// ..............^               ^               ^
+// ..............t0              t1              t2
 //
 // ParamsAt(activation - 1) = prev
 // ParamsAt(activation)     = next

--- a/governance/default.go
+++ b/governance/default.go
@@ -177,7 +177,7 @@ type txPool interface {
 }
 
 type Governance struct {
-	ChainConfig *params.ChainConfig // NOTE: only exists for miscDB, read-only
+	ChainConfig *params.ChainConfig // Only exists to keep DB backward compatibility in WriteGovernanceState()
 	// Map used to keep multiple types of votes
 	voteMap VoteMap
 

--- a/governance/default.go
+++ b/governance/default.go
@@ -177,6 +177,7 @@ type txPool interface {
 }
 
 type Governance struct {
+	ChainConfig *params.ChainConfig // NOTE: only exists for miscDB, read-only
 	// Map used to keep multiple types of votes
 	voteMap VoteMap
 
@@ -417,8 +418,9 @@ func (gs *GovernanceSet) Merge(change map[string]interface{}) {
 }
 
 // NewGovernance creates Governance with the given configuration.
-func NewGovernance(dbm database.DBManager) *Governance {
+func NewGovernance(chainConfig *params.ChainConfig, dbm database.DBManager) *Governance {
 	return &Governance{
+		ChainConfig:              chainConfig,
 		voteMap:                  NewVoteMap(),
 		db:                       dbm,
 		itemCache:                newGovernanceCache(),
@@ -436,7 +438,7 @@ func NewGovernance(dbm database.DBManager) *Governance {
 // NewGovernanceInitialize creates Governance with the given configuration and read governance state from DB.
 // If any items are not stored in DB, it stores governance items of the genesis block to DB.
 func NewGovernanceInitialize(chainConfig *params.ChainConfig, dbm database.DBManager) *Governance {
-	ret := NewGovernance(dbm)
+	ret := NewGovernance(chainConfig, dbm)
 	// nil is for testing or simple function usage
 	if dbm != nil {
 		ret.ReadGovernanceState()
@@ -996,6 +998,7 @@ type governanceJSON struct {
 func (gov *Governance) toJSON(num uint64) ([]byte, error) {
 	ret := &governanceJSON{
 		BlockNumber:     num,
+		ChainConfig:     gov.ChainConfig,
 		VoteMap:         gov.voteMap.Copy(),
 		NodeAddress:     gov.nodeAddress.Load().(common.Address),
 		GovernanceVotes: gov.GovernanceVotes.Copy(),
@@ -1012,6 +1015,7 @@ func (gov *Governance) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &j); err != nil {
 		return err
 	}
+	// DO NOT overwrite gov.ChainConfig
 	gov.voteMap.Import(j.VoteMap)
 	gov.nodeAddress.Store(j.NodeAddress)
 	gov.GovernanceVotes.Import(j.GovernanceVotes)

--- a/governance/default.go
+++ b/governance/default.go
@@ -1015,7 +1015,7 @@ func (gov *Governance) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &j); err != nil {
 		return err
 	}
-	// DO NOT overwrite gov.ChainConfig
+	// gov.ChainConfig is to be updated in MixedEngine. Do not overwrite it here.
 	gov.voteMap.Import(j.VoteMap)
 	gov.nodeAddress.Store(j.NodeAddress)
 	gov.GovernanceVotes.Import(j.GovernanceVotes)

--- a/governance/mixed.go
+++ b/governance/mixed.go
@@ -99,7 +99,7 @@ func newMixedEngine(config *params.ChainConfig, db database.DBManager, doInit bo
 	if doInit {
 		e.headerGov = NewGovernanceInitialize(config, db)
 	} else {
-		e.headerGov = NewGovernance(db)
+		e.headerGov = NewGovernance(config, db)
 	}
 
 	e.contractGov = NewContractEngine(e.headerGov)


### PR DESCRIPTION
## Proposed changes

[This commit](https://github.com/klaytn/klaytn/commit/3e3727df6b9c5f213358d8d0e7197164fe65b5d2) removes `chainConfig` from `struct Governance`.
This resulted in a panic when downgrading node from v1.10.0 to v1.9.1.

### How to reproduce the bug

1. Start a chain with v1.10.0.
2. Wait until it passes block 1024 (checkpointInterval)
3. Stop the chain
4. Restart the chain with v1.9.1
5. Below panic appears.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x12877e5]

goroutine 1 [running]:
github.com/klaytn/klaytn/governance.(*Governance).ReadGovernance(0xc0297b4120, 0x6998604)
	/klaytn/governance/default.go:814 +0x25
github.com/klaytn/klaytn/governance.(*Governance).initializeCache(0xc0297b4120)
	/klaytn/governance/default.go:717 +0x3c5
github.com/klaytn/klaytn/governance.NewGovernanceInitialize(0x290b100, {0x1d39250, 0xc00013da40})
	/klaytn/governance/default.go:450 +0x5d
github.com/klaytn/klaytn/governance.newMixedEngine(0x290b100, {0x1d39250, 0xc00013da40}, 0x1)
	/klaytn/governance/mixed.go:45 +0x1a8
github.com/klaytn/klaytn/governance.NewMixedEngine(...)
	/klaytn/governance/mixed.go:58
github.com/klaytn/klaytn/node/cn.New(0xc00039ec80, 0xc0004c9800)
	/klaytn/node/cn/backend.go:218 +0x15c
github.com/klaytn/klaytn/cmd/utils.RegisterCNService.func1(0x203000)
	/klaytn/cmd/utils/flags.go:1988 +0x54
github.com/klaytn/klaytn/node.(*Node).initService(0xc00030a000, {0xc00020a460, 0x1, 0xc00039ec60}, 0x0)
	/klaytn/node/node.go:298 +0x183
github.com/klaytn/klaytn/node.(*Node).Start(0xc00030a000)
	/klaytn/node/node.go:199 +0x6d8
github.com/klaytn/klaytn/cmd/utils.StartNode(0xc00030a000)
	/klaytn/cmd/utils/cmd.go:46 +0x25
github.com/klaytn/klaytn/cmd/utils/nodecmd.startNode(0x0, 0xc00030a000)
	/klaytn/cmd/utils/nodecmd/defaultcmd.go:65 +0x65
github.com/klaytn/klaytn/cmd/utils/nodecmd.RunKlaytnNode(0x0)
	/klaytn/cmd/utils/nodecmd/defaultcmd.go:53 +0x30
gopkg.in/urfave/cli%2ev1.HandleAction({0x16e45e0, 0x1a56f48}, 0xc0001b8c00)
	/go/pkg/mod/gopkg.in/urfave/cli.v1@v1.20.0/app.go:490 +0x5a
gopkg.in/urfave/cli%2ev1.(*App).Run(0xc0000b69c0, {0xc00003c300, 0x30, 0x30})
	/go/pkg/mod/gopkg.in/urfave/cli.v1@v1.20.0/app.go:264 +0x5e6
main.main()
	/klaytn/cmd/ken/main.go:91 +0x70
```

FYI, the panic line in v1.9.1:
https://github.com/klaytn/klaytn/blob/8664bc88319567f560bc5244131672d554e55293/governance/default.go#L814

### The fix

This panic attributes to the discrepancy of miscDB's `governanceState.chainConfig` field between v1.9.1 and v1.10.0.

Therefore, this PR revives chainConfig in `struct Governance` to make "governanceState" in miscDB backward-compatible.

Before this PR:
```
// miscDB lookup with key=governanceState
{
  blockNumber: 8,
  chainConfig: null,
  ...
}
```

After this PR:
```
// miscDB lookup with key=governanceState
{
  blockNumber: 8,
  chainConfig: {
    chainId: 10000,
    istanbulCompatibleBlock: 0,
    londonCompatibleBlock: 0,
    ...
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
