### PR TITLE
Fix to resolve node loading failure after unexpected node termination

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -708,7 +708,7 @@ func (sb *backend) CreateSnapshot(chain consensus.ChainReader, number uint64, ha
 	if _, err := sb.snapshot(chain, number, hash, parents, true); err != nil {
 		return err
 	}
-	if err := sb.governance.UpdateParams(); err != nil {
+	if err := sb.governance.UpdateParams(number); err != nil {
 		return err
 	}
 	return nil

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -1721,7 +1721,7 @@ func TestGovernance_ReaderEngine(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Load parameters for the next block
-			err = engine.governance.UpdateParams()
+			err = engine.governance.UpdateParams(currentBlock.NumberU64())
 			assert.NoError(t, err)
 		}
 

--- a/governance/api.go
+++ b/governance/api.go
@@ -81,7 +81,7 @@ func (api *GovernanceKlayAPI) NodeAddress() common.Address {
 // or returns gas price of txpool if the block is pending block.
 func (api *GovernanceKlayAPI) GasPriceAt(num *rpc.BlockNumber) (*hexutil.Big, error) {
 	if num == nil || *num == rpc.LatestBlockNumber {
-		header := api.chain.CurrentHeader()
+		header := api.chain.CurrentBlock().Header()
 		if header.BaseFee == nil {
 			return (*hexutil.Big)(new(big.Int).SetUint64(api.governance.Params().UnitPrice())), nil
 		}
@@ -94,7 +94,7 @@ func (api *GovernanceKlayAPI) GasPriceAt(num *rpc.BlockNumber) (*hexutil.Big, er
 
 		// Return the BaseFee in header at the block number
 		header := api.chain.GetHeaderByNumber(blockNum)
-		if blockNum > api.chain.CurrentHeader().Number.Uint64() || header == nil {
+		if blockNum > api.chain.CurrentBlock().NumberU64() || header == nil {
 			return nil, errUnknownBlock
 		} else if header.BaseFee != nil {
 			return (*hexutil.Big)(header.BaseFee), nil
@@ -113,7 +113,7 @@ func (api *GovernanceKlayAPI) GasPriceAt(num *rpc.BlockNumber) (*hexutil.Big, er
 func (api *GovernanceKlayAPI) GetRewards(num *rpc.BlockNumber) (*reward.RewardSpec, error) {
 	blockNumber := uint64(0)
 	if num == nil || *num == rpc.LatestBlockNumber {
-		blockNumber = api.governance.BlockChain().CurrentHeader().Number.Uint64()
+		blockNumber = api.chain.CurrentBlock().NumberU64()
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
@@ -218,7 +218,7 @@ func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interf
 func itemsAt(governance Engine, num *rpc.BlockNumber) (map[string]interface{}, error) {
 	blockNumber := uint64(0)
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blockNumber = governance.BlockChain().CurrentHeader().Number.Uint64()
+		blockNumber = governance.BlockChain().CurrentBlock().NumberU64()
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
@@ -237,7 +237,7 @@ func (api *PublicGovernanceAPI) GetStakingInfo(num *rpc.BlockNumber) (*reward.St
 func getStakingInfo(governance Engine, num *rpc.BlockNumber) (*reward.StakingInfo, error) {
 	blockNumber := uint64(0)
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blockNumber = governance.BlockChain().CurrentHeader().Number.Uint64()
+		blockNumber = governance.BlockChain().CurrentBlock().NumberU64()
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
@@ -264,7 +264,7 @@ func (api *PublicGovernanceAPI) IdxCacheFromDb() []uint64 {
 func (api *PublicGovernanceAPI) ItemCacheFromDb(num *rpc.BlockNumber) map[string]interface{} {
 	blockNumber := uint64(0)
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blockNumber = api.governance.BlockChain().CurrentHeader().Number.Uint64()
+		blockNumber = api.governance.BlockChain().CurrentBlock().NumberU64()
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
@@ -314,7 +314,7 @@ func (api *PublicGovernanceAPI) ChainConfigAt(num *rpc.BlockNumber) *params.Chai
 func chainConfigAt(governance Engine, num *rpc.BlockNumber) *params.ChainConfig {
 	var blocknum uint64
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blocknum = governance.BlockChain().CurrentHeader().Number.Uint64()
+		blocknum = governance.BlockChain().CurrentBlock().NumberU64()
 	} else {
 		blocknum = num.Uint64()
 	}
@@ -366,7 +366,7 @@ func (api *GovernanceKlayAPI) GasPriceAtNumber(num uint64) (uint64, error) {
 // 	} else {
 // 		blockNum := num.Int64()
 //
-// 		if blockNum > api.chain.CurrentHeader().Number.Int64() {
+// 		if blockNum > api.chain.CurrentBlock().NumberU64() {
 // 			return 0, errUnknownBlock
 // 		}
 //

--- a/governance/api_test.go
+++ b/governance/api_test.go
@@ -175,7 +175,7 @@ func (bc *testBlockChain) Config() *params.ChainConfig {
 }
 
 func (bc *testBlockChain) CurrentBlock() *types.Block {
-	return types.NewBlock(bc.CurrentHeader(), nil, nil)
+	return types.NewBlockWithHeader(bc.CurrentHeader())
 }
 
 func (bc *testBlockChain) CurrentHeader() *types.Header {

--- a/governance/api_test.go
+++ b/governance/api_test.go
@@ -122,7 +122,7 @@ func TestGetRewards(t *testing.T) {
 
 		e := NewMixedEngine(config, dbm)
 		e.SetBlockchain(bc)
-		e.UpdateParams()
+		e.UpdateParams(bc.CurrentBlock().NumberU64())
 
 		// write initial gov items and overrides to database
 		pset, _ := params.NewGovParamSetChainConfig(config)

--- a/governance/api_test.go
+++ b/governance/api_test.go
@@ -174,6 +174,10 @@ func (bc *testBlockChain) Config() *params.ChainConfig {
 	return bc.config
 }
 
+func (bc *testBlockChain) CurrentBlock() *types.Block {
+	return types.NewBlock(bc.CurrentHeader(), nil, nil)
+}
+
 func (bc *testBlockChain) CurrentHeader() *types.Header {
 	return &types.Header{
 		Number: new(big.Int).SetUint64(bc.num),

--- a/governance/contract.go
+++ b/governance/contract.go
@@ -62,16 +62,9 @@ func (e *ContractEngine) ParamsAt(num uint64) (*params.GovParamSet, error) {
 }
 
 // if UpdateParam fails, leave currentParams as-is
-func (e *ContractEngine) UpdateParams() error {
-	chain := e.headerGov.BlockChain()
-	if chain == nil {
-		logger.Crit("headerGov.BlockChain() is nil")
-		return errContractEngineNotReady
-	}
-
+func (e *ContractEngine) UpdateParams(num uint64) error {
 	// request the parameters required for generating the next block
-	head := chain.CurrentBlock().NumberU64()
-	pset, err := e.contractGetAllParamsAt(head + 1)
+	pset, err := e.contractGetAllParamsAt(num + 1)
 	if err != nil {
 		return err
 	}

--- a/governance/contract.go
+++ b/governance/contract.go
@@ -70,7 +70,7 @@ func (e *ContractEngine) UpdateParams() error {
 	}
 
 	// request the parameters required for generating the next block
-	head := chain.CurrentHeader().Number.Uint64()
+	head := chain.CurrentBlock().NumberU64()
 	pset, err := e.contractGetAllParamsAt(head + 1)
 	if err != nil {
 		return err

--- a/governance/contract_connector.go
+++ b/governance/contract_connector.go
@@ -108,7 +108,7 @@ func (c *contractCaller) makeTx(contractAbi abi.ABI, fn string, args ...interfac
 // Make contract execution transaction
 func (c *contractCaller) makeEVM(tx *types.Transaction) (*vm.EVM, error) {
 	// Load the latest state
-	block := c.chain.GetBlockByNumber(c.chain.CurrentHeader().Number.Uint64())
+	block := c.chain.GetBlockByNumber(c.chain.CurrentBlock().NumberU64())
 	if block == nil {
 		logger.Error("Could not find the latest block", "num", c.chain.CurrentHeader().Number.Uint64())
 		return nil, errors.New("no block")

--- a/governance/contract_connector.go
+++ b/governance/contract_connector.go
@@ -108,7 +108,7 @@ func (c *contractCaller) makeTx(contractAbi abi.ABI, fn string, args ...interfac
 // Make contract execution transaction
 func (c *contractCaller) makeEVM(tx *types.Transaction) (*vm.EVM, error) {
 	// Load the latest state
-	block := c.chain.GetBlockByNumber(c.chain.CurrentBlock().NumberU64())
+	block := c.chain.CurrentBlock()
 	if block == nil {
 		logger.Error("Could not find the latest block", "num", c.chain.CurrentBlock().NumberU64())
 		return nil, errors.New("no block")

--- a/governance/contract_connector.go
+++ b/governance/contract_connector.go
@@ -83,7 +83,7 @@ func (c *contractCaller) makeTx(contractAbi abi.ABI, fn string, args ...interfac
 		return nil, err
 	}
 
-	rules := c.chain.Config().Rules(c.chain.CurrentHeader().Number)
+	rules := c.chain.Config().Rules(c.chain.CurrentBlock().Number())
 	intrinsicGas, err := types.IntrinsicGas(calldata, nil, false, rules)
 	if err != nil {
 		logger.Error("Could not fetch intrinsicGas", "err", err)
@@ -110,13 +110,13 @@ func (c *contractCaller) makeEVM(tx *types.Transaction) (*vm.EVM, error) {
 	// Load the latest state
 	block := c.chain.GetBlockByNumber(c.chain.CurrentBlock().NumberU64())
 	if block == nil {
-		logger.Error("Could not find the latest block", "num", c.chain.CurrentHeader().Number.Uint64())
+		logger.Error("Could not find the latest block", "num", c.chain.CurrentBlock().NumberU64())
 		return nil, errors.New("no block")
 	}
 
 	statedb, err := c.chain.StateAt(block.Root())
 	if err != nil {
-		logger.Error("Could not find the state", "err", err, "num", c.chain.CurrentHeader().Number.Uint64())
+		logger.Error("Could not find the state", "err", err, "num", c.chain.CurrentBlock().NumberU64())
 		return nil, err
 	}
 

--- a/governance/contract_test.go
+++ b/governance/contract_test.go
@@ -258,7 +258,7 @@ func TestContractEngine_Params(t *testing.T) {
 
 		assert.Equal(t, expected, e.Params(), "Params() on block %d failed", num)
 		sim.Commit()
-		err := e.UpdateParams(num)
+		err := e.UpdateParams(sim.BlockChain().CurrentBlock().NumberU64())
 		assert.Nil(t, err)
 	}
 }
@@ -318,7 +318,7 @@ func TestContractEngine_ParamsAt(t *testing.T) {
 		}
 
 		sim.Commit()
-		err := e.UpdateParams(num)
+		err := e.UpdateParams(sim.BlockChain().CurrentBlock().NumberU64())
 		assert.Nil(t, err)
 	}
 }

--- a/governance/contract_test.go
+++ b/governance/contract_test.go
@@ -199,7 +199,7 @@ func prepareContractEngine(t *testing.T, bc *blockchain.BlockChain, addr common.
 	gov.SetBlockchain(bc)
 
 	e := NewContractEngine(gov)
-	err = e.UpdateParams()
+	err = e.UpdateParams(bc.CurrentBlock().NumberU64())
 	require.Nil(t, err)
 
 	return e
@@ -229,7 +229,7 @@ func TestContractEngine_Params(t *testing.T) {
 	e := prepareContractEngine(t, sim.BlockChain(), addr)
 
 	var (
-		start      = sim.BlockChain().CurrentHeader().Number.Uint64()
+		start      = sim.BlockChain().CurrentBlock().NumberU64()
 		setparam   = start + 5
 		activation = setparam + 5
 		end        = activation + 5
@@ -258,7 +258,7 @@ func TestContractEngine_Params(t *testing.T) {
 
 		assert.Equal(t, expected, e.Params(), "Params() on block %d failed", num)
 		sim.Commit()
-		err := e.UpdateParams()
+		err := e.UpdateParams(num)
 		assert.Nil(t, err)
 	}
 }
@@ -285,7 +285,7 @@ func TestContractEngine_ParamsAt(t *testing.T) {
 	e := prepareContractEngine(t, sim.BlockChain(), addr)
 
 	var (
-		start      = sim.BlockChain().CurrentHeader().Number.Uint64()
+		start      = sim.BlockChain().CurrentBlock().NumberU64()
 		setparam   = start + 5
 		activation = setparam + 5
 		end        = activation + 5
@@ -318,7 +318,7 @@ func TestContractEngine_ParamsAt(t *testing.T) {
 		}
 
 		sim.Commit()
-		err := e.UpdateParams()
+		err := e.UpdateParams(num)
 		assert.Nil(t, err)
 	}
 }

--- a/governance/default.go
+++ b/governance/default.go
@@ -741,7 +741,7 @@ func (g *Governance) initializeCache(chainConfig *params.ChainConfig) error {
 	}
 	// Reflect g.currentSet -> g.currentParams (for g.Params())
 	// Outside initializeCache, istanbul.CreateSnapshot() will trigger UpdateParams().
-	g.UpdateParams()
+	g.UpdateParams(headBlockNumber)
 	// Reflect g.currentSet -> global params in params/governance_params.go
 	// Outside initializeCache, GovernanceItems[].trigger will reflect changes to globals.
 	g.updateGovernanceParams()
@@ -1247,7 +1247,7 @@ func (gov *Governance) ParamsAt(num uint64) (*params.GovParamSet, error) {
 	return pset, nil
 }
 
-func (gov *Governance) UpdateParams() error {
+func (gov *Governance) UpdateParams(num uint64) error {
 	strMap := gov.currentSet.Items()
 	pset, err := params.NewGovParamSetStrMap(strMap)
 	if err != nil {

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -106,10 +106,8 @@ type HeaderEngine interface {
 type blockChain interface {
 	blockchain.ChainContext
 
-	CurrentHeader() *types.Header
 	CurrentBlock() *types.Block
 	GetHeaderByNumber(val uint64) *types.Header
-	GetBlockByNumber(num uint64) *types.Block
 	StateAt(root common.Hash) (*state.StateDB, error)
 	Config() *params.ChainConfig
 }

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -47,7 +47,7 @@ type ReaderEngine interface {
 	// Update the current params (the ones returned by Params()).
 	// by reading the latest blockchain states.
 	// This function must be called after every block is mined to
-	// guarantee that Params(num) works correctly.
+	// guarantee that Params() works correctly.
 	UpdateParams(num uint64) error
 }
 

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -107,6 +107,7 @@ type blockChain interface {
 	blockchain.ChainContext
 
 	CurrentHeader() *types.Header
+	CurrentBlock() *types.Block
 	GetHeaderByNumber(val uint64) *types.Header
 	GetBlockByNumber(num uint64) *types.Block
 	StateAt(root common.Hash) (*state.StateDB, error)

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -47,8 +47,8 @@ type ReaderEngine interface {
 	// Update the current params (the ones returned by Params()).
 	// by reading the latest blockchain states.
 	// This function must be called after every block is mined to
-	// guarantee that Params() works correctly.
-	UpdateParams() error
+	// guarantee that Params(num) works correctly.
+	UpdateParams(num uint64) error
 }
 
 type HeaderEngine interface {

--- a/governance/mixed.go
+++ b/governance/mixed.go
@@ -144,18 +144,13 @@ func (e *MixedEngine) ParamsAt(num uint64) (*params.GovParamSet, error) {
 	return e.assembleParams(headerParams, contractParams), nil
 }
 
-func (e *MixedEngine) UpdateParams() error {
-	// some functions call UpdateParams() without blockchain, such as initGenesis()
-	// in this case, fall back to num=zero
-	num := big.NewInt(0)
-	if e.blockchain != nil {
-		num = e.blockchain.CurrentBlock().Number()
-	}
-
+func (e *MixedEngine) UpdateParams(num uint64) error {
 	var contractParams *params.GovParamSet
-	if e.config.IsKoreForkEnabled(num) {
-		if err := e.contractGov.UpdateParams(); err != nil {
-			logger.Error("contractGov.UpdateParams() failed", "err", err)
+	numBigInt := big.NewInt(int64(num))
+
+	if e.config.IsKoreForkEnabled(numBigInt) {
+		if err := e.contractGov.UpdateParams(num); err != nil {
+			logger.Error("contractGov.UpdateParams(num) failed", "num", num, "err", err)
 			return err
 		}
 		contractParams = e.contractGov.Params()
@@ -163,8 +158,8 @@ func (e *MixedEngine) UpdateParams() error {
 		contractParams = params.NewGovParamSet()
 	}
 
-	if err := e.headerGov.UpdateParams(); err != nil {
-		logger.Error("headerGov.UpdateParams() failed", "err", err)
+	if err := e.headerGov.UpdateParams(num); err != nil {
+		logger.Error("headerGov.UpdateParams(num) failed", "num", num, "err", err)
 		return err
 	}
 

--- a/governance/mixed.go
+++ b/governance/mixed.go
@@ -149,7 +149,7 @@ func (e *MixedEngine) UpdateParams() error {
 	// in this case, fall back to num=zero
 	num := big.NewInt(0)
 	if e.blockchain != nil {
-		num = e.blockchain.CurrentHeader().Number
+		num = e.blockchain.CurrentBlock().Number()
 	}
 
 	var contractParams *params.GovParamSet

--- a/governance/mixed_test.go
+++ b/governance/mixed_test.go
@@ -82,7 +82,7 @@ func TestMixedEngine_Header_Params(t *testing.T) {
 	assert.Equal(t, valueA, e.Params().GasTarget())
 
 	e.headerGov.currentSet.SetValue(params.GasTarget, valueB)
-	err := e.UpdateParams(e.headerGov.blockChain.CurrentBlock().NumberU64())
+	err := e.UpdateParams(0)
 	assert.Nil(t, err)
 
 	assert.Equal(t, valueB, e.Params().GasTarget())

--- a/governance/mixed_test.go
+++ b/governance/mixed_test.go
@@ -82,7 +82,7 @@ func TestMixedEngine_Header_Params(t *testing.T) {
 	assert.Equal(t, valueA, e.Params().GasTarget())
 
 	e.headerGov.currentSet.SetValue(params.GasTarget, valueB)
-	err := e.UpdateParams()
+	err := e.UpdateParams(e.headerGov.blockChain.CurrentBlock().NumberU64())
 	assert.Nil(t, err)
 
 	assert.Equal(t, valueB, e.Params().GasTarget())
@@ -154,7 +154,7 @@ func TestMixedEngine_Params(t *testing.T) {
 
 	// 2. fallback to headerGov because contractGov doesn't have the param
 	e.headerGov.currentSet.SetValue(params.GasTarget, valueB)
-	err := e.UpdateParams()
+	err := e.UpdateParams(e.headerGov.blockChain.CurrentBlock().NumberU64())
 	assert.Nil(t, err)
 
 	assert.Equal(t, valueB, e.Params().GasTarget(), "fallback to headerGov failed")
@@ -165,7 +165,7 @@ func TestMixedEngine_Params(t *testing.T) {
 
 	sim.Commit() // mine SetParamIn
 
-	err = e.UpdateParams()
+	err = e.UpdateParams(e.headerGov.blockChain.CurrentBlock().NumberU64())
 	assert.Nil(t, err)
 	assert.Equal(t, valueC, e.Params().GasTarget(), "fallback to contractGov failed")
 }
@@ -204,12 +204,12 @@ func TestMixedEngine_ParamsAt(t *testing.T) {
 
 	// write minimal params for test to headerGov
 	// note that mainnet will have all parameters in the headerGov db
-	headerBlock := sim.BlockChain().CurrentHeader().Number.Uint64()
+	headerBlock := sim.BlockChain().CurrentBlock().NumberU64()
 	e.headerGov.db.WriteGovernance(map[string]interface{}{
 		name:                          valueB,
 		"governance.govparamcontract": config.Governance.GovParamContract,
 	}, headerBlock)
-	err := e.UpdateParams()
+	err := e.UpdateParams(headerBlock)
 	assert.Nil(t, err)
 
 	// forward a few blocks

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -269,7 +269,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	cn.blockchain = bc
 	governance.SetBlockchain(cn.blockchain)
-	if err := governance.UpdateParams(); err != nil {
+	if err := governance.UpdateParams(cn.blockchain.CurrentBlock().NumberU64()); err != nil {
 		return nil, err
 	}
 	blockchain.InitDeriveShaWithGov(cn.chainConfig, governance)

--- a/tests/gov_contract_test.go
+++ b/tests/gov_contract_test.go
@@ -113,7 +113,7 @@ func TestGovernance_Engines(t *testing.T) {
 		time.Sleep(100 * time.Millisecond) // wait for tx sender thread to set deployBlock, etc.
 
 		num := ev.Block.Number().Uint64()
-		mixedEngine.UpdateParams()
+		mixedEngine.UpdateParams(num)
 
 		mixedVal, _ := mixedEngine.Params().Get(params.CommitteeSize)
 		contractVal, _ := contractEngine.Params().Get(params.CommitteeSize)


### PR DESCRIPTION
## Proposed changes

### Root cause 
In the `loadLastState` method, `bc.currentHeader` can be updated after storing `bc.currentBlock`. This mismatch causes an expected result during the node initializing process. 

https://github.com/klaytn/klaytn/blob/5d7a03b7bb2d834393d26719e52896ed3eeb1a06/blockchain/blockchain.go#L468-L478

`Governance.UpdateParams` requires the head block number of the canonical chain, but it had used the head of header chain that is used for light client usually. This PR does
 1. Replace the use of `bc.currentHeader` to `bc.currentBlock`
 2. Add a parameter indicating a block number for `UpdateParams` method


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
