### PR TITLE
[Consensus] Correctly calculates the required number of msgs

### DIFF
--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -425,7 +425,12 @@ func PrepareCommittedSeal(hash common.Hash) []byte {
 
 // Minimum required number of consensus messages to proceed
 func requiredMessageCount(valSet istanbul.ValidatorSet) int {
-	size := valSet.Size()
+	var size uint64
+	if valSet.IsSubSet() {
+		size = valSet.SubGroupSize()
+	} else {
+		size = valSet.Size()
+	}
 	switch size {
 	// in the certain cases we must receive the messages from all consensus nodes to ensure finality...
 	case 1, 2, 3:


### PR DESCRIPTION
## Proposed changes

The previous PR #1462 did not take into account the sub-group size (committee size), which resulted in only one committee seal being included in the proposal header when the committee size is 1, 2, and 3

As-Is: With the committee size 1,2, and 3, the block contains only one committee seal
To-be: With the committee size 1,2, and 3, the block should contain 1,2 and 3 committee seals, respectively.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
