### PR TITLE
Refactor Trie hasher using onRoot flag

### DIFF
--- a/storage/statedb/hasher.go
+++ b/storage/statedb/hasher.go
@@ -74,6 +74,11 @@ func returnHasherToPool(h *hasher) {
 	hasherPool.Put(h)
 }
 
+// hashRoot is similar to hash() but adds special treatment for the root node
+func (h *hasher) hashRoot(n node, db *Database, force bool) (node, node) {
+	return h.hash(n, db, force, true)
+}
+
 // hash collapses a node down into a hash node, also returning a copy of the
 // original node initialized with the computed hash to replace the original one.
 func (h *hasher) hash(n node, db *Database, force bool, onRoot bool) (node, node) {

--- a/storage/statedb/iterator.go
+++ b/storage/statedb/iterator.go
@@ -202,7 +202,7 @@ func (it *nodeIterator) LeafProof() [][]byte {
 
 			for i, item := range it.stack[:len(it.stack)-1] {
 				// Gather nodes that end up as hash nodes (or the root)
-				node, _ := hasher.hashChildren(item.node, nil)
+				node, _ := hasher.hashChildren(item.node, nil, false)
 				hashed, _ := hasher.store(node, nil, false)
 				if _, ok := hashed.(hashNode); ok || i == 0 {
 					enc, _ := rlp.EncodeToBytes(node)

--- a/storage/statedb/proof.go
+++ b/storage/statedb/proof.go
@@ -83,7 +83,7 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDB ProofDBWriter) error {
 	for i, n := range nodes {
 		// Don't bother checking for errors here since hasher panics
 		// if encoding doesn't work and we're not writing to any database.
-		n, _ = hasher.hashChildren(n, nil)
+		n, _ = hasher.hashChildren(n, nil, false)
 		hn, _ := hasher.store(n, nil, false)
 		if hash, ok := hn.(hashNode); ok || i == 0 {
 			// If the node's database encoding is a hash (or is the

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -539,7 +539,7 @@ func (t *Trie) hashRoot(db *Database, onleaf LeafCallback) (node, node) {
 	}
 	h := newHasher(onleaf)
 	defer returnHasherToPool(h)
-	return h.hash(t.root, db, true, true)
+	return h.hashRoot(t.root, db, true)
 }
 
 func GetHashAndHexKey(key []byte) ([]byte, []byte) {

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -539,7 +539,7 @@ func (t *Trie) hashRoot(db *Database, onleaf LeafCallback) (node, node) {
 	}
 	h := newHasher(onleaf)
 	defer returnHasherToPool(h)
-	return h.hashRoot(t.root, db, true)
+	return h.hash(t.root, db, true, true)
 }
 
 func GetHashAndHexKey(key []byte) ([]byte, []byte) {


### PR DESCRIPTION
## Proposed changes

De-duplicate code in the trie hasher (storage/statedb/hasher.go).

- Current implementation has two pairs of similar functions:
  - single-threaded version `hash()` + `hashChildren()`
  - multi-threaded version `hashRoot()` + `hashChildrenFromRoot()`
- This PR removes the latter. Instead, the `onRoot` argument switches multi-threading.
  - `hashNode(..., onRoot)` + `hashChildren(..., onRoot)` runs multi-threaded if onRoot == true.
	  - `hash(...) = hashNode(..., onRoot=false)`
	  - `hashRoot(...) = hashNode(..., onRoot=true)`

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

Benchmark results show that this PR does not affect hashing performance (on Apple M1 Max 10-core)
- Before PR
	```
	$ go test -run=^$ -bench=BenchmarkHash
	BenchmarkHash-10                 2582688               402.2 ns/op           684 B/op          7 allocs/op
	BenchmarkHashFixedSize/10-10       26340             43323 ns/op           14891 B/op        179 allocs/op
	BenchmarkHashFixedSize/100-10              12986             89688 ns/op           66881 B/op        809 allocs/op
	BenchmarkHashFixedSize/1K-10                2024            618712 ns/op          659172 B/op       7811 allocs/op
	BenchmarkHashFixedSize/10K-10                282           4171724 ns/op         6907710 B/op      79703 allocs/op
	BenchmarkHashFixedSize/100K-10                33          35102691 ns/op        68240330 B/op     794537 allocs/op
	```
- After PR
	```
	BenchmarkHash-10                 3081148               439.9 ns/op           677 B/op          7 allocs/op
	BenchmarkHashFixedSize/10-10       27524             42308 ns/op           14262 B/op        178 allocs/op
	BenchmarkHashFixedSize/100-10              13624             88954 ns/op           66293 B/op        808 allocs/op
	BenchmarkHashFixedSize/1K-10                2050            604276 ns/op          658532 B/op       7810 allocs/op
	BenchmarkHashFixedSize/10K-10                280           4168147 ns/op         6906603 B/op      79701 allocs/op
	BenchmarkHashFixedSize/100K-10                30          38524168 ns/op        68240050 B/op     794539 allocs/op
	```
- (for comparison) After PR, if onRoot == false
	```
	BenchmarkHash-10                  564274              2035 ns/op             628 B/op          7 allocs/op
	BenchmarkHashFixedSize/10-10       41187             28873 ns/op           13213 B/op        155 allocs/op
	BenchmarkHashFixedSize/100-10               8718            134050 ns/op           64321 B/op        772 allocs/op
	BenchmarkHashFixedSize/1K-10                 842           1415162 ns/op          649540 B/op       7742 allocs/op
	BenchmarkHashFixedSize/10K-10                 70          17122263 ns/op         6865380 B/op      79500 allocs/op
	BenchmarkHashFixedSize/100K-10                 7         164345345 ns/op        68196154 B/op     794339 allocs/op	
	```