### PR TITLE
Update klay_getRewards

### DIFF
--- a/reward/reward_distributor.go
+++ b/reward/reward_distributor.go
@@ -292,7 +292,9 @@ func CalcDeferredReward(header *types.Header, rules params.Rules, pset *params.G
 	// Remainder from (CN, KGF, KIR) split goes to KGF
 	kgf = kgf.Add(kgf, splitRem)
 	// Remainder from staker shares goes to Proposer
+	// Then, deduct it from stakers so that `minted + totalFee - burntFee = proposer + stakers + kgf + kir`
 	proposer = proposer.Add(proposer, shareRem)
+	stakers = stakers.Sub(stakers, shareRem)
 
 	// if KGF or KIR is not set, proposer gets the portion
 	if stakingInfo == nil || common.EmptyAddress(stakingInfo.PoCAddr) {

--- a/reward/reward_distributor.go
+++ b/reward/reward_distributor.go
@@ -198,7 +198,7 @@ func GetBlockReward(header *types.Header, rules params.Rules, pset *params.GovPa
 	// some non-zero fee already has been paid to the proposer.
 	if !pset.DeferredTxFee() {
 		blockFee := GetTotalTxFee(header, rules, pset)
-		spec.Proposer = spec.Proposer.Add(spec.Proposer, spec.TotalFee)
+		spec.Proposer = spec.Proposer.Add(spec.Proposer, blockFee)
 		spec.TotalFee = spec.TotalFee.Add(spec.TotalFee, blockFee)
 		incrementRewardsMap(spec.Rewards, header.Rewardbase, blockFee)
 	}
@@ -237,7 +237,7 @@ func CalcDeferredRewardSimple(header *types.Header, rules params.Rules, pset *pa
 		spec.TotalFee = big.NewInt(0)
 		spec.BurntFee = big.NewInt(0)
 		spec.Proposer = proposer
-		spec.Rewards[header.Rewardbase] = proposer
+		incrementRewardsMap(spec.Rewards, header.Rewardbase, proposer)
 		return spec, nil
 	}
 
@@ -264,7 +264,7 @@ func CalcDeferredRewardSimple(header *types.Header, rules params.Rules, pset *pa
 	spec.TotalFee = totalFee
 	spec.BurntFee = burntFee
 	spec.Proposer = proposer
-	spec.Rewards[header.Rewardbase] = proposer
+	incrementRewardsMap(spec.Rewards, header.Rewardbase, proposer)
 	return spec, nil
 }
 


### PR DESCRIPTION
## Proposed changes

Adjust return values of klay_getRewards so that `minted + totalFee - burntFee = proposer + stakers + kgf + kir`
- Deduct shareRem from stakers


Updated output:
```
{
    "minted": 6400000000000000000,
    "totalFee": 0,
    "burntFee": 0,
    "proposer": 640000000000000001,
    "stakers": 2559999999999999999,
    "kgf": 2560000000000000000,
    "kir": 640000000000000000,
    "rewards": {
        "0x09635f643e140090a9a8dcd712ed6285858cebef": 640000000000000000,
        "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc": 2275555555555555555,
        "0x70997970c51812dc3a010c7d01b50e0d17dc79c8": 284444444444444444,
        "0x7a2088a1bfc9d81c55368ae168c2c02570cb814f": 2560000000000000000,
        "0xb76ff0fe2b836040f67cf84581e9c9d0a5945d6a": 640000000000000001
    }
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
