### PR TITLE
Add `--mnemonic`, `--mnemonic-path` flag to homi for mnemonic-based key generation

### DIFF
--- a/cmd/homi/common/utils.go
+++ b/cmd/homi/common/utils.go
@@ -25,14 +25,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/log"
+	uuid "github.com/satori/go.uuid"
 	"github.com/tyler-smith/go-bip32"
 	"golang.org/x/crypto/pbkdf2"
-
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/crypto"
-	uuid "github.com/satori/go.uuid"
 )
 
 const (

--- a/cmd/homi/common/utils.go
+++ b/cmd/homi/common/utils.go
@@ -89,7 +89,6 @@ func GenerateKeysFromMnemonic(num int, mnemonic string) (keys []*ecdsa.PrivateKe
 	for i := 0; i < num; i++ {
 		derived, _ := m44h_60h_0h_0.NewChildKey(uint32(i))
 		nodekey := hexutil.Encode(derived.Key)[2:]
-
 		nodekeys = append(nodekeys, nodekey)
 
 		key, err := crypto.HexToECDSA(nodekey)

--- a/cmd/homi/common/utils.go
+++ b/cmd/homi/common/utils.go
@@ -96,10 +96,10 @@ func GenerateKeysFromMnemonic(num int, mnemonic, path string) (keys []*ecdsa.Pri
 			num := uint64(0)
 			var err error
 			if strings.HasSuffix(level, "'") {
-				num, err = strconv.ParseUint(level[:len(level)-1], 10, 64)
+				num, err = strconv.ParseUint(level[:len(level)-1], 10, 32)
 				num += 0x80000000
 			} else {
-				num, err = strconv.ParseUint(level, 10, 64)
+				num, err = strconv.ParseUint(level, 10, 32)
 			}
 			if err != nil {
 				logger.Error("Failed to parse path", "err", err)

--- a/cmd/homi/common/utils.go
+++ b/cmd/homi/common/utils.go
@@ -79,10 +79,7 @@ func GenerateKeys(num int) (keys []*ecdsa.PrivateKey, nodekeys []string, addrs [
 }
 
 func GenerateKeysFromMnemonic(num int, mnemonic, path string) (keys []*ecdsa.PrivateKey, nodekeys []string, addrs []common.Address) {
-	// Ethereum key derivation path: m/44'/60'/0'/0/
-	var (
-		key *bip32.Key
-	)
+	var key *bip32.Key
 
 	for _, level := range strings.Split(path, "/") {
 		if len(level) == 0 {

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -78,6 +78,7 @@ var HomiFlags = []cli.Flag{
 	altsrc.NewIntFlag(numOfSENsFlag),
 	altsrc.NewIntFlag(numOfTestKeyFlag),
 	altsrc.NewStringFlag(mnemonic),
+	altsrc.NewStringFlag(mnemonicPath),
 	altsrc.NewUint64Flag(chainIDFlag),
 	altsrc.NewUint64Flag(serviceChainIDFlag),
 	altsrc.NewUint64Flag(unitPriceFlag),
@@ -626,7 +627,14 @@ func Gen(ctx *cli.Context) error {
 		if mnemonic == "test junk" {
 			mnemonic = "test test test test test test test test test test test junk"
 		}
-		privKeys, nodeKeys, nodeAddrs = istcommon.GenerateKeysFromMnemonic(cnNum, mnemonic)
+		path := ctx.String(mnemonicPath.Name)
+		switch path {
+		case "klay":
+			path = "m/44'/8217'/0'/0/"
+		default:
+			path = "m/44'/60'/0'/0/"
+		}
+		privKeys, nodeKeys, nodeAddrs = istcommon.GenerateKeysFromMnemonic(cnNum, mnemonic, path)
 	}
 
 	testPrivKeys, testKeys, testAddrs := istcommon.GenerateKeys(numTestAccs)

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -632,8 +632,10 @@ func Gen(ctx *cli.Context) error {
 			switch path {
 			case "klay":
 				path = "m/44'/8217'/0'/0/"
-			default:
+			case "eth":
 				path = "m/44'/60'/0'/0/"
+			default:
+				return fmt.Errorf("invalid mnemonic path (format: m/44'/60'/0'/0/)")
 			}
 		}
 		privKeys, nodeKeys, nodeAddrs = istcommon.GenerateKeysFromMnemonic(cnNum, mnemonic, path)

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -77,6 +77,7 @@ var HomiFlags = []cli.Flag{
 	altsrc.NewIntFlag(numOfSPNsFlag),
 	altsrc.NewIntFlag(numOfSENsFlag),
 	altsrc.NewIntFlag(numOfTestKeyFlag),
+	altsrc.NewStringFlag(mnemonic),
 	altsrc.NewUint64Flag(chainIDFlag),
 	altsrc.NewUint64Flag(serviceChainIDFlag),
 	altsrc.NewUint64Flag(unitPriceFlag),
@@ -610,7 +611,24 @@ func Gen(ctx *cli.Context) error {
 		return fmt.Errorf("validators-num(%d) cannot be greater than num(%d)", numValidators, cnNum)
 	}
 
-	privKeys, nodeKeys, nodeAddrs := istcommon.GenerateKeys(cnNum)
+	var (
+		privKeys  []*ecdsa.PrivateKey
+		nodeKeys  []string
+		nodeAddrs []common.Address
+	)
+
+	if len(ctx.String(mnemonic.Name)) == 0 {
+		privKeys, nodeKeys, nodeAddrs = istcommon.GenerateKeys(cnNum)
+	} else {
+		mnemonic := ctx.String(mnemonic.Name)
+		mnemonic = strings.ReplaceAll(mnemonic, ",", " ")
+		// common keys used by web3 tools such as hardhat, foundry, etc.
+		if mnemonic == "test junk" {
+			mnemonic = "test test test test test test test test test test test junk"
+		}
+		privKeys, nodeKeys, nodeAddrs = istcommon.GenerateKeysFromMnemonic(cnNum, mnemonic)
+	}
+
 	testPrivKeys, testKeys, testAddrs := istcommon.GenerateKeys(numTestAccs)
 
 	var (

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -627,7 +627,7 @@ func Gen(ctx *cli.Context) error {
 		if mnemonic == "test junk" {
 			mnemonic = "test test test test test test test test test test test junk"
 		}
-		path := ctx.String(mnemonicPath.Name)
+		path := strings.ToLower(ctx.String(mnemonicPath.Name))
 		if !strings.HasPrefix(path, "m") {
 			switch path {
 			case "klay":

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -628,11 +628,13 @@ func Gen(ctx *cli.Context) error {
 			mnemonic = "test test test test test test test test test test test junk"
 		}
 		path := ctx.String(mnemonicPath.Name)
-		switch path {
-		case "klay":
-			path = "m/44'/8217'/0'/0/"
-		default:
-			path = "m/44'/60'/0'/0/"
+		if !strings.HasPrefix(path, "m") {
+			switch path {
+			case "klay":
+				path = "m/44'/8217'/0'/0/"
+			default:
+				path = "m/44'/60'/0'/0/"
+			}
 		}
 		privKeys, nodeKeys, nodeAddrs = istcommon.GenerateKeysFromMnemonic(cnNum, mnemonic, path)
 	}

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -124,6 +124,12 @@ var (
 		Value: 0,
 	}
 
+	mnemonic = cli.StringFlag{
+		Name:  "mnemonic",
+		Usage: "Use given mnemonic to derive node keys",
+		Value: "",
+	}
+
 	chainIDFlag = cli.Uint64Flag{
 		Name:  "chainID",
 		Usage: "ChainID",

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -130,6 +130,12 @@ var (
 		Value: "",
 	}
 
+	mnemonicPath = cli.StringFlag{
+		Name:  "mnemonic-path",
+		Usage: "Use given path/coin to derive node keys (format: m/44'/60'/0'/0/). Effective only if --mnemonic is given",
+		Value: "eth",
+	}
+
 	chainIDFlag = cli.Uint64Flag{
 		Name:  "chainID",
 		Usage: "ChainID",

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+	github.com/tyler-smith/go-bip32 v1.0.0
 	github.com/urfave/cli v1.20.0
 	github.com/valyala/fasthttp v1.34.0
 	go.uber.org/zap v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,10 @@ github.com/DataDog/sketches-go v1.2.1 h1:qTBzWLnZ3kM2kw39ymh6rMcnN+5VULwFs++lEYU
 github.com/DataDog/sketches-go v1.2.1/go.mod h1:1xYmPLY1So10AwxV6MJV0J53XVH+WL9Ad1KetxVivVI=
 github.com/DataDog/zstd v1.3.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e h1:ahyvB3q25YnZWly5Gq1ekg6jcmWaGj/vG/MhF4aisoc=
+github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e/go.mod h1:kGUqhHd//musdITWjFvNTHn90WG9bMLBEPQZ17Cmlpw=
+github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec h1:1Qb69mGp/UtRPn422BH4/Y4Q3SLUrD9KHuDkm8iodFc=
+github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec/go.mod h1:CD8UlnlLDiqb36L110uqiP2iSflVjx9g/3U9hCI4q2U=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
@@ -144,6 +148,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/clevergo/websocket v1.0.0 h1:F25R9qxGrHL321kztl2E3kSydIo0+VIQE8uDMdWKuaw=
 github.com/clevergo/websocket v1.0.0/go.mod h1:4cxGDd7ljHn+Ng5VPV2neXYBGNZRWx9JMisSmCwQxFU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cmars/basen v0.0.0-20150613233007-fe3947df716e h1:0XBUw73chJ1VYSsfvcPvVT7auykAJce9FpRr10L6Qhw=
+github.com/cmars/basen v0.0.0-20150613233007-fe3947df716e/go.mod h1:P13beTBKr5Q18lJe1rIoLUqjM+CB1zYrRg44ZqGuQSA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/confluentinc/confluent-kafka-go v1.4.0/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
@@ -784,6 +790,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.1.5-0.20170601210322-f6abca593680/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -819,6 +826,8 @@ github.com/tjfoc/gmsm v1.0.1/go.mod h1:XxO4hdhhrzAd+G4CjDqaOkd0hUzmtPR/d3EiBBMn/
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twitchtv/twirp v8.1.1+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
+github.com/tyler-smith/go-bip32 v1.0.0 h1:sDR9juArbUgX+bO/iblgZnMPeWY1KZMUC2AFUJdv5KE=
+github.com/tyler-smith/go-bip32 v1.0.0/go.mod h1:onot+eHknzV4BVPwrzqY5OoVpyCvnwD7lMawL5aQupE=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
@@ -884,6 +893,7 @@ go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3m
 go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+golang.org/x/crypto v0.0.0-20170613210332-850760c427c5/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1339,6 +1349,8 @@ k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
 mellium.im/sasl v0.2.1/go.mod h1:ROaEDLQNuf9vjKqE1SrAfnsobm2YKXT1gnN1uDp1PjQ=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=


### PR DESCRIPTION
## Proposed changes

This PR adds `--mnemonic` and `--mnemonic-path` flags to homi. Homi will generate nodekeys based on the given mnemonic and path. Default path is `eth` (`m/44'/60'/0'/0/`).
It also provides a special alias `test,junk` = `test,test,test,test,test,test,test,test,test,test,test,junk` which is commonly used among dev tools.

```
$ homi setup --baobab-test --cn-num 4 --mnemonic test,junk 
...
$ cat homi-output/keys/keystore* | jq .address
"f39fd6e51aad88f6f4ce6ab8827279cfffb92266"
"70997970c51812dc3a010c7d01b50e0d17dc79c8"
"3c44cdddb6a900fa2b585dd299e03d12fa4293bc"
"90f79bf6eb2c4f870365e785982e1f101e93b906"
```


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
