### PR TITLE
fixed deterministic logic for first findnode method

### DIFF
--- a/networks/p2p/discover/table.go
+++ b/networks/p2p/discover/table.go
@@ -275,7 +275,9 @@ func (tab *Table) findNewNode(seeds *nodesByDistance, targetID NodeID, targetNT 
 				for _, n := range <-reply {
 					if n != nil && !seen[n.ID] {
 						seen[n.ID] = true
-						seeds.push(n, max)
+						if len(seeds.entries) < max {
+							seeds.entries = append(seeds.entries, n)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Proposed changes

- While initial `lookup`, the returned PN list is used after `findNewNode` method. The PN list will be constructed with `nodeByDistance` struct, which is implemented for Kademlia algorithm originally by Ethereum. The list is made deterministic and it always returns the same PN. This PR fixes this problem.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
