### PR TITLE
implemented staking information syncing API

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -477,6 +477,15 @@ web3._extend({
 			name: 'getSpamThrottlerCandidateList',
 			call: 'admin_getSpamThrottlerCandidateList',
 		}),
+		new web3._extend.Method({
+			name: 'syncStakingInfo',
+			call: 'admin_syncStakingInfo',
+			params: 3,
+		}),
+		new web3._extend.Method({
+			name: 'syncStakingInfoStatus',
+			call: 'admin_syncStakingInfoStatus',
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/datasync/downloader/api.go
+++ b/datasync/downloader/api.go
@@ -184,7 +184,6 @@ func NewPrivateDownloaderAPI(d downloader) *PrivateDownloaderAPI {
 	api := &PrivateDownloaderAPI{
 		d: d,
 	}
-
 	return api
 }
 

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -100,10 +100,10 @@ type Downloader struct {
 	mode uint32         // Synchronisation mode defining the strategy used (per sync cycle), use d.getMode() to get the SyncMode
 	mux  *event.TypeMux // Event multiplexer to announce sync operation events
 
-	fixing       bool
-	fixingTotal  int
-	fixingCh     chan []*reward.StakingInfo
-	fixingBlocks []uint64
+	isStakingInfoRecovery     bool
+	stakingInfoRecoveryTotal  int
+	stakingInfoRecoveryCh     chan []*reward.StakingInfo
+	stakingInfoRecoveryBlocks []uint64
 
 	queue *queue   // Scheduler for selecting the hashes to download
 	peers *peerSet // Set of active peers from which download can proceed
@@ -228,31 +228,31 @@ func New(mode SyncMode, stateDB database.DBManager, stateBloom *statedb.SyncBloo
 	}
 
 	dl := &Downloader{
-		mode:              uint32(mode),
-		stateDB:           stateDB,
-		stateBloom:        stateBloom,
-		mux:               mux,
-		fixing:            false,
-		fixingBlocks:      []uint64{},
-		queue:             newQueue(blockCacheMaxItems, blockCacheInitialItems, proposerPolicy),
-		peers:             newPeerSet(),
-		rttEstimate:       uint64(rttMaxEstimate),
-		rttConfidence:     uint64(1000000),
-		blockchain:        chain,
-		lightchain:        lightchain,
-		dropPeer:          dropPeer,
-		headerCh:          make(chan dataPack, 1),
-		bodyCh:            make(chan dataPack, 1),
-		receiptCh:         make(chan dataPack, 1),
-		stakingInfoCh:     make(chan dataPack, 1),
-		bodyWakeCh:        make(chan bool, 1),
-		receiptWakeCh:     make(chan bool, 1),
-		stakingInfoWakeCh: make(chan bool, 1),
-		headerProcCh:      make(chan []*types.Header, 1),
-		quitCh:            make(chan struct{}),
-		stateCh:           make(chan dataPack),
-		SnapSyncer:        snap.NewSyncer(stateDB),
-		stateSyncStart:    make(chan *stateSync),
+		mode:                      uint32(mode),
+		stateDB:                   stateDB,
+		stateBloom:                stateBloom,
+		mux:                       mux,
+		isStakingInfoRecovery:     false,
+		stakingInfoRecoveryBlocks: []uint64{},
+		queue:                     newQueue(blockCacheMaxItems, blockCacheInitialItems, proposerPolicy),
+		peers:                     newPeerSet(),
+		rttEstimate:               uint64(rttMaxEstimate),
+		rttConfidence:             uint64(1000000),
+		blockchain:                chain,
+		lightchain:                lightchain,
+		dropPeer:                  dropPeer,
+		headerCh:                  make(chan dataPack, 1),
+		bodyCh:                    make(chan dataPack, 1),
+		receiptCh:                 make(chan dataPack, 1),
+		stakingInfoCh:             make(chan dataPack, 1),
+		bodyWakeCh:                make(chan bool, 1),
+		receiptWakeCh:             make(chan bool, 1),
+		stakingInfoWakeCh:         make(chan bool, 1),
+		headerProcCh:              make(chan []*types.Header, 1),
+		quitCh:                    make(chan struct{}),
+		stateCh:                   make(chan dataPack),
+		SnapSyncer:                snap.NewSyncer(stateDB),
+		stateSyncStart:            make(chan *stateSync),
 		syncStatsState: stateSyncStats{
 			processed: stateDB.ReadFastTrieProgress(),
 		},
@@ -585,45 +585,45 @@ func (d *Downloader) spawnSync(fetchers []func() error, peerID string) error {
 }
 
 func (d *Downloader) SyncStakingInfo(id string, from, to uint64) error {
-	if d.fixing == true {
+	if d.isStakingInfoRecovery == true {
 		return errors.New("already syncing")
 	}
 	logger.Info("start syncing staking infos", "from", from, "to", to)
-	d.fixing = true
+	d.isStakingInfoRecovery = true
 
 	var hashes []common.Hash
 	from = params.CalcStakingBlockNumber(from)
 	for i := from; i <= to; i += params.StakingUpdateInterval() {
 		if hash, has, err := reward.HasStakingInfoFromDB(i); err == nil && !has {
 			if hash == (common.Hash{}) {
-				d.fixing = false
+				d.isStakingInfoRecovery = false
 				return fmt.Errorf("failed to retrieve block hash by number (blockNumber: %v)", i)
 			}
-			d.fixingBlocks = append(d.fixingBlocks, i)
+			d.stakingInfoRecoveryBlocks = append(d.stakingInfoRecoveryBlocks, i)
 			hashes = append(hashes, hash)
 		}
 	}
 
-	if len(d.fixingBlocks) == 0 && len(hashes) == 0 {
-		d.fixing = false
+	if len(d.stakingInfoRecoveryBlocks) == 0 && len(hashes) == 0 {
+		d.isStakingInfoRecovery = false
 		return fmt.Errorf("there is no staking info to be synced")
 	}
 
 	conn := d.peers.Peer(id)
 	if conn == nil {
-		d.fixing = false
+		d.isStakingInfoRecovery = false
 		return errors.New("the given peer is not registered")
 	}
 
-	d.fixingTotal = len(d.fixingBlocks)
+	d.stakingInfoRecoveryTotal = len(d.stakingInfoRecoveryBlocks)
 
 	go func() {
 		defer func() {
-			d.fixing = false
-			d.fixingBlocks = []uint64{}
-			d.fixingTotal = 0
+			d.isStakingInfoRecovery = false
+			d.stakingInfoRecoveryBlocks = []uint64{}
+			d.stakingInfoRecoveryTotal = 0
 		}()
-		d.fixingCh = make(chan []*reward.StakingInfo, 1)
+		d.stakingInfoRecoveryCh = make(chan []*reward.StakingInfo, 1)
 
 		fixed := 0
 		for {
@@ -637,7 +637,7 @@ func (d *Downloader) SyncStakingInfo(id string, from, to uint64) error {
 				logger.Info("requested staking infos", "num", len(hashes))
 				hashes = []common.Hash{}
 			} else {
-				logger.Error("no more requests, but not completed", "not completed", len(d.fixingBlocks))
+				logger.Error("no more requests, but not completed", "not completed", len(d.stakingInfoRecoveryBlocks))
 				return
 			}
 
@@ -645,10 +645,10 @@ func (d *Downloader) SyncStakingInfo(id string, from, to uint64) error {
 			case <-timer.C:
 				logger.Error("timeout")
 				return
-			case stakingInfos := <-d.fixingCh:
+			case stakingInfos := <-d.stakingInfoRecoveryCh:
 				for _, stakingInfo := range stakingInfos {
-					if d.fixingBlocks[0] != stakingInfo.BlockNum {
-						logger.Error("failed to receive expected block", "expected", d.fixingBlocks[0], "actual", stakingInfo.BlockNum)
+					if d.stakingInfoRecoveryBlocks[0] != stakingInfo.BlockNum {
+						logger.Error("failed to receive expected block", "expected", d.stakingInfoRecoveryBlocks[0], "actual", stakingInfo.BlockNum)
 						return
 					}
 
@@ -657,10 +657,10 @@ func (d *Downloader) SyncStakingInfo(id string, from, to uint64) error {
 						return
 					}
 					fixed++
-					d.fixingBlocks = d.fixingBlocks[1:]
+					d.stakingInfoRecoveryBlocks = d.stakingInfoRecoveryBlocks[1:]
 				}
 
-				if len(d.fixingBlocks) == 0 {
+				if len(d.stakingInfoRecoveryBlocks) == 0 {
 					logger.Info("syncing staking info is finished", "fixed", fixed)
 					return
 				}
@@ -679,10 +679,10 @@ type SyncingStatus struct {
 
 func (d *Downloader) SyncStakingInfoStatus() *SyncingStatus {
 	return &SyncingStatus{
-		Syncing:   d.fixing,
-		Pending:   d.fixingBlocks,
-		Total:     d.fixingTotal,
-		Completed: d.fixingTotal - len(d.fixingBlocks),
+		Syncing:   d.isStakingInfoRecovery,
+		Pending:   d.stakingInfoRecoveryBlocks,
+		Total:     d.stakingInfoRecoveryTotal,
+		Completed: d.stakingInfoRecoveryTotal - len(d.stakingInfoRecoveryBlocks),
 	}
 }
 
@@ -1920,9 +1920,9 @@ func (d *Downloader) DeliverReceipts(id string, receipts [][]*types.Receipt) (er
 
 // DeliverStakingInfos injects a new batch of staking information received from a remote node.
 func (d *Downloader) DeliverStakingInfos(id string, stakingInfos []*reward.StakingInfo) error {
-	if d.fixing {
+	if d.isStakingInfoRecovery {
 		logger.Info("received stakinginfos", "len", len(stakingInfos))
-		d.fixingCh <- stakingInfos
+		d.stakingInfoRecoveryCh <- stakingInfos
 	}
 	return d.deliver(id, d.stakingInfoCh, &stakingInfoPack{id, stakingInfos}, stakingInfoInMeter, stakingInfoDropMeter)
 }

--- a/datasync/downloader/downloader_fake.go
+++ b/datasync/downloader/downloader_fake.go
@@ -58,4 +58,6 @@ func (*FakeDownloader) Synchronise(id string, head common.Hash, td *big.Int, mod
 func (*FakeDownloader) Progress() klaytn.SyncProgress { return klaytn.SyncProgress{} }
 func (*FakeDownloader) Cancel()                       {}
 
-func (*FakeDownloader) GetSnapSyncer() *snap.Syncer { return nil }
+func (*FakeDownloader) GetSnapSyncer() *snap.Syncer                      { return nil }
+func (*FakeDownloader) SyncStakingInfo(id string, from, to uint64) error { return nil }
+func (*FakeDownloader) SyncStakingInfoStatus() *SyncingStatus            { return nil }

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -21,10 +21,12 @@
 package downloader
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -37,6 +39,7 @@ import (
 	"github.com/klaytn/klaytn/consensus/istanbul"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/event"
+	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/reward"
 	"github.com/klaytn/klaytn/snapshot"
@@ -65,7 +68,7 @@ type govSetter struct {
 }
 
 // setTestGovernance sets staking manager with memory db and staking update interval to 4.
-func setTestGovernance() {
+func setTestGovernance(db database.DBManager) {
 	lock.Lock()
 	defer lock.Unlock()
 	if setter == nil {
@@ -75,7 +78,7 @@ func setTestGovernance() {
 			origStakingManager:  reward.GetStakingManager(),
 		}
 
-		reward.SetTestStakingManagerWithDB(database.NewMemoryDBManager())
+		reward.SetTestStakingManagerWithDB(db)
 		params.SetStakingUpdateInterval(testStakingUpdateInterval)
 	}
 	setter.numTesting += 1
@@ -123,13 +126,14 @@ type downloadTester struct {
 
 // newTester creates a new downloader test mocker.
 func newTester() *downloadTester {
-	testdb := database.NewMemoryDBManager()
-	genesis := blockchain.GenesisBlockForTesting(testdb, testAddress, big.NewInt(1000000000))
-	setTestGovernance()
+	remotedb := database.NewMemoryDBManager()
+	localdb := database.NewMemoryDBManager()
+	genesis := blockchain.GenesisBlockForTesting(remotedb, testAddress, big.NewInt(1000000000))
+	setTestGovernance(localdb)
 
 	tester := &downloadTester{
 		genesis:           genesis,
-		peerDb:            testdb,
+		peerDb:            remotedb,
 		ownHashes:         []common.Hash{genesis.Hash()},
 		ownHeaders:        map[common.Hash]*types.Header{genesis.Hash(): genesis.Header()},
 		ownBlocks:         map[common.Hash]*types.Block{genesis.Hash(): genesis},
@@ -144,7 +148,7 @@ func newTester() *downloadTester {
 		peerChainTds:      make(map[string]map[common.Hash]*big.Int),
 		peerMissingStates: make(map[string]map[common.Hash]bool),
 	}
-	tester.stateDb = database.NewMemoryDBManager()
+	tester.stateDb = localdb
 	tester.stateDb.GetMemDB().Put(genesis.Root().Bytes(), []byte{0x00})
 
 	tester.downloader = New(FullSync, tester.stateDb, statedb.NewSyncBloom(1, tester.stateDb.GetMemDB()), new(event.TypeMux), tester, nil, tester.dropPeer, uint64(istanbul.WeightedRandom))
@@ -292,6 +296,10 @@ func (dl *downloadTester) sync(id string, td *big.Int, mode SyncMode) error {
 		panic("downloader active post sync cycle") // panic will be caught by tester
 	}
 	return err
+}
+
+func (dl *downloadTester) syncStakingInfos(id string, from, to uint64) error {
+	return dl.downloader.SyncStakingInfo(id, from, to)
 }
 
 // HasHeader checks if a header is present in the testers canonical chain.
@@ -1892,5 +1900,51 @@ func testDeliverHeadersHang(t *testing.T, protocol int, mode SyncMode) {
 
 		// Flush all goroutines to prevent messing with subsequent tests
 		tester.downloader.peers.peers["peer"].peer.(*floodingTestPeer).pend.Wait()
+	}
+}
+
+func TestStakingInfoSync(t *testing.T) { testStakingInfoSync(t, 65) }
+
+func testStakingInfoSync(t *testing.T, protocol int) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlInfo)
+
+	tester := newTester()
+	defer tester.terminate()
+
+	// Create a small enough block chain to download
+	targetBlocks := blockCacheMaxItems - 15
+	hashes, headers, blocks, receipts, stakingInfos := tester.makeChain(targetBlocks, 0, tester.genesis, nil, false)
+
+	tester.newPeer("peer", protocol, hashes, headers, blocks, receipts, stakingInfos)
+
+	stakedBlocks := make([]uint64, len(stakingInfos))
+	for blockHash, stakingInfo := range stakingInfos {
+		stakedBlocks = append(stakedBlocks, stakingInfo.BlockNum)
+		tester.stateDb.WriteCanonicalHash(blockHash, stakingInfo.BlockNum)
+	}
+
+	// check staking information is not stored in database
+	for _, block := range stakedBlocks {
+		si, err := tester.stateDb.ReadStakingInfo(block)
+		if len(si) != 0 && !strings.Contains(err.Error(), "data is not found with the given key") {
+			t.Errorf("already staking info exists")
+		}
+	}
+
+	if err := tester.downloader.SyncStakingInfo("peer", 0, uint64(targetBlocks)); err != nil {
+		t.Errorf("sync staking info failed: %v", err)
+	}
+
+	time.Sleep(3 * time.Second)
+
+	for _, stakingInfo := range stakingInfos {
+		expected, _ := json.Marshal(stakingInfo)
+		actual, err := tester.stateDb.ReadStakingInfo(stakingInfo.BlockNum)
+		if err != nil {
+			t.Errorf("failed to read stakingInfo: %v", err)
+		}
+		if bytes.Compare(expected, actual) != 0 {
+			t.Errorf("staking infos are different (expected: %v, actual: %v)", string(expected), string(actual))
+		}
 	}
 }

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -487,6 +487,7 @@ func (s *CN) APIs() []rpc.API {
 	governanceKlayAPI := governance.NewGovernanceKlayAPI(s.governance, s.blockchain)
 	publicGovernanceAPI := governance.NewGovernanceAPI(s.governance)
 	publicDownloaderAPI := downloader.NewPublicDownloaderAPI(s.protocolManager.Downloader(), s.eventMux)
+	privateDownloaderAPI := downloader.NewPrivateDownloaderAPI(s.protocolManager.Downloader())
 
 	ethAPI.SetPublicFilterAPI(publicFilterAPI)
 	ethAPI.SetGovernanceKlayAPI(governanceKlayAPI)
@@ -529,6 +530,10 @@ func (s *CN) APIs() []rpc.API {
 			Version:   "1.0",
 			Service:   publicDownloaderAPI,
 			Public:    true,
+		}, {
+			Namespace: "admin",
+			Version:   "1.0",
+			Service:   privateDownloaderAPI,
 		}, {
 			Namespace: "admin",
 			Version:   "1.0",

--- a/node/cn/mocks/downloader_mock.go
+++ b/node/cn/mocks/downloader_mock.go
@@ -17,42 +17,42 @@ import (
 	reward "github.com/klaytn/klaytn/reward"
 )
 
-// MockProtocolManagerDownloader is a mock of ProtocolManagerDownloader interface
+// MockProtocolManagerDownloader is a mock of ProtocolManagerDownloader interface.
 type MockProtocolManagerDownloader struct {
 	ctrl     *gomock.Controller
 	recorder *MockProtocolManagerDownloaderMockRecorder
 }
 
-// MockProtocolManagerDownloaderMockRecorder is the mock recorder for MockProtocolManagerDownloader
+// MockProtocolManagerDownloaderMockRecorder is the mock recorder for MockProtocolManagerDownloader.
 type MockProtocolManagerDownloaderMockRecorder struct {
 	mock *MockProtocolManagerDownloader
 }
 
-// NewMockProtocolManagerDownloader creates a new mock instance
+// NewMockProtocolManagerDownloader creates a new mock instance.
 func NewMockProtocolManagerDownloader(ctrl *gomock.Controller) *MockProtocolManagerDownloader {
 	mock := &MockProtocolManagerDownloader{ctrl: ctrl}
 	mock.recorder = &MockProtocolManagerDownloaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProtocolManagerDownloader) EXPECT() *MockProtocolManagerDownloaderMockRecorder {
 	return m.recorder
 }
 
-// Cancel mocks base method
+// Cancel mocks base method.
 func (m *MockProtocolManagerDownloader) Cancel() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Cancel")
 }
 
-// Cancel indicates an expected call of Cancel
+// Cancel indicates an expected call of Cancel.
 func (mr *MockProtocolManagerDownloaderMockRecorder) Cancel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).Cancel))
 }
 
-// DeliverBodies mocks base method
+// DeliverBodies mocks base method.
 func (m *MockProtocolManagerDownloader) DeliverBodies(arg0 string, arg1 [][]*types.Transaction) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeliverBodies", arg0, arg1)
@@ -60,13 +60,13 @@ func (m *MockProtocolManagerDownloader) DeliverBodies(arg0 string, arg1 [][]*typ
 	return ret0
 }
 
-// DeliverBodies indicates an expected call of DeliverBodies
+// DeliverBodies indicates an expected call of DeliverBodies.
 func (mr *MockProtocolManagerDownloaderMockRecorder) DeliverBodies(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverBodies", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).DeliverBodies), arg0, arg1)
 }
 
-// DeliverHeaders mocks base method
+// DeliverHeaders mocks base method.
 func (m *MockProtocolManagerDownloader) DeliverHeaders(arg0 string, arg1 []*types.Header) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeliverHeaders", arg0, arg1)
@@ -74,13 +74,13 @@ func (m *MockProtocolManagerDownloader) DeliverHeaders(arg0 string, arg1 []*type
 	return ret0
 }
 
-// DeliverHeaders indicates an expected call of DeliverHeaders
+// DeliverHeaders indicates an expected call of DeliverHeaders.
 func (mr *MockProtocolManagerDownloaderMockRecorder) DeliverHeaders(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverHeaders", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).DeliverHeaders), arg0, arg1)
 }
 
-// DeliverNodeData mocks base method
+// DeliverNodeData mocks base method.
 func (m *MockProtocolManagerDownloader) DeliverNodeData(arg0 string, arg1 [][]byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeliverNodeData", arg0, arg1)
@@ -88,13 +88,13 @@ func (m *MockProtocolManagerDownloader) DeliverNodeData(arg0 string, arg1 [][]by
 	return ret0
 }
 
-// DeliverNodeData indicates an expected call of DeliverNodeData
+// DeliverNodeData indicates an expected call of DeliverNodeData.
 func (mr *MockProtocolManagerDownloaderMockRecorder) DeliverNodeData(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverNodeData", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).DeliverNodeData), arg0, arg1)
 }
 
-// DeliverReceipts mocks base method
+// DeliverReceipts mocks base method.
 func (m *MockProtocolManagerDownloader) DeliverReceipts(arg0 string, arg1 [][]*types.Receipt) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeliverReceipts", arg0, arg1)
@@ -102,13 +102,13 @@ func (m *MockProtocolManagerDownloader) DeliverReceipts(arg0 string, arg1 [][]*t
 	return ret0
 }
 
-// DeliverReceipts indicates an expected call of DeliverReceipts
+// DeliverReceipts indicates an expected call of DeliverReceipts.
 func (mr *MockProtocolManagerDownloaderMockRecorder) DeliverReceipts(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverReceipts", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).DeliverReceipts), arg0, arg1)
 }
 
-// DeliverSnapPacket mocks base method
+// DeliverSnapPacket mocks base method.
 func (m *MockProtocolManagerDownloader) DeliverSnapPacket(arg0 *snap.Peer, arg1 snap.Packet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeliverSnapPacket", arg0, arg1)
@@ -116,13 +116,13 @@ func (m *MockProtocolManagerDownloader) DeliverSnapPacket(arg0 *snap.Peer, arg1 
 	return ret0
 }
 
-// DeliverSnapPacket indicates an expected call of DeliverSnapPacket
+// DeliverSnapPacket indicates an expected call of DeliverSnapPacket.
 func (mr *MockProtocolManagerDownloaderMockRecorder) DeliverSnapPacket(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverSnapPacket", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).DeliverSnapPacket), arg0, arg1)
 }
 
-// DeliverStakingInfos mocks base method
+// DeliverStakingInfos mocks base method.
 func (m *MockProtocolManagerDownloader) DeliverStakingInfos(arg0 string, arg1 []*reward.StakingInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeliverStakingInfos", arg0, arg1)
@@ -130,13 +130,13 @@ func (m *MockProtocolManagerDownloader) DeliverStakingInfos(arg0 string, arg1 []
 	return ret0
 }
 
-// DeliverStakingInfos indicates an expected call of DeliverStakingInfos
+// DeliverStakingInfos indicates an expected call of DeliverStakingInfos.
 func (mr *MockProtocolManagerDownloaderMockRecorder) DeliverStakingInfos(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverStakingInfos", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).DeliverStakingInfos), arg0, arg1)
 }
 
-// GetSnapSyncer mocks base method
+// GetSnapSyncer mocks base method.
 func (m *MockProtocolManagerDownloader) GetSnapSyncer() *snap.Syncer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSnapSyncer")
@@ -144,13 +144,13 @@ func (m *MockProtocolManagerDownloader) GetSnapSyncer() *snap.Syncer {
 	return ret0
 }
 
-// GetSnapSyncer indicates an expected call of GetSnapSyncer
+// GetSnapSyncer indicates an expected call of GetSnapSyncer.
 func (mr *MockProtocolManagerDownloaderMockRecorder) GetSnapSyncer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapSyncer", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).GetSnapSyncer))
 }
 
-// Progress mocks base method
+// Progress mocks base method.
 func (m *MockProtocolManagerDownloader) Progress() klaytn.SyncProgress {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Progress")
@@ -158,13 +158,13 @@ func (m *MockProtocolManagerDownloader) Progress() klaytn.SyncProgress {
 	return ret0
 }
 
-// Progress indicates an expected call of Progress
+// Progress indicates an expected call of Progress.
 func (mr *MockProtocolManagerDownloaderMockRecorder) Progress() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Progress", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).Progress))
 }
 
-// RegisterPeer mocks base method
+// RegisterPeer mocks base method.
 func (m *MockProtocolManagerDownloader) RegisterPeer(arg0 string, arg1 int, arg2 downloader.Peer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterPeer", arg0, arg1, arg2)
@@ -172,13 +172,41 @@ func (m *MockProtocolManagerDownloader) RegisterPeer(arg0 string, arg1 int, arg2
 	return ret0
 }
 
-// RegisterPeer indicates an expected call of RegisterPeer
+// RegisterPeer indicates an expected call of RegisterPeer.
 func (mr *MockProtocolManagerDownloaderMockRecorder) RegisterPeer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterPeer", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).RegisterPeer), arg0, arg1, arg2)
 }
 
-// Synchronise mocks base method
+// SyncStakingInfo mocks base method.
+func (m *MockProtocolManagerDownloader) SyncStakingInfo(arg0 string, arg1, arg2 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncStakingInfo", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SyncStakingInfo indicates an expected call of SyncStakingInfo.
+func (mr *MockProtocolManagerDownloaderMockRecorder) SyncStakingInfo(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStakingInfo", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).SyncStakingInfo), arg0, arg1, arg2)
+}
+
+// SyncStakingInfoStatus mocks base method.
+func (m *MockProtocolManagerDownloader) SyncStakingInfoStatus() *downloader.SyncingStatus {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncStakingInfoStatus")
+	ret0, _ := ret[0].(*downloader.SyncingStatus)
+	return ret0
+}
+
+// SyncStakingInfoStatus indicates an expected call of SyncStakingInfoStatus.
+func (mr *MockProtocolManagerDownloaderMockRecorder) SyncStakingInfoStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStakingInfoStatus", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).SyncStakingInfoStatus))
+}
+
+// Synchronise mocks base method.
 func (m *MockProtocolManagerDownloader) Synchronise(arg0 string, arg1 common.Hash, arg2 *big.Int, arg3 downloader.SyncMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Synchronise", arg0, arg1, arg2, arg3)
@@ -186,25 +214,25 @@ func (m *MockProtocolManagerDownloader) Synchronise(arg0 string, arg1 common.Has
 	return ret0
 }
 
-// Synchronise indicates an expected call of Synchronise
+// Synchronise indicates an expected call of Synchronise.
 func (mr *MockProtocolManagerDownloaderMockRecorder) Synchronise(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Synchronise", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).Synchronise), arg0, arg1, arg2, arg3)
 }
 
-// Terminate mocks base method
+// Terminate mocks base method.
 func (m *MockProtocolManagerDownloader) Terminate() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Terminate")
 }
 
-// Terminate indicates an expected call of Terminate
+// Terminate indicates an expected call of Terminate.
 func (mr *MockProtocolManagerDownloaderMockRecorder) Terminate() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Terminate", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).Terminate))
 }
 
-// UnregisterPeer mocks base method
+// UnregisterPeer mocks base method.
 func (m *MockProtocolManagerDownloader) UnregisterPeer(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnregisterPeer", arg0)
@@ -212,7 +240,7 @@ func (m *MockProtocolManagerDownloader) UnregisterPeer(arg0 string) error {
 	return ret0
 }
 
-// UnregisterPeer indicates an expected call of UnregisterPeer
+// UnregisterPeer indicates an expected call of UnregisterPeer.
 func (mr *MockProtocolManagerDownloaderMockRecorder) UnregisterPeer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterPeer", reflect.TypeOf((*MockProtocolManagerDownloader)(nil).UnregisterPeer), arg0)

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -147,6 +147,8 @@ type ProtocolManagerDownloader interface {
 	Cancel()
 
 	GetSnapSyncer() *snap.Syncer
+	SyncStakingInfo(id string, from, to uint64) error
+	SyncStakingInfoStatus() *downloader.SyncingStatus
 }
 
 //go:generate mockgen -destination=node/cn/mocks/fetcher_mock.go -package=mocks github.com/klaytn/klaytn/node/cn ProtocolManagerFetcher

--- a/reward/staking_info_db.go
+++ b/reward/staking_info_db.go
@@ -19,8 +19,6 @@ package reward
 import (
 	"encoding/json"
 	"errors"
-
-	"github.com/klaytn/klaytn/common"
 )
 
 var ErrStakingDBNotSet = errors.New("stakingInfoDB is not set")
@@ -29,21 +27,14 @@ type stakingInfoDB interface {
 	HasStakingInfo(blockNum uint64) (bool, error)
 	ReadStakingInfo(blockNum uint64) ([]byte, error)
 	WriteStakingInfo(blockNum uint64, stakingInfo []byte) error
-
-	ReadCanonicalHash(number uint64) common.Hash
 }
 
-// HasStakingInfoFromDB returns existence of staking information from miscdb with blockhash.
-// Note that blockhash is also returned in order to check the validity of the block.
-func HasStakingInfoFromDB(blockNumber uint64) (common.Hash, bool, error) {
+// HasStakingInfoFromDB returns existence of staking information from miscdb.
+func HasStakingInfoFromDB(blockNumber uint64) (bool, error) {
 	if stakingManager.stakingInfoDB == nil {
-		return common.Hash{}, false, ErrStakingDBNotSet
+		return false, ErrStakingDBNotSet
 	}
-
-	hash := stakingManager.stakingInfoDB.ReadCanonicalHash(blockNumber)
-	has, err := stakingManager.stakingInfoDB.HasStakingInfo(blockNumber)
-
-	return hash, has, err
+	return stakingManager.stakingInfoDB.HasStakingInfo(blockNumber)
 }
 
 func getStakingInfoFromDB(blockNum uint64) (*StakingInfo, error) {

--- a/reward/staking_info_db.go
+++ b/reward/staking_info_db.go
@@ -19,13 +19,31 @@ package reward
 import (
 	"encoding/json"
 	"errors"
+
+	"github.com/klaytn/klaytn/common"
 )
 
 var ErrStakingDBNotSet = errors.New("stakingInfoDB is not set")
 
 type stakingInfoDB interface {
+	HasStakingInfo(blockNum uint64) (bool, error)
 	ReadStakingInfo(blockNum uint64) ([]byte, error)
 	WriteStakingInfo(blockNum uint64, stakingInfo []byte) error
+
+	ReadCanonicalHash(number uint64) common.Hash
+}
+
+// HasStakingInfoFromDB returns existence of staking information from miscdb with blockhash.
+// Note that blockhash is also returned in order to check the validity of the block.
+func HasStakingInfoFromDB(blockNumber uint64) (common.Hash, bool, error) {
+	if stakingManager.stakingInfoDB == nil {
+		return common.Hash{}, false, ErrStakingDBNotSet
+	}
+
+	hash := stakingManager.stakingInfoDB.ReadCanonicalHash(blockNumber)
+	has, err := stakingManager.stakingInfoDB.HasStakingInfo(blockNumber)
+
+	return hash, has, err
 }
 
 func getStakingInfoFromDB(blockNum uint64) (*StakingInfo, error) {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -282,6 +282,7 @@ type DBManager interface {
 	// StakingInfo related functions
 	ReadStakingInfo(blockNum uint64) ([]byte, error)
 	WriteStakingInfo(blockNum uint64, stakingInfo []byte) error
+	HasStakingInfo(blockNum uint64) (bool, error)
 
 	// DB migration related function
 	StartDBMigration(DBManager) error

--- a/storage/database/db_manager_stakinginfo.go
+++ b/storage/database/db_manager_stakinginfo.go
@@ -16,6 +16,14 @@
 
 package database
 
+// HasStakingInfo returns existence of staking information of the given block number from database.
+func (dbm *databaseManager) HasStakingInfo(blockNum uint64) (bool, error) {
+	db := dbm.getDatabase(MiscDB)
+
+	key := makeKey(stakingInfoPrefix, blockNum)
+	return db.Has(key)
+}
+
 // ReadStakingInfo reads staking information from database. It returns
 // (StakingInfo, nil) if it succeeds to read and (nil, error) if it fails.
 // StakingInfo is stored in MiscDB.


### PR DESCRIPTION
## Proposed changes

Staking information was stored in misc db after state-db migration was developed. It is possible not to retrieve staking information on some past blocks. This PR add an API to sync staking information from other peers to update staking information on misc db.

Since staking information won't be validated, it would fetch the data from trusted node given by node id. Also, the boundary was given as well so that only a few staking information can be retrieved in the boundary. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
