### PR TITLE
Fix docker publish failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,7 +593,7 @@ workflows:
             - tagger-verify
           filters: *filter-version-not-release
 
-      - docker/publish:
+      - docker/publish: # for dev branch
           filters:
             branches:
               only: dev
@@ -605,6 +605,23 @@ workflows:
           executor: docker/docker
           use-remote-docker: true
           remote-docker-version: 20.10.14
+          use-buildkit: true
+
+      - docker/publish: # for release versions
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+            branches:
+              ignore: /.*/
+          requires:
+            - pass-tests
+          extra_build_args: '--platform=linux/amd64'
+          image: klaytn/klaytn
+          tag: latest,$CIRCLE_TAG
+          executor: docker/docker
+          use-remote-docker: true
+          remote-docker-version: 20.10.14
+          use-buildkit: true
 
       - tag-verify:
           filters: *filter-only-version-tag
@@ -661,21 +678,6 @@ workflows:
           filters: *filter-only-version-tag
           requires:
             - pass-tests
-
-      - docker/publish:
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
-            branches:
-              ignore: /.*/
-          requires:
-            - pass-tests
-          extra_build_args: '--platform=linux/amd64'
-          image: klaytn/klaytn
-          tag: latest,$CIRCLE_TAG
-          executor: docker/docker
-          use-remote-docker: true
-          remote-docker-version: 20.10.14
 
       - major-tagging:
           filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV KLAYTN_DISABLE_SYMBOL=$KLAYTN_DISABLE_SYMBOL
 
 WORKDIR $SRC_DIR
 # Cache default $GOMODCACHE
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 
 # Cache default $GOCACHE


### PR DESCRIPTION
## Proposed changes

CircleCI is failing to publish a docker image because of two kinds of reasons ([case](https://app.circleci.com/pipelines/github/klaytn/klaytn/9209/workflows/31b6dee4-1691-4153-aa79-08ed5ab61590/jobs/49670)):

1) missing `/` 
```
Step 15/27 : COPY go.mod go.sum .
When using COPY with more than one source file, the destination must be a directory and end with a /`
```

2) Docker BuildKit not enabled
```
Step 17/28 : RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
```

Changes
1. Add `/` in `Dockerfile`
2. Add environment variable `DOCKER_BUILDKIT=1` in `circleci/config.yml`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
