### PR TITLE
[RPC] Added timeout trigger for the default trace logger

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -504,9 +504,21 @@ type StructLogRes struct {
 }
 
 // formatLogs formats EVM returned structured logs for json output
-func FormatLogs(logs []vm.StructLog) []StructLogRes {
+func FormatLogs(timeout time.Duration, logs []vm.StructLog) ([]StructLogRes, error) {
+	logTimeout := false
+	deadlineCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	go func() {
+		<-deadlineCtx.Done()
+		logger.Error("[Trace logger] Timeout reached", "timeout", timeout, "err", deadlineCtx.Err())
+		logTimeout = true
+	}()
+	defer cancel()
+
 	formatted := make([]StructLogRes, len(logs))
 	for index, trace := range logs {
+		if logTimeout {
+			return nil, fmt.Errorf("[Trace logger] Log truncated by timeout")
+		}
 		formatted[index] = StructLogRes{
 			Pc:      trace.Pc,
 			Op:      trace.Op.String(),
@@ -537,7 +549,7 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 			formatted[index].Storage = &storage
 		}
 	}
-	return formatted
+	return formatted, nil
 }
 
 func RpcOutputBlock(b *types.Block, td *big.Int, inclTx bool, fullTx bool, isEnabledEthTxTypeFork bool) (map[string]interface{}, error) {

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -509,7 +509,7 @@ func FormatLogs(timeout time.Duration, logs []vm.StructLog) ([]StructLogRes, err
 	deadlineCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	go func() {
 		<-deadlineCtx.Done()
-		logger.Error("[Trace logger] Timeout reached", "timeout", timeout, "err", deadlineCtx.Err())
+		logger.Debug("trace logger timeout", "timeout", timeout, "err", deadlineCtx.Err())
 		logTimeout = true
 	}()
 	defer cancel()

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -517,7 +517,7 @@ func FormatLogs(timeout time.Duration, logs []vm.StructLog) ([]StructLogRes, err
 	formatted := make([]StructLogRes, len(logs))
 	for index, trace := range logs {
 		if logTimeout {
-			return nil, fmt.Errorf("[Trace logger] Log truncated by timeout")
+			return nil, fmt.Errorf("trace logger timeout")
 		}
 		formatted[index] = StructLogRes{
 			Pc:      trace.Pc,


### PR DESCRIPTION
## Proposed changes

The default trace logger (`debug.traceTransaction(txHash)`) aggregates all stack, memory and storage logs. The time that the log dump loop ends depends on the given set of instructions for the given transaction. It may crash the node through a huge loop that may arise OOM. The tracer has two parts, one for transaction executor and another one for log aggregation. A default timeout exists for the early exit of the former case but not for the latter. This PR proposes a default timeout trigger for the latter case, which is hard-coded 1s, but it can be overwritten with `loggerTimeout` option. For instance, `debug.traceTransaction(txHash, {loggerTimeout:"100ms"})` overwrites the timeout to 100ms.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
