### PR TITLE
node: call CreateSnapshot explicitly when node starts

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2021,6 +2021,13 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		if bc.engine.CreateSnapshot(bc, block.NumberU64(), block.Hash(), nil) != nil {
 			return i, events, coalescedLogs, err
 		}
+
+		// update governance parameters
+		if istanbul, ok := bc.engine.(consensus.Istanbul); ok {
+			if err = istanbul.UpdateParam(block.NumberU64()); err != nil {
+				return i, events, coalescedLogs, err
+			}
+		}
 	}
 	// Append a single chain head event if we've progressed the chain
 	if lastCanon != nil && bc.CurrentBlock().Hash() == lastCanon.Hash() {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -359,7 +359,7 @@ func (c *Clique) verifyCascadingFields(chain consensus.ChainReader, header *type
 	return c.verifySeal(chain, header, parents)
 }
 
-// CreateSnapshot does not return a snapshot but creates a new snapshot at a given point in time.
+// CreateSnapshot does not return a snapshot but creates a new snapshot if not exists at a given point in time
 func (c *Clique) CreateSnapshot(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) error {
 	_, err := c.snapshot(chain, number, hash, parents)
 	return err

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -112,7 +112,7 @@ type Engine interface {
 	// Protocol returns the protocol for this consensus
 	Protocol() Protocol
 
-	// CreateSnapshot does not return a snapshot but creates a new snapshot at a given point in time.
+	// CreateSnapshot does not return a snapshot but creates a new snapshot if not exists at a given point in time.
 	CreateSnapshot(chain ChainReader, number uint64, hash common.Hash, parents []*types.Header) error
 
 	// GetConsensusInfo returns consensus information regarding the given block number.
@@ -154,6 +154,9 @@ type Istanbul interface {
 
 	// SetChain sets chain of the Istanbul backend
 	SetChain(chain ChainReader)
+
+	// UpdateParam updates the governance parameter
+	UpdateParam(num uint64) error
 }
 
 type ConsensusInfo struct {

--- a/work/worker.go
+++ b/work/worker.go
@@ -437,6 +437,13 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 				logger.Error("Failed to call snapshot", "err", err)
 			}
 
+			// update governance parameters
+			if istanbul, ok := self.engine.(consensus.Istanbul); ok {
+				if err := istanbul.UpdateParam(block.NumberU64()); err != nil {
+					logger.Error("Failed to update governance parameters", "err", err)
+				}
+			}
+
 			logger.Info("Successfully wrote mined block", "num", block.NumberU64(),
 				"hash", block.Hash(), "txs", len(block.Transactions()), "elapsed", blockWriteTime)
 			self.chain.PostChainEvents(events, logs)


### PR DESCRIPTION
## Proposed changes
- gov.changeSet
  - gov.changeSet is one of the governance state cache: the vote data which is not stored in governance db yet.
  - It is a memory value. So, if the node shut down before it is flushed into gov db at governance block, it is deleted.
  - but it would restored well when the node restarts during the first `snapshot` call.
- However, after https://github.com/klaytn/klaytn/pull/1706 is applied, missing gov.changeSet problem appears
  - if the first `snapshot` is called by getValidator, it creates the snapshot caches without restoring gov.changeSet (because the snapshot called by getValidator is not able to write governance data)
  -  the next `snapshot` call skip the restoration part always whether it is able to write governance data or not because there's already snapshot cache.
  - and it leads to a verification error due to the mismatch between gov.changeSet and blockHeader.governanceData.
- So, the solution is calling `snapshot` explictly before sync starts to ensure the first `snapshot` call restores gov.changeSet always.
  - currentSet or idxCache are restored during intializeCache, but changeSet does not.

dev
- vote at block 34 and restart immediately
- at the next epoch start block (e.g. 60), it returned verification error
```
ERROR[05/05,09:01:42 Z] [30] Verification Error                        len(receivedChangeSet)=1 len(changeSet)=0
ERROR[05/05,09:01:42 Z] [5]
########## BAD BLOCK #########
...
```
PR
- vote at block 34 and restart immediately
- at the next epoch start block (e.g. 60), it handles governance data properly with out error.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
