### PR TITLE
Stop loading rewardwallet

### DIFF
--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -92,7 +92,6 @@ type BackendProtocolManager interface {
 	ProtocolVersion() int
 	ReBroadcastTxs(transactions types.Transactions)
 	SetAcceptTxs()
-	SetRewardbase(addr common.Address)
 	NodeType() common.ConnType
 	Start(maxPeers int)
 	Stop()
@@ -421,7 +420,6 @@ func (s *CN) setRewardWallet() error {
 		if err != nil {
 			return err
 		}
-		s.protocolManager.SetRewardbase(s.rewardbase)
 	}
 	return nil
 }
@@ -624,7 +622,6 @@ func (s *CN) SetRewardbase(rewardbase common.Address) {
 	if err != nil {
 		logger.Error("find err", "err", err)
 	}
-	s.protocolManager.SetRewardbase(rewardbase)
 }
 
 func (s *CN) StartMining(local bool) error {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -598,12 +598,6 @@ func (s *CN) Rewardbase() (eb common.Address, err error) {
 	return common.Address{}, fmt.Errorf("rewardbase must be explicitly specified")
 }
 
-func (s *CN) SetRewardbase(rewardbase common.Address) {
-	s.lock.Lock()
-	s.rewardbase = rewardbase
-	s.lock.Unlock()
-}
-
 func (s *CN) StartMining(local bool) error {
 	if local {
 		// If local (CPU) mining is started, we can disable the transaction rejection

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -93,7 +93,6 @@ type BackendProtocolManager interface {
 	ReBroadcastTxs(transactions types.Transactions)
 	SetAcceptTxs()
 	SetRewardbase(addr common.Address)
-	SetRewardbaseWallet(wallet accounts.Wallet)
 	NodeType() common.ConnType
 	Start(maxPeers int)
 	Stop()
@@ -418,11 +417,9 @@ func (s *CN) setAcceptTxs() error {
 // setRewardWallet sets reward base and reward base wallet if the node is CN.
 func (s *CN) setRewardWallet() error {
 	if s.protocolManager.NodeType() == common.CONSENSUSNODE {
-		wallet, err := s.RewardbaseWallet()
+		_, err := s.RewardbaseWallet()
 		if err != nil {
 			return err
-		} else {
-			s.protocolManager.SetRewardbaseWallet(wallet)
 		}
 		s.protocolManager.SetRewardbase(s.rewardbase)
 	}
@@ -623,12 +620,11 @@ func (s *CN) SetRewardbase(rewardbase common.Address) {
 	s.lock.Lock()
 	s.rewardbase = rewardbase
 	s.lock.Unlock()
-	wallet, err := s.RewardbaseWallet()
+	_, err := s.RewardbaseWallet()
 	if err != nil {
 		logger.Error("find err", "err", err)
 	}
 	s.protocolManager.SetRewardbase(rewardbase)
-	s.protocolManager.SetRewardbaseWallet(wallet)
 }
 
 func (s *CN) StartMining(local bool) error {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -318,8 +318,10 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	cn.protocolManager.SetWsEndPoint(config.WsEndpoint)
 
-	if err := cn.setRewardWallet(); err != nil {
-		logger.Error("Error happened while setting the reward wallet", "err", err)
+	if ctx.NodeType() == common.CONSENSUSNODE {
+		if _, err := cn.Rewardbase(); err != nil {
+			logger.Error("Cannot determine the rewardbase address", "err", err)
+		}
 	}
 
 	if pset.Policy() == uint64(istanbul.WeightedRandom) {
@@ -408,16 +410,6 @@ func (s *CN) setAcceptTxs() error {
 			if len(istanbulExtra.Validators) == 1 {
 				s.protocolManager.SetAcceptTxs()
 			}
-		}
-	}
-	return nil
-}
-
-// setRewardWallet sets reward base and reward base wallet if the node is CN.
-func (s *CN) setRewardWallet() error {
-	if s.protocolManager.NodeType() == common.CONSENSUSNODE {
-		if _, err := s.Rewardbase(); err != nil {
-			return err
 		}
 	}
 	return nil

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -416,8 +416,7 @@ func (s *CN) setAcceptTxs() error {
 // setRewardWallet sets reward base and reward base wallet if the node is CN.
 func (s *CN) setRewardWallet() error {
 	if s.protocolManager.NodeType() == common.CONSENSUSNODE {
-		_, err := s.RewardbaseWallet()
-		if err != nil {
+		if _, err := s.Rewardbase(); err != nil {
 			return err
 		}
 	}
@@ -599,29 +598,10 @@ func (s *CN) Rewardbase() (eb common.Address, err error) {
 	return common.Address{}, fmt.Errorf("rewardbase must be explicitly specified")
 }
 
-func (s *CN) RewardbaseWallet() (accounts.Wallet, error) {
-	rewardBase, err := s.Rewardbase()
-	if err != nil {
-		return nil, err
-	}
-
-	account := accounts.Account{Address: rewardBase}
-	wallet, err := s.AccountManager().Find(account)
-	if err != nil {
-		logger.Error("find err", "err", err)
-		return nil, err
-	}
-	return wallet, nil
-}
-
 func (s *CN) SetRewardbase(rewardbase common.Address) {
 	s.lock.Lock()
 	s.rewardbase = rewardbase
 	s.lock.Unlock()
-	_, err := s.RewardbaseWallet()
-	if err != nil {
-		logger.Error("find err", "err", err)
-	}
 }
 
 func (s *CN) StartMining(local bool) error {

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -127,8 +127,6 @@ type ProtocolManager struct {
 	// istanbul BFT
 	engine consensus.Engine
 
-	rewardbase common.Address
-
 	wsendpoint string
 
 	nodetype          common.ConnType
@@ -349,10 +347,6 @@ func (pm *ProtocolManager) RegisterValidator(connType common.ConnType, validator
 
 func (pm *ProtocolManager) getWSEndPoint() string {
 	return pm.wsendpoint
-}
-
-func (pm *ProtocolManager) SetRewardbase(addr common.Address) {
-	pm.rewardbase = addr
 }
 
 func (pm *ProtocolManager) removePeer(id string) {

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -33,7 +33,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -128,8 +127,7 @@ type ProtocolManager struct {
 	// istanbul BFT
 	engine consensus.Engine
 
-	rewardbase   common.Address
-	rewardwallet accounts.Wallet
+	rewardbase common.Address
 
 	wsendpoint string
 
@@ -355,10 +353,6 @@ func (pm *ProtocolManager) getWSEndPoint() string {
 
 func (pm *ProtocolManager) SetRewardbase(addr common.Address) {
 	pm.rewardbase = addr
-}
-
-func (pm *ProtocolManager) SetRewardbaseWallet(wallet accounts.Wallet) {
-	pm.rewardwallet = wallet
 }
 
 func (pm *ProtocolManager) removePeer(id string) {

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -209,14 +209,6 @@ func TestProtocolManager_getWSEndPoint(t *testing.T) {
 	assert.Equal(t, ws2, pm.getWSEndPoint())
 }
 
-func TestProtocolManager_SetRewardbase(t *testing.T) {
-	pm := &ProtocolManager{rewardbase: addrs[0]}
-	assert.Equal(t, addrs[0], pm.rewardbase)
-
-	pm.SetRewardbase(addrs[1])
-	assert.Equal(t, addrs[1], pm.rewardbase)
-}
-
 func TestProtocolManager_removePeer(t *testing.T) {
 	peerID := nodeids[0].String()
 


### PR DESCRIPTION
## Proposed changes

Klaytn consensus node does not need the wallet (private key) for rewardbase address, yet it tries to load it from accounts.
Klaytn prints an irrelevant log "Error happened while setting the reward wallet" during node startup.

Therefore this PR
- removes the rewardbase wallet (`rewardwallet`) from Klaytn codebase.
- removes unused or unnecessary wrapper functions related to rewardbase and rewardwallet.
- modifies the log message

In the diagram below, red boxes are the ones removed.

```mermaid
flowchart LR

  flag{{--rewardbase 0xaddr}} -->|cn.Config.Rb| cn.New("cn.New()")
  
  cn.New -->|cn.rb| cn.setRW
  cn.New -->|cn.Config.Rb| CreateConsensusEngine
  CreateConsensusEngine --> istanbulBackend.New
  istanbulBackend.New --> sb.rb

  api.Rb("rpc klay_rewardbase") --> cn.Rb

  subgraph type cn.ProtocolManager
	  pm.Set --> pm.rb{{pm.rewardbase}}
	  pm.Set --> pm.rw{{pm.rewardwallet}}
  end

  subgraph type cn.CN
    cn.setRW("setRewardWallet()") --> cn.RbW("RewardbaseWallet()")
	cn.setRW --> pm.Set("pm.SetRb(), pm.SetRbW()")

    cn.SetRb("SetRewardbase()") --> cn.RbW
    cn.SetRb --> pm.Set

    cn.RbW --> cn.Rb("Rewardbase()")
    cn.Rb <--> cn.rb{{cn.rb}}
  end

  subgraph type istanbul.backend
    sb.rb{{sb.rewardbase}}
	  sb.rb --> ib.Prepare("Prepare()")
    sb.rb --> ib.GetRB("GetRewardBase()")
  end

  classDef red fill:#fcc
  class cn.setRW,cn.RbW,pm.rb,pm.rw,pm.Set,cn.SetRb red
```

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
