### PR TITLE
filters: ensure that filter unsubscription requests are not blocked

### DIFF
--- a/node/cn/filters/api.go
+++ b/node/cn/filters/api.go
@@ -41,7 +41,7 @@ import (
 )
 
 var (
-	deadline = 5 * time.Minute // consider a filter inactive if it has not been polled for within deadline
+	defaultFilterDeadline = 5 * time.Minute // consider a filter inactive if it has not been polled for within deadline
 
 	getLogsCxtKeyMaxItems = "maxItems"       // the value of the context key should have the type of GetLogsMaxItems
 	GetLogsDeadline       = 10 * time.Second // execution deadlines for getLogs and getFilterLogs APIs
@@ -82,7 +82,7 @@ func NewPublicFilterAPI(backend Backend, lightMode bool) *PublicFilterAPI {
 		chainDB: backend.ChainDB(),
 		events:  NewEventSystem(backend.EventMux(), backend, lightMode),
 		filters: make(map[rpc.ID]*filter),
-		timeout: deadline,
+		timeout: defaultFilterDeadline,
 	}
 	go api.timeoutLoop()
 


### PR DESCRIPTION
## Proposed changes
- This PR is from https://github.com/ethereum/go-ethereum/issues/22131
- In the original PR, timeout field for unit test is added at `PublicFilterAPI`. Rather than remove it, it is better to keep it for the flexible timeout settings in future tests.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
