### PR TITLE
Refactor DiskDB trie accessors

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1553,9 +1553,7 @@ func (bc *BlockChain) writeBlockWithStateSerial(block *types.Block, receipts []*
 		if err := bc.writeTxLookupEntries(block); err != nil {
 			return WriteResult{Status: NonStatTy}, err
 		}
-		if err := bc.db.WritePreimages(block.NumberU64(), state.Preimages()); err != nil {
-			return WriteResult{Status: NonStatTy}, err
-		}
+		bc.db.WritePreimages(block.NumberU64(), state.Preimages())
 		status = CanonStatTy
 	} else {
 		status = SideStatTy
@@ -1654,9 +1652,7 @@ func (bc *BlockChain) writeBlockWithStateParallel(block *types.Block, receipts [
 
 		go func() {
 			defer parallelDBWriteWG.Done()
-			if err := bc.db.WritePreimages(block.NumberU64(), state.Preimages()); err != nil {
-				parallelDBWriteErrCh <- err
-			}
+			bc.db.WritePreimages(block.NumberU64(), state.Preimages())
 		}()
 
 		// Wait until all writing goroutines are terminated.

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1553,7 +1553,9 @@ func (bc *BlockChain) writeBlockWithStateSerial(block *types.Block, receipts []*
 		if err := bc.writeTxLookupEntries(block); err != nil {
 			return WriteResult{Status: NonStatTy}, err
 		}
-		bc.db.WritePreimages(block.NumberU64(), state.Preimages())
+		if err := bc.db.WritePreimages(block.NumberU64(), state.Preimages()); err != nil {
+			return WriteResult{Status: NonStatTy}, err
+		}
 		status = CanonStatTy
 	} else {
 		status = SideStatTy
@@ -1652,7 +1654,9 @@ func (bc *BlockChain) writeBlockWithStateParallel(block *types.Block, receipts [
 
 		go func() {
 			defer parallelDBWriteWG.Done()
-			bc.db.WritePreimages(block.NumberU64(), state.Preimages())
+			if err := bc.db.WritePreimages(block.NumberU64(), state.Preimages()); err != nil {
+				parallelDBWriteErrCh <- err
+			}
 		}()
 
 		// Wait until all writing goroutines are terminated.

--- a/blockchain/state/sync_test.go
+++ b/blockchain/state/sync_test.go
@@ -147,7 +147,7 @@ func checkStateAccounts(t *testing.T, newDB database.DBManager, root common.Hash
 
 // checkTrieConsistency checks that all nodes in a (sub-)trie are indeed present.
 func checkTrieConsistency(db database.DBManager, root common.Hash) error {
-	if v, _ := db.ReadStateTrieNode(root[:]); v == nil {
+	if v, _ := db.ReadTrieNode(root); v == nil {
 		return nil // Consider a non existent state consistent.
 	}
 	trie, err := statedb.NewTrie(root, statedb.NewDatabase(db))
@@ -163,7 +163,7 @@ func checkTrieConsistency(db database.DBManager, root common.Hash) error {
 // checkStateConsistency checks that all data of a state root is present.
 func checkStateConsistency(db database.DBManager, root common.Hash) error {
 	// Create and iterate a state trie rooted in a sub-node
-	if _, err := db.ReadStateTrieNode(root.Bytes()); err != nil {
+	if _, err := db.ReadTrieNode(root); err != nil {
 		return nil // Consider a non existent state consistent.
 	}
 	state, err := New(root, NewDatabase(db), nil)

--- a/blockchain/state/sync_test.go
+++ b/blockchain/state/sync_test.go
@@ -387,7 +387,7 @@ func TestCheckStateConsistencyMissNode(t *testing.T) {
 				srcState.DeleteCode(hash)
 				newState.DeleteCode(hash)
 			} else {
-				data, _ = srcDiskDB.ReadCachedTrieNode(hash)
+				data, _ = srcDiskDB.ReadTrieNode(hash)
 				srcDiskDB.GetMemDB().Delete(hash[:])
 				newDiskDB.GetMemDB().Delete(hash[:])
 			}
@@ -670,7 +670,7 @@ func TestIncompleteStateSync(t *testing.T) {
 			val = dstDb.ReadCode(node)
 			dstState.DeleteCode(node)
 		} else {
-			val, _ = dstDb.ReadCachedTrieNode(node)
+			val, _ = dstDb.ReadTrieNode(node)
 			dstDb.GetMemDB().Delete(node[:])
 		}
 

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -46,8 +46,8 @@ type stateTrieMigrationDB struct {
 	database.DBManager
 }
 
-func (td *stateTrieMigrationDB) ReadCachedTrieNode(hash common.Hash) ([]byte, error) {
-	return td.ReadCachedTrieNodeFromNew(hash)
+func (td *stateTrieMigrationDB) ReadTrieNode(hash common.Hash) ([]byte, error) {
+	return td.ReadTrieNodeFromNew(hash)
 }
 
 func (td *stateTrieMigrationDB) ReadCachedTrieNodePreimage(secureKey []byte) ([]byte, error) {

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -50,10 +50,6 @@ func (td *stateTrieMigrationDB) ReadTrieNode(hash common.Hash) ([]byte, error) {
 	return td.ReadTrieNodeFromNew(hash)
 }
 
-func (td *stateTrieMigrationDB) ReadCachedTrieNodePreimage(secureKey []byte) ([]byte, error) {
-	return td.ReadCachedTrieNodePreimageFromNew(secureKey)
-}
-
 func (td *stateTrieMigrationDB) HasTrieNode(hash common.Hash) (bool, error) {
 	return td.HasTrieNodeFromNew(hash)
 }

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -54,10 +54,6 @@ func (td *stateTrieMigrationDB) ReadCachedTrieNodePreimage(secureKey []byte) ([]
 	return td.ReadCachedTrieNodePreimageFromNew(secureKey)
 }
 
-func (td *stateTrieMigrationDB) ReadStateTrieNode(key []byte) ([]byte, error) {
-	return td.ReadStateTrieNodeFromNew(key)
-}
-
 func (td *stateTrieMigrationDB) HasStateTrieNode(key []byte) (bool, error) {
 	return td.HasStateTrieNodeFromNew(key)
 }

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -54,8 +54,8 @@ func (td *stateTrieMigrationDB) ReadCachedTrieNodePreimage(secureKey []byte) ([]
 	return td.ReadCachedTrieNodePreimageFromNew(secureKey)
 }
 
-func (td *stateTrieMigrationDB) HasStateTrieNode(key []byte) (bool, error) {
-	return td.HasStateTrieNodeFromNew(key)
+func (td *stateTrieMigrationDB) HasTrieNode(hash common.Hash) (bool, error) {
+	return td.HasTrieNodeFromNew(hash)
 }
 
 func (td *stateTrieMigrationDB) HasCodeWithPrefix(hash common.Hash) bool {

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -149,7 +149,7 @@ func newTester() *downloadTester {
 		peerMissingStates: make(map[string]map[common.Hash]bool),
 	}
 	tester.stateDb = localdb
-	tester.stateDb.GetMemDB().Put(genesis.Root().Bytes(), []byte{0x00})
+	tester.stateDb.WriteTrieNode(genesis.Root(), []byte{0x00})
 
 	tester.downloader = New(FullSync, tester.stateDb, statedb.NewSyncBloom(1, tester.stateDb.GetMemDB()), new(event.TypeMux), tester, nil, tester.dropPeer, uint64(istanbul.WeightedRandom))
 
@@ -348,7 +348,7 @@ func (dl *downloadTester) CurrentBlock() *types.Block {
 
 	for i := len(dl.ownHashes) - 1; i >= 0; i-- {
 		if block := dl.ownBlocks[dl.ownHashes[i]]; block != nil {
-			if _, err := dl.stateDb.GetMemDB().Get(block.Root().Bytes()); err == nil {
+			if has, _ := dl.stateDb.HasTrieNode(block.Root()); has {
 				return block
 			}
 		}
@@ -430,15 +430,15 @@ func (dl *downloadTester) InsertChain(blocks types.Blocks) (int, error) {
 	for i, block := range blocks {
 		if parent, ok := dl.ownBlocks[block.ParentHash()]; !ok {
 			return i, fmt.Errorf("InsertChain: unknown parent at position %d / %d", i, len(blocks))
-		} else if _, err := dl.stateDb.GetMemDB().Get(parent.Root().Bytes()); err != nil {
-			return i, fmt.Errorf("InsertChain: unknown parent state %x: %v", parent.Root(), err)
+		} else if has, _ := dl.stateDb.HasTrieNode(parent.Root()); !has {
+			return i, fmt.Errorf("InsertChain: unknown parent state %x", parent.Root())
 		}
 		if _, ok := dl.ownHeaders[block.Hash()]; !ok {
 			dl.ownHashes = append(dl.ownHashes, block.Hash())
 			dl.ownHeaders[block.Hash()] = block.Header()
 		}
 		dl.ownBlocks[block.Hash()] = block
-		dl.stateDb.GetMemDB().Put(block.Root().Bytes(), []byte{0x00})
+		dl.stateDb.WriteTrieNode(block.Root(), []byte{0x00})
 		dl.ownChainTd[block.Hash()] = new(big.Int).Add(dl.ownChainTd[block.ParentHash()], block.BlockScore())
 	}
 	return len(blocks), nil
@@ -734,7 +734,7 @@ func (dlp *downloadTesterPeer) RequestNodeData(hashes []common.Hash) error {
 
 	results := make([][]byte, 0, len(hashes))
 	for _, hash := range hashes {
-		if data, err := dlp.dl.peerDb.GetMemDB().Get(hash.Bytes()); err == nil {
+		if data, err := dlp.dl.peerDb.ReadTrieNode(hash); err == nil {
 			if !dlp.dl.peerMissingStates[dlp.id][hash] {
 				results = append(results, data)
 			}

--- a/node/cn/snap/nodeset.go
+++ b/node/cn/snap/nodeset.go
@@ -47,7 +47,7 @@ func NewNodeSet() *NodeSet {
 	}
 }
 
-func (db *NodeSet) ReadCachedTrieNode(hash common.Hash) ([]byte, error) {
+func (db *NodeSet) ReadTrieNode(hash common.Hash) ([]byte, error) {
 	return db.Get(hash.Bytes())
 }
 

--- a/node/cn/snap/sync.go
+++ b/node/cn/snap/sync.go
@@ -1791,7 +1791,7 @@ func (s *Syncer) processAccountResponse(res *accountResponse) {
 		}
 		// Check if the account is a contract with an unknown storage trie
 		if pacc != nil && pacc.GetStorageRoot() != emptyRoot {
-			if ok, err := s.db.HasStateTrieNode(pacc.GetStorageRoot().Bytes()); err != nil || !ok {
+			if ok, err := s.db.HasTrieNode(pacc.GetStorageRoot()); err != nil || !ok {
 				// If there was a previous large state retrieval in progress,
 				// don't restart it from scratch. This happens if a sync cycle
 				// is interrupted and resumed later. However, *do* update the

--- a/node/cn/snap/sync.go
+++ b/node/cn/snap/sync.go
@@ -1854,9 +1854,7 @@ func (s *Syncer) processBytecodeResponse(res *bytecodeResponse) {
 		}
 		// Push the bytecode into a database batch
 		codes++
-		if err := batch.Put(database.CodeKey(hash), code); err != nil {
-			logger.Crit("Failed to store contract code", "err", err)
-		}
+		s.db.PutCodeToBatch(batch, hash, code)
 	}
 	bytes := common.StorageSize(batch.ValueSize())
 	if err := batch.Write(); err != nil {

--- a/snapshot/generate_test.go
+++ b/snapshot/generate_test.go
@@ -467,7 +467,7 @@ func TestGenerateCorruptAccountTrie(t *testing.T) {
 	// Delete an account trie leaf and ensure the generator chokes
 	// TODO-Klaytn-Snapshot put propoer block number
 	triedb.Commit(common.HexToHash("0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978"), false, 0)
-	diskdb.GetMemDB().Delete(common.HexToHash("0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7").Bytes())
+	diskdb.DeleteTrieNode(common.HexToHash("0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7"))
 
 	snap := generateSnapshot(diskdb, triedb, 16, common.HexToHash("0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978"))
 	select {
@@ -531,7 +531,7 @@ func TestGenerateMissingStorageTrie(t *testing.T) {
 	triedb.Commit(common.HexToHash("0xa2282b99de1fc11e32d26bee37707ef49a6978b2d375796a1b026a497193a2ef"), false, 0)
 
 	// Delete a storage trie root and ensure the generator chokes
-	diskdb.GetMemDB().Delete(common.HexToHash("0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67").Bytes())
+	diskdb.DeleteTrieNode(common.HexToHash("0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67"))
 
 	snap := generateSnapshot(diskdb, triedb, 16, common.HexToHash("0xa2282b99de1fc11e32d26bee37707ef49a6978b2d375796a1b026a497193a2ef"))
 	select {
@@ -594,7 +594,7 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 	triedb.Commit(common.HexToHash("0x4a651234bc4b8c7462b5ad4eb95bbb724eb636fed72bb5278d886f9ea4c345f8"), false, 0)
 
 	// Delete a storage trie leaf and ensure the generator chokes
-	diskdb.GetMemDB().Delete(common.HexToHash("0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371").Bytes())
+	diskdb.DeleteTrieNode(common.HexToHash("0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371"))
 
 	snap := generateSnapshot(diskdb, triedb, 16, common.HexToHash("0x4a651234bc4b8c7462b5ad4eb95bbb724eb636fed72bb5278d886f9ea4c345f8"))
 	select {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -147,7 +147,6 @@ type DBManager interface {
 	ReadTrieNode(hash common.Hash) ([]byte, error)
 	HasTrieNode(hash common.Hash) (bool, error)
 	ReadCachedTrieNodePreimage(secureKey []byte) ([]byte, error)
-	ReadStateTrieNode(key []byte) ([]byte, error)
 	HasStateTrieNode(key []byte) (bool, error)
 	HasCodeWithPrefix(hash common.Hash) bool
 	ReadPreimage(hash common.Hash) []byte
@@ -156,7 +155,6 @@ type DBManager interface {
 	ReadTrieNodeFromNew(hash common.Hash) ([]byte, error)
 	HasTrieNodeFromNew(hash common.Hash) (bool, error)
 	ReadCachedTrieNodePreimageFromNew(secureKey []byte) ([]byte, error)
-	ReadStateTrieNodeFromNew(key []byte) ([]byte, error)
 	HasStateTrieNodeFromNew(key []byte) (bool, error)
 	HasCodeWithPrefixFromNew(hash common.Hash) bool
 	ReadPreimageFromNew(hash common.Hash) []byte
@@ -165,7 +163,6 @@ type DBManager interface {
 	ReadTrieNodeFromOld(hash common.Hash) ([]byte, error)
 	HasTrieNodeFromOld(hash common.Hash) (bool, error)
 	ReadCachedTrieNodePreimageFromOld(secureKey []byte) ([]byte, error)
-	ReadStateTrieNodeFromOld(key []byte) ([]byte, error)
 	HasStateTrieNodeFromOld(key []byte) (bool, error)
 	HasCodeWithPrefixFromOld(hash common.Hash) bool
 	ReadPreimageFromOld(hash common.Hash) []byte

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1792,7 +1792,7 @@ func (dbm *databaseManager) ReadPreimage(hash common.Hash) []byte {
 }
 
 func (dbm *databaseManager) ReadTrieNodeFromNew(hash common.Hash) ([]byte, error) {
-	return dbm.GetStateTrieMigrationDB().Get(hash[:])
+	return dbm.GetStateTrieMigrationDB().Get(TrieNodeKey(hash))
 }
 
 func (dbm *databaseManager) HasTrieNodeFromNew(hash common.Hash) (bool, error) {
@@ -1818,7 +1818,7 @@ func (dbm *databaseManager) ReadPreimageFromNew(hash common.Hash) []byte {
 
 func (dbm *databaseManager) ReadTrieNodeFromOld(hash common.Hash) ([]byte, error) {
 	db := dbm.getDatabase(StateTrieDB)
-	return db.Get(hash[:])
+	return db.Get(TrieNodeKey(hash))
 }
 
 func (dbm *databaseManager) HasTrieNodeFromOld(hash common.Hash) (bool, error) {
@@ -1848,15 +1848,15 @@ func (dbm *databaseManager) WriteTrieNode(hash common.Hash, node []byte) error {
 	defer dbm.lockInMigration.RUnlock()
 
 	if dbm.inMigration {
-		if err := dbm.getDatabase(StateTrieMigrationDB).Put(hash[:], node); err != nil {
+		if err := dbm.getDatabase(StateTrieMigrationDB).Put(TrieNodeKey(hash), node); err != nil {
 			return err
 		}
 	}
-	return dbm.getDatabase(StateTrieDB).Put(hash[:], node)
+	return dbm.getDatabase(StateTrieDB).Put(TrieNodeKey(hash), node)
 }
 
 func (dbm *databaseManager) PutTrieNodeToBatch(batch Batch, hash common.Hash, node []byte) error {
-	return batch.Put(hash[:], node)
+	return batch.Put(TrieNodeKey(hash), node)
 }
 
 // WritePreimages writes the provided set of preimages to the database. `number` is the
@@ -1880,7 +1880,7 @@ func (dbm *databaseManager) WritePreimages(number uint64, preimages map[common.H
 }
 
 func (dbm *databaseManager) DeleteTrieNode(hash common.Hash) error {
-	return dbm.getDatabase(StateTrieDB).Delete(hash[:])
+	return dbm.getDatabase(StateTrieDB).Delete(TrieNodeKey(hash))
 }
 
 // ReadTxLookupEntry retrieves the positional metadata associated with a transaction

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -464,9 +464,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		assert.False(t, hasStateTrieNode)
 
 		batch := dbm.NewBatch(StateTrieDB)
-		if err := dbm.PutTrieNodeToBatch(batch, hash1, node2); err != nil {
-			t.Fatal("Failed putting a row into the batch", "err", err)
-		}
+		dbm.PutTrieNodeToBatch(batch, hash1, node2)
 		if _, err := WriteBatches(batch); err != nil {
 			t.Fatal("Failed writing batch", "err", err)
 		}
@@ -474,9 +472,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		cachedNode, _ = dbm.ReadTrieNode(hash1)
 		assert.Equal(t, node2, cachedNode)
 
-		if err := dbm.PutTrieNodeToBatch(batch, hash1, node1); err != nil {
-			t.Fatal("Failed putting a row into the batch", "err", err)
-		}
+		dbm.PutTrieNodeToBatch(batch, hash1, node1)
 		if _, err := WriteBatches(batch); err != nil {
 			t.Fatal("Failed writing batch", "err", err)
 		}
@@ -504,9 +500,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		assert.True(t, hasOldStateTrieNode)
 
 		batch = dbm.NewBatch(StateTrieDB)
-		if err := dbm.PutTrieNodeToBatch(batch, hash2, node2); err != nil {
-			t.Fatal("Failed putting a row into the batch", "err", err)
-		}
+		dbm.PutTrieNodeToBatch(batch, hash2, node2)
 		if _, err := WriteBatches(batch); err != nil {
 			t.Fatal("Failed writing batch", "err", err)
 		}

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -453,6 +453,10 @@ func TestDBManager_IstanbulSnapshot(t *testing.T) {
 // TestDBManager_TrieNode tests read and write operations of state trie nodes.
 func TestDBManager_TrieNode(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
+	var (
+		node1 = hash1[:]
+		node2 = hash2[:]
+	)
 	for _, dbm := range dbManagers {
 		cachedNode, _ := dbm.ReadTrieNode(hash1)
 		assert.Nil(t, cachedNode)
@@ -460,7 +464,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		assert.False(t, hasStateTrieNode)
 
 		batch := dbm.NewBatch(StateTrieDB)
-		if err := batch.Put(hash1[:], hash2[:]); err != nil {
+		if err := dbm.PutTrieNodeToBatch(batch, hash1, node2); err != nil {
 			t.Fatal("Failed putting a row into the batch", "err", err)
 		}
 		if _, err := WriteBatches(batch); err != nil {
@@ -468,9 +472,9 @@ func TestDBManager_TrieNode(t *testing.T) {
 		}
 
 		cachedNode, _ = dbm.ReadTrieNode(hash1)
-		assert.Equal(t, hash2[:], cachedNode)
+		assert.Equal(t, node2, cachedNode)
 
-		if err := batch.Put(hash1[:], hash1[:]); err != nil {
+		if err := dbm.PutTrieNodeToBatch(batch, hash1, node1); err != nil {
 			t.Fatal("Failed putting a row into the batch", "err", err)
 		}
 		if _, err := WriteBatches(batch); err != nil {
@@ -478,7 +482,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		}
 
 		cachedNode, _ = dbm.ReadTrieNode(hash1)
-		assert.Equal(t, hash1[:], cachedNode)
+		assert.Equal(t, node1, cachedNode)
 
 		hasStateTrieNode, _ = dbm.HasTrieNode(hash1)
 		assert.True(t, hasStateTrieNode)
@@ -491,8 +495,8 @@ func TestDBManager_TrieNode(t *testing.T) {
 
 		cachedNode, _ = dbm.ReadTrieNode(hash1)
 		oldCachedNode, _ := dbm.ReadTrieNodeFromOld(hash1)
-		assert.Equal(t, hash1[:], cachedNode)
-		assert.Equal(t, hash1[:], oldCachedNode)
+		assert.Equal(t, node1, cachedNode)
+		assert.Equal(t, node1, oldCachedNode)
 
 		hasStateTrieNode, _ = dbm.HasTrieNode(hash1)
 		hasOldStateTrieNode, _ := dbm.HasTrieNodeFromOld(hash1)
@@ -500,7 +504,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		assert.True(t, hasOldStateTrieNode)
 
 		batch = dbm.NewBatch(StateTrieDB)
-		if err := batch.Put(hash2[:], hash2[:]); err != nil {
+		if err := dbm.PutTrieNodeToBatch(batch, hash2, node2); err != nil {
 			t.Fatal("Failed putting a row into the batch", "err", err)
 		}
 		if _, err := WriteBatches(batch); err != nil {
@@ -509,8 +513,8 @@ func TestDBManager_TrieNode(t *testing.T) {
 
 		cachedNode, _ = dbm.ReadTrieNode(hash2)
 		oldCachedNode, _ = dbm.ReadTrieNodeFromOld(hash2)
-		assert.Equal(t, hash2[:], cachedNode)
-		assert.Equal(t, hash2[:], oldCachedNode)
+		assert.Equal(t, node2, cachedNode)
+		assert.Equal(t, node2, oldCachedNode)
 
 		hasStateTrieNode, _ = dbm.HasTrieNode(hash2)
 		hasOldStateTrieNode, _ = dbm.HasTrieNodeFromOld(hash2)

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -456,7 +456,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 	for _, dbm := range dbManagers {
 		cachedNode, _ := dbm.ReadTrieNode(hash1)
 		assert.Nil(t, cachedNode)
-		hasStateTrieNode, _ := dbm.HasStateTrieNode(hash1[:])
+		hasStateTrieNode, _ := dbm.HasTrieNode(hash1)
 		assert.False(t, hasStateTrieNode)
 
 		batch := dbm.NewBatch(StateTrieDB)
@@ -480,7 +480,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 		cachedNode, _ = dbm.ReadTrieNode(hash1)
 		assert.Equal(t, hash1[:], cachedNode)
 
-		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash1[:])
+		hasStateTrieNode, _ = dbm.HasTrieNode(hash1)
 		assert.True(t, hasStateTrieNode)
 
 		if dbm.IsSingle() {
@@ -494,8 +494,8 @@ func TestDBManager_TrieNode(t *testing.T) {
 		assert.Equal(t, hash1[:], cachedNode)
 		assert.Equal(t, hash1[:], oldCachedNode)
 
-		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash1[:])
-		hasOldStateTrieNode, _ := dbm.HasStateTrieNodeFromOld(hash1[:])
+		hasStateTrieNode, _ = dbm.HasTrieNode(hash1)
+		hasOldStateTrieNode, _ := dbm.HasTrieNodeFromOld(hash1)
 		assert.True(t, hasStateTrieNode)
 		assert.True(t, hasOldStateTrieNode)
 
@@ -512,8 +512,8 @@ func TestDBManager_TrieNode(t *testing.T) {
 		assert.Equal(t, hash2[:], cachedNode)
 		assert.Equal(t, hash2[:], oldCachedNode)
 
-		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash2[:])
-		hasOldStateTrieNode, _ = dbm.HasStateTrieNodeFromOld(hash2[:])
+		hasStateTrieNode, _ = dbm.HasTrieNode(hash2)
+		hasOldStateTrieNode, _ = dbm.HasTrieNodeFromOld(hash2)
 		assert.True(t, hasStateTrieNode)
 		assert.True(t, hasOldStateTrieNode)
 

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -480,9 +480,6 @@ func TestDBManager_TrieNode(t *testing.T) {
 		cachedNode, _ = dbm.ReadTrieNode(hash1)
 		assert.Equal(t, hash1[:], cachedNode)
 
-		stateTrieNode, _ := dbm.ReadStateTrieNode(hash1[:])
-		assert.Equal(t, hash1[:], stateTrieNode)
-
 		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash1[:])
 		assert.True(t, hasStateTrieNode)
 
@@ -496,11 +493,6 @@ func TestDBManager_TrieNode(t *testing.T) {
 		oldCachedNode, _ := dbm.ReadTrieNodeFromOld(hash1)
 		assert.Equal(t, hash1[:], cachedNode)
 		assert.Equal(t, hash1[:], oldCachedNode)
-
-		stateTrieNode, _ = dbm.ReadStateTrieNode(hash1[:])
-		oldStateTrieNode, _ := dbm.ReadStateTrieNodeFromOld(hash1[:])
-		assert.Equal(t, hash1[:], stateTrieNode)
-		assert.Equal(t, hash1[:], oldStateTrieNode)
 
 		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash1[:])
 		hasOldStateTrieNode, _ := dbm.HasStateTrieNodeFromOld(hash1[:])
@@ -519,11 +511,6 @@ func TestDBManager_TrieNode(t *testing.T) {
 		oldCachedNode, _ = dbm.ReadTrieNodeFromOld(hash2)
 		assert.Equal(t, hash2[:], cachedNode)
 		assert.Equal(t, hash2[:], oldCachedNode)
-
-		stateTrieNode, _ = dbm.ReadStateTrieNode(hash2[:])
-		oldStateTrieNode, _ = dbm.ReadStateTrieNodeFromOld(hash2[:])
-		assert.Equal(t, hash2[:], stateTrieNode)
-		assert.Equal(t, hash2[:], oldStateTrieNode)
 
 		hasStateTrieNode, _ = dbm.HasStateTrieNode(hash2[:])
 		hasOldStateTrieNode, _ = dbm.HasStateTrieNodeFromOld(hash2[:])

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -454,7 +454,7 @@ func TestDBManager_IstanbulSnapshot(t *testing.T) {
 func TestDBManager_TrieNode(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	for _, dbm := range dbManagers {
-		cachedNode, _ := dbm.ReadCachedTrieNode(hash1)
+		cachedNode, _ := dbm.ReadTrieNode(hash1)
 		assert.Nil(t, cachedNode)
 		hasStateTrieNode, _ := dbm.HasStateTrieNode(hash1[:])
 		assert.False(t, hasStateTrieNode)
@@ -467,7 +467,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 			t.Fatal("Failed writing batch", "err", err)
 		}
 
-		cachedNode, _ = dbm.ReadCachedTrieNode(hash1)
+		cachedNode, _ = dbm.ReadTrieNode(hash1)
 		assert.Equal(t, hash2[:], cachedNode)
 
 		if err := batch.Put(hash1[:], hash1[:]); err != nil {
@@ -477,7 +477,7 @@ func TestDBManager_TrieNode(t *testing.T) {
 			t.Fatal("Failed writing batch", "err", err)
 		}
 
-		cachedNode, _ = dbm.ReadCachedTrieNode(hash1)
+		cachedNode, _ = dbm.ReadTrieNode(hash1)
 		assert.Equal(t, hash1[:], cachedNode)
 
 		stateTrieNode, _ := dbm.ReadStateTrieNode(hash1[:])
@@ -492,8 +492,8 @@ func TestDBManager_TrieNode(t *testing.T) {
 		err := dbm.CreateMigrationDBAndSetStatus(123)
 		assert.NoError(t, err)
 
-		cachedNode, _ = dbm.ReadCachedTrieNode(hash1)
-		oldCachedNode, _ := dbm.ReadCachedTrieNodeFromOld(hash1)
+		cachedNode, _ = dbm.ReadTrieNode(hash1)
+		oldCachedNode, _ := dbm.ReadTrieNodeFromOld(hash1)
 		assert.Equal(t, hash1[:], cachedNode)
 		assert.Equal(t, hash1[:], oldCachedNode)
 
@@ -515,8 +515,8 @@ func TestDBManager_TrieNode(t *testing.T) {
 			t.Fatal("Failed writing batch", "err", err)
 		}
 
-		cachedNode, _ = dbm.ReadCachedTrieNode(hash2)
-		oldCachedNode, _ = dbm.ReadCachedTrieNodeFromOld(hash2)
+		cachedNode, _ = dbm.ReadTrieNode(hash2)
+		oldCachedNode, _ = dbm.ReadTrieNodeFromOld(hash2)
 		assert.Equal(t, hash2[:], cachedNode)
 		assert.Equal(t, hash2[:], oldCachedNode)
 

--- a/storage/database/interface.go
+++ b/storage/database/interface.go
@@ -136,18 +136,3 @@ func WriteBatchesOverThreshold(batches ...Batch) (int, error) {
 	}
 	return bytes, nil
 }
-
-func PutAndWriteBatchesOverThreshold(batch Batch, key, val []byte) error {
-	if err := batch.Put(key, val); err != nil {
-		return err
-	}
-
-	if batch.ValueSize() >= IdealBatchSize {
-		if err := batch.Write(); err != nil {
-			return err
-		}
-		batch.Reset()
-	}
-
-	return nil
-}

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -261,3 +261,8 @@ func makeKey(prefix []byte, num uint64) []byte {
 func databaseDirKey(dbEntryType uint64) []byte {
 	return append(databaseDirPrefix, common.Int64ToByteBigEndian(dbEntryType)...)
 }
+
+// TrieNodeKey = hash
+func TrieNodeKey(hash common.Hash) []byte {
+	return hash.Bytes()
+}

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -516,7 +516,7 @@ func (db *Database) node(hash common.Hash) (n node, fromDB bool) {
 	}
 
 	// Content unavailable in memory, attempt to retrieve from disk
-	enc, err := db.diskDB.ReadCachedTrieNode(hash)
+	enc, err := db.diskDB.ReadTrieNode(hash)
 	if err != nil || enc == nil {
 		return nil, true
 	}
@@ -544,7 +544,7 @@ func (db *Database) Node(hash common.Hash) ([]byte, error) {
 		return node.rlp(), nil
 	}
 	// Content unavailable in memory, attempt to retrieve from disk
-	enc, err := db.diskDB.ReadCachedTrieNode(hash)
+	enc, err := db.diskDB.ReadTrieNode(hash)
 	if err == nil && enc != nil {
 		db.setCachedNode(hash[:], enc)
 	}
@@ -571,7 +571,7 @@ func (db *Database) NodeFromOld(hash common.Hash) ([]byte, error) {
 		return node.rlp(), nil
 	}
 	// Content unavailable in memory, attempt to retrieve from disk
-	enc, err := db.diskDB.ReadCachedTrieNodeFromOld(hash)
+	enc, err := db.diskDB.ReadTrieNodeFromOld(hash)
 	if err == nil && enc != nil {
 		db.setCachedNode(hash[:], enc)
 	}
@@ -595,7 +595,7 @@ func (db *Database) DoesExistNodeInPersistent(hash common.Hash) bool {
 	}
 
 	// Content unavailable in DB cache, attempt to retrieve from disk
-	enc, err := db.diskDB.ReadCachedTrieNode(hash)
+	enc, err := db.diskDB.ReadTrieNode(hash)
 	if err == nil && enc != nil {
 		return true
 	}

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -815,7 +815,8 @@ func (db *Database) Cap(limit common.StorageSize) error {
 }
 
 func (db *Database) writeBatchPreimages() error {
-	return db.diskDB.WritePreimages(0, db.preimages)
+	db.diskDB.WritePreimages(0, db.preimages)
+	return nil
 }
 
 // commitResult contains the result from concurrent commit calls.

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -751,10 +751,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 		// Fetch the oldest referenced node and push into the batch
 		node := db.nodes[oldest]
 		enc := node.rlp()
-		if err := db.diskDB.PutTrieNodeToBatch(batch, oldest, enc); err != nil {
-			db.lock.RUnlock()
-			return err
-		}
+		db.diskDB.PutTrieNodeToBatch(batch, oldest, enc)
 		if _, err := database.WriteBatchesOverThreshold(batch); err != nil {
 			db.lock.RUnlock()
 			return err
@@ -853,18 +850,14 @@ func (db *Database) writeBatchNodes(node common.Hash) error {
 			continue
 		}
 
-		if err := db.diskDB.PutTrieNodeToBatch(batch, result.hash, result.val); err != nil {
-			return err
-		}
+		db.diskDB.PutTrieNodeToBatch(batch, result.hash, result.val)
 		if _, err := database.WriteBatchesOverThreshold(batch); err != nil {
 			return err
 		}
 	}
 
 	enc := rootNode.rlp()
-	if err := db.diskDB.PutTrieNodeToBatch(batch, node, enc); err != nil {
-		return err
-	}
+	db.diskDB.PutTrieNodeToBatch(batch, node, enc)
 	if err := batch.Write(); err != nil {
 		logger.Error("Failed to write trie to disk", "err", err)
 		return err

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -605,17 +605,17 @@ func (db *Database) DoesExistNodeInPersistent(hash common.Hash) bool {
 
 // preimage retrieves a cached trie node pre-image from memory. If it cannot be
 // found cached, the method queries the persistent database for the content.
-func (db *Database) preimage(hash common.Hash) ([]byte, error) {
+func (db *Database) preimage(hash common.Hash) []byte {
 	// Retrieve the node from cache if available
 	db.lock.RLock()
 	preimage := db.preimages[hash]
 	db.lock.RUnlock()
 
 	if preimage != nil {
-		return preimage, nil
+		return preimage
 	}
 	// Content unavailable in memory, attempt to retrieve from disk
-	return db.diskDB.ReadCachedTrieNodePreimage(secureKey(hash))
+	return db.diskDB.ReadPreimage(hash)
 }
 
 // secureKey returns the database key for the preimage of key (as a newly

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -112,17 +112,6 @@ func TestDatabase_Size(t *testing.T) {
 	assert.Equal(t, common.StorageSize(100), preimagesSize)
 }
 
-func TestDatabase_SecureKey(t *testing.T) {
-	secKey1 := secureKey(childHash)
-	copiedSecKey := make([]byte, len(secKey1))
-	copy(copiedSecKey, secKey1)
-
-	secKey2 := secureKey(parentHash)
-
-	assert.Equal(t, secKey1, copiedSecKey) // after the next call of secureKey, secKey1 became different from the copied
-	assert.NotEqual(t, secKey1, secKey2)   // secKey1 has changed into secKey2 as they are created from the different buffer
-}
-
 func TestCache(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
 	db := NewDatabaseWithNewCache(memDB, &TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMiB: 10})

--- a/storage/statedb/hasher_test.go
+++ b/storage/statedb/hasher_test.go
@@ -41,7 +41,7 @@ func checkHasherHashFunc(t *testing.T, idx int, tc *testNodeEncodingTC, hashFunc
 	assert.Equal(t, tc.inserted, inserted, idx)
 
 	db.Cap(0)
-	encoded, _ := memDB.ReadCachedTrieNode(hash)
+	encoded, _ := memDB.ReadTrieNode(hash)
 	assert.Equal(t, tc.encoded, encoded, idx)
 }
 

--- a/storage/statedb/iterator.go
+++ b/storage/statedb/iterator.go
@@ -314,7 +314,7 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 func (it *nodeIterator) resolveHash(hash hashNode, path []byte) (node, error) {
 	if it.resolver != nil {
 		hash := common.BytesToHash(hash)
-		enc, _ := it.resolver.ReadCachedTrieNode(hash)
+		enc, _ := it.resolver.ReadTrieNode(hash)
 		if enc != nil {
 			if resolved, err := decodeNode(hash[:], enc); err == nil {
 				return resolved, nil

--- a/storage/statedb/iterator_test.go
+++ b/storage/statedb/iterator_test.go
@@ -293,9 +293,9 @@ func TestIteratorContinueAfterErrorDisk(t *testing.T)    { testIteratorContinueA
 func TestIteratorContinueAfterErrorMemonly(t *testing.T) { testIteratorContinueAfterError(t, true) }
 
 func testIteratorContinueAfterError(t *testing.T, memonly bool) {
-	memDBManager := database.NewMemoryDBManager()
-	diskdb := memDBManager.GetMemDB()
-	triedb := NewDatabase(memDBManager)
+	dbm := database.NewMemoryDBManager()
+	diskdb := dbm.GetMemDB()
+	triedb := NewDatabase(dbm)
 
 	tr, _ := NewTrie(common.Hash{}, triedb)
 	for _, val := range testdata1 {
@@ -341,8 +341,8 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 			robj = triedb.nodes[rkey]
 			delete(triedb.nodes, rkey)
 		} else {
-			rval, _ = diskdb.Get(rkey[:])
-			diskdb.Delete(rkey[:])
+			rval, _ = dbm.ReadTrieNode(rkey)
+			dbm.DeleteTrieNode(rkey)
 		}
 		// Iterate until the error is hit.
 		seen := make(map[string]bool)
@@ -357,7 +357,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 		if memonly {
 			triedb.nodes[rkey] = robj
 		} else {
-			diskdb.Put(rkey[:], rval)
+			dbm.WriteTrieNode(rkey, rval)
 		}
 		checkIteratorNoDups(t, it, seen)
 		if it.Error() != nil {
@@ -382,9 +382,8 @@ func TestIteratorContinueAfterSeekErrorMemonly(t *testing.T) {
 
 func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	// Commit test trie to db, then remove the node containing "bars".
-	memDBManager := database.NewMemoryDBManager()
-	diskdb := memDBManager.GetMemDB()
-	triedb := NewDatabase(memDBManager)
+	dbm := database.NewMemoryDBManager()
+	triedb := NewDatabase(dbm)
 
 	ctr, _ := NewTrie(common.Hash{}, triedb)
 	for _, val := range testdata1 {
@@ -403,8 +402,8 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 		barNodeObj = triedb.nodes[barNodeHash]
 		delete(triedb.nodes, barNodeHash)
 	} else {
-		barNodeBlob, _ = diskdb.Get(barNodeHash[:])
-		diskdb.Delete(barNodeHash[:])
+		barNodeBlob, _ = dbm.ReadTrieNode(barNodeHash)
+		dbm.DeleteTrieNode(barNodeHash)
 	}
 	// Create a new iterator that seeks to "bars". Seeking can't proceed because
 	// the node is missing.
@@ -420,7 +419,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	if memonly {
 		triedb.nodes[barNodeHash] = barNodeObj
 	} else {
-		diskdb.Put(barNodeHash[:], barNodeBlob)
+		dbm.WriteTrieNode(barNodeHash, barNodeBlob)
 	}
 	// Check that iteration produces the right set of values.
 	if err := checkIteratorOrder(testdata1[2:], NewIterator(it)); err != nil {

--- a/storage/statedb/proof.go
+++ b/storage/statedb/proof.go
@@ -36,7 +36,7 @@ type ProofDBWriter interface {
 }
 
 type ProofDBReader interface {
-	ReadCachedTrieNode(hash common.Hash) ([]byte, error)
+	ReadTrieNode(hash common.Hash) ([]byte, error)
 }
 
 // Prove constructs a merkle proof for key. The result contains all encoded nodes
@@ -121,7 +121,7 @@ func VerifyProof(rootHash common.Hash, key []byte, proofDB database.DBManager) (
 	key = keybytesToHex(key)
 	wantHash := rootHash
 	for i := 0; ; i++ {
-		buf, _ := proofDB.ReadCachedTrieNode(wantHash)
+		buf, _ := proofDB.ReadTrieNode(wantHash)
 		if buf == nil {
 			return nil, fmt.Errorf("proof node %d (hash %064x) missing", i, wantHash), i
 		}
@@ -151,7 +151,7 @@ func VerifyProof(rootHash common.Hash, key []byte, proofDB database.DBManager) (
 func proofToPath(rootHash common.Hash, root node, key []byte, proofDb ProofDBReader, allowNonExistent bool) (node, []byte, error) {
 	// resolveNode retrieves and resolves trie node from merkle proof stream
 	resolveNode := func(hash common.Hash) (node, error) {
-		buf, _ := proofDb.ReadCachedTrieNode(hash)
+		buf, _ := proofDb.ReadTrieNode(hash)
 		if buf == nil {
 			return nil, fmt.Errorf("proof node (hash %064x) missing", hash)
 		}

--- a/storage/statedb/secure_trie.go
+++ b/storage/statedb/secure_trie.go
@@ -159,7 +159,7 @@ func (t *SecureTrie) GetKey(shaKey []byte) []byte {
 	if key, ok := t.getSecKeyCache()[string(shaKey)]; ok {
 		return key
 	}
-	key, _ := t.trie.db.preimage(common.BytesToHash(shaKey))
+	key := t.trie.db.preimage(common.BytesToHash(shaKey))
 	return key
 }
 

--- a/storage/statedb/stacktrie.go
+++ b/storage/statedb/stacktrie.go
@@ -463,9 +463,7 @@ func (st *StackTrie) hash() {
 	h.sha.Write(h.tmp)
 	h.sha.Read(st.val)
 	if st.db != nil {
-		// TODO! Is it safe to Put the slice here?
-		// Do all db implementations copy the value provided?
-		st.db.GetStateTrieDB().Put(st.val, h.tmp)
+		st.db.WriteTrieNode(common.BytesToHash(st.val), h.tmp)
 	}
 }
 
@@ -509,7 +507,7 @@ func (st *StackTrie) Commit() (common.Hash, error) {
 		h.sha.Reset()
 		h.sha.Write(st.val)
 		h.sha.Read(ret)
-		st.db.GetStateTrieDB().Put(ret, st.val)
+		st.db.WriteTrieNode(common.BytesToHash(ret), st.val)
 		return common.BytesToHash(ret), nil
 	}
 	return common.BytesToHash(st.val), nil

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -127,7 +127,7 @@ func (batch *syncMemBatch) hasCode(hash common.Hash) bool {
 
 type StateTrieReadDB interface {
 	ReadTrieNode(hash common.Hash) ([]byte, error)
-	HasStateTrieNode(key []byte) (bool, error)
+	HasTrieNode(hash common.Hash) (bool, error)
 	HasCodeWithPrefix(hash common.Hash) bool
 }
 
@@ -184,7 +184,7 @@ func (s *TrieSync) AddSubTrie(root common.Hash, path []byte, depth int, parent c
 		// Bloom filter says this might be a duplicate, double check.
 		// If database says yes, then at least the trie node is present
 		// and we hold the assumption that it's NOT legacy contract code.
-		if ok, _ := s.database.HasStateTrieNode(root[:]); ok {
+		if ok, _ := s.database.HasTrieNode(root); ok {
 			logger.Debug("skip write sub-trie", "root", root.String())
 			return
 		}
@@ -480,7 +480,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 				// Bloom filter says this might be a duplicate, double check.
 				// If database says yes, then at least the trie node is present
 				// and we hold the assumption that it's NOT legacy contract code.
-				if ok, _ := s.database.HasStateTrieNode(node); ok {
+				if ok, _ := s.database.HasTrieNode(hash); ok {
 					continue
 				}
 				// False positive, bump fault meter

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -346,7 +346,7 @@ func (s *TrieSync) Commit(dbw database.Batch) (int, error) {
 	written := 0
 	// Dump the membatch into a database dbw
 	for key, value := range s.membatch.nodes {
-		if err := dbw.Put(key[:], value); err != nil {
+		if err := dbw.Put(database.TrieNodeKey(key), value); err != nil {
 			return written, err
 		}
 		if s.bloom != nil {

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -126,7 +126,7 @@ func (batch *syncMemBatch) hasCode(hash common.Hash) bool {
 }
 
 type StateTrieReadDB interface {
-	ReadStateTrieNode(key []byte) ([]byte, error)
+	ReadTrieNode(hash common.Hash) ([]byte, error)
 	HasStateTrieNode(key []byte) (bool, error)
 	HasCodeWithPrefix(hash common.Hash) bool
 }

--- a/storage/statedb/sync_test.go
+++ b/storage/statedb/sync_test.go
@@ -508,7 +508,7 @@ func TestSyncOrdering(t *testing.T) {
 				t.Fatalf("failed to process result %v", err)
 			}
 		}
-		batch := diskdb.GetMemDB().NewBatch()
+		batch := diskdb.NewBatch(database.StateTrieDB)
 		if _, err := sched.Commit(batch); err != nil {
 			t.Fatalf("failed to commit data: %v", err)
 		}

--- a/storage/statedb/sync_test.go
+++ b/storage/statedb/sync_test.go
@@ -424,10 +424,9 @@ func TestIncompleteTrieSync(t *testing.T) {
 	srcDb, srcTrie, _ := makeTestTrie()
 
 	// Create a destination trie and sync with the scheduler
-	memDBManager := database.NewMemoryDBManager()
-	diskdb := memDBManager.GetMemDB()
-	triedb := NewDatabase(memDBManager)
-	sched := NewTrieSync(srcTrie.Hash(), memDBManager, nil, NewSyncBloom(1, diskdb), nil)
+	dbm := database.NewMemoryDBManager()
+	triedb := NewDatabase(dbm)
+	sched := NewTrieSync(srcTrie.Hash(), dbm, nil, NewSyncBloom(1, dbm.GetMemDB()), nil)
 
 	var added []common.Hash
 	nodes, _, codes := sched.Missing(1)
@@ -448,7 +447,7 @@ func TestIncompleteTrieSync(t *testing.T) {
 				t.Fatalf("failed to process result #%d: %v", index, err)
 			}
 		}
-		batch := diskdb.NewBatch()
+		batch := dbm.NewBatch(database.StateTrieDB)
 		if index, err := sched.Commit(batch); err != nil {
 			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
@@ -467,15 +466,14 @@ func TestIncompleteTrieSync(t *testing.T) {
 		queue = append(append(queue[:0], nodes...), codes...)
 	}
 	// Sanity check that removing any node from the database is detected
-	for _, node := range added[1:] {
-		key := node.Bytes()
-		value, _ := diskdb.Get(key)
+	for _, hash := range added[1:] {
+		value, _ := dbm.ReadTrieNode(hash)
 
-		diskdb.Delete(key)
+		dbm.DeleteTrieNode(hash)
 		if err := checkTrieConsistency(triedb, added[0]); err == nil {
-			t.Fatalf("trie inconsistency not caught, missing: %x", key)
+			t.Fatalf("trie inconsistency not caught, missing: %x", hash)
 		}
-		diskdb.Put(key, value)
+		dbm.WriteTrieNode(hash, value)
 	}
 }
 

--- a/storage/statedb/trie_test.go
+++ b/storage/statedb/trie_test.go
@@ -85,9 +85,8 @@ func TestMissingNodeDisk(t *testing.T)    { testMissingNode(t, false) }
 func TestMissingNodeMemonly(t *testing.T) { testMissingNode(t, true) }
 
 func testMissingNode(t *testing.T, memonly bool) {
-	memDBManager := database.NewMemoryDBManager()
-	diskdb := memDBManager.GetMemDB()
-	triedb := NewDatabase(memDBManager)
+	dbm := database.NewMemoryDBManager()
+	triedb := NewDatabase(dbm)
 
 	trie, _ := NewTrie(common.Hash{}, triedb)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
@@ -127,7 +126,7 @@ func testMissingNode(t *testing.T, memonly bool) {
 	if memonly {
 		delete(triedb.nodes, hash)
 	} else {
-		diskdb.Delete(hash[:])
+		dbm.DeleteTrieNode(hash)
 	}
 
 	trie, _ = NewTrie(root, triedb)

--- a/tests/state_migration_test.go
+++ b/tests/state_migration_test.go
@@ -85,7 +85,7 @@ func TestMigration_StartMigrationByMiscDB(t *testing.T) {
 		assert.Len(t, key, 0)
 
 		// write values in stateDB and check if the values are stored in DB
-		entries := writeRandomValueToStateTrieDB(t, cn.ChainDB().NewBatch(database.StateTrieDB))
+		entries := writeRandomValueToStateTrieDB(t, cn.ChainDB())
 		stopNode(t, fullNode) // stop node to release DB lock
 		checkIfStoredInDB(t, cn.ChainDB().GetDBConfig().NumStateTrieShards, filepath.Join(cn.ChainDB().GetDBConfig().Dir, "statetrie"), entries)
 		fullNode, cn = startNode(t, workspace, validator)
@@ -105,12 +105,13 @@ func TestMigration_StartMigrationByMiscDB(t *testing.T) {
 	}
 }
 
-func writeRandomValueToStateTrieDB(t *testing.T, batch database.Batch) map[string]string {
+func writeRandomValueToStateTrieDB(t *testing.T, dbm database.DBManager) map[string]string {
+	batch := dbm.NewBatch(database.StateTrieDB)
 	entries := make(map[string]string, 10)
 
 	for i := 0; i < 10; i++ {
 		key, value := common.MakeRandomBytes(common.HashLength), common.MakeRandomBytes(400)
-		err := batch.Put(key, value)
+		err := dbm.PutTrieNodeToBatch(batch, common.BytesToHash(key), value)
 		assert.NoError(t, err)
 		entries[string(key)] = string(value)
 	}

--- a/tests/state_migration_test.go
+++ b/tests/state_migration_test.go
@@ -111,8 +111,7 @@ func writeRandomValueToStateTrieDB(t *testing.T, dbm database.DBManager) map[str
 
 	for i := 0; i < 10; i++ {
 		key, value := common.MakeRandomBytes(common.HashLength), common.MakeRandomBytes(400)
-		err := dbm.PutTrieNodeToBatch(batch, common.BytesToHash(key), value)
-		assert.NoError(t, err)
+		dbm.PutTrieNodeToBatch(batch, common.BytesToHash(key), value)
 		entries[string(key)] = string(value)
 	}
 	assert.NoError(t, batch.Write())


### PR DESCRIPTION
## Proposed changes

- This PR contains several refactoring changes related to state trie accessors.

### Change 1. Cleanup DiskDB trie accessors

| Category             | Before                                                                                                                                    | After                                                                                                                                                                     |
|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Contract code        | ReadCode(Hash)<br>ReadCodeWithPrefix(Hash)<br>HasCode(Hash)<br>HasCodeWithPrefix(Hash)<br>WriteCode(Hash,[]byte)<br>-<br>DeleteCode(Hash) | ReadCode(Hash)<br>ReadCodeWithPrefix(Hash)<br>HasCode(Hash)<br>HasCodeWithPrefix(Hash)<br>WriteCode(Hash,[]byte)<br>PutCodeToBatch(Batch,Hash,[]byte)<br>DeleteCode(Hash) |
| Trie node            | ReadCachedTrieNode(Hash)<br>ReadStateTrieNode([]byte)<br>HasStateTrieNode([]byte)<br>-<br>-<br>-                                          | ReadTrieNode(Hash)<br>-<br>HasTrieNode(Hash)<br>WriteTrieNode(Hash,[]byte)<br>PutTrieNodeToBatch(Batch,Hash,[]byte)<br>DeleteTrieNode(Hash)                               |
| Secure trie preimage | ReadCachedTrieNodePreimage([]byte)<br>ReadPreimage(Hash)<br>WritePreimages(map[Hash][]byte)                                               | -<br>ReadPreimage(Hash)<br>WritePreimages(map[Hash][]byte)                                                                                                                |

### Change 2. No direct access to the underlying Key-Value database

- Make sure all codes use the above Read~, Write~ functions instead of low-level DB.Get(), Batcher.Put(), etc.
- One exception is in TrieSync.Commit where too much change is required.

### Change 3. Use TrieNodeKey before calling DB

- Use `TrieNodeKey()` before calling DB.Get(), Batcher.Put(), etc.
- Currently, `TrieNodeKey(hash) == hash.Bytes`. Additional logic may be introduced later.

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

Later, `TrieNodeKey()` may process ExtHash and legacy Hash to support state pruning.