### PR TITLE
Add klay, governance APIs

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -303,6 +303,12 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
+			name: 'getParams',
+			call: 'governance_getParams',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
 			name: 'itemCacheFromDb',
 			call: 'governance_itemCacheFromDb',
 			params: 1,
@@ -317,6 +323,12 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'chainConfigAt',
 			call: 'governance_chainConfigAt',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'getChainConfig',
+			call: 'governance_getChainConfig',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		})
@@ -900,8 +912,20 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
+			name: 'getParams',
+			call: 'klay_getParams',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
 			name: 'chainConfigAt',
 			call: 'klay_chainConfigAt',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter],
+		}),
+		new web3._extend.Method({
+			name: 'getChainConfig',
+			call: 'klay_getChainConfig',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter],
 		}),

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -351,10 +351,6 @@ web3._extend({
 			getter: 'governance_myVotingPower',
 		}),
 		new web3._extend.Property({
-			name: 'chainConfig',
-			getter: 'governance_chainConfig',
-		}),
-		new web3._extend.Property({
 			name: 'nodeAddress',
 			getter: 'governance_nodeAddress',
 		}),
@@ -1092,10 +1088,6 @@ web3._extend({
 			name: 'maxPriorityFeePerGas',
 			getter: 'klay_maxPriorityFeePerGas',
 			outputFormatter: web3._extend.utils.toBigNumber
-		}),
-		new web3._extend.Property({
-			name: 'chainConfig',
-			getter: 'klay_chainConfig',
 		}),
 	]
 });

--- a/governance/api.go
+++ b/governance/api.go
@@ -68,8 +68,13 @@ func (api *GovernanceKlayAPI) GetStakingInfo(num *rpc.BlockNumber) (*reward.Stak
 	return getStakingInfo(api.governance, num)
 }
 
+// TODO-Klaytn-Mantle: deprecate this
 func (api *GovernanceKlayAPI) GovParamsAt(num *rpc.BlockNumber) (map[string]interface{}, error) {
-	return itemsAt(api.governance, num)
+	return getParams(api.governance, num)
+}
+
+func (api *GovernanceKlayAPI) GetParams(num *rpc.BlockNumber) (map[string]interface{}, error) {
+	return getParams(api.governance, num)
 }
 
 func (api *GovernanceKlayAPI) NodeAddress() common.Address {
@@ -143,11 +148,16 @@ func (api *GovernanceKlayAPI) GetRewards(num *rpc.BlockNumber) (*reward.RewardSp
 
 func (api *GovernanceKlayAPI) ChainConfig() *params.ChainConfig {
 	num := rpc.LatestBlockNumber
-	return chainConfigAt(api.governance, &num)
+	return getChainConfig(api.governance, &num)
 }
 
+// TODO-Klaytn-Mantle: deprecate this
 func (api *GovernanceKlayAPI) ChainConfigAt(num *rpc.BlockNumber) *params.ChainConfig {
-	return chainConfigAt(api.governance, num)
+	return getChainConfig(api.governance, num)
+}
+
+func (api *GovernanceKlayAPI) GetChainConfig(num *rpc.BlockNumber) *params.ChainConfig {
+	return getChainConfig(api.governance, num)
 }
 
 // Vote injects a new vote for governance targets such as unitprice and governingnode.
@@ -220,11 +230,16 @@ func (api *PublicGovernanceAPI) TotalVotingPower() (float64, error) {
 	return float64(api.governance.TotalVotingPower()) / 1000.0, nil
 }
 
+// TODO-Klaytn-Mantle: deprecate this
 func (api *PublicGovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interface{}, error) {
-	return itemsAt(api.governance, num)
+	return getParams(api.governance, num)
 }
 
-func itemsAt(governance Engine, num *rpc.BlockNumber) (map[string]interface{}, error) {
+func (api *PublicGovernanceAPI) GetParams(num *rpc.BlockNumber) (map[string]interface{}, error) {
+	return getParams(api.governance, num)
+}
+
+func getParams(governance Engine, num *rpc.BlockNumber) (map[string]interface{}, error) {
 	blockNumber := uint64(0)
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
 		blockNumber = governance.BlockChain().CurrentBlock().NumberU64()
@@ -313,14 +328,19 @@ func (api *PublicGovernanceAPI) MyVotingPower() (float64, error) {
 
 func (api *PublicGovernanceAPI) ChainConfig() *params.ChainConfig {
 	num := rpc.LatestBlockNumber
-	return chainConfigAt(api.governance, &num)
+	return getChainConfig(api.governance, &num)
 }
 
+// TODO-Klaytn-Mantle: deprecate this
 func (api *PublicGovernanceAPI) ChainConfigAt(num *rpc.BlockNumber) *params.ChainConfig {
-	return chainConfigAt(api.governance, num)
+	return getChainConfig(api.governance, num)
 }
 
-func chainConfigAt(governance Engine, num *rpc.BlockNumber) *params.ChainConfig {
+func (api *PublicGovernanceAPI) GetChainConfig(num *rpc.BlockNumber) *params.ChainConfig {
+	return getChainConfig(api.governance, num)
+}
+
+func getChainConfig(governance Engine, num *rpc.BlockNumber) *params.ChainConfig {
 	var blocknum uint64
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
 		blocknum = governance.BlockChain().CurrentBlock().NumberU64()


### PR DESCRIPTION
## Proposed changes
### New APIs
APIs whose suffix is `At` usually take a block number as input but have two meanings thus causing confusion:
- API is executed on the state after having processed the block N (e.g., `klay_getStorageAt(N)`)
- API returns the values for generating the block N (e.g., `klay_chainConfigAt(N)`)

Therefore, for the second usage, we ditch the suffix `At` and prepend `get` (just like `getBlock` or `getCouncil`. see #1468). For example, `klay_chainConfigAt(N)` -> `klay_getChainConfig(N)`.

For v1.10.2, we leave the legacy functions for grace period. **However, they will be deprecated from v1.11**.

In summary,

New APIs:
```
governance_getParams
governance_getChainConfig
klay_getParams
klay_getChainConfig
```

Deprecated property:
```
governance_chainConfig
klay_chainConfig
```

APIs to be deprecated in v1.11:
```
governance_itemsAt
governance_chainConfigAt
governance_chainConfig
klay_govParamsAt
klay_chainConfigAt
klay_chainConfig
```


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

### Deprecated property
This PR deprecates `governance_chainConfig` and `klay_chainConfig` property since web3.js will automatically generate `governance_getChainConfig` getter in the presence of the property, which conflicts the new API.

https://github.com/klaytn/klaytn/blob/8032923e80dabc5472a6274f685ab2e52b6f60ef/console/jsre/deps/web3.js#L6685-L6705