### PR TITLE
fix incomplete pending block handling logic regarding API requests

### DIFF
--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -278,6 +278,9 @@ func (api *PublicDebugAPI) DumpBlock(ctx context.Context, blockNrOrHash rpc.Bloc
 		// both the pending block as well as the pending state from
 		// the miner and operate on those
 		_, stateDb := api.cn.miner.Pending()
+		if stateDb == nil {
+			return state.Dump{}, fmt.Errorf("pending block is not prepared yet")
+		}
 		return stateDb.RawDump(), nil
 	}
 

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -87,6 +87,9 @@ func (b *CNAPIBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumb
 	// Pending block is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
 		block := b.cn.miner.PendingBlock()
+		if block == nil {
+			return nil, fmt.Errorf("pending block is not prepared yet")
+		}
 		return block.Header(), nil
 	}
 	// Otherwise resolve and return the block
@@ -125,6 +128,9 @@ func (b *CNAPIBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumbe
 	// Pending block is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
 		block := b.cn.miner.PendingBlock()
+		if block == nil {
+			return nil, fmt.Errorf("pending block is not prepared yet")
+		}
 		return block, nil
 	}
 	// Otherwise resolve and return the block
@@ -156,6 +162,9 @@ func (b *CNAPIBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.B
 	// Pending state is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
 		block, state := b.cn.miner.Pending()
+		if block == nil || state == nil {
+			return nil, nil, fmt.Errorf("pending block is not prepared yet")
+		}
 		return state, block.Header(), nil
 	}
 	// Otherwise resolve the block number and return its state

--- a/work/worker.go
+++ b/work/worker.go
@@ -207,6 +207,9 @@ func (self *worker) pending() (*types.Block, *state.StateDB) {
 		// return a snapshot to avoid contention on currentMu mutex
 		self.snapshotMu.RLock()
 		defer self.snapshotMu.RUnlock()
+		if self.snapshotState == nil {
+			return nil, nil
+		}
 		return self.snapshotBlock, self.snapshotState.Copy()
 	}
 
@@ -227,6 +230,9 @@ func (self *worker) pendingBlock() *types.Block {
 
 	self.currentMu.Lock()
 	defer self.currentMu.Unlock()
+	if self.current == nil {
+		return nil
+	}
 	return self.current.Block
 }
 

--- a/work/worker.go
+++ b/work/worker.go
@@ -471,7 +471,9 @@ func (self *worker) makeCurrent(parent *types.Block, header *types.Header) error
 	}
 	work := NewTask(self.config, types.MakeSigner(self.config, header.Number), stateDB, header)
 	if self.nodetype != common.CONSENSUSNODE {
+		// set the current block and header as pending block and header to support APIs requesting a pending block.
 		work.Block = parent
+		work.header = parent.Header()
 	}
 
 	// Keep track of transactions which return errors so they can be removed


### PR DESCRIPTION
## Proposed changes

This PR contains two different fixes regarding "pending" block requests. 

1) panic because of the absence of pending block
Panic was reported in #1841 regarding API servicing with "pending" block parameter. The panic can be triggered when a pending block has never been created yet but a user requests API with "pending" parameter. 


2) occasional API error with  "invalid signature length" error message
During the synchronization, a node uses a worker's snapshot to return a pending block. The block is created with the worker's `current` data in `updateSnapshot()` method. Since EN doesn't create a pending block correctly, however, the `current.header` doesn't have enough information including a miner's signature. Therefore, `eth_getBlockByNumber` and other API fail to recover a block proposer's address and return an error message. This PR set the previous block header for a pending block of EN/PN to support the API correctly. 


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

Resolve #1842 
