### PR TITLE
Change ntp check logic

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -814,6 +814,7 @@ func (n *Node) apis() []rpc.API {
 const (
 	ntpTolerance = time.Second
 	RFC3339Nano  = "2006-01-02T15:04:05.999999999Z07:00"
+	retry        = 10
 )
 
 func timeIsNear(lhs, rhs time.Time) bool {
@@ -840,14 +841,29 @@ func NtpCheckWithLocal(n *Node) error {
 		return err
 	}
 
+	ntpRetryTime := time.Duration(1)
+	var remote *time.Time
+	for i := 0; ; i++ {
+		time.Sleep(ntpRetryTime)
+		remote, err = ntpclient.GetNetworkTime(url, portNum)
+		if remote != nil {
+			break
+		}
+		// remote == nil && err != nil && i >= retry
+		if i >= retry {
+			return err
+		}
+		ntpRetryTime = ntpRetryTime * 2
+	}
 	local := time.Now()
-	remote, err := ntpclient.GetNetworkTime(url, portNum)
+
 	if err != nil {
 		return err
 	}
 	if !timeIsNear(local, *remote) {
 		errFormat := "System time is out of sync, local:%s remote:%s"
-		return fmt.Errorf(errFormat, local.UTC().Format(RFC3339Nano), remote.UTC().Format(RFC3339Nano))
+		usage := "You can use \"--ntp.disable\" option to disable ntp time checking"
+		return fmt.Errorf(errFormat+"\n"+usage, local.UTC().Format(RFC3339Nano), remote.UTC().Format(RFC3339Nano))
 	}
 	logger.Info("Ntp time check", "local", local.UTC().Format(RFC3339Nano), "remote", remote.UTC().Format(RFC3339Nano))
 	return nil

--- a/node/node.go
+++ b/node/node.go
@@ -843,23 +843,19 @@ func NtpCheckWithLocal(n *Node) error {
 
 	ntpRetryTime := time.Duration(1)
 	var remote *time.Time
-	for i := 0; ; i++ {
+	for i := 0; i < ntpMaxRetry; i++ {
 		time.Sleep(ntpRetryTime)
 		remote, err = ntpclient.GetNetworkTime(url, portNum)
 		if remote != nil {
 			break
 		}
-		// remote == nil && err != nil && i >= retry
-		if i >= retry {
-			return err
-		}
 		ntpRetryTime = ntpRetryTime * 2
 	}
-	local := time.Now()
-
 	if err != nil {
 		return err
 	}
+
+	local := time.Now()
 	if !timeIsNear(local, *remote) {
 		errFormat := "System time is out of sync, local:%s remote:%s"
 		usage := "You can use \"--ntp.disable\" option to disable ntp time checking"

--- a/node/node.go
+++ b/node/node.go
@@ -814,7 +814,7 @@ func (n *Node) apis() []rpc.API {
 const (
 	ntpTolerance = time.Second
 	RFC3339Nano  = "2006-01-02T15:04:05.999999999Z07:00"
-	retry        = 10
+	ntpMaxRetry  = 10
 )
 
 func timeIsNear(lhs, rhs time.Time) bool {


### PR DESCRIPTION
## Proposed changes

- Changed ntp time check with local to be more flexible (`stop server` -> `warning periodically`)
  - It checks the ntp time periodically until synced in ntp time and warn the status
- Changed it to use the `ntp` module in `discover` package and tuned ntp check count for average

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

