### PR TITLE
Remove KIR/PoC and introduce KCF/KFF from API returns and internal code 

### DIFF
--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -157,7 +157,7 @@ func (dl *downloadTester) makeStakingInfoData(blockNumber uint64) (*reward.Staki
 	addr := crypto.PubkeyToAddress(k.PublicKey)
 	si := &reward.StakingInfo{
 		BlockNum: blockNumber,
-		KIRAddr:  addr, // assign KIR in order to put unique staking information
+		KCFAddr:  addr, // assign KCF in order to put unique staking information
 	}
 	siBytes, _ := json.Marshal(si)
 	return si, siBytes

--- a/reward/doc.go
+++ b/reward/doc.go
@@ -37,8 +37,8 @@ StakingInfo is made every 86400 blocks (stakingInterval) and used in a next inte
 		CouncilNodeAddrs      []common.Address // Address of Council
 		CouncilStakingAddrs   []common.Address // Address of Staking contract which holds staking balance
 		CouncilRewardAddrs    []common.Address // Address of Council account which will get a block reward
-		KIRAddr               common.Address   // Address of KCF contract
-		PoCAddr               common.Address   // Address of KFF contract
+		KCFAddr               common.Address   // Address of KCF contract
+		KFFAddr               common.Address   // Address of KFF contract
 		UseGini               bool             // configure whether Gini is used or not
 		Gini                  float64          // Gini coefficient
 		CouncilStakingAmounts []uint64         // StakingAmounts of Council. They are derived from Staking addresses of council

--- a/reward/reward_distributor.go
+++ b/reward/reward_distributor.go
@@ -297,12 +297,12 @@ func CalcDeferredReward(header *types.Header, rules params.Rules, pset *params.G
 	stakers = stakers.Sub(stakers, shareRem)
 
 	// if KFF or KCF is not set, proposer gets the portion
-	if stakingInfo == nil || common.EmptyAddress(stakingInfo.PoCAddr) {
+	if stakingInfo == nil || common.EmptyAddress(stakingInfo.KFFAddr) {
 		logger.Debug("KFF empty, proposer gets its portion", "kff", kff)
 		proposer = proposer.Add(proposer, kff)
 		kff = big.NewInt(0)
 	}
-	if stakingInfo == nil || common.EmptyAddress(stakingInfo.KIRAddr) {
+	if stakingInfo == nil || common.EmptyAddress(stakingInfo.KCFAddr) {
 		logger.Debug("KCF empty, proposer gets its portion", "kcf", kcf)
 		proposer = proposer.Add(proposer, kcf)
 		kcf = big.NewInt(0)
@@ -319,11 +319,11 @@ func CalcDeferredReward(header *types.Header, rules params.Rules, pset *params.G
 
 	incrementRewardsMap(spec.Rewards, header.Rewardbase, proposer)
 
-	if stakingInfo != nil && !common.EmptyAddress(stakingInfo.PoCAddr) {
-		incrementRewardsMap(spec.Rewards, stakingInfo.PoCAddr, kff)
+	if stakingInfo != nil && !common.EmptyAddress(stakingInfo.KFFAddr) {
+		incrementRewardsMap(spec.Rewards, stakingInfo.KFFAddr, kff)
 	}
-	if stakingInfo != nil && !common.EmptyAddress(stakingInfo.KIRAddr) {
-		incrementRewardsMap(spec.Rewards, stakingInfo.KIRAddr, kcf)
+	if stakingInfo != nil && !common.EmptyAddress(stakingInfo.KCFAddr) {
+		incrementRewardsMap(spec.Rewards, stakingInfo.KCFAddr, kcf)
 	}
 
 	for rewardAddr, rewardAmount := range shares {

--- a/reward/reward_distributor.go
+++ b/reward/reward_distributor.go
@@ -75,16 +75,14 @@ type rewardConfig struct {
 }
 
 type RewardSpec struct {
-	Minted   *big.Int `json:"minted"`   // the amount newly minted
-	TotalFee *big.Int `json:"totalFee"` // total tx fee spent
-	BurntFee *big.Int `json:"burntFee"` // the amount burnt
-	Proposer *big.Int `json:"proposer"` // the amount allocated to the block proposer
-	Stakers  *big.Int `json:"stakers"`  // total amount allocated to stakers
-	// TODO-klaytn-fund: change kgf json tag to kff
-	KFF *big.Int `json:"kgf"` // the amount allocated to KGF
-	// TODO-klaytn-fund: change kir json tag to kcf
-	KCF     *big.Int                    `json:"kir"`     // the amount allocated to KIR
-	Rewards map[common.Address]*big.Int `json:"rewards"` // mapping from reward recipient to amounts
+	Minted   *big.Int                    `json:"minted"`   // the amount newly minted
+	TotalFee *big.Int                    `json:"totalFee"` // total tx fee spent
+	BurntFee *big.Int                    `json:"burntFee"` // the amount burnt
+	Proposer *big.Int                    `json:"proposer"` // the amount allocated to the block proposer
+	Stakers  *big.Int                    `json:"stakers"`  // total amount allocated to stakers
+	KFF      *big.Int                    `json:"kff"`      // the amount allocated to KFF
+	KCF      *big.Int                    `json:"kcf"`      // the amount allocated to KCF
+	Rewards  map[common.Address]*big.Int `json:"rewards"`  // mapping from reward recipient to amounts
 }
 
 func NewRewardSpec() *RewardSpec {

--- a/reward/reward_distributor_test.go
+++ b/reward/reward_distributor_test.go
@@ -104,8 +104,8 @@ func genStakingInfo(cnNum int, rewardOverride map[int]int, amountOverride map[in
 		CouncilNodeAddrs:      cns,
 		CouncilStakingAddrs:   stakes,
 		CouncilRewardAddrs:    rewards,
-		KIRAddr:               kcfAddr,
-		PoCAddr:               kffAddr,
+		KCFAddr:               kcfAddr,
+		KFFAddr:               kffAddr,
 		UseGini:               false,
 		CouncilStakingAmounts: amounts,
 	}
@@ -768,8 +768,8 @@ func TestRewardDistributor_CalcDeferredReward_StakingInfos(t *testing.T) {
 		{
 			desc: "stakingInfo has no kff, its portion goes to proposer",
 			stakingInfo: &StakingInfo{
-				KIRAddr: kcfAddr,
-				PoCAddr: common.Address{},
+				KCFAddr: kcfAddr,
+				KFFAddr: common.Address{},
 			},
 			expected: &RewardSpec{
 				Minted:   minted,
@@ -788,8 +788,8 @@ func TestRewardDistributor_CalcDeferredReward_StakingInfos(t *testing.T) {
 		{
 			desc: "stakingInfo has no kcf, its portion goes to proposer",
 			stakingInfo: &StakingInfo{
-				KIRAddr: common.Address{},
-				PoCAddr: kffAddr,
+				KCFAddr: common.Address{},
+				KFFAddr: kffAddr,
 			},
 			expected: &RewardSpec{
 				Minted:   minted,
@@ -808,8 +808,8 @@ func TestRewardDistributor_CalcDeferredReward_StakingInfos(t *testing.T) {
 		{
 			desc: "stakingInfo has the same kff and kcf",
 			stakingInfo: &StakingInfo{
-				KIRAddr: kffAddr,
-				PoCAddr: kffAddr,
+				KCFAddr: kffAddr,
+				KFFAddr: kffAddr,
 			},
 			expected: &RewardSpec{
 				Minted:   minted,

--- a/reward/staking_info.go
+++ b/reward/staking_info.go
@@ -61,6 +61,43 @@ type StakingInfo struct {
 	CouncilStakingAmounts []uint64 `json:"councilStakingAmounts"` // Staking amounts of Council
 }
 
+// MarshalJSON supports json marshalling for both oldStakingInfo and StakingInfo
+// TODO-klaytn-Mantle: remove this marshal function when backward-compatibility for KIR/PoC is not needed
+func (st StakingInfo) MarshalJSON() ([]byte, error) {
+	type extendedSt struct {
+		BlockNum              uint64           `json:"blockNum"`
+		CouncilNodeAddrs      []common.Address `json:"councilNodeAddrs"`
+		CouncilStakingAddrs   []common.Address `json:"councilStakingAddrs"`
+		CouncilRewardAddrs    []common.Address `json:"councilRewardAddrs"`
+		KCFAddr               common.Address   `json:"kcfAddr"`
+		KFFAddr               common.Address   `json:"kffAddr"`
+		UseGini               bool             `json:"useGini"`
+		Gini                  float64          `json:"gini"`
+		CouncilStakingAmounts []uint64         `json:"councilStakingAmounts"`
+
+		// legacy fields of StakingInfo
+		KIRAddr common.Address `json:"KIRAddr"` // KIRAddr -> KCFAddr from v1.10.2
+		PoCAddr common.Address `json:"PoCAddr"` // PoCAddr -> KFFAddr from v1.10.2
+	}
+
+	var ext extendedSt
+	ext.BlockNum = st.BlockNum
+	ext.CouncilNodeAddrs = st.CouncilNodeAddrs
+	ext.CouncilStakingAddrs = st.CouncilStakingAddrs
+	ext.CouncilRewardAddrs = st.CouncilRewardAddrs
+	ext.KCFAddr = st.KCFAddr
+	ext.KFFAddr = st.KFFAddr
+	ext.UseGini = st.UseGini
+	ext.Gini = st.Gini
+	ext.CouncilStakingAmounts = st.CouncilStakingAmounts
+
+	// KIRAddr and PoCAddr are for backward-compatibility of database
+	ext.KIRAddr = st.KCFAddr
+	ext.PoCAddr = st.KFFAddr
+
+	return json.Marshal(&ext)
+}
+
 // UnmarshalJSON supports json unmarshalling for both oldStakingInfo and StakingInfo
 func (st *StakingInfo) UnmarshalJSON(input []byte) error {
 	type extendedSt struct {

--- a/reward/staking_info_db.go
+++ b/reward/staking_info_db.go
@@ -39,11 +39,9 @@ func getStakingInfoFromDB(blockNum uint64) (*StakingInfo, error) {
 	}
 
 	stakingInfo := new(StakingInfo)
-	err = json.Unmarshal(jsonByte, stakingInfo)
-	if err != nil {
+	if err = json.Unmarshal(jsonByte, stakingInfo); err != nil {
 		return nil, err
 	}
-
 	return stakingInfo, nil
 }
 

--- a/reward/staking_info_test.go
+++ b/reward/staking_info_test.go
@@ -464,12 +464,12 @@ func TestGetStakingInfoFromDB(t *testing.T) {
 		[]uint64{5000000, 5000000, 5000000, 5000000},
 	}
 
-	// initialize StakingManager
-	_ = NewStakingManager(newTestBlockChain(), newDefaultTestGovernance(), nil)
+	oldStakingManager := GetStakingManager()
+	defer SetTestStakingManager(oldStakingManager)
 
 	for _, info := range []interface{}{oldInfo, newInfo} {
 		// reset database
-		stakingManager.stakingInfoDB = database.NewMemoryDBManager()
+		SetTestStakingManagerWithDB(database.NewMemoryDBManager())
 
 		infoBytes, err := json.Marshal(info)
 		if err != nil {

--- a/reward/staking_info_test.go
+++ b/reward/staking_info_test.go
@@ -393,77 +393,77 @@ func TestConsolidatedStakingInfo(t *testing.T) {
 	}
 }
 
+// oldStakingInfo is a legacy of StakingInfo providing backward-compatibility.
+// Since json tags of StakingInfo were changed, a node may fail to unmarshal stored data without this.
+// oldStakingInfo's field names are the same with StakingInfo's names, but json tag is different.
+type oldStakingInfo struct {
+	BlockNum              uint64           `json:"BlockNum"`
+	CouncilNodeAddrs      []common.Address `json:"CouncilNodeAddrs"`
+	CouncilStakingAddrs   []common.Address `json:"CouncilStakingAddrs"`
+	CouncilRewardAddrs    []common.Address `json:"CouncilRewardAddrs"`
+	KCFAddr               common.Address   `json:"KIRAddr"` // KIRAddr -> KCFAddr from v1.10.2
+	KFFAddr               common.Address   `json:"PoCAddr"` // PoCAddr -> KFFAddr from v1.10.2
+	UseGini               bool             `json:"UseGini"`
+	Gini                  float64          `json:"Gini"`
+	CouncilStakingAmounts []uint64         `json:"CouncilStakingAmounts"`
+}
+
+var oldInfo = oldStakingInfo{
+	2880,
+	[]common.Address{
+		common.HexToAddress("0x159ae5ccda31b77475c64d88d4499c86f77b7ecc"),
+		common.HexToAddress("0x181deb121304b0430d99328ff1a9122df9f09d7f"),
+		common.HexToAddress("0x324ec8f2681cd73642cc55057970540a1f4393e0"),
+		common.HexToAddress("0x11191029025d3fcd21001746f949b25c6e8435cc"),
+	},
+	[]common.Address{
+		common.HexToAddress("0x70e051c46ea76b9af9977407bb32192319907f9e"),
+		common.HexToAddress("0xe4a0c3821a2711758306ed57c2f4900aa9ddbb3d"),
+		common.HexToAddress("0xf3ba3a33b3bf7cf2085890315b41cc788770feb3"),
+		common.HexToAddress("0x9285a85777d0ae7e12bee3ffd7842908b2295f45"),
+	},
+	[]common.Address{
+		common.HexToAddress("0xd155d4277c99fa837c54a37a40a383f71a3d082a"),
+		common.HexToAddress("0x2b8cc0ca62537fa5e49dce197acc8a15d3c5d4a8"),
+		common.HexToAddress("0x7d892f470ecde693f52588dd0cfe46c3d26b6219"),
+		common.HexToAddress("0xa0f7354a0cef878246820b6caa19d2bdef74a0cc"),
+	},
+	common.HexToAddress("0x673003e5f9a852d3dc85b83d16ef62d45497fb96"),
+	common.HexToAddress("0x576dc0c2afeb1661da3cf53a60e76dd4e32c7ab1"),
+	false,
+	-1,
+	[]uint64{5000000, 5000000, 5000000, 5000000},
+}
+
+var newInfo = StakingInfo{
+	oldInfo.BlockNum,
+	[]common.Address{
+		common.HexToAddress("0x70e051c46ea76b9af9977407bb32192319907f9e"),
+		common.HexToAddress("0xe4a0c3821a2711758306ed57c2f4900aa9ddbb3d"),
+		common.HexToAddress("0xf3ba3a33b3bf7cf2085890315b41cc788770feb3"),
+		common.HexToAddress("0x11191029025d3fcd21001746f949b25c6e8435cc"),
+	},
+	[]common.Address{
+		common.HexToAddress("0x7d892f470ecde693f52588dd0cfe46c3d26b6219"),
+		common.HexToAddress("0x2b8cc0ca62537fa5e49dce197acc8a15d3c5d4a8"),
+		common.HexToAddress("0xa0f7354a0cef878246820b6caa19d2bdef74a0cc"),
+		common.HexToAddress("0x576dc0c2afeb1661da3cf53a60e76dd4e32c7ab1"),
+	},
+	[]common.Address{
+		common.HexToAddress("0xd155d4277c99fa837c54a37a40a383f71a3d082a"),
+		common.HexToAddress("0x159ae5ccda31b77475c64d88d4499c86f77b7ecc"),
+		common.HexToAddress("0x181deb121304b0430d99328ff1a9122df9f09d7f"),
+		common.HexToAddress("0x673003e5f9a852d3dc85b83d16ef62d45497fb96"),
+	},
+	common.HexToAddress("0x324ec8f2681cd73642cc55057970540a1f4393e0"),
+	common.HexToAddress("0x9285a85777d0ae7e12bee3ffd7842908b2295f45"),
+	false,
+	0.3,
+	[]uint64{15000000, 4000000, 25000000, 35000000},
+}
+
 // TestGetStakingInfoFromDB tests whether the node can read oldStakingInfo and StakingInfo data or not.
 func TestGetStakingInfoFromDB(t *testing.T) {
-	// oldStakingInfo is a legacy of StakingInfo providing backward-compatibility.
-	// Since json tags of StakingInfo were changed, a node may fail to unmarshal stored data without this.
-	// oldStakingInfo's field names are the same with StakingInfo's names, but json tag is different.
-	type oldStakingInfo struct {
-		BlockNum              uint64           `json:"BlockNum"`
-		CouncilNodeAddrs      []common.Address `json:"CouncilNodeAddrs"`
-		CouncilStakingAddrs   []common.Address `json:"CouncilStakingAddrs"`
-		CouncilRewardAddrs    []common.Address `json:"CouncilRewardAddrs"`
-		KCFAddr               common.Address   `json:"KIRAddr"` // KIRAddr -> KCFAddr from v1.10.2
-		KFFAddr               common.Address   `json:"PoCAddr"` // PoCAddr -> KFFAddr from v1.10.2
-		UseGini               bool             `json:"UseGini"`
-		Gini                  float64          `json:"Gini"`
-		CouncilStakingAmounts []uint64         `json:"CouncilStakingAmounts"`
-	}
-
-	oldInfo := oldStakingInfo{
-		2880,
-		[]common.Address{
-			common.HexToAddress("0x159ae5ccda31b77475c64d88d4499c86f77b7ecc"),
-			common.HexToAddress("0x181deb121304b0430d99328ff1a9122df9f09d7f"),
-			common.HexToAddress("0x324ec8f2681cd73642cc55057970540a1f4393e0"),
-			common.HexToAddress("0x11191029025d3fcd21001746f949b25c6e8435cc"),
-		},
-		[]common.Address{
-			common.HexToAddress("0x70e051c46ea76b9af9977407bb32192319907f9e"),
-			common.HexToAddress("0xe4a0c3821a2711758306ed57c2f4900aa9ddbb3d"),
-			common.HexToAddress("0xf3ba3a33b3bf7cf2085890315b41cc788770feb3"),
-			common.HexToAddress("0x9285a85777d0ae7e12bee3ffd7842908b2295f45"),
-		},
-		[]common.Address{
-			common.HexToAddress("0xd155d4277c99fa837c54a37a40a383f71a3d082a"),
-			common.HexToAddress("0x2b8cc0ca62537fa5e49dce197acc8a15d3c5d4a8"),
-			common.HexToAddress("0x7d892f470ecde693f52588dd0cfe46c3d26b6219"),
-			common.HexToAddress("0xa0f7354a0cef878246820b6caa19d2bdef74a0cc"),
-		},
-		common.HexToAddress("0x673003e5f9a852d3dc85b83d16ef62d45497fb96"),
-		common.HexToAddress("0x576dc0c2afeb1661da3cf53a60e76dd4e32c7ab1"),
-		false,
-		-1,
-		[]uint64{5000000, 5000000, 5000000, 5000000},
-	}
-
-	newInfo := StakingInfo{
-		oldInfo.BlockNum,
-		[]common.Address{
-			common.HexToAddress("0x159ae5ccda31b77475c64d88d4499c86f77b7ecc"),
-			common.HexToAddress("0x181deb121304b0430d99328ff1a9122df9f09d7f"),
-			common.HexToAddress("0x324ec8f2681cd73642cc55057970540a1f4393e0"),
-			common.HexToAddress("0x11191029025d3fcd21001746f949b25c6e8435cc"),
-		},
-		[]common.Address{
-			common.HexToAddress("0x70e051c46ea76b9af9977407bb32192319907f9e"),
-			common.HexToAddress("0xe4a0c3821a2711758306ed57c2f4900aa9ddbb3d"),
-			common.HexToAddress("0xf3ba3a33b3bf7cf2085890315b41cc788770feb3"),
-			common.HexToAddress("0x9285a85777d0ae7e12bee3ffd7842908b2295f45"),
-		},
-		[]common.Address{
-			common.HexToAddress("0xd155d4277c99fa837c54a37a40a383f71a3d082a"),
-			common.HexToAddress("0x2b8cc0ca62537fa5e49dce197acc8a15d3c5d4a8"),
-			common.HexToAddress("0x7d892f470ecde693f52588dd0cfe46c3d26b6219"),
-			common.HexToAddress("0xa0f7354a0cef878246820b6caa19d2bdef74a0cc"),
-		},
-		common.HexToAddress("0x673003e5f9a852d3dc85b83d16ef62d45497fb96"),
-		common.HexToAddress("0x576dc0c2afeb1661da3cf53a60e76dd4e32c7ab1"),
-		false,
-		-1,
-		[]uint64{5000000, 5000000, 5000000, 5000000},
-	}
-
 	oldStakingManager := GetStakingManager()
 	defer SetTestStakingManager(oldStakingManager)
 
@@ -489,5 +489,61 @@ func TestGetStakingInfoFromDB(t *testing.T) {
 		for i := 0; i < vInfo.NumField(); i++ {
 			assert.Equal(t, vInfo.Field(i).Interface(), vRetriedInfo.Field(i).Interface())
 		}
+	}
+}
+
+// TestStakingInfo_MarshalJSON tests marshal/unmarshal staking info data.
+func TestStakingInfo_MarshalJSON(t *testing.T) {
+	// old marshalled data, new unmarshal method
+	{
+		oldInfoByte, err := json.Marshal(oldInfo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var unmarshalled StakingInfo
+		if err := json.Unmarshal(oldInfoByte, &unmarshalled); err != nil {
+			t.Fatal(err)
+		}
+		checkStakingInfoValues(t, oldInfo, unmarshalled)
+	}
+
+	// new marshalled data, old unmarshal method
+	{
+		newInfoByte, err := json.Marshal(newInfo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var unmarshalled oldStakingInfo
+		if err := json.Unmarshal(newInfoByte, &unmarshalled); err != nil {
+			t.Fatal(err)
+		}
+		checkStakingInfoValues(t, newInfo, unmarshalled)
+	}
+
+	// new marshalled data, new unmarshal method
+	{
+		newInfoByte, err := json.Marshal(newInfo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var unmarshalled StakingInfo
+		if err := json.Unmarshal(newInfoByte, &unmarshalled); err != nil {
+			t.Fatal(err)
+		}
+		checkStakingInfoValues(t, newInfo, unmarshalled)
+	}
+}
+
+func checkStakingInfoValues(t *testing.T, info interface{}, stakingInfo interface{}) {
+	vOld := reflect.ValueOf(info)
+	vNew := reflect.ValueOf(stakingInfo)
+	assert.Equal(t, vOld.NumField(), vNew.NumField())
+
+	for i := 0; i < vOld.NumField(); i++ {
+		field := reflect.TypeOf(info).Field(i).Name
+		assert.Equal(t, vOld.FieldByName(field).Interface(), vNew.FieldByName(field).Interface())
 	}
 }

--- a/storage/database/db_manager_stakinginfo_test.go
+++ b/storage/database/db_manager_stakinginfo_test.go
@@ -25,6 +25,7 @@ func TestDatabaseManager_StakingInfo(t *testing.T) {
 	dbm := dbManagers[0]
 
 	key := uint64(1234)
+	// legacy staking info format
 	value := []byte("{\"BlockNum\":2880,\"CouncilNodeAddrs\":[\"0x159ae5ccda31b77475c64d88d4499c86f77b7ecc\",\"0x181deb121304b0430d99328ff1a9122df9f09d7f\",\"0x324ec8f2681cd73642cc55057970540a1f4393e0\",\"0x11191029025d3fcd21001746f949b25c6e8435cc\"],\"CouncilStakingAddrs\":[\"0x70e051c46ea76b9af9977407bb32192319907f9e\",\"0xe4a0c3821a2711758306ed57c2f4900aa9ddbb3d\",\"0xf3ba3a33b3bf7cf2085890315b41cc788770feb3\",\"0x9285a85777d0ae7e12bee3ffd7842908b2295f45\"],\"CouncilRewardAddrs\":[\"0xd155d4277c99fa837c54a37a40a383f71a3d082a\",\"0x2b8cc0ca62537fa5e49dce197acc8a15d3c5d4a8\",\"0x7d892f470ecde693f52588dd0cfe46c3d26b6219\",\"0xa0f7354a0cef878246820b6caa19d2bdef74a0cc\"],\"KIRAddr\":\"0x673003e5f9a852d3dc85b83d16ef62d45497fb96\",\"PoCAddr\":\"0x576dc0c2afeb1661da3cf53a60e76dd4e32c7ab1\",\"UseGini\":false,\"Gini\":-1,\"CouncilStakingAmounts\":[5000000,5000000,5000000,5000000]}")
 	err := dbm.WriteStakingInfo(key, value)
 	if err != nil {


### PR DESCRIPTION
## Proposed changes

This PR is a part of KGP-6 implementation, however, it causes a change in the API return format. 

1. The change in RewardSpec affects to `klay_getRewards` API
Before
```
{
        "minted": 6400000000000000000,
        "totalFee": 70825700000000000,
        "burntFee": 35412850000000000,
        "proposer": 3217706425000000000,
        "stakers": 0,
        "kgf": 2574165140000000000,
        "kir": 643541285000000000,
        "rewards": {
            "0x179679457f93094a4e7186abcb2089661e92fc22": 3217706425000000000,
            "0x278e6332d69eed782784d21802e3504a64a16456": 2574165140000000000,
            "0x3d803a7375a8ee5996f52a8d6725637a89f5bbf8": 643541285000000000
        }
```

After
```
{
        "minted": 6400000000000000000,
        "totalFee": 70825700000000000,
        "burntFee": 35412850000000000,
        "proposer": 3217706425000000000,
        "stakers": 0,
        "kff": 2574165140000000000,
        "kcf": 643541285000000000,
        "rewards": {
            "0x179679457f93094a4e7186abcb2089661e92fc22": 3217706425000000000,
            "0x278e6332d69eed782784d21802e3504a64a16456": 2574165140000000000,
            "0x3d803a7375a8ee5996f52a8d6725637a89f5bbf8": 643541285000000000
        }
```

2. The change in StakingInfo struct affects to `klay_getStakingInfo` API.
This change also affects to StakingInfo data stored in database, so the unmarshal function of StakingInfo is added to support both legacy data and new data. 

Before
```
{
        "BlockNum": 115171200,
        "CouncilNodeAddrs": [ ... ... ],
        "CouncilStakingAddrs": [ ... ... ],
        "CouncilRewardAddrs": [ ... ... ],
        "KIRAddr": "0x3d803a7375a8ee5996f52a8d6725637a89f5bbf8",
        "PoCAddr": "0x278e6332d69eed782784d21802e3504a64a16456",
        "UseGini": true,
        "Gini": 0.61,
        "CouncilStakingAmounts": [ ... ... ]
    }
```

After
```
{
        "blockNum": 115171200,
        "councilNodeAddrs":  [ ... ... ],
        "councilStakingAddrs":  [ ... ... ],
        "councilRewardAddrs":  [ ... ... ],
        "kcfAddr": "0x3d803a7375a8ee5996f52a8d6725637a89f5bbf8",
        "kffAddr": "0x278e6332d69eed782784d21802e3504a64a16456",
        "useGini": true,
        "gini": 0.61,
        "councilStakingAmounts":  [ ... ... ],
    }
```


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
