### PR TITLE
Change HeaderGov Activation after Kore

### DIFF
--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -28,8 +28,9 @@ import (
 	"github.com/klaytn/klaytn/event"
 )
 
-//go:generate mockgen -destination=consensus/istanbul/mocks/backend_mock.go github.com/klaytn/klaytn/consensus/istanbul Backend
 // Backend provides application specific functions for Istanbul core
+//
+//go:generate mockgen -destination=consensus/istanbul/mocks/backend_mock.go github.com/klaytn/klaytn/consensus/istanbul Backend
 type Backend interface {
 	// Address returns the owner's address
 	Address() common.Address
@@ -79,8 +80,6 @@ type Backend interface {
 	HasBadProposal(hash common.Hash) bool
 
 	GetRewardBase() common.Address
-
-	GetSubGroupSize() uint64
 
 	SetCurrentView(view *View)
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -379,7 +379,15 @@ func (sb *backend) GetProposer(number uint64) common.Address {
 
 // ParentValidators implements istanbul.Backend.GetParentValidators
 func (sb *backend) ParentValidators(proposal istanbul.Proposal) istanbul.ValidatorSet {
-	return sb.getValidators(proposal.Number().Uint64()-1, proposal.ParentHash())
+	if block, ok := proposal.(*types.Block); ok {
+		return sb.getValidators(block.Number().Uint64()-1, block.ParentHash())
+	}
+
+	// TODO-Klaytn-Governance The following return case should not be called. Refactor it to error handling.
+	return validator.NewValidatorSet(nil, nil,
+		istanbul.ProposerPolicy(sb.chain.Config().Istanbul.ProposerPolicy),
+		sb.chain.Config().Istanbul.SubGroupSize,
+		sb.chain)
 }
 
 func (sb *backend) getValidators(number uint64, hash common.Hash) istanbul.ValidatorSet {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -193,6 +193,9 @@ func (sb *backend) verifyHeader(chain consensus.ChainReader, header *types.Heade
 	if chain.Config().IsMagmaForkEnabled(header.Number) {
 		// the kip71Config used when creating the block number is a previous block config.
 		blockNum := header.Number.Uint64()
+		if !chain.Config().IsKoreForkEnabled(header.Number) && header.Number.BitLen() != 0 {
+			blockNum = blockNum - 1
+		}
 		pset, err := sb.governance.ParamsAt(blockNum)
 		if err != nil {
 			return err

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -193,9 +193,6 @@ func (sb *backend) verifyHeader(chain consensus.ChainReader, header *types.Heade
 	if chain.Config().IsMagmaForkEnabled(header.Number) {
 		// the kip71Config used when creating the block number is a previous block config.
 		blockNum := header.Number.Uint64()
-		if !chain.Config().IsKoreForkEnabled(header.Number) && header.Number.BitLen() != 0 {
-			blockNum = blockNum - 1
-		}
 		pset, err := sb.governance.ParamsAt(blockNum)
 		if err != nil {
 			return err
@@ -254,8 +251,12 @@ func (sb *backend) verifyCascadingFields(chain consensus.ChainReader, header *ty
 	}
 
 	// At every epoch governance data will come in block header. Verify it.
+	pset, err := sb.governance.ParamsAt(number)
+	if err != nil {
+		return err
+	}
 	pendingBlockNum := new(big.Int).Add(chain.CurrentHeader().Number, common.Big1)
-	if number%sb.governance.Params().Epoch() == 0 && len(header.Governance) > 0 && pendingBlockNum.Cmp(header.Number) == 0 {
+	if number%pset.Epoch() == 0 && len(header.Governance) > 0 && pendingBlockNum.Cmp(header.Number) == 0 {
 		if err := sb.governance.VerifyGovernance(header.Governance); err != nil {
 			return err
 		}
@@ -400,7 +401,11 @@ func (sb *backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 	}
 
 	// If it reaches the Epoch, governance config will be added to block header
-	if number%sb.governance.Params().Epoch() == 0 {
+	pset, err := sb.governance.ParamsAt(number)
+	if err != nil {
+		return err
+	}
+	if number%pset.Epoch() == 0 {
 		if g := sb.governance.GetGovernanceChange(); g != nil {
 			if data, err := json.Marshal(g); err != nil {
 				logger.Error("Failed to encode governance changes!! Possible configuration mismatch!! ")
@@ -464,14 +469,9 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 	if err != nil {
 		return nil, err
 	}
-	rewardParamNum := reward.CalcRewardParamBlock(header.Number.Uint64(), pset.Epoch(), rules)
-	rewardParamSet, err := sb.governance.ParamsAt(rewardParamNum)
-	if err != nil {
-		return nil, err
-	}
 
 	// If sb.chain is nil, it means backend is not initialized yet.
-	if sb.chain != nil && !reward.IsRewardSimple(sb.governance.Params()) {
+	if sb.chain != nil && !reward.IsRewardSimple(pset) {
 		// TODO-Klaytn Let's redesign below logic and remove dependency between block reward and istanbul consensus.
 
 		lastHeader := chain.CurrentHeader()
@@ -494,9 +494,9 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 			logger.Trace(logMsg, "header.Number", header.Number.Uint64(), "node address", sb.address, "rewardbase", header.Rewardbase)
 		}
 
-		rewardSpec, err = reward.CalcDeferredReward(header, rules, rewardParamSet)
+		rewardSpec, err = reward.CalcDeferredReward(header, rules, pset)
 	} else {
-		rewardSpec, err = reward.CalcDeferredRewardSimple(header, rules, rewardParamSet)
+		rewardSpec, err = reward.CalcDeferredRewardSimple(header, rules, pset)
 	}
 
 	if err != nil {
@@ -671,9 +671,13 @@ func (sb *backend) initSnapshot(chain consensus.ChainReader) (*Snapshot, error) 
 		return nil, err
 	}
 
+	pset, err := sb.governance.ParamsAt(0)
+	if err != nil {
+		return nil, err
+	}
 	valSet := validator.NewValidatorSet(istanbulExtra.Validators, nil,
-		istanbul.ProposerPolicy(sb.governance.Params().Policy()),
-		sb.governance.Params().CommitteeSize(), chain)
+		istanbul.ProposerPolicy(pset.Policy()),
+		pset.CommitteeSize(), chain)
 	snap := newSnapshot(sb.governance, 0, genesis.Hash(), valSet, chain.Config())
 
 	if err := snap.store(sb.db); err != nil {
@@ -832,7 +836,11 @@ func (sb *backend) snapshot(chain consensus.ChainReader, number uint64, hash com
 	for i := 0; i < len(headers)/2; i++ {
 		headers[i], headers[len(headers)-1-i] = headers[len(headers)-1-i], headers[i]
 	}
-	snap, err := snap.apply(headers, sb.governance, sb.address, sb.governance.Params().Policy(), chain, writable)
+	pset, err := sb.governance.ParamsAt(number)
+	if err != nil {
+		return nil, err
+	}
+	snap, err = snap.apply(headers, sb.governance, sb.address, pset.Policy(), chain, writable)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -193,9 +193,6 @@ func (sb *backend) verifyHeader(chain consensus.ChainReader, header *types.Heade
 	if chain.Config().IsMagmaForkEnabled(header.Number) {
 		// the kip71Config used when creating the block number is a previous block config.
 		blockNum := header.Number.Uint64()
-		if header.Number.BitLen() != 0 {
-			blockNum = blockNum - 1
-		}
 		pset, err := sb.governance.ParamsAt(blockNum)
 		if err != nil {
 			return err

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -1673,7 +1673,7 @@ func TestGovernance_ReaderEngine(t *testing.T) {
 				3: {"governance.unitprice": uint64(1)},
 				4: {"governance.unitprice": uint64(1)},
 				5: {"governance.unitprice": uint64(1)},
-				6: {"governance.unitprice": uint64(17)},
+				6: {"governance.unitprice": uint64(1)},
 				7: {"governance.unitprice": uint64(17)},
 				8: {"governance.unitprice": uint64(17)},
 			},
@@ -1704,8 +1704,8 @@ func TestGovernance_ReaderEngine(t *testing.T) {
 		for num := 0; num <= tc.length; num++ {
 			// Validate current params with Params() and CurrentSetCopy().
 			// Check that both returns the expected result.
-			assertMapSubset(t, tc.expected[num], engine.governance.Params().StrMap())
-			assertMapSubset(t, tc.expected[num], engine.governance.CurrentSetCopy())
+			assertMapSubset(t, tc.expected[num+1], engine.governance.Params().StrMap())
+			assertMapSubset(t, tc.expected[num+1], engine.governance.CurrentSetCopy())
 
 			// Place a vote if a vote is scheduled in upcoming block
 			// Note that we're building (head+1)'th block here.
@@ -1728,14 +1728,13 @@ func TestGovernance_ReaderEngine(t *testing.T) {
 		// Validate historic parameters with ParamsAt() and ReadGovernance().
 		// Check that both returns the expected result.
 		for num := 0; num <= tc.length; num++ {
-			// Before Kore, query num+1
-			pset, err := engine.governance.ParamsAt(uint64(num) + 1)
+			pset, err := engine.governance.ParamsAt(uint64(num))
 			assert.NoError(t, err)
 			assertMapSubset(t, tc.expected[num], pset.StrMap())
 
 			_, items, err := engine.governance.ReadGovernance(uint64(num))
 			assert.NoError(t, err)
-			assertMapSubset(t, tc.expected[num], items)
+			assertMapSubset(t, tc.expected[num+1], items)
 		}
 
 		reward.SetTestStakingManager(oldStakingManager)

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -1728,7 +1728,8 @@ func TestGovernance_ReaderEngine(t *testing.T) {
 		// Validate historic parameters with ParamsAt() and ReadGovernance().
 		// Check that both returns the expected result.
 		for num := 0; num <= tc.length; num++ {
-			pset, err := engine.governance.ParamsAt(uint64(num))
+			// Before Kore, query num+1
+			pset, err := engine.governance.ParamsAt(uint64(num) + 1)
 			assert.NoError(t, err)
 			assertMapSubset(t, tc.expected[num], pset.StrMap())
 

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -193,7 +193,9 @@ func (s *Snapshot) apply(headers []*types.Header, gov governance.Engine, addr co
 			//
 			// Proposers for Block N+1 can be calculated from the nearest previous proposersUpdateInterval block.
 			// Refresh proposers in Snapshot_N using previous proposersUpdateInterval block for N+1, if not updated yet.
-			pset, err := gov.ParamsAt(number)
+
+			// because snapshot(num)'s ValSet = validators for num+1
+			pset, err := gov.ParamsAt(number + 1)
 			if err != nil {
 				return nil, err
 			}

--- a/governance/api.go
+++ b/governance/api.go
@@ -353,6 +353,7 @@ func (api *PublicGovernanceAPI) isGovernanceModeBallot() bool {
 	blockNumber := api.governance.BlockChain().CurrentBlock().NumberU64()
 	pset, err := api.governance.ParamsAt(blockNumber)
 	if err != nil {
+		return false
 	}
 	gMode := pset.GovernanceModeInt()
 	return gMode == params.GovernanceMode_Ballot

--- a/governance/api_test.go
+++ b/governance/api_test.go
@@ -31,6 +31,8 @@ func newTestGovernanceApi() *PublicGovernanceAPI {
 	config.Governance.KIP71 = params.GetDefaultKIP71Config()
 	govApi := NewGovernanceAPI(NewMixedEngine(config, database.NewMemoryDBManager()))
 	govApi.governance.SetNodeAddress(common.HexToAddress("0x52d41ca72af615a1ac3301b0a93efa222ecc7541"))
+	bc := newTestBlockchain(config)
+	govApi.governance.SetBlockchain(bc)
 	return govApi
 }
 

--- a/governance/default.go
+++ b/governance/default.go
@@ -459,17 +459,13 @@ func NewGovernanceInitialize(chainConfig *params.ChainConfig, dbm database.DBMan
 
 // updateGovernanceParams takes the current block number
 // and sets the parameterss to be used for generating the next block
-func (g *Governance) updateGovernanceParams(num uint64) {
+func (g *Governance) updateGovernanceParams() {
 	params.SetStakingUpdateInterval(g.stakingUpdateInterval())
 	params.SetProposerUpdateInterval(g.proposerUpdateInterval())
 
 	// NOTE: HumanReadable related functions are inactivated now
-	pset, err := g.ParamsAt(num + 1)
-	if err != nil {
-		return
-	}
-	if v, ok := pset.Get(params.ConstTxGasHumanReadable); ok {
-		params.TxGasHumanReadable = v.(uint64)
+	if txGasHumanReadable, ok := g.currentSet.GetValue(params.ConstTxGasHumanReadable); ok {
+		params.TxGasHumanReadable = txGasHumanReadable.(uint64)
 	}
 }
 
@@ -750,7 +746,7 @@ func (g *Governance) initializeCache(chainConfig *params.ChainConfig) error {
 	g.UpdateParams(headBlockNumber)
 	// Reflect g.currentSet -> global params in params/governance_params.go
 	// Outside initializeCache, GovernanceItems[].trigger will reflect changes to globals.
-	g.updateGovernanceParams(headBlockNumber)
+	g.updateGovernanceParams()
 
 	return nil
 }
@@ -1067,7 +1063,7 @@ func (gov *Governance) ReadGovernanceState() {
 		return
 	}
 	gov.UnmarshalJSON(b)
-	gov.updateGovernanceParams(gov.blockChain.CurrentBlock().NumberU64())
+	gov.updateGovernanceParams()
 
 	logger.Info("Successfully loaded governance state from database", "blockNumber", atomic.LoadUint64(&gov.lastGovernanceStateBlock))
 }

--- a/governance/default.go
+++ b/governance/default.go
@@ -1248,12 +1248,23 @@ func (gov *Governance) ParamsAt(num uint64) (*params.GovParamSet, error) {
 }
 
 func (gov *Governance) UpdateParams(num uint64) error {
-	strMap := gov.currentSet.Items()
-	pset, err := params.NewGovParamSetStrMap(strMap)
-	if err != nil {
-		return err
-	}
+	bignum := new(big.Int).SetUint64(num)
 
-	gov.currentParams = pset
+	// pre-Kore's activation : epoch block + 1 at which currentSet is updated
+	// post-Kore's activation: epoch block (fetch params for num + 1)
+	if !gov.ChainConfig.IsKoreForkEnabled(bignum) {
+		strMap := gov.currentSet.Items()
+		pset, err := params.NewGovParamSetStrMap(strMap)
+		if err != nil {
+			return err
+		}
+		gov.currentParams = pset
+	} else {
+		pset, err := gov.ParamsAt(num + 1)
+		if err != nil {
+			return err
+		}
+		gov.currentParams = pset
+	}
 	return nil
 }

--- a/governance/default.go
+++ b/governance/default.go
@@ -1226,8 +1226,13 @@ func (gov *Governance) epochWithFallback() uint64 {
 		return v.(uint64)
 	}
 
-	// now that gov.ChainConfig is gone, we return default instead of gov.ChainConfig.Epoch
-	return params.DefaultEpoch
+	// Otherwise fallback to ChainConfig that is supplied to NewGovernance()
+	if gov.ChainConfig.Istanbul != nil {
+		return gov.ChainConfig.Istanbul.Epoch
+	}
+	// We shouldn't reach here because Governance is only relevant with Istanbul engine.
+	logger.Crit("Failed to read governance. ChainConfig.Istanbul == nil")
+	return params.DefaultEpoch // unreachable. just satisfying compiler.
 }
 
 func (gov *Governance) Params() *params.GovParamSet {

--- a/governance/default.go
+++ b/governance/default.go
@@ -457,8 +457,6 @@ func NewGovernanceInitialize(chainConfig *params.ChainConfig, dbm database.DBMan
 	return ret
 }
 
-// updateGovernanceParams takes the current block number
-// and sets the parameterss to be used for generating the next block
 func (g *Governance) updateGovernanceParams() {
 	params.SetStakingUpdateInterval(g.stakingUpdateInterval())
 	params.SetProposerUpdateInterval(g.proposerUpdateInterval())

--- a/governance/default.go
+++ b/governance/default.go
@@ -1262,23 +1262,10 @@ func (gov *Governance) ParamsAt(num uint64) (*params.GovParamSet, error) {
 }
 
 func (gov *Governance) UpdateParams(num uint64) error {
-	bignum := new(big.Int).SetUint64(num)
-
-	// pre-Kore's activation : epoch block + 1 at which currentSet is updated
-	// post-Kore's activation: epoch block (fetch params for num + 1)
-	if !gov.ChainConfig.IsKoreForkEnabled(bignum) {
-		strMap := gov.currentSet.Items()
-		pset, err := params.NewGovParamSetStrMap(strMap)
-		if err != nil {
-			return err
-		}
-		gov.currentParams = pset
-	} else {
-		pset, err := gov.ParamsAt(num + 1)
-		if err != nil {
-			return err
-		}
-		gov.currentParams = pset
+	pset, err := gov.ParamsAt(num + 1)
+	if err != nil {
+		return err
 	}
+	gov.currentParams = pset
 	return nil
 }

--- a/governance/default.go
+++ b/governance/default.go
@@ -1232,6 +1232,10 @@ func (gov *Governance) ParamsAt(num uint64) (*params.GovParamSet, error) {
 	// TODO-Klaytn: Either handle epoch change, or permanently forbid epoch change.
 	epoch := gov.epochWithFallback()
 
+	bignum := new(big.Int).SetUint64(num)
+	if !gov.ChainConfig.IsKoreForkEnabled(bignum) && num != 0 {
+		num -= 1
+	}
 	// Should be equivalent to Governance.ReadGovernance(), but without in-memory caches.
 	// Not using in-memory caches to make it stateless, hence less error-prone.
 	_, strMap, err := gov.db.ReadGovernanceAtNumber(num, epoch)

--- a/governance/default.go
+++ b/governance/default.go
@@ -1235,11 +1235,14 @@ func (gov *Governance) Params() *params.GovParamSet {
 	return gov.currentParams
 }
 
+// ParamsAt returns the parameter set used for generating the block `num`
 func (gov *Governance) ParamsAt(num uint64) (*params.GovParamSet, error) {
 	// TODO-Klaytn: Either handle epoch change, or permanently forbid epoch change.
 	epoch := gov.epochWithFallback()
 
 	bignum := new(big.Int).SetUint64(num)
+
+	// Before Kore, ReadGovernance(num - 1) is used to generate block num
 	if !gov.ChainConfig.IsKoreForkEnabled(bignum) && num != 0 {
 		num -= 1
 	}

--- a/governance/default_test.go
+++ b/governance/default_test.go
@@ -1262,3 +1262,49 @@ func TestGovernance_VerifyGovernance(t *testing.T) {
 	err = gov.VerifyGovernance(r)
 	assert.Equal(t, ErrVoteValueMismatch, err)
 }
+
+func TestGovernance_ParamsAt(t *testing.T) {
+	valueA := uint64(0x11)
+	valueB := uint64(0x22)
+	valueC := uint64(0x33)
+	koreBlock := uint64(100)
+
+	dbm := database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB})
+	config := getTestConfig()
+	config.Istanbul.Epoch = 30
+	config.Istanbul.SubGroupSize = valueA
+	config.KoreCompatibleBlock = new(big.Int).SetUint64(koreBlock)
+	gov := NewGovernanceInitialize(config, dbm)
+
+	// Write to database. Note that we must use gov.WriteGovernance(), not db.WriteGovernance()
+	// The reason is that gov.ReadGovernance() depends on the caches, and that
+	// gov.WriteGovernance() sets idxCache accordingly, whereas db.WriteGovernance don't
+	items := gov.Params().StrMap()
+	gset := NewGovernanceSet()
+
+	items["istanbul.committeesize"] = valueB
+	gset.Import(items)
+	gov.WriteGovernance(30, NewGovernanceSet(), gset)
+
+	items["istanbul.committeesize"] = valueC
+	gset.Import(items)
+	gov.WriteGovernance(120, NewGovernanceSet(), gset)
+
+	testcases := []struct {
+		num   uint64
+		value uint64
+	}{
+		{59, valueA},
+		{60, valueA},
+		{61, valueB},
+		{149, valueB},
+		{150, valueC},
+		{151, valueC},
+	}
+	for _, tc := range testcases {
+		// Check that e.ParamsAt() == tc
+		pset, err := gov.ParamsAt(tc.num)
+		assert.Nil(t, err)
+		assert.Equal(t, tc.value, pset.CommitteeSize(), "Wrong at %d", tc.num)
+	}
+}

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -383,8 +383,13 @@ func (gov *Governance) HandleGovernanceVote(valset istanbul.ValidatorSet, votes 
 		number := header.Number.Uint64()
 		// Check vote's validity
 		if gVote, ok := gov.ValidateVote(gVote); ok {
-			governanceMode := gov.Params().GovernanceModeInt()
-			governingNode := gov.Params().GoverningNode()
+			pset, err := gov.ParamsAt(number)
+			if err != nil {
+				logger.Error("ParamsAt failed", "number", number)
+				return valset, votes, tally
+			}
+			governanceMode := pset.GovernanceModeInt()
+			governingNode := pset.GoverningNode()
 
 			// Remove old vote with same validator and key
 			votes, tally = gov.removePreviousVote(valset, votes, tally, proposer, gVote, governanceMode, governingNode, writable)

--- a/governance/mixed.go
+++ b/governance/mixed.go
@@ -122,6 +122,7 @@ func (e *MixedEngine) Params() *params.GovParamSet {
 	return e.currentParams
 }
 
+// ParamsAt returns the parameter set used for generating the block `num`
 func (e *MixedEngine) ParamsAt(num uint64) (*params.GovParamSet, error) {
 	var contractParams *params.GovParamSet
 	var err error

--- a/governance/mixed_test.go
+++ b/governance/mixed_test.go
@@ -81,8 +81,13 @@ func TestMixedEngine_Header_Params(t *testing.T) {
 	e := newTestMixedEngineNoContractEngine(t, config)
 	assert.Equal(t, valueA, e.Params().GasTarget())
 
-	e.headerGov.currentSet.SetValue(params.GasTarget, valueB)
-	err := e.UpdateParams(0)
+	items := e.Params().StrMap()
+	items["kip71.gastarget"] = valueB
+	gset := NewGovernanceSet()
+	gset.Import(items)
+	err := e.headerGov.WriteGovernance(e.Params().Epoch(), NewGovernanceSet(), gset)
+	assert.Nil(t, err)
+	err = e.UpdateParams(e.Params().Epoch() * 2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, valueB, e.Params().GasTarget())

--- a/governance/mixed_test.go
+++ b/governance/mixed_test.go
@@ -90,9 +90,9 @@ func TestMixedEngine_Header_Params(t *testing.T) {
 	assert.Equal(t, valueB, config.Governance.KIP71.GasTarget)
 }
 
-// Without ContractGov, Check that
-// - after DB is written at [n - epoch], ParamsAt(n) returns the new value
-// - ParamsAt(n) == ReadGovernance(n)
+// Before Kore hardfork (i.e., without ContractGov), check that
+// - after DB is written at [n - epoch], ParamsAt(n+1) returns the new value
+// - ParamsAt(n+1) == ReadGovernance(n)
 func TestMixedEngine_Header_ParamsAt(t *testing.T) {
 	valueA := uint64(0x11)
 	valueB := uint64(0x22)
@@ -124,7 +124,7 @@ func TestMixedEngine_Header_ParamsAt(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		// Check that e.ParamsAt() == tc
-		pset, err := e.ParamsAt(tc.num)
+		pset, err := e.ParamsAt(tc.num + 1)
 		assert.Nil(t, err)
 		assert.Equal(t, tc.value, pset.CommitteeSize())
 

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -286,18 +286,28 @@ func (b *CNAPIBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
 }
 
 func (b *CNAPIBackend) UpperBoundGasPrice(ctx context.Context) *big.Int {
-	if b.cn.chainConfig.IsMagmaForkEnabled(b.CurrentBlock().Number()) {
-		return new(big.Int).SetUint64(b.cn.governance.Params().UpperBoundBaseFee())
+	bignum := b.CurrentBlock().Number()
+	pset, err := b.cn.governance.ParamsAt(bignum.Uint64())
+	if err != nil {
+		return nil
+	}
+	if b.cn.chainConfig.IsMagmaForkEnabled(bignum) {
+		return new(big.Int).SetUint64(pset.UpperBoundBaseFee())
 	} else {
-		return new(big.Int).SetUint64(b.cn.governance.Params().UnitPrice())
+		return new(big.Int).SetUint64(pset.UnitPrice())
 	}
 }
 
 func (b *CNAPIBackend) LowerBoundGasPrice(ctx context.Context) *big.Int {
-	if b.cn.chainConfig.IsMagmaForkEnabled(b.CurrentBlock().Number()) {
-		return new(big.Int).SetUint64(b.cn.governance.Params().LowerBoundBaseFee())
+	bignum := b.CurrentBlock().Number()
+	pset, err := b.cn.governance.ParamsAt(bignum.Uint64())
+	if err != nil {
+		return nil
+	}
+	if b.cn.chainConfig.IsMagmaForkEnabled(bignum) {
+		return new(big.Int).SetUint64(pset.LowerBoundBaseFee())
 	} else {
-		return new(big.Int).SetUint64(b.cn.governance.Params().UnitPrice())
+		return new(big.Int).SetUint64(pset.UnitPrice())
 	}
 }
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -275,11 +275,15 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	blockchain.InitDeriveShaWithGov(cn.chainConfig, governance)
 
 	// Synchronize proposerpolicy & useGiniCoeff
+	pset, err := governance.ParamsAt(bc.CurrentBlock().NumberU64() + 1)
+	if err != nil {
+		return nil, err
+	}
 	if cn.blockchain.Config().Istanbul != nil {
-		cn.blockchain.Config().Istanbul.ProposerPolicy = governance.Params().Policy()
+		cn.blockchain.Config().Istanbul.ProposerPolicy = pset.Policy()
 	}
 	if cn.blockchain.Config().Governance.Reward != nil {
-		cn.blockchain.Config().Governance.Reward.UseGiniCoeff = governance.Params().UseGiniCoeff()
+		cn.blockchain.Config().Governance.Reward.UseGiniCoeff = pset.UseGiniCoeff()
 	}
 
 	if config.SenderTxHashIndexing {
@@ -320,7 +324,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		logger.Error("Error happened while setting the reward wallet", "err", err)
 	}
 
-	if governance.Params().Policy() == uint64(istanbul.WeightedRandom) {
+	if pset.Policy() == uint64(istanbul.WeightedRandom) {
 		// NewStakingManager is called with proper non-nil parameters
 		reward.NewStakingManager(cn.blockchain, governance, cn.chainDB)
 	}


### PR DESCRIPTION
## Proposed changes
This PR is twofold.

### Changing the semantic of headerGov.ParamsAt(N)
This PR changes the activation of headerGov from `k*epoch+1` to `k*epoch` after Kore. (Before Kore, activation is still `k*epoch+1`)
Changing the semantic of `headerGov.ParamsAt(N)` facilitates the activation block change:
- before, it naively called `headerGov.db.ReadGovernanceAtNumber`
- after, it returns the parameters used for generating block #N

That is, given N where `headerGov.ReadGovernance(N-1)=A` and `headerGov.ReadGovernance(N)=B`,
`headerGov.ParamsAt(N)` returned `B` before this PR, and will return `A` after this PR.

Therefore, callers need to be updated as follows:
```diff
- if n is Pre-Kore:
-   ParamsAt(n-1)
- else:
-   ParamsAt(n)
+ ParamsAt(n)
```

Notable changes:
- [Removed] This was intentionally added so that activation is epoch+1. Now we no longer need it.
https://github.com/klaytn/klaytn/blob/a7ac680ffc7267c2f51adc792992127648af54c3/consensus/istanbul/backend/engine.go#L196-L199

- [Removed] This was also there to calculate the correct parameters for finalizing the block
https://github.com/klaytn/klaytn/blob/a7ac680ffc7267c2f51adc792992127648af54c3/consensus/istanbul/backend/engine.go#L467-L468

- [Updated] num -> num + 1
https://github.com/klaytn/klaytn/blob/a7ac680ffc7267c2f51adc792992127648af54c3/consensus/istanbul/backend/engine_test.go#L1731

- [Updated] number -> number + 1
https://github.com/klaytn/klaytn/blob/a7ac680ffc7267c2f51adc792992127648af54c3/consensus/istanbul/backend/snapshot.go#L196

Note that this is not supposed to cause a conflict with Baobab even though it's already on Kore and governance change took place.
Baobab's activation of DeriveShaImpl was already `k*epoch` (`112492800`).


### Replacing Params with ParamsAt
In the meantime, to remove the ambiguity of `Params()`, it is replaced with `ParamsAt()`.
Therefore, callers need to be updated as follows:
```diff
- Params()
+ ParamsAt(head + 1) // or, ParamsAt(num) when num is given
```


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
