### PR TITLE
Introduce trie constructors with TrieOpts

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -136,7 +136,7 @@ func (b *SimulatedBackend) rollback() {
 	stateDB, _ := b.blockchain.State()
 
 	b.pendingBlock = blocks[0]
-	b.pendingState, _ = state.New(b.pendingBlock.Root(), stateDB.Database(), nil)
+	b.pendingState, _ = state.New(b.pendingBlock.Root(), stateDB.Database(), nil, nil)
 }
 
 // stateByBlockNumber retrieves a state by a given blocknumber.
@@ -591,7 +591,7 @@ func (b *SimulatedBackend) SendTransaction(_ context.Context, tx *types.Transact
 	stateDB, _ := b.blockchain.State()
 
 	b.pendingBlock = blocks[0]
-	b.pendingState, _ = state.New(b.pendingBlock.Root(), stateDB.Database(), nil)
+	b.pendingState, _ = state.New(b.pendingBlock.Root(), stateDB.Database(), nil, nil)
 	return nil
 }
 
@@ -711,7 +711,7 @@ func (b *SimulatedBackend) AdjustTime(adjustment time.Duration) error {
 	stateDB, _ := b.blockchain.State()
 
 	b.pendingBlock = blocks[0]
-	b.pendingState, _ = state.New(b.pendingBlock.Root(), stateDB.Database(), nil)
+	b.pendingState, _ = state.New(b.pendingBlock.Root(), stateDB.Database(), nil, nil)
 
 	return nil
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -381,7 +381,8 @@ func (bc *BlockChain) prefetchTxWorker(index int) {
 		snaps = bc.snaps
 	}
 	for followup := range bc.prefetchTxCh {
-		stateDB, err := state.NewForPrefetching(bc.CurrentBlock().Root(), bc.stateCache, snaps)
+		stateDB, err := state.NewWithOpts(bc.CurrentBlock().Root(), bc.stateCache, snaps,
+			&statedb.TrieOpts{Prefetching: true})
 		if err != nil {
 			logger.Debug("failed to retrieve stateDB for prefetchTxWorker", "err", err)
 			continue
@@ -1818,7 +1819,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 						}
 					}()
 
-					throwaway, err := state.NewForPrefetching(parent.Root(), bc.stateCache, snaps)
+					throwaway, err := state.NewWithOpts(parent.Root(), bc.stateCache, snaps,
+						&statedb.TrieOpts{Prefetching: true})
 					if throwaway == nil || err != nil {
 						logger.Warn("failed to get StateDB for prefetcher", "err", err,
 							"parentBlockNum", parent.NumberU64(), "currBlockNum", bc.CurrentBlock().NumberU64())

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -285,7 +285,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 	}
 	// Make sure the state associated with the block is available
 	head := bc.CurrentBlock()
-	if _, err := state.New(head.Root(), bc.stateCache, bc.snaps); err != nil {
+	if _, err := state.New(head.Root(), bc.stateCache, bc.snaps, nil); err != nil {
 		// Head state is missing, before the state recovery, find out the
 		// disk layer point of snapshot(if it's enabled). Make sure the
 		// rewound point is lower than disk layer.
@@ -381,7 +381,7 @@ func (bc *BlockChain) prefetchTxWorker(index int) {
 		snaps = bc.snaps
 	}
 	for followup := range bc.prefetchTxCh {
-		stateDB, err := state.NewWithOpts(bc.CurrentBlock().Root(), bc.stateCache, snaps,
+		stateDB, err := state.New(bc.CurrentBlock().Root(), bc.stateCache, snaps,
 			&statedb.TrieOpts{Prefetching: true})
 		if err != nil {
 			logger.Debug("failed to retrieve stateDB for prefetchTxWorker", "err", err)
@@ -414,7 +414,7 @@ func (bc *BlockChain) SetCanonicalBlock(blockNum uint64) {
 	}
 	// Make sure the state associated with the block is available
 	head := bc.CurrentBlock()
-	if _, err := state.New(head.Root(), bc.stateCache, bc.snaps); err != nil {
+	if _, err := state.New(head.Root(), bc.stateCache, bc.snaps, nil); err != nil {
 		// Dangling block without a state associated, init from scratch
 		logger.Warn("Head state missing, repairing chain",
 			"number", head.NumberU64(), "hash", head.Hash().String())
@@ -545,7 +545,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 					if root != (common.Hash{}) && !beyondRoot && newHeadBlock.Root() == root {
 						beyondRoot, rootNumber = true, newHeadBlock.NumberU64()
 					}
-					if _, err := state.New(newHeadBlock.Root(), bc.stateCache, bc.snaps); err != nil {
+					if _, err := state.New(newHeadBlock.Root(), bc.stateCache, bc.snaps, nil); err != nil {
 						// Rewound state missing, rolled back to the parent block, reset to genesis
 						logger.Trace("Block state missing, rewinding further", "number", newHeadBlock.NumberU64(), "hash", newHeadBlock.Hash())
 						parent := bc.GetBlock(newHeadBlock.ParentHash(), newHeadBlock.NumberU64()-1)
@@ -637,7 +637,7 @@ func (bc *BlockChain) FastSyncCommitHead(hash common.Hash) error {
 	if block == nil {
 		return fmt.Errorf("non existent block [%x…]", hash[:4])
 	}
-	if _, err := statedb.NewSecureTrie(block.Root(), bc.stateCache.TrieDB()); err != nil {
+	if _, err := statedb.NewSecureTrie(block.Root(), bc.stateCache.TrieDB(), nil); err != nil {
 		return err
 	}
 	// If all checks out, manually set the head block
@@ -684,7 +684,7 @@ func (bc *BlockChain) State() (*state.StateDB, error) {
 
 // StateAt returns a new mutable state based on a particular point in time.
 func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
-	return state.New(root, bc.stateCache, bc.snaps)
+	return state.New(root, bc.stateCache, bc.snaps, nil)
 }
 
 // StateAtWithPersistent returns a new mutable state based on a particular point in time with persistent trie nodes.
@@ -693,7 +693,7 @@ func (bc *BlockChain) StateAtWithPersistent(root common.Hash) (*state.StateDB, e
 	if !exist {
 		return nil, ErrNotExistNode
 	}
-	return state.New(root, bc.stateCache, bc.snaps)
+	return state.New(root, bc.stateCache, bc.snaps, nil)
 }
 
 // StateAtWithGCLock returns a new mutable state based on a particular point in time with read lock of the state nodes.
@@ -706,7 +706,7 @@ func (bc *BlockChain) StateAtWithGCLock(root common.Hash) (*state.StateDB, error
 		return nil, ErrNotExistNode
 	}
 
-	stateDB, err := state.New(root, bc.stateCache, bc.snaps)
+	stateDB, err := state.New(root, bc.stateCache, bc.snaps, nil)
 	if err != nil {
 		bc.RUnlockGCCachedNode()
 		return nil, err
@@ -759,7 +759,7 @@ func (bc *BlockChain) ResetWithGenesisBlock(genesis *types.Block) error {
 func (bc *BlockChain) repair(head **types.Block) error {
 	for {
 		// Abort if we've rewound to a head block that does have associated state
-		if _, err := state.New((*head).Root(), bc.stateCache, bc.snaps); err == nil {
+		if _, err := state.New((*head).Root(), bc.stateCache, bc.snaps, nil); err == nil {
 			logger.Info("Rewound blockchain to past state", "number", (*head).Number(), "hash", (*head).Hash())
 			return nil
 		} else {
@@ -854,7 +854,7 @@ func (bc *BlockChain) HasBlock(hash common.Hash, number uint64) bool {
 
 // HasState checks if state trie is fully present in the database or not.
 func (bc *BlockChain) HasState(hash common.Hash) bool {
-	_, err := bc.stateCache.OpenTrie(hash)
+	_, err := bc.stateCache.OpenTrie(hash, nil)
 	return err == nil
 }
 
@@ -1819,7 +1819,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 						}
 					}()
 
-					throwaway, err := state.NewWithOpts(parent.Root(), bc.stateCache, snaps,
+					throwaway, err := state.New(parent.Root(), bc.stateCache, snaps,
 						&statedb.TrieOpts{Prefetching: true})
 					if throwaway == nil || err != nil {
 						logger.Warn("failed to get StateDB for prefetcher", "err", err,

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -162,7 +162,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 			}
 			return err
 		}
-		statedb, err := state.New(blockchain.GetBlockByHash(block.ParentHash()).Root(), blockchain.stateCache, nil)
+		statedb, err := state.New(blockchain.GetBlockByHash(block.ParentHash()).Root(), blockchain.stateCache, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -209,7 +209,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		return nil, nil
 	}
 	for i := 0; i < n; i++ {
-		statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil)
+		statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -148,7 +148,7 @@ func findBlockWithState(db database.DBManager) *types.Block {
 	}
 
 	startBlock := headBlock
-	for _, err := state.New(headBlock.Root(), state.NewDatabase(db), nil); err != nil; {
+	for _, err := state.New(headBlock.Root(), state.NewDatabase(db), nil, nil); err != nil; {
 		if headBlock.NumberU64() == 0 {
 			logger.Crit("failed to find state from the head block to the genesis block",
 				"headBlockNum", headBlock.NumberU64(),
@@ -298,7 +298,7 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 	if db == nil {
 		db = database.NewMemoryDBManager()
 	}
-	stateDB, _ := state.New(baseStateRoot, state.NewDatabase(db), nil)
+	stateDB, _ := state.New(baseStateRoot, state.NewDatabase(db), nil, nil)
 	for addr, account := range g.Alloc {
 		if len(account.Code) != 0 {
 			originalCode := stateDB.GetCode(addr)

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -45,12 +45,10 @@ const (
 type Database interface {
 	// OpenTrie opens the main account trie.
 	OpenTrie(root common.Hash) (Trie, error)
-	OpenTrieForPrefetching(root common.Hash) (Trie, error)
 	OpenTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error)
 
 	// OpenStorageTrie opens the storage trie of an account.
 	OpenStorageTrie(root common.Hash) (Trie, error)
-	OpenStorageTrieForPrefetching(root common.Hash) (Trie, error)
 	OpenStorageTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error)
 
 	// CopyTrie returns an independent copy of the given trie.
@@ -170,11 +168,6 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 	return statedb.NewSecureTrie(root, db.db)
 }
 
-// OpenTrieForPrefetching opens the main account trie at a specific root hash.
-func (db *cachingDB) OpenTrieForPrefetching(root common.Hash) (Trie, error) {
-	return statedb.NewSecureTrieForPrefetching(root, db.db)
-}
-
 // OpenTrieWithOpts opens the main account trie at a specific root hash.
 func (db *cachingDB) OpenTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error) {
 	return statedb.NewSecureTrieWithOpts(root, db.db, opts)
@@ -183,11 +176,6 @@ func (db *cachingDB) OpenTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) 
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(root common.Hash) (Trie, error) {
 	return statedb.NewSecureTrie(root, db.db)
-}
-
-// OpenStorageTrieForPrefetching opens the storage trie of an account.
-func (db *cachingDB) OpenStorageTrieForPrefetching(root common.Hash) (Trie, error) {
-	return statedb.NewSecureTrieForPrefetching(root, db.db)
 }
 
 // OpenStorageTrieWithOpts opens the storage trie of an account.

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -46,10 +46,12 @@ type Database interface {
 	// OpenTrie opens the main account trie.
 	OpenTrie(root common.Hash) (Trie, error)
 	OpenTrieForPrefetching(root common.Hash) (Trie, error)
+	OpenTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error)
 
 	// OpenStorageTrie opens the storage trie of an account.
 	OpenStorageTrie(root common.Hash) (Trie, error)
 	OpenStorageTrieForPrefetching(root common.Hash) (Trie, error)
+	OpenStorageTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error)
 
 	// CopyTrie returns an independent copy of the given trie.
 	CopyTrie(Trie) Trie
@@ -173,6 +175,11 @@ func (db *cachingDB) OpenTrieForPrefetching(root common.Hash) (Trie, error) {
 	return statedb.NewSecureTrieForPrefetching(root, db.db)
 }
 
+// OpenTrieWithOpts opens the main account trie at a specific root hash.
+func (db *cachingDB) OpenTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error) {
+	return statedb.NewSecureTrieWithOpts(root, db.db, opts)
+}
+
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(root common.Hash) (Trie, error) {
 	return statedb.NewSecureTrie(root, db.db)
@@ -181,6 +188,11 @@ func (db *cachingDB) OpenStorageTrie(root common.Hash) (Trie, error) {
 // OpenStorageTrieForPrefetching opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrieForPrefetching(root common.Hash) (Trie, error) {
 	return statedb.NewSecureTrieForPrefetching(root, db.db)
+}
+
+// OpenStorageTrieWithOpts opens the storage trie of an account.
+func (db *cachingDB) OpenStorageTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error) {
+	return statedb.NewSecureTrieWithOpts(root, db.db, opts)
 }
 
 // CopyTrie returns an independent copy of the given trie.

--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -44,12 +44,10 @@ const (
 // Database wraps access to tries and contract code.
 type Database interface {
 	// OpenTrie opens the main account trie.
-	OpenTrie(root common.Hash) (Trie, error)
-	OpenTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error)
+	OpenTrie(root common.Hash, opts *statedb.TrieOpts) (Trie, error)
 
 	// OpenStorageTrie opens the storage trie of an account.
-	OpenStorageTrie(root common.Hash) (Trie, error)
-	OpenStorageTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error)
+	OpenStorageTrie(root common.Hash, opts *statedb.TrieOpts) (Trie, error)
 
 	// CopyTrie returns an independent copy of the given trie.
 	CopyTrie(Trie) Trie
@@ -164,23 +162,13 @@ type cachingDB struct {
 }
 
 // OpenTrie opens the main account trie at a specific root hash.
-func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
-	return statedb.NewSecureTrie(root, db.db)
-}
-
-// OpenTrieWithOpts opens the main account trie at a specific root hash.
-func (db *cachingDB) OpenTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error) {
-	return statedb.NewSecureTrieWithOpts(root, db.db, opts)
+func (db *cachingDB) OpenTrie(root common.Hash, opts *statedb.TrieOpts) (Trie, error) {
+	return statedb.NewSecureTrie(root, db.db, opts)
 }
 
 // OpenStorageTrie opens the storage trie of an account.
-func (db *cachingDB) OpenStorageTrie(root common.Hash) (Trie, error) {
-	return statedb.NewSecureTrie(root, db.db)
-}
-
-// OpenStorageTrieWithOpts opens the storage trie of an account.
-func (db *cachingDB) OpenStorageTrieWithOpts(root common.Hash, opts *statedb.TrieOpts) (Trie, error) {
-	return statedb.NewSecureTrieWithOpts(root, db.db, opts)
+func (db *cachingDB) OpenStorageTrie(root common.Hash, opts *statedb.TrieOpts) (Trie, error) {
+	return statedb.NewSecureTrie(root, db.db, opts)
 }
 
 // CopyTrie returns an independent copy of the given trie.

--- a/blockchain/state/iterator.go
+++ b/blockchain/state/iterator.go
@@ -126,7 +126,7 @@ func (it *NodeIterator) step() error {
 	obj := serializer.GetAccount()
 
 	if pa := account.GetProgramAccount(obj); pa != nil {
-		dataTrie, err := it.state.db.OpenStorageTrie(pa.GetStorageRoot())
+		dataTrie, err := it.state.db.OpenStorageTrie(pa.GetStorageRoot(), nil)
 		if err != nil {
 			return err
 		}
@@ -189,11 +189,11 @@ func (it *NodeIterator) retrieve() bool {
 // CheckStateConsistencyParallel checks the consistency of all state/storage trie of given two state databases in parallel.
 func CheckStateConsistencyParallel(oldDB Database, newDB Database, root common.Hash, quitCh chan struct{}) error {
 	// Check if the tries can be called
-	_, err := oldDB.OpenTrie(root)
+	_, err := oldDB.OpenTrie(root, nil)
 	if err != nil {
 		return errors.WithMessage(err, "can not open oldDB trie")
 	}
-	_, err = newDB.OpenTrie(root)
+	_, err = newDB.OpenTrie(root, nil)
 	if err != nil {
 		return errors.WithMessage(err, "can not open newDB trie")
 	}
@@ -253,12 +253,12 @@ func concurrentIterator(oldDB Database, newDB Database, root common.Hash, quit c
 	}()
 
 	// Create and iterate a state trie rooted in a sub-node
-	oldState, err := New(root, oldDB, nil)
+	oldState, err := New(root, oldDB, nil, nil)
 	if err != nil {
 		return errors.WithMessage(err, "can not open oldDB trie")
 	}
 
-	newState, err := New(root, newDB, nil)
+	newState, err := New(root, newDB, nil, nil)
 	if err != nil {
 		return errors.WithMessage(err, "can not open newDB trie")
 	}
@@ -326,12 +326,12 @@ func concurrentIterator(oldDB Database, newDB Database, root common.Hash, quit c
 // CheckStateConsistency checks the consistency of all state/storage trie of given two state database.
 func CheckStateConsistency(oldDB Database, newDB Database, root common.Hash, mapSize int, quit chan struct{}) error {
 	// Create and iterate a state trie rooted in a sub-node
-	oldState, err := New(root, oldDB, nil)
+	oldState, err := New(root, oldDB, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	newState, err := New(root, newDB, nil)
+	newState, err := New(root, newDB, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/blockchain/state/iterator_test.go
+++ b/blockchain/state/iterator_test.go
@@ -32,7 +32,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 	db, root, _ := makeTestState(t)
 	db.TrieDB().Commit(root, false, 0)
 
-	state, err := New(root, db, nil)
+	state, err := New(root, db, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create state trie at %x: %v", root, err)
 	}

--- a/blockchain/state/state_object.go
+++ b/blockchain/state/state_object.go
@@ -35,6 +35,7 @@ import (
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/rlp"
+	"github.com/klaytn/klaytn/storage/statedb"
 )
 
 var emptyCodeHash = crypto.Keccak256(nil)
@@ -156,10 +157,7 @@ func (c *stateObject) touch() {
 }
 
 func (c *stateObject) openStorageTrie(hash common.Hash, db Database) (Trie, error) {
-	if c.db.prefetching {
-		return db.OpenStorageTrieForPrefetching(hash)
-	}
-	return db.OpenStorageTrie(hash)
+	return db.OpenStorageTrieWithOpts(hash, &statedb.TrieOpts{Prefetching: c.db.prefetching})
 }
 
 func (c *stateObject) getStorageTrie(db Database) Trie {

--- a/blockchain/state/state_object.go
+++ b/blockchain/state/state_object.go
@@ -157,7 +157,7 @@ func (c *stateObject) touch() {
 }
 
 func (c *stateObject) openStorageTrie(hash common.Hash, db Database) (Trie, error) {
-	return db.OpenStorageTrieWithOpts(hash, &statedb.TrieOpts{Prefetching: c.db.prefetching})
+	return db.OpenStorageTrie(hash, &statedb.TrieOpts{Prefetching: c.db.prefetching})
 }
 
 func (c *stateObject) getStorageTrie(db Database) Trie {

--- a/blockchain/state/state_test.go
+++ b/blockchain/state/state_test.go
@@ -94,7 +94,7 @@ func (s *StateSuite) TestDump(c *checker.C) {
 
 func (s *StateSuite) SetUpTest(c *checker.C) {
 	s.db = database.NewMemoryDBManager()
-	s.state, _ = New(common.Hash{}, NewDatabase(s.db), nil)
+	s.state, _ = New(common.Hash{}, NewDatabase(s.db), nil, nil)
 }
 
 func (s *StateSuite) TestNull(c *checker.C) {
@@ -151,7 +151,7 @@ func (s *StateSuite) TestSnapshotEmpty(c *checker.C) {
 // This test is to compare deleted/non-deleted stateObject after restoring.
 func TestSnapshotForDeletedObject(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
-	state, _ := New(common.Hash{}, NewDatabase(memDB), nil)
+	state, _ := New(common.Hash{}, NewDatabase(memDB), nil, nil)
 
 	stateObjAddr0 := toAddr([]byte("so0"))
 	stateObjAddr1 := toAddr([]byte("so1"))

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -121,11 +121,6 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 	return NewWithOpts(root, db, snaps, nil)
 }
 
-// Create a new state from a given trie with prefetching
-func NewForPrefetching(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) {
-	return NewWithOpts(root, db, snaps, &statedb.TrieOpts{Prefetching: true})
-}
-
 func NewWithOpts(root common.Hash, db Database, snaps *snapshot.Tree, opts *statedb.TrieOpts) (*StateDB, error) {
 	tr, err := db.OpenTrieWithOpts(root, opts)
 	if err != nil {

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -117,12 +117,8 @@ type StateDB struct {
 }
 
 // Create a new state from a given trie.
-func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) {
-	return NewWithOpts(root, db, snaps, nil)
-}
-
-func NewWithOpts(root common.Hash, db Database, snaps *snapshot.Tree, opts *statedb.TrieOpts) (*StateDB, error) {
-	tr, err := db.OpenTrieWithOpts(root, opts)
+func New(root common.Hash, db Database, snaps *snapshot.Tree, opts *statedb.TrieOpts) (*StateDB, error) {
+	tr, err := db.OpenTrie(root, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +171,7 @@ func (self *StateDB) Error() error {
 // Reset clears out all ephemeral state objects from the state db, but keeps
 // the underlying state trie to avoid reloading data for the next operations.
 func (self *StateDB) Reset(root common.Hash) error {
-	tr, err := self.db.OpenTrie(root)
+	tr, err := self.db.OpenTrie(root, nil)
 	if err != nil {
 		return err
 	}

--- a/blockchain/state/statedb_test.go
+++ b/blockchain/state/statedb_test.go
@@ -46,7 +46,7 @@ func TestUpdateLeaks(t *testing.T) {
 	// Create an empty state database
 	memDBManager := database.NewMemoryDBManager()
 	db := memDBManager.GetMemDB()
-	state, _ := New(common.Hash{}, NewDatabase(memDBManager), nil)
+	state, _ := New(common.Hash{}, NewDatabase(memDBManager), nil, nil)
 
 	// Update it with some accounts
 	for i := byte(0); i < 255; i++ {
@@ -79,8 +79,8 @@ func TestIntermediateLeaks(t *testing.T) {
 	transDb := transDBManager.GetMemDB()
 	finalDb := finalDBManager.GetMemDB()
 
-	transState, _ := New(common.Hash{}, NewDatabase(transDBManager), nil)
-	finalState, _ := New(common.Hash{}, NewDatabase(finalDBManager), nil)
+	transState, _ := New(common.Hash{}, NewDatabase(transDBManager), nil, nil)
+	finalState, _ := New(common.Hash{}, NewDatabase(finalDBManager), nil, nil)
 
 	modify := func(state *StateDB, addr common.Address, i, tweak byte) {
 		if i%2 == 0 {
@@ -133,7 +133,7 @@ func TestIntermediateLeaks(t *testing.T) {
 // https://github.com/ethereum/go-ethereum/pull/15549.
 func TestCopy(t *testing.T) {
 	// Create a random state test to copy and modify "independently"
-	orig, _ := New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
+	orig, _ := New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil, nil)
 
 	for i := byte(0); i < 255; i++ {
 		obj := orig.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
@@ -195,7 +195,7 @@ func TestSnapshotRandom(t *testing.T) {
 // TestStateObjects tests basic functional operations of StateObjects.
 // It will be updated by StateDB.Commit() with state objects in StateDB.stateObjects.
 func TestStateObjects(t *testing.T) {
-	stateDB, _ := New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
+	stateDB, _ := New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil, nil)
 
 	// Update each account, it will update StateDB.stateObjects.
 	for i := byte(0); i < 128; i++ {
@@ -387,7 +387,7 @@ func (test *snapshotTest) String() string {
 func (test *snapshotTest) run() bool {
 	// Run all actions and create snapshots.
 	var (
-		state, _     = New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
+		state, _     = New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil, nil)
 		snapshotRevs = make([]int, len(test.snapshots))
 		sindex       = 0
 	)
@@ -401,7 +401,7 @@ func (test *snapshotTest) run() bool {
 	// Revert all snapshots in reverse order. Each revert must yield a state
 	// that is equivalent to fresh state with all actions up the snapshot applied.
 	for sindex--; sindex >= 0; sindex-- {
-		checkstate, _ := New(common.Hash{}, state.Database(), nil)
+		checkstate, _ := New(common.Hash{}, state.Database(), nil, nil)
 		for _, action := range test.actions[:test.snapshots[sindex]] {
 			action.fn(action, checkstate)
 		}
@@ -480,7 +480,7 @@ func (s *StateSuite) TestSnapshotWithJournalDirties(c *check.C) {
 // TestCopyOfCopy tests that modified objects are carried over to the copy, and the copy of the copy.
 // See https://github.com/ethereum/go-ethereum/pull/15225#issuecomment-380191512
 func TestCopyOfCopy(t *testing.T) {
-	sdb, _ := New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
+	sdb, _ := New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	addr := common.HexToAddress("aaaa")
 	sdb.SetBalance(addr, big.NewInt(42))
 
@@ -516,7 +516,7 @@ func TestMissingTrieNodes(t *testing.T) {
 	memDb := database.NewMemoryDBManager()
 	db := NewDatabase(memDb)
 	var root common.Hash
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil, nil)
 	addr := toAddr([]byte("so"))
 	{
 		state.SetBalance(addr, big.NewInt(1))
@@ -530,7 +530,7 @@ func TestMissingTrieNodes(t *testing.T) {
 		state.Database().TrieDB().Cap(0)
 	}
 	// Create a new state on the old root
-	state, _ = New(root, db, nil)
+	state, _ = New(root, db, nil, nil)
 	// Now we clear out the memdb
 	it := memDb.GetMemDB().NewIterator(nil, nil)
 	for it.Next() {
@@ -565,7 +565,7 @@ func TestStateDBAccessList(t *testing.T) {
 
 	memDb := database.NewMemoryDBManager()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil, nil)
 	state.accessList = newAccessList()
 
 	verifyAddrs := func(astrings ...string) {

--- a/blockchain/state/sync_test.go
+++ b/blockchain/state/sync_test.go
@@ -49,7 +49,7 @@ type testAccount struct {
 func makeTestState(t *testing.T) (Database, common.Hash, []*testAccount) {
 	// Create an empty state
 	db := NewDatabase(database.NewMemoryDBManager())
-	statedb, err := New(common.Hash{}, db, nil)
+	statedb, err := New(common.Hash{}, db, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func makeTestState(t *testing.T) (Database, common.Hash, []*testAccount) {
 // account array.
 func checkStateAccounts(t *testing.T, newDB database.DBManager, root common.Hash, accounts []*testAccount) {
 	// Check root availability and state contents
-	state, err := New(root, NewDatabase(newDB), nil)
+	state, err := New(root, NewDatabase(newDB), nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create state trie at %x: %v", root, err)
 	}
@@ -150,7 +150,7 @@ func checkTrieConsistency(db database.DBManager, root common.Hash) error {
 	if v, _ := db.ReadStateTrieNode(root[:]); v == nil {
 		return nil // Consider a non existent state consistent.
 	}
-	trie, err := statedb.NewTrie(root, statedb.NewDatabase(db))
+	trie, err := statedb.NewTrie(root, statedb.NewDatabase(db), nil)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func checkStateConsistency(db database.DBManager, root common.Hash) error {
 	if _, err := db.ReadStateTrieNode(root.Bytes()); err != nil {
 		return nil // Consider a non existent state consistent.
 	}
-	state, err := New(root, NewDatabase(db), nil)
+	state, err := New(root, NewDatabase(db), nil, nil)
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 	if commit {
 		srcState.TrieDB().Commit(srcRoot, false, 0)
 	}
-	srcTrie, _ := statedb.NewTrie(srcRoot, srcState.TrieDB())
+	srcTrie, _ := statedb.NewTrie(srcRoot, srcState.TrieDB(), nil)
 
 	// Create a destination state and sync with the scheduler
 	dstDiskDb := database.NewMemoryDBManager()
@@ -299,7 +299,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 				if pacc == nil {
 					t.Errorf("failed to get contract")
 				}
-				stTrie, err := statedb.NewTrie(pacc.GetStorageRoot(), srcState.TrieDB())
+				stTrie, err := statedb.NewTrie(pacc.GetStorageRoot(), srcState.TrieDB(), nil)
 				if err != nil {
 					t.Fatalf("failed to retriev storage trie for path %x: %v", path, err)
 				}
@@ -365,7 +365,7 @@ func TestCheckStateConsistencyMissNode(t *testing.T) {
 		return false
 	}
 
-	srcStateDB, err := New(srcRoot, srcState, nil)
+	srcStateDB, err := New(srcRoot, srcState, nil, nil)
 	assert.NoError(t, err)
 
 	it := NewNodeIterator(srcStateDB)

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -283,12 +283,12 @@ func (st *migrationStats) stateMigrationReport(force bool, pending int, progress
 }
 
 func (bc *BlockChain) checkTrieContents(oldDB, newDB *statedb.Database, root common.Hash) ([]common.Address, error) {
-	oldTrie, err := statedb.NewSecureTrie(root, oldDB)
+	oldTrie, err := statedb.NewSecureTrie(root, oldDB, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	newTrie, err := statedb.NewSecureTrie(root, newDB)
+	newTrie, err := statedb.NewSecureTrie(root, newDB, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func (bc *BlockChain) StateMigrationStatus() (bool, uint64, int, int, int, float
 func (bc *BlockChain) iterateStateTrie(root common.Hash, db state.Database, resultCh chan struct{}, errCh chan error) (resultErr error) {
 	defer func() { errCh <- resultErr }()
 
-	stateDB, err := state.New(root, db, nil)
+	stateDB, err := state.New(root, db, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -652,7 +652,7 @@ func printDepthStats(depthCounter map[int]int) {
 
 // GetContractStorageRoot returns the storage root of a contract based on the given block.
 func (bc *BlockChain) GetContractStorageRoot(block *types.Block, db state.Database, contractAddr common.Address) (common.Hash, error) {
-	stateDB, err := state.New(block.Root(), db, nil)
+	stateDB, err := state.New(block.Root(), db, nil, nil)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to get StateDB - %w", err)
 	}
@@ -701,7 +701,7 @@ func (bc *BlockChain) iterateStorageTrie(child common.Hash, storageTrie state.Tr
 }
 
 func prepareContractWarmUp(block *types.Block, db state.Database, contractAddr common.Address) (common.Hash, state.Trie, error) {
-	stateDB, err := state.New(block.Root(), db, nil)
+	stateDB, err := state.New(block.Root(), db, nil, nil)
 	if err != nil {
 		return common.Hash{}, nil, fmt.Errorf("failed to get StateDB, err: %w", err)
 	}
@@ -709,7 +709,7 @@ func prepareContractWarmUp(block *types.Block, db state.Database, contractAddr c
 	if err != nil {
 		return common.Hash{}, nil, err
 	}
-	storageTrie, err := db.OpenStorageTrie(storageTrieRoot)
+	storageTrie, err := db.OpenStorageTrie(storageTrieRoot, nil)
 	if err != nil {
 		return common.Hash{}, nil, err
 	}

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -192,7 +192,7 @@ func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
 }
 
 func setupTxPoolWithConfig(config *params.ChainConfig) (*TxPool, *ecdsa.PrivateKey) {
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 10000000, new(event.Feed)}
 
 	key, _ := crypto.GenerateKey()
@@ -278,7 +278,7 @@ func (c *testChain) State() (*state.StateDB, error) {
 	// a state change between those fetches.
 	stdb := c.statedb
 	if *c.trigger {
-		c.statedb, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+		c.statedb, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 		// simulate that the new head block included tx0 and tx1
 		c.statedb.SetNonce(c.address, 2)
 		c.statedb.SetBalance(c.address, new(big.Int).SetUint64(params.KLAY))
@@ -296,7 +296,7 @@ func TestStateChangeDuringTransactionPoolReset(t *testing.T) {
 	var (
 		key, _     = crypto.GenerateKey()
 		address    = crypto.PubkeyToAddress(key.PublicKey)
-		statedb, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+		statedb, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 		trigger    = false
 	)
 
@@ -590,7 +590,7 @@ func TestTransactionChainFork(t *testing.T) {
 
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	resetState := func() {
-		statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+		statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 		statedb.AddBalance(addr, big.NewInt(100000000000000))
 
 		pool.chain = &testBlockChain{statedb, 1000000, new(event.Feed)}
@@ -619,7 +619,7 @@ func TestTransactionDoubleNonce(t *testing.T) {
 
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	resetState := func() {
-		statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+		statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 		statedb.AddBalance(addr, big.NewInt(100000000000000))
 
 		pool.chain = &testBlockChain{statedb, 1000000, new(event.Feed)}
@@ -790,7 +790,7 @@ func TestTransactionPostponing(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the postponing with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
@@ -1005,7 +1005,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 	t.Parallel()
 
 	// Create the pool to test the limit enforcement with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1106,7 +1106,7 @@ func testTransactionQueueTimeLimiting(t *testing.T, nolocals, keepLocals bool) {
 	evictionInterval = time.Second
 
 	// Create the pool to test the non-expiration enforcement
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1271,7 +1271,7 @@ func TestTransactionPendingGlobalLimiting(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the limit enforcement with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1381,7 +1381,7 @@ func TestTransactionCapClearsFromAll(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the limit enforcement with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1415,7 +1415,7 @@ func TestTransactionPendingMinimumAllowance(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the limit enforcement with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1933,7 +1933,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	os.Remove(journal)
 
 	// Create the original pool to inject transaction into the journal
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -2031,7 +2031,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the status retrievals with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
@@ -2650,7 +2650,7 @@ func TestTransactionJournalingSortedByTime(t *testing.T) {
 	os.Remove(journal)
 
 	// Create the pool to test the status retrievals with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig

--- a/blockchain/vm/contracts_test.go
+++ b/blockchain/vm/contracts_test.go
@@ -107,7 +107,7 @@ func prepare(reqGas uint64) (*Contract, *EVM, error) {
 		nil, new(big.Int), reqGas)
 
 	// Generate EVM
-	stateDb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	stateDb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	txhash := common.HexToHash("0xc6a37e155d3fa480faea012a68ad35fd53c8cc3cd8263a434c697755985a6577")
 	stateDb.Prepare(txhash, common.Hash{}, 0)
 	evm := NewEVM(Context{BlockNumber: big.NewInt(0)}, stateDb, &params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)}, &Config{})
@@ -392,7 +392,7 @@ func TestEVM_CVE_2021_39137(t *testing.T) {
 		CanTransfer: func(StateDB, common.Address, *big.Int) bool { return true },
 		Transfer:    func(StateDB, common.Address, common.Address, *big.Int) {},
 	}
-	stateDb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	stateDb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 
 	for _, tc := range testCases {
 		stateDb.SetCode(contractAddr, tc.testCode)

--- a/blockchain/vm/evm_test.go
+++ b/blockchain/vm/evm_test.go
@@ -36,7 +36,7 @@ func runPrecompiledContractTestWithHFCondition(t *testing.T, config *params.Chai
 	for _, tc := range testData {
 		// Make StateDB
 		callerAddr := common.BytesToAddress([]byte("contract"))
-		statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+		statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 		statedb.CreateSmartContractAccount(callerAddr, params.CodeFormatEVM, params.Rules{IsIstanbul: tc.isDeployedAfterIstanbulHF})
 
 		// Make EVM environment

--- a/blockchain/vm/gas_table_test.go
+++ b/blockchain/vm/gas_table_test.go
@@ -107,7 +107,7 @@ func TestEIP2200(t *testing.T) {
 	for i, tt := range eip2200Tests {
 		address := common.BytesToAddress([]byte("contract"))
 
-		statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+		statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 		statedb.CreateSmartContractAccount(address, params.CodeFormatEVM, params.Rules{IsIstanbul: true})
 		statedb.SetCode(address, hexutil.MustDecode(tt.input))
 		statedb.SetState(address, common.Hash{}, common.BytesToHash([]byte{tt.original}))

--- a/blockchain/vm/instructions_test.go
+++ b/blockchain/vm/instructions_test.go
@@ -268,7 +268,7 @@ func TestJsonTestcases(t *testing.T) {
 
 func initStateDB(db database.DBManager) *state.StateDB {
 	sdb := state.NewDatabase(db)
-	statedb, _ := state.New(common.Hash{}, sdb, nil)
+	statedb, _ := state.New(common.Hash{}, sdb, nil, nil)
 
 	contractAddress := common.HexToAddress("0x18f30de96ce789fe778b9a5f420f6fdbbd9b34d8")
 	code := "60ca60205260005b612710811015630000004557602051506020515060205150602051506020515060205150602051506020515060205150602051506001016300000007565b00"
@@ -291,7 +291,7 @@ func initStateDB(db database.DBManager) *state.StateDB {
 
 	// Commit and re-open to start with a clean state.
 	root, _ := statedb.Commit(false)
-	statedb, _ = state.New(root, sdb, nil)
+	statedb, _ = state.New(root, sdb, nil, nil)
 
 	return statedb
 }

--- a/blockchain/vm/runtime/runtime.go
+++ b/blockchain/vm/runtime/runtime.go
@@ -107,7 +107,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 
 	if cfg.State == nil {
 		memDBManager := database.NewMemoryDBManager()
-		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(memDBManager), nil)
+		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(memDBManager), nil, nil)
 	}
 	var (
 		address = common.BytesToAddress([]byte("contract"))
@@ -142,7 +142,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 
 	if cfg.State == nil {
 		memDBManager := database.NewMemoryDBManager()
-		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(memDBManager), nil)
+		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(memDBManager), nil, nil)
 	}
 	var (
 		vmenv  = NewEnv(cfg)

--- a/blockchain/vm/runtime/runtime_test.go
+++ b/blockchain/vm/runtime/runtime_test.go
@@ -102,7 +102,7 @@ func TestExecute(t *testing.T) {
 }
 
 func TestCall(t *testing.T) {
-	state, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	state, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	address := common.HexToAddress("0x0a00")
 	state.SetCode(address, []byte{
 		byte(vm.PUSH1), 10,
@@ -159,7 +159,7 @@ func BenchmarkCall(b *testing.B) {
 
 func benchmarkEVM_Create(bench *testing.B, code string) {
 	var (
-		statedb, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+		statedb, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 		sender     = common.BytesToAddress([]byte("sender"))
 		receiver   = common.BytesToAddress([]byte("receiver"))
 	)

--- a/cmd/utils/nodecmd/snapshot.go
+++ b/cmd/utils/nodecmd/snapshot.go
@@ -229,7 +229,7 @@ func traceTrie(ctx *cli.Context) error {
 
 	logger.Info("Trace Start", "BlockNum", blockNumber)
 
-	sdb, err := state.New(root, state.NewDatabase(dbm), nil)
+	sdb, err := state.New(root, state.NewDatabase(dbm), nil, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to open newDB trie : %v", err)
 	}
@@ -273,7 +273,7 @@ func traceTrie(ctx *cli.Context) error {
 func doTraceTrie(db state.Database, root common.Hash) (resultErr error) {
 	logger.Info("Trie Tracer Start", "Hash Root", root)
 	// Create and iterate a state trie rooted in a sub-node
-	oldState, err := state.New(root, db, nil)
+	oldState, err := state.New(root, db, nil, nil)
 	if err != nil {
 		logger.Error("can not open trie DB", err.Error())
 		panic(err)
@@ -309,7 +309,7 @@ func doTraceTrie(db state.Database, root common.Hash) (resultErr error) {
 func iterateTrie(ctx *cli.Context) error {
 	stack := MakeFullNode(ctx)
 	dbm := stack.OpenDatabase(getConfig(ctx))
-	sdb, err := state.New(common.Hash{}, state.NewDatabase(dbm), nil)
+	sdb, err := state.New(common.Hash{}, state.NewDatabase(dbm), nil, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to open newDB trie : %v", err)
 	}

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -373,7 +373,7 @@ func (dl *downloadTester) CurrentFastBlock() *types.Block {
 func (dl *downloadTester) FastSyncCommitHead(hash common.Hash) error {
 	// For now only check that the state trie is correct
 	if block := dl.GetBlockByHash(hash); block != nil {
-		_, err := statedb.NewSecureTrie(block.Root(), statedb.NewDatabase(dl.stateDb))
+		_, err := statedb.NewSecureTrie(block.Root(), statedb.NewDatabase(dl.stateDb), nil)
 		return err
 	}
 	return fmt.Errorf("non existent block: %x", hash[:4])

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -325,7 +325,7 @@ func (api *PublicDebugAPI) DumpStateTrie(ctx context.Context, blockNrOrHash rpc.
 	}
 
 	db := state.NewDatabaseWithExistingCache(api.cn.chainDB, api.cn.blockchain.StateCache().TrieDB().TrieNodeCache())
-	stateDB, err := state.New(block.Root(), db, nil)
+	stateDB, err := state.New(block.Root(), db, nil, nil)
 	if err != nil {
 		return DumpStateTrieResult{}, err
 	}
@@ -496,11 +496,11 @@ func (api *PublicDebugAPI) GetModifiedAccountsByHash(startHash common.Hash, endH
 func (api *PublicDebugAPI) getModifiedAccounts(startBlock, endBlock *types.Block) ([]common.Address, error) {
 	trieDB := api.cn.blockchain.StateCache().TrieDB()
 
-	oldTrie, err := statedb.NewSecureTrie(startBlock.Root(), trieDB)
+	oldTrie, err := statedb.NewSecureTrie(startBlock.Root(), trieDB, nil)
 	if err != nil {
 		return nil, err
 	}
-	newTrie, err := statedb.NewSecureTrie(endBlock.Root(), trieDB)
+	newTrie, err := statedb.NewSecureTrie(endBlock.Root(), trieDB, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -574,11 +574,11 @@ func (api *PublicDebugAPI) getModifiedStorageNodes(contractAddr common.Address, 
 	}
 
 	trieDB := api.cn.blockchain.StateCache().TrieDB()
-	oldTrie, err := statedb.NewSecureTrie(startBlockRoot, trieDB)
+	oldTrie, err := statedb.NewSecureTrie(startBlockRoot, trieDB, nil)
 	if err != nil {
 		return 0, err
 	}
-	newTrie, err := statedb.NewSecureTrie(endBlockRoot, trieDB)
+	newTrie, err := statedb.NewSecureTrie(endBlockRoot, trieDB, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/node/cn/api_backend_test.go
+++ b/node/cn/api_backend_test.go
@@ -386,7 +386,7 @@ func TestCNAPIBackend_StateAndHeaderByNumber(t *testing.T) {
 	blockNum := uint64(123)
 	block := newBlock(int(blockNum))
 
-	stateDB, err := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	stateDB, err := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/cn/api_test.go
+++ b/node/cn/api_test.go
@@ -34,7 +34,7 @@ var dumper = spew.ConfigState{Indent: "    "}
 func TestStorageRangeAt(t *testing.T) {
 	// Create a state where account 0x010000... has a few storage entries.
 	var (
-		state, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+		state, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 		addr     = common.Address{0x01}
 		keys     = []common.Hash{ // hashes of Keys of storage
 			common.HexToHash("340dd630ad21bf010b4e676dbfa9ba9a02175262d1fa356232cfde6cb5b47ef2"),

--- a/node/cn/snap/handler.go
+++ b/node/cn/snap/handler.go
@@ -234,7 +234,7 @@ func ServiceGetAccountRangeQuery(chain SnapshotReader, req *GetAccountRangePacke
 	}
 	// TODO-Klaytn-SnapSync investigate the cache pollution
 	// Retrieve the requested state and bail out if non existent
-	tr, err := statedb.NewTrie(req.Root, chain.StateCache().TrieDB())
+	tr, err := statedb.NewTrie(req.Root, chain.StateCache().TrieDB(), nil)
 	if err != nil {
 		return nil, nil
 	}
@@ -364,7 +364,7 @@ func ServiceGetStorageRangesQuery(chain SnapshotReader, req *GetStorageRangesPac
 		if origin != (common.Hash{}) || abort {
 			// Request started at a non-zero hash or was capped prematurely, add
 			// the endpoint Merkle proofs
-			accTrie, err := statedb.NewTrie(req.Root, chain.StateCache().TrieDB())
+			accTrie, err := statedb.NewTrie(req.Root, chain.StateCache().TrieDB(), nil)
 			if err != nil {
 				return nil, nil
 			}
@@ -378,7 +378,7 @@ func ServiceGetStorageRangesQuery(chain SnapshotReader, req *GetStorageRangesPac
 				// TODO-Klaytn-SnapSync it would be better to continue rather than return. Do not waste the completed job until now.
 				return nil, nil
 			}
-			stTrie, err := statedb.NewTrie(pacc.GetStorageRoot(), chain.StateCache().TrieDB())
+			stTrie, err := statedb.NewTrie(pacc.GetStorageRoot(), chain.StateCache().TrieDB(), nil)
 			if err != nil {
 				return nil, nil
 			}
@@ -444,7 +444,7 @@ func ServiceGetTrieNodesQuery(chain SnapshotReader, req *GetTrieNodesPacket, sta
 	// Make sure we have the state associated with the request
 	triedb := chain.StateCache().TrieDB()
 
-	accTrie, err := statedb.NewSecureTrie(req.Root, triedb)
+	accTrie, err := statedb.NewSecureTrie(req.Root, triedb, nil)
 	if err != nil {
 		// We don't have the requested state available, bail out
 		return nil, nil
@@ -490,7 +490,7 @@ func ServiceGetTrieNodesQuery(chain SnapshotReader, req *GetTrieNodesPacket, sta
 			if pacc == nil {
 				break
 			}
-			stTrie, err := statedb.NewSecureTrie(pacc.GetStorageRoot(), triedb)
+			stTrie, err := statedb.NewSecureTrie(pacc.GetStorageRoot(), triedb, nil)
 			loads++ // always account database reads, even for failures
 			if err != nil {
 				break

--- a/node/cn/snap/handler_test.go
+++ b/node/cn/snap/handler_test.go
@@ -58,7 +58,7 @@ type testKV struct {
 func NewTestSnapshotReader(items []*testKV) (*testSnapshotReader, common.Hash) {
 	memdb := database.NewMemoryDBManager()
 	db := state.NewDatabase(memdb)
-	trie, _ := statedb.NewTrie(common.Hash{}, db.TrieDB())
+	trie, _ := statedb.NewTrie(common.Hash{}, db.TrieDB(), nil)
 	for _, kv := range items {
 		trie.Update(kv.k, kv.v)
 	}

--- a/node/cn/snap/sync.go
+++ b/node/cn/snap/sync.go
@@ -710,12 +710,12 @@ func (s *Syncer) loadSyncStatus() {
 			s.tasks = progress.Tasks
 			for _, task := range s.tasks {
 				task.trieDb = statedb.NewDatabase(s.db)
-				task.genTrie, err = statedb.NewTrie(common.Hash{}, task.trieDb)
+				task.genTrie, err = statedb.NewTrie(common.Hash{}, task.trieDb, nil)
 
 				for _, subtasks := range task.SubTasks {
 					for _, subtask := range subtasks {
 						subtask.trieDb = statedb.NewDatabase(s.db)
-						subtask.genTrie, _ = statedb.NewTrie(common.Hash{}, subtask.trieDb)
+						subtask.genTrie, _ = statedb.NewTrie(common.Hash{}, subtask.trieDb, nil)
 					}
 				}
 			}
@@ -762,7 +762,7 @@ func (s *Syncer) loadSyncStatus() {
 			last = common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 		}
 		db := statedb.NewDatabase(s.db)
-		trie, _ := statedb.NewTrie(common.Hash{}, db)
+		trie, _ := statedb.NewTrie(common.Hash{}, db, nil)
 		s.tasks = append(s.tasks, &accountTask{
 			Next:     next,
 			Last:     last,
@@ -1952,7 +1952,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 
 					// Our first task is the one that was just filled by this response.
 					db := statedb.NewDatabase(s.db)
-					trie, _ := statedb.NewTrie(common.Hash{}, db)
+					trie, _ := statedb.NewTrie(common.Hash{}, db, nil)
 					tasks = append(tasks, &storageTask{
 						Next:    common.Hash{},
 						Last:    r.End(),
@@ -1962,7 +1962,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 					})
 					for r.Next() {
 						db := statedb.NewDatabase(s.db)
-						trie, _ := statedb.NewTrie(common.Hash{}, db)
+						trie, _ := statedb.NewTrie(common.Hash{}, db, nil)
 						tasks = append(tasks, &storageTask{
 							Next:    r.Start(),
 							Last:    r.End(),
@@ -2014,7 +2014,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 
 		if i < len(res.hashes)-1 || res.subTask == nil {
 			db := statedb.NewDatabase(s.db)
-			tr, _ := statedb.NewTrie(common.Hash{}, db)
+			tr, _ := statedb.NewTrie(common.Hash{}, db, nil)
 			for j := 0; j < len(res.hashes[i]); j++ {
 				tr.Update(res.hashes[i][j][:], res.slots[i][j])
 			}

--- a/node/cn/snap/sync_test.go
+++ b/node/cn/snap/sync_test.go
@@ -1369,7 +1369,7 @@ func getCodeByHash(hash common.Hash) []byte {
 // makeAccountTrieNoStorage spits out a trie, along with the leafs
 func makeAccountTrieNoStorage(n int) (*statedb.Trie, entrySlice) {
 	db := statedb.NewDatabase(database.NewMemoryDBManager())
-	accTrie, _ := statedb.NewTrie(common.Hash{}, db)
+	accTrie, _ := statedb.NewTrie(common.Hash{}, db, nil)
 	var entries entrySlice
 	for i := uint64(1); i <= uint64(n); i++ {
 		acc, _ := genExternallyOwnedAccount(i, big.NewInt(int64(i)))
@@ -1394,7 +1394,7 @@ func makeBoundaryAccountTrie(n int) (*statedb.Trie, entrySlice) {
 		boundaries []common.Hash
 
 		db      = statedb.NewDatabase(database.NewMemoryDBManager())
-		trie, _ = statedb.NewTrie(common.Hash{}, db)
+		trie, _ = statedb.NewTrie(common.Hash{}, db, nil)
 	)
 	// Initialize boundaries
 	var next common.Hash
@@ -1440,7 +1440,7 @@ func makeBoundaryAccountTrie(n int) (*statedb.Trie, entrySlice) {
 func makeAccountTrieWithStorageWithUniqueStorage(accounts, slots int, code bool) (*statedb.Trie, entrySlice, map[common.Hash]*statedb.Trie, map[common.Hash]entrySlice) {
 	var (
 		db             = statedb.NewDatabase(database.NewMemoryDBManager())
-		accTrie, _     = statedb.NewTrie(common.Hash{}, db)
+		accTrie, _     = statedb.NewTrie(common.Hash{}, db, nil)
 		entries        entrySlice
 		storageTries   = make(map[common.Hash]*statedb.Trie)
 		storageEntries = make(map[common.Hash]entrySlice)
@@ -1476,7 +1476,7 @@ func makeAccountTrieWithStorageWithUniqueStorage(accounts, slots int, code bool)
 func makeAccountTrieWithStorage(accounts, slots int, code, boundary bool) (*statedb.Trie, entrySlice, map[common.Hash]*statedb.Trie, map[common.Hash]entrySlice) {
 	var (
 		db             = statedb.NewDatabase(database.NewMemoryDBManager())
-		accTrie, _     = statedb.NewTrie(common.Hash{}, db)
+		accTrie, _     = statedb.NewTrie(common.Hash{}, db, nil)
 		entries        entrySlice
 		storageTries   = make(map[common.Hash]*statedb.Trie)
 		storageEntries = make(map[common.Hash]entrySlice)
@@ -1520,7 +1520,7 @@ func makeAccountTrieWithStorage(accounts, slots int, code, boundary bool) (*stat
 // not-yet-committed trie and the sorted entries. The seeds can be used to ensure
 // that tries are unique.
 func makeStorageTrieWithSeed(n, seed uint64, db *statedb.Database) (*statedb.Trie, entrySlice) {
-	trie, _ := statedb.NewTrie(common.Hash{}, db)
+	trie, _ := statedb.NewTrie(common.Hash{}, db, nil)
 	var entries entrySlice
 	for i := uint64(1); i <= n; i++ {
 		// store 'x' at slot 'x'
@@ -1546,7 +1546,7 @@ func makeBoundaryStorageTrie(n int, db *statedb.Database) (*statedb.Trie, entryS
 	var (
 		entries    entrySlice
 		boundaries []common.Hash
-		trie, _    = statedb.NewTrie(common.Hash{}, db)
+		trie, _    = statedb.NewTrie(common.Hash{}, db, nil)
 	)
 	// Initialize boundaries
 	var next common.Hash
@@ -1593,7 +1593,7 @@ func makeBoundaryStorageTrie(n int, db *statedb.Database) (*statedb.Trie, entryS
 func verifyTrie(db database.DBManager, root common.Hash, t *testing.T) {
 	t.Helper()
 	triedb := statedb.NewDatabase(db)
-	accTrie, err := statedb.NewTrie(root, triedb)
+	accTrie, err := statedb.NewTrie(root, triedb, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1608,7 +1608,7 @@ func verifyTrie(db database.DBManager, root common.Hash, t *testing.T) {
 		pacc := account.GetProgramAccount(acc)
 		accounts++
 		if pacc != nil && pacc.GetStorageRoot() != emptyRoot {
-			storeTrie, err := statedb.NewSecureTrie(pacc.GetStorageRoot(), triedb)
+			storeTrie, err := statedb.NewSecureTrie(pacc.GetStorageRoot(), triedb, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/node/cn/state_accessor.go
+++ b/node/cn/state_accessor.go
@@ -67,7 +67,7 @@ func (cn *CN) stateAtBlock(block *types.Block, reexec uint64, base *state.StateD
 			// Create an ephemeral trie.Database for isolating the live one. Otherwise
 			// the internal junks created by tracing will be persisted into the disk.
 			database = state.NewDatabaseWithExistingCache(cn.ChainDB(), cn.blockchain.StateCache().TrieDB().TrieNodeCache())
-			if statedb, err = state.New(block.Root(), database, nil); err == nil {
+			if statedb, err = state.New(block.Root(), database, nil, nil); err == nil {
 				logger.Info("Found disk backend for state trie", "root", block.Root(), "number", block.Number())
 				return statedb, nil
 			}
@@ -93,7 +93,7 @@ func (cn *CN) stateAtBlock(block *types.Block, reexec uint64, base *state.StateD
 			}
 			current = parent
 
-			statedb, err = state.New(current.Root(), database, nil)
+			statedb, err = state.New(current.Root(), database, nil, nil)
 			if err == nil {
 				break
 			}

--- a/snapshot/conversion.go
+++ b/snapshot/conversion.go
@@ -317,7 +317,7 @@ func generateTrieRoot(it Iterator, accountHash common.Hash, generatorFn trieGene
 
 func trieGenerate(in chan trieKV, out chan common.Hash) {
 	db := statedb.NewDatabase(database.NewMemoryDBManager())
-	t, _ := statedb.NewTrie(common.Hash{}, db)
+	t, _ := statedb.NewTrie(common.Hash{}, db, nil)
 	for leaf := range in {
 		t.TryUpdate(leaf.key[:], leaf.value)
 	}

--- a/snapshot/generate.go
+++ b/snapshot/generate.go
@@ -310,7 +310,7 @@ func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix 
 			dbm    = database.NewMemoryDBManager()
 			triedb = statedb.NewDatabase(dbm)
 		)
-		tr, _ := statedb.NewTrie(common.Hash{}, triedb)
+		tr, _ := statedb.NewTrie(common.Hash{}, triedb, nil)
 		for i, key := range keys {
 			tr.TryUpdate(key, vals[i])
 		}
@@ -324,7 +324,7 @@ func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix 
 		return &proofResult{keys: keys, vals: vals}, nil
 	}
 	// Snap state is chunked, generate edge proofs for verification.
-	tr, err := statedb.NewTrie(root, dl.triedb)
+	tr, err := statedb.NewTrie(root, dl.triedb, nil)
 	if err != nil {
 		stats.Log("Trie missing, state snapshotting paused", dl.root, dl.genMarker)
 		return nil, errMissingTrie
@@ -437,7 +437,7 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 	if len(result.keys) > 0 {
 		snapNodeCache = database.NewMemoryDBManager()
 		snapTrieDb := statedb.NewDatabase(snapNodeCache)
-		snapTrie, _ := statedb.NewTrie(common.Hash{}, snapTrieDb)
+		snapTrie, _ := statedb.NewTrie(common.Hash{}, snapTrieDb, nil)
 		for i, key := range result.keys {
 			snapTrie.Update(key, result.vals[i])
 		}
@@ -447,7 +447,7 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 	}
 	tr := result.tr
 	if tr == nil {
-		tr, err = statedb.NewTrie(root, dl.triedb)
+		tr, err = statedb.NewTrie(root, dl.triedb, nil)
 		if err != nil {
 			stats.Log("Trie missing, state snapshotting paused", dl.root, dl.genMarker)
 			return false, nil, errMissingTrie

--- a/snapshot/generate_test.go
+++ b/snapshot/generate_test.go
@@ -68,13 +68,13 @@ func TestGeneration(t *testing.T) {
 		dbm    = database.NewMemoryDBManager()
 		triedb = statedb.NewDatabase(dbm)
 	)
-	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
 	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
 	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
 	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
 
-	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 
 	acc1, _ := genSmartContractAccount(0, big.NewInt(1), stTrie.Hash(), emptyCode.Bytes())
 	serializer := account.NewAccountSerializerWithAccount(acc1)
@@ -136,13 +136,13 @@ func TestGenerateExistentState(t *testing.T) {
 		diskdb = database.NewMemoryDBManager()
 		triedb = statedb.NewDatabase(diskdb)
 	)
-	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
 	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
 	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
 	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
 
-	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	acc, _ := genSmartContractAccount(uint64(0), big.NewInt(1), stTrie.Hash(), emptyCode.Bytes())
 	serializer := account.NewAccountSerializerWithAccount(acc)
 	val, _ := rlp.EncodeToBytes(serializer)
@@ -219,7 +219,7 @@ type testHelper struct {
 func newHelper() *testHelper {
 	diskdb := database.NewMemoryDBManager()
 	triedb := statedb.NewDatabase(diskdb)
-	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	return &testHelper{
 		diskdb:  diskdb,
 		triedb:  triedb,
@@ -251,7 +251,7 @@ func (t *testHelper) addSnapStorage(accKey string, keys []string, vals []string)
 }
 
 func (t *testHelper) makeStorageTrie(keys []string, vals []string) common.Hash {
-	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, t.triedb)
+	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, t.triedb, nil)
 	for i, k := range keys {
 		stTrie.Update([]byte(k), []byte(vals[i]))
 	}
@@ -447,7 +447,7 @@ func TestGenerateCorruptAccountTrie(t *testing.T) {
 		diskdb = database.NewMemoryDBManager()
 		triedb = statedb.NewDatabase(diskdb)
 	)
-	tr, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	tr, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	acc1, _ := genExternallyOwnedAccount(0, big.NewInt(1))
 	serializer1 := account.NewAccountSerializerWithAccount(acc1)
 	val, _ := rlp.EncodeToBytes(serializer1)
@@ -497,13 +497,13 @@ func TestGenerateMissingStorageTrie(t *testing.T) {
 		diskdb = database.NewMemoryDBManager()
 		triedb = statedb.NewDatabase(diskdb)
 	)
-	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
 	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
 	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
 	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
 
-	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	acc, _ := genSmartContractAccount(0, big.NewInt(1), stTrie.Hash(), emptyCode.Bytes())
 	val, _ := rlp.EncodeToBytes(account.NewAccountSerializerWithAccount(acc))
 	accTrie.Update([]byte("acc-1"), val) // 0x30301e37c9af8ee5f609f1d60a3307d3e113bea03bef203e39aadc46bd5ad5ee
@@ -558,13 +558,13 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 		diskdb = database.NewMemoryDBManager()
 		triedb = statedb.NewDatabase(diskdb)
 	)
-	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
 	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
 	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
 	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
 
-	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	acc, _ := genSmartContractAccount(0, big.NewInt(1), stTrie.Hash(), emptyCode.Bytes())
 	serializer := account.NewAccountSerializerWithAccount(acc)
 	val, _ := rlp.EncodeToBytes(serializer)
@@ -612,7 +612,7 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 }
 
 func getStorageTrie(n int, triedb *statedb.Database) *statedb.SecureTrie {
-	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	for i := 0; i < n; i++ {
 		k := fmt.Sprintf("key-%d", i)
 		v := fmt.Sprintf("val-%d", i)
@@ -629,7 +629,7 @@ func TestGenerateWithExtraAccounts(t *testing.T) {
 		triedb = statedb.NewDatabase(diskdb)
 		stTrie = getStorageTrie(5, triedb)
 	)
-	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	{ // Account one in the trie
 		acc, _ := genSmartContractAccount(0, big.NewInt(1), stTrie.Hash(), emptyCode.Bytes())
 		val, _ := rlp.EncodeToBytes(account.NewAccountSerializerWithAccount(acc))
@@ -689,7 +689,7 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 		triedb = statedb.NewDatabase(diskdb)
 		stTrie = getStorageTrie(3, triedb)
 	)
-	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb)
+	accTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
 	{ // Account one in the trie
 		acc, _ := genSmartContractAccount(0, big.NewInt(1), stTrie.Hash(), emptyCode.Bytes())
 		val, _ := rlp.EncodeToBytes(account.NewAccountSerializerWithAccount(acc))
@@ -745,7 +745,7 @@ func TestGenerateWithExtraBeforeAndAfter(t *testing.T) {
 		diskdb = database.NewMemoryDBManager()
 		triedb = statedb.NewDatabase(diskdb)
 	)
-	accTrie, _ := statedb.NewTrie(common.Hash{}, triedb)
+	accTrie, _ := statedb.NewTrie(common.Hash{}, triedb, nil)
 	{
 		acc, _ := genExternallyOwnedAccount(0, big.NewInt(1))
 		val, _ := rlp.EncodeToBytes(account.NewAccountSerializerWithAccount(acc))
@@ -790,7 +790,7 @@ func TestGenerateWithMalformedSnapdata(t *testing.T) {
 		diskdb = database.NewMemoryDBManager()
 		triedb = statedb.NewDatabase(diskdb)
 	)
-	accTrie, _ := statedb.NewTrie(common.Hash{}, triedb)
+	accTrie, _ := statedb.NewTrie(common.Hash{}, triedb, nil)
 	{
 		acc, _ := genExternallyOwnedAccount(0, big.NewInt(1))
 		val, _ := rlp.EncodeToBytes(account.NewAccountSerializerWithAccount(acc))

--- a/storage/statedb/iterator_test.go
+++ b/storage/statedb/iterator_test.go
@@ -297,7 +297,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	diskdb := memDBManager.GetMemDB()
 	triedb := NewDatabase(memDBManager)
 
-	tr, _ := NewTrie(common.Hash{}, triedb)
+	tr, _ := NewTrie(common.Hash{}, triedb, nil)
 	for _, val := range testdata1 {
 		tr.Update([]byte(val.k), []byte(val.v))
 	}
@@ -318,7 +318,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	}
 	for i := 0; i < 20; i++ {
 		// Create trie that will load all nodes from DB.
-		tr, _ := NewTrie(tr.Hash(), triedb)
+		tr, _ := NewTrie(tr.Hash(), triedb, nil)
 
 		// Remove a random node from the database. It can't be the root node
 		// because that one is already loaded.
@@ -386,7 +386,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	diskdb := memDBManager.GetMemDB()
 	triedb := NewDatabase(memDBManager)
 
-	ctr, _ := NewTrie(common.Hash{}, triedb)
+	ctr, _ := NewTrie(common.Hash{}, triedb, nil)
 	for _, val := range testdata1 {
 		ctr.Update([]byte(val.k), []byte(val.v))
 	}
@@ -408,7 +408,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	}
 	// Create a new iterator that seeks to "bars". Seeking can't proceed because
 	// the node is missing.
-	tr, _ := NewTrie(root, triedb)
+	tr, _ := NewTrie(root, triedb, nil)
 	it := tr.NodeIterator([]byte("bars"))
 	missing, ok := it.Error().(*MissingNodeError)
 	if !ok {

--- a/storage/statedb/proof.go
+++ b/storage/statedb/proof.go
@@ -495,7 +495,7 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, lastKey []byte, key
 	// Special case, there is no edge proof at all. The given range is expected
 	// to be the whole leaf-set in the trie.
 	if proof == nil {
-		tr, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+		tr, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 		for index, key := range keys {
 			tr.TryUpdate(key, values[index])
 		}

--- a/storage/statedb/secure_trie.go
+++ b/storage/statedb/secure_trie.go
@@ -53,21 +53,15 @@ type SecureTrie struct {
 // A new cache generation is created by each call to Commit.
 // cachelimit sets the number of past cache generations to keep.
 func NewSecureTrie(root common.Hash, db *Database) (*SecureTrie, error) {
-	if db == nil {
-		panic("statedb.NewSecureTrie called without a database")
-	}
-	trie, err := NewTrie(root, db)
-	if err != nil {
-		return nil, err
-	}
-	return &SecureTrie{trie: *trie}, nil
+	return NewSecureTrieWithOpts(root, db, nil)
 }
 
 func NewSecureTrieForPrefetching(root common.Hash, db *Database) (*SecureTrie, error) {
-	if db == nil {
-		panic("statedb.NewSecureTrieForPrefetching called without a database")
-	}
-	trie, err := NewTrieForPrefetching(root, db)
+	return NewSecureTrieWithOpts(root, db, &TrieOpts{Prefetching: true})
+}
+
+func NewSecureTrieWithOpts(root common.Hash, db *Database, opts *TrieOpts) (*SecureTrie, error) {
+	trie, err := NewTrieWithOpts(root, db, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/statedb/secure_trie.go
+++ b/storage/statedb/secure_trie.go
@@ -52,12 +52,8 @@ type SecureTrie struct {
 // Loaded nodes are kept around until their 'cache generation' expires.
 // A new cache generation is created by each call to Commit.
 // cachelimit sets the number of past cache generations to keep.
-func NewSecureTrie(root common.Hash, db *Database) (*SecureTrie, error) {
-	return NewSecureTrieWithOpts(root, db, nil)
-}
-
-func NewSecureTrieWithOpts(root common.Hash, db *Database, opts *TrieOpts) (*SecureTrie, error) {
-	trie, err := NewTrieWithOpts(root, db, opts)
+func NewSecureTrie(root common.Hash, db *Database, opts *TrieOpts) (*SecureTrie, error) {
+	trie, err := NewTrie(root, db, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/statedb/secure_trie.go
+++ b/storage/statedb/secure_trie.go
@@ -56,10 +56,6 @@ func NewSecureTrie(root common.Hash, db *Database) (*SecureTrie, error) {
 	return NewSecureTrieWithOpts(root, db, nil)
 }
 
-func NewSecureTrieForPrefetching(root common.Hash, db *Database) (*SecureTrie, error) {
-	return NewSecureTrieWithOpts(root, db, &TrieOpts{Prefetching: true})
-}
-
 func NewSecureTrieWithOpts(root common.Hash, db *Database, opts *TrieOpts) (*SecureTrie, error) {
 	trie, err := NewTrieWithOpts(root, db, opts)
 	if err != nil {

--- a/storage/statedb/secure_trie_test.go
+++ b/storage/statedb/secure_trie_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func newEmptySecureTrie() *SecureTrie {
-	trie, _ := NewSecureTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	trie, _ := NewSecureTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 	return trie
 }
 
@@ -41,7 +41,7 @@ func makeTestSecureTrie() (*Database, *SecureTrie, map[string][]byte) {
 	// Create an empty trie
 	triedb := NewDatabase(database.NewMemoryDBManager())
 
-	trie, _ := NewSecureTrie(common.Hash{}, triedb)
+	trie, _ := NewSecureTrie(common.Hash{}, triedb, nil)
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)

--- a/storage/statedb/stacktrie_test.go
+++ b/storage/statedb/stacktrie_test.go
@@ -192,7 +192,7 @@ func TestStackTrieInsertAndHash(t *testing.T) {
 
 func TestSizeBug(t *testing.T) {
 	st := NewStackTrie(nil)
-	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 
 	leaf := common.FromHex("290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
 	value := common.FromHex("94cf40d0d2b44f2b66e07cace1372ca42b73cf21a3")
@@ -207,7 +207,7 @@ func TestSizeBug(t *testing.T) {
 
 func TestEmptyBug(t *testing.T) {
 	st := NewStackTrie(nil)
-	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 
 	// leaf := common.FromHex("290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
 	// value := common.FromHex("94cf40d0d2b44f2b66e07cace1372ca42b73cf21a3")
@@ -233,7 +233,7 @@ func TestEmptyBug(t *testing.T) {
 
 func TestValLength56(t *testing.T) {
 	st := NewStackTrie(nil)
-	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 
 	// leaf := common.FromHex("290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
 	// value := common.FromHex("94cf40d0d2b44f2b66e07cace1372ca42b73cf21a3")
@@ -258,7 +258,7 @@ func TestValLength56(t *testing.T) {
 // which causes a lot of node-within-node. This case was found via fuzzing.
 func TestUpdateSmallNodes(t *testing.T) {
 	st := NewStackTrie(nil)
-	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 	kvs := []struct {
 		K string
 		V string
@@ -286,7 +286,7 @@ func TestUpdateSmallNodes(t *testing.T) {
 func TestUpdateVariableKeys(t *testing.T) {
 	t.SkipNow()
 	st := NewStackTrie(nil)
-	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	nt, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 	kvs := []struct {
 		K string
 		V string
@@ -356,7 +356,7 @@ func TestStacktrieNotModifyValues(t *testing.T) {
 func TestStacktrieSerialization(t *testing.T) {
 	var (
 		st       = NewStackTrie(nil)
-		nt, _    = NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+		nt, _    = NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 		keyB     = big.NewInt(1)
 		keyDelta = big.NewInt(1)
 		vals     [][]byte

--- a/storage/statedb/sync_test.go
+++ b/storage/statedb/sync_test.go
@@ -36,7 +36,7 @@ import (
 func makeTestTrie() (*Database, *SecureTrie, map[string][]byte) {
 	// Create an empty trie
 	triedb := NewDatabase(database.NewMemoryDBManager())
-	trie, _ := NewSecureTrie(common.Hash{}, triedb)
+	trie, _ := NewSecureTrie(common.Hash{}, triedb, nil)
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
@@ -67,7 +67,7 @@ func makeTestTrie() (*Database, *SecureTrie, map[string][]byte) {
 // content map.
 func checkTrieContents(t *testing.T, db *Database, root []byte, content map[string][]byte) {
 	// Check root availability and trie contents
-	trie, err := NewSecureTrie(common.BytesToHash(root), db)
+	trie, err := NewSecureTrie(common.BytesToHash(root), db, nil)
 	if err != nil {
 		t.Fatalf("failed to create trie at %x: %v", root, err)
 	}
@@ -84,7 +84,7 @@ func checkTrieContents(t *testing.T, db *Database, root []byte, content map[stri
 // checkTrieConsistency checks that all nodes in a trie are indeed present.
 func checkTrieConsistency(db *Database, root common.Hash) error {
 	// Create and iterate a trie rooted in a subnode
-	trie, err := NewSecureTrie(root, db)
+	trie, err := NewSecureTrie(root, db, nil)
 	if err != nil {
 		return nil // Consider a non existent state consistent
 	}
@@ -100,8 +100,8 @@ func TestEmptyTrieSync(t *testing.T) {
 	memDBManagerB := database.NewMemoryDBManager()
 	dbA := NewDatabase(memDBManagerA)
 	dbB := NewDatabase(memDBManagerB)
-	emptyA, _ := NewTrie(common.Hash{}, dbA)
-	emptyB, _ := NewTrie(emptyRoot, dbB)
+	emptyA, _ := NewTrie(common.Hash{}, dbA, nil)
+	emptyB, _ := NewTrie(emptyRoot, dbB, nil)
 
 	for i, trie := range []*Trie{emptyA, emptyB} {
 		sync := NewTrieSync(trie.Hash(), database.NewMemoryDBManager(), nil, NewSyncBloom(1, database.NewMemDB()), nil)

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -81,11 +81,7 @@ func (t *Trie) newFlag() nodeFlag {
 // trie is initially empty and does not require a database. Otherwise,
 // NewTrie will panic if db is nil and returns a MissingNodeError if root does
 // not exist in the database. Accessing the trie loads nodes from db on demand.
-func NewTrie(root common.Hash, db *Database) (*Trie, error) {
-	return NewTrieWithOpts(root, db, nil)
-}
-
-func NewTrieWithOpts(root common.Hash, db *Database, opts *TrieOpts) (*Trie, error) {
+func NewTrie(root common.Hash, db *Database, opts *TrieOpts) (*Trie, error) {
 	if db == nil {
 		panic("statedb.NewTrie called without a database")
 	}

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -85,11 +85,6 @@ func NewTrie(root common.Hash, db *Database) (*Trie, error) {
 	return NewTrieWithOpts(root, db, nil)
 }
 
-// Deprecated: Prefer NewTrieWithOpts
-func NewTrieForPrefetching(root common.Hash, db *Database) (*Trie, error) {
-	return NewTrieWithOpts(root, db, &TrieOpts{Prefetching: true})
-}
-
 func NewTrieWithOpts(root common.Hash, db *Database, opts *TrieOpts) (*Trie, error) {
 	if db == nil {
 		panic("statedb.NewTrie called without a database")

--- a/storage/statedb/trie_test.go
+++ b/storage/statedb/trie_test.go
@@ -48,7 +48,7 @@ func init() {
 
 // Used for testing
 func newEmptyTrie() *Trie {
-	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 	return trie
 }
 
@@ -72,7 +72,7 @@ func TestNull(t *testing.T) {
 }
 
 func TestMissingRoot(t *testing.T) {
-	trie, err := NewTrie(common.HexToHash("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"), NewDatabase(database.NewMemoryDBManager()))
+	trie, err := NewTrie(common.HexToHash("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"), NewDatabase(database.NewMemoryDBManager()), nil)
 	if trie != nil {
 		t.Error("NewTrie returned non-nil trie for invalid root")
 	}
@@ -89,7 +89,7 @@ func testMissingNode(t *testing.T, memonly bool) {
 	diskdb := memDBManager.GetMemDB()
 	triedb := NewDatabase(memDBManager)
 
-	trie, _ := NewTrie(common.Hash{}, triedb)
+	trie, _ := NewTrie(common.Hash{}, triedb, nil)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
 	root, _ := trie.Commit(nil)
@@ -97,27 +97,27 @@ func testMissingNode(t *testing.T, memonly bool) {
 		triedb.Commit(root, true, 0)
 	}
 
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	_, err := trie.TryGet([]byte("120000"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	_, err = trie.TryGet([]byte("120099"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	_, err = trie.TryGet([]byte("123456"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	err = trie.TryUpdate([]byte("120099"), []byte("zxcvzxcvzxcvzxcvzxcvzxcvzxcvzxcv"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	err = trie.TryDelete([]byte("123456"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -130,27 +130,27 @@ func testMissingNode(t *testing.T, memonly bool) {
 		diskdb.Delete(hash[:])
 	}
 
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	_, err = trie.TryGet([]byte("120000"))
 	if _, ok := err.(*MissingNodeError); !ok {
 		t.Errorf("Wrong error: %v", err)
 	}
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	_, err = trie.TryGet([]byte("120099"))
 	if _, ok := err.(*MissingNodeError); !ok {
 		t.Errorf("Wrong error: %v", err)
 	}
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	_, err = trie.TryGet([]byte("123456"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	err = trie.TryUpdate([]byte("120099"), []byte("zxcv"))
 	if _, ok := err.(*MissingNodeError); !ok {
 		t.Errorf("Wrong error: %v", err)
 	}
-	trie, _ = NewTrie(root, triedb)
+	trie, _ = NewTrie(root, triedb, nil)
 	err = trie.TryDelete([]byte("123456"))
 	if _, ok := err.(*MissingNodeError); !ok {
 		t.Errorf("Wrong error: %v", err)
@@ -278,7 +278,7 @@ func TestReplication(t *testing.T) {
 	}
 
 	// create a new trie on top of the database and check that lookups work.
-	trie2, err := NewTrie(exp, trie.db)
+	trie2, err := NewTrie(exp, trie.db, nil)
 	if err != nil {
 		t.Fatalf("can't recreate trie at %x: %v", exp, err)
 	}
@@ -387,7 +387,7 @@ func (randTest) Generate(r *rand.Rand, size int) reflect.Value {
 func runRandTest(rt randTest) bool {
 	triedb := NewDatabase(database.NewMemoryDBManager())
 
-	tr, _ := NewTrie(common.Hash{}, triedb)
+	tr, _ := NewTrie(common.Hash{}, triedb, nil)
 	values := make(map[string]string) // tracks content of the trie
 
 	for i, step := range rt {
@@ -414,14 +414,14 @@ func runRandTest(rt randTest) bool {
 				rt[i].err = err
 				return false
 			}
-			newtr, err := NewTrie(hash, triedb)
+			newtr, err := NewTrie(hash, triedb, nil)
 			if err != nil {
 				rt[i].err = err
 				return false
 			}
 			tr = newtr
 		case opItercheckhash:
-			checktr, _ := NewTrie(common.Hash{}, triedb)
+			checktr, _ := NewTrie(common.Hash{}, triedb, nil)
 			it := NewIterator(tr.NodeIterator(nil))
 			for it.Next() {
 				checktr.Update(it.Key, it.Value)
@@ -459,7 +459,7 @@ func benchGet(b *testing.B, commit bool) {
 
 	if commit {
 		dbDir, tmpdb := tempDB()
-		trie, _ = NewTrie(common.Hash{}, tmpdb)
+		trie, _ = NewTrie(common.Hash{}, tmpdb, nil)
 
 		defer os.RemoveAll(dbDir)
 		defer tmpdb.diskDB.Close()
@@ -540,7 +540,7 @@ func BenchmarkCommitAfterHash(b *testing.B) {
 func benchmarkCommitAfterHash(b *testing.B) {
 	// Make the random benchmark deterministic
 	addresses, accounts := makeAccounts(b.N)
-	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 	for i := 0; i < len(addresses); i++ {
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
@@ -642,7 +642,7 @@ func BenchmarkHashFixedSize(b *testing.B) {
 
 func benchmarkHashFixedSize(b *testing.B, addresses [][20]byte, accounts [][]byte) {
 	b.ReportAllocs()
-	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 	for i := 0; i < len(addresses); i++ {
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
@@ -693,7 +693,7 @@ func BenchmarkCommitAfterHashFixedSize(b *testing.B) {
 
 func benchmarkCommitAfterHashFixedSize(b *testing.B, addresses [][20]byte, accounts [][]byte) {
 	b.ReportAllocs()
-	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()))
+	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
 	for i := 0; i < len(addresses); i++ {
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
@@ -746,7 +746,7 @@ func BenchmarkDerefRootFixedSize(b *testing.B) {
 func benchmarkDerefRootFixedSize(b *testing.B, addresses [][20]byte, accounts [][]byte) {
 	b.ReportAllocs()
 	triedb := NewDatabase(database.NewMemoryDBManager())
-	trie, _ := NewTrie(common.Hash{}, triedb)
+	trie, _ := NewTrie(common.Hash{}, triedb, nil)
 	for i := 0; i < len(addresses); i++ {
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}

--- a/tests/benchmarks/benchmarks_test_utils.go
+++ b/tests/benchmarks/benchmarks_test_utils.go
@@ -61,7 +61,7 @@ func makeBenchConfig() *BenchConfig {
 	// EVMConfig   vm.Config
 
 	memDBManager := database.NewMemoryDBManager()
-	cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(memDBManager), nil)
+	cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(memDBManager), nil, nil)
 	cfg.GetHashFn = func(n uint64) common.Hash {
 		return common.BytesToHash(crypto.Keccak256([]byte(new(big.Int).SetUint64(n).String())))
 	}

--- a/tests/klay_scenario_test.go
+++ b/tests/klay_scenario_test.go
@@ -1743,7 +1743,7 @@ func TestValidateSender(t *testing.T) {
 
 	initialBalance := big.NewInt(1000000)
 
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	statedb.CreateEOA(anon.Addr, false, anon.AccKey)
 	statedb.SetNonce(anon.Addr, nonce)
 	statedb.SetBalance(anon.Addr, initialBalance)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -197,7 +197,7 @@ func (t *StateTest) gasLimit(subtest StateSubtest) uint64 {
 
 func MakePreState(db database.DBManager, accounts blockchain.GenesisAlloc) *state.StateDB {
 	sdb := state.NewDatabase(db)
-	statedb, _ := state.New(common.Hash{}, sdb, nil)
+	statedb, _ := state.New(common.Hash{}, sdb, nil, nil)
 	for addr, a := range accounts {
 		if len(a.Code) != 0 {
 			statedb.SetCode(addr, a.Code)
@@ -210,7 +210,7 @@ func MakePreState(db database.DBManager, accounts blockchain.GenesisAlloc) *stat
 	}
 	// Commit and re-open to start with a clean state.
 	root, _ := statedb.Commit(false)
-	statedb, _ = state.New(root, sdb, nil)
+	statedb, _ = state.New(root, sdb, nil, nil)
 	return statedb
 }
 


### PR DESCRIPTION
## Proposed changes

- Replace `NewXxxForPrefetching(...)` with `NewXxx(..., &TrieOpts{Prefetching: true})`
- Later, the TrieOpts will contain the KIP-111 state pruning flags. The flags shall be injected from the command line -> cn.New -> blockchain -> ...TrieOpts... -> trie.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

- Q. Why call it Opts not Config?
  - A. I want to reserve "Config" for the future. Just in case we ever use Database config.
  - geth is using `trie.Config` struct to pass cache-related options. ([source](https://github.com/ethereum/go-ethereum/blob/v1.11.5/trie/database.go#L266-L305))
-  To compare klaytn `statedb` and geth `trie` packages:

| Type | klaytn (after this PR)                                                      | geth 1.11.5                                             |
|----------|-----------------------------------------------------------------------------|---------------------------------------------------------|
| Database | NewDatabase<br>NewDatabaseWithNewCache<br>NewDatabaseWithExistingCache | struct Config{ Cache }<br>NewDatabase<br>NewDatabaseWithConfig |
| Trie     | struct TrieOpts{ Prefetching }<br>New<br><s>NewForPrefetching</s>         | New                                                |