### PR TITLE
txpool: move txpool adjustments(reset,promote) and event handling to background goroutine

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2063,7 +2063,7 @@ func (bc *BlockChain) BlockSubscriptionLoop(pool *TxPool) {
 
 		oldHead := bc.CurrentHeader()
 		bc.replaceCurrentBlock(block)
-		pool.lockedReset(oldHead, bc.CurrentHeader())
+		pool.requestReset(oldHead, bc.CurrentHeader())
 
 		// just in case the block number jumps up more than one, iterates all missed blocks
 		for blockNum := oldHead.Number.Uint64() + 1; blockNum < block.Number().Uint64(); blockNum++ {

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1181,16 +1181,20 @@ func (pool *TxPool) AddRemote(tx *types.Transaction) error {
 	return errs[0]
 }
 
-// AddLocals enqueues a batch of transactions into the pool if they are valid,
-// marking the senders as a local ones in the mean time, ensuring they go around
-// the local pricing constraints.
+// AddLocals enqueues a batch of transactions into the pool if they are valid, marking the
+// senders as a local ones, ensuring they go around the local pricing constraints.
+//
+// This method is used to add transactions from the RPC API and performs synchronous pool
+// reorganization and event propagation.
 func (pool *TxPool) AddLocals(txs []*types.Transaction) []error {
 	return pool.checkAndAddTxs(txs, !pool.config.NoLocals, true)
 }
 
-// AddRemotes enqueues a batch of transactions into the pool if they are valid.
-// If the senders are not among the locally tracked ones, full pricing constraints
-// will apply.
+// AddRemotes enqueues a batch of transactions into the pool if they are valid. If the
+// senders are not among the locally tracked ones, full pricing constraints will apply.
+//
+// This method is used to add transactions from the p2p network and does not wait for pool
+// reorganization and internal event propagation.
 func (pool *TxPool) AddRemotes(txs []*types.Transaction) []error {
 	return pool.checkAndAddTxs(txs, false, false)
 }

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1199,6 +1199,17 @@ func (pool *TxPool) AddRemotes(txs []*types.Transaction) []error {
 	return pool.checkAndAddTxs(txs, false, false)
 }
 
+// AddRemotesSync is like AddRemotes, but waits for pool reorganization. Tests use this method.
+func (pool *TxPool) AddRemotesSync(txs []*types.Transaction) []error {
+	return pool.checkAndAddTxs(txs, false, true)
+}
+
+// AddRemoteSync is like AddRemote, but waits for pool reorganization. Tests use this method.
+func (pool *TxPool) AddRemoteSync(tx *types.Transaction) error {
+	errs := pool.AddRemotesSync([]*types.Transaction{tx})
+	return errs[0]
+}
+
 // checkAndAddTxs compares the size of given transactions and the capacity of TxPool.
 // If given transactions exceed the capacity of TxPool, it slices the given transactions
 // so it can fit into TxPool's capacity.

--- a/node/sc/main_bridge_handler.go
+++ b/node/sc/main_bridge_handler.go
@@ -117,11 +117,11 @@ func (mbh *MainBridgeHandler) handleServiceChainTxDataMsg(p BridgePeer, msg p2p.
 			invalidTxs = append(invalidTxs, InvalidParentChainTx{tx.Hash(), errResp(ErrDecode, "tx is nil").Error()})
 			continue
 		}
-		if err := mbh.mainbridge.txPool.AddRemote(tx); err != nil {
+		if errs := mbh.mainbridge.txPool.AddRemotes(types.Transactions{tx}); errs[0] != nil {
 			txHash := tx.Hash()
 			logger.Trace("Invalid tx found",
-				"txType", tx.Type(), "txNonce", tx.Nonce(), "txHash", txHash.String(), "err", err)
-			invalidTxs = append(invalidTxs, InvalidParentChainTx{txHash, err.Error()})
+				"txType", tx.Type(), "txNonce", tx.Nonce(), "txHash", txHash.String(), "err", errs[0])
+			invalidTxs = append(invalidTxs, InvalidParentChainTx{txHash, errs[0].Error()})
 		}
 	}
 	if len(invalidTxs) > 0 {

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -721,7 +721,7 @@ func TestAccountUpdateMultiSigKeyMaxKey(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrMaxKeysExceed, err)
 		}
 
@@ -835,7 +835,7 @@ func TestAccountUpdateMultiSigKeyBigThreshold(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrUnsatisfiableThreshold, err)
 		}
 
@@ -946,7 +946,7 @@ func TestAccountUpdateMultiSigKeyDupPrvKeys(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrDuplicatedKey, err)
 		}
 
@@ -1062,7 +1062,7 @@ func TestAccountUpdateMultiSigKeyWeightOverflow(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrWeightedSumOverflow, err)
 		}
 
@@ -1170,7 +1170,7 @@ func TestAccountUpdateRoleBasedKeyInvalidNumKey(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrLengthTooLong, err)
 		}
 
@@ -1202,7 +1202,7 @@ func TestAccountUpdateRoleBasedKeyInvalidNumKey(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrZeroLength, err)
 		}
 
@@ -1313,7 +1313,7 @@ func TestAccountUpdateRoleBasedKeyInvalidTypeKey(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrAccountKeyNilUninitializable, err)
 		}
 
@@ -1349,7 +1349,7 @@ func TestAccountUpdateRoleBasedKeyInvalidTypeKey(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrAccountKeyNilUninitializable, err)
 		}
 
@@ -1385,7 +1385,7 @@ func TestAccountUpdateRoleBasedKeyInvalidTypeKey(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrAccountKeyNilUninitializable, err)
 		}
 
@@ -1602,7 +1602,7 @@ func TestAccountUpdateRoleBasedKey(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
 		}
 
@@ -1631,7 +1631,7 @@ func TestAccountUpdateRoleBasedKey(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
 		}
 
@@ -1789,7 +1789,7 @@ func TestAccountUpdateRoleBasedKeyNested(t *testing.T) {
 
 		// For tx pool validation test
 		{
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrNestedCompositeType, err)
 		}
 
@@ -1991,7 +1991,7 @@ func TestRoleBasedKeySendTx(t *testing.T) {
 			} else {
 				// For tx pool validation test
 				{
-					err = txpool.AddRemote(tx)
+					err = txpool.AddRemoteSync(tx)
 					assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
 				}
 
@@ -2188,7 +2188,7 @@ func TestRoleBasedKeyFeeDelegation(t *testing.T) {
 			} else {
 				// For tx pool validation test
 				{
-					err = txpool.AddRemote(tx)
+					err = txpool.AddRemoteSync(tx)
 					assert.Equal(t, types.ErrFeePayer(types.ErrInvalidSigFeePayer), err)
 				}
 

--- a/tests/klay_scenario_test.go
+++ b/tests/klay_scenario_test.go
@@ -281,7 +281,7 @@ func TestFeeDelegatedWithSmallBalance(t *testing.T) {
 
 		p := makeTxPool(bcdata, 10)
 
-		p.AddRemote(tx)
+		p.AddRemoteSync(tx)
 
 		if err := bcdata.GenABlockWithTxpool(accountMap, p, prof); err != nil {
 			t.Fatal(err)

--- a/tests/klay_test.go
+++ b/tests/klay_test.go
@@ -414,7 +414,7 @@ func TestValueTransferRing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txpool.AddRemotes(txs)
+	txpool.AddRemotesSync(txs)
 
 	for {
 		if err := bcdata.GenABlockWithTxpool(accountMap, txpool, prof); err != nil {
@@ -679,7 +679,7 @@ func BenchmarkValueTransfer(t *testing.B) {
 
 	t.ResetTimer()
 
-	txpool.AddRemotes(txs)
+	txpool.AddRemotesSync(txs)
 
 	for {
 		if err := bcdata.GenABlockWithTxpool(accountMap, txpool, prof); err != nil {
@@ -730,7 +730,7 @@ func BenchmarkNewValueTransfer(t *testing.B) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	txpool.AddRemotes(txs)
+	txpool.AddRemotesSync(txs)
 
 	t.ResetTimer()
 	for {

--- a/tests/pregenerated_data_execution_test.go
+++ b/tests/pregenerated_data_execution_test.go
@@ -227,7 +227,7 @@ func executeTxs(bcData *BCData, txPool *blockchain.TxPool, txs types.Transaction
 		if end > len(txs) {
 			end = len(txs)
 		}
-		txPool.AddRemotes(txs[i:end])
+		txPool.AddRemotesSync(txs[i:end])
 		for {
 			if err := bcData.GenABlockWithTxPoolWithoutAccountMap(txPool); err != nil {
 				if err == errEmptyPending {

--- a/tests/pregenerated_data_generation_test.go
+++ b/tests/pregenerated_data_generation_test.go
@@ -304,7 +304,7 @@ func dataGenerationTest(b *testing.B, tc *preGeneratedTC) {
 			pprof.StartCPUProfile(profileFile)
 		}
 
-		txPool.AddRemotes(txs)
+		txPool.AddRemotesSync(txs)
 
 		for {
 			if err := bcData.GenABlockWithTxPoolWithoutAccountMap(txPool); err != nil {

--- a/tests/resend_nil_test.go
+++ b/tests/resend_nil_test.go
@@ -109,7 +109,7 @@ func BenchmarkResendNilDereference(t *testing.B) {
 				fmt.Println("sign err", err)
 			}
 			time.Sleep(1 * time.Nanosecond)
-			txpool.AddRemotes(types.Transactions{signedTx})
+			txpool.AddRemotesSync(types.Transactions{signedTx})
 
 			reservoir.Nonce++
 		}

--- a/tests/role_based_account_test.go
+++ b/tests/role_based_account_test.go
@@ -838,7 +838,7 @@ func TestAccountUpdateRoleBasedTransition(t *testing.T) {
 		assert.Equal(t, nil, err)
 
 		txpool := makeTxPool(bcdata, 10)
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, nil, err)
 	}
 
@@ -858,7 +858,7 @@ func TestAccountUpdateRoleBasedTransition(t *testing.T) {
 		assert.Equal(t, nil, err)
 
 		txpool := makeTxPool(bcdata, 10)
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
 	}
 
@@ -903,7 +903,7 @@ func TestAccountUpdateRoleBasedTransition(t *testing.T) {
 		assert.Equal(t, nil, err)
 
 		txpool := makeTxPool(bcdata, 10)
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
 	}
 
@@ -923,7 +923,7 @@ func TestAccountUpdateRoleBasedTransition(t *testing.T) {
 		assert.Equal(t, nil, err)
 
 		txpool := makeTxPool(bcdata, 10)
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, nil, err)
 	}
 }

--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -104,7 +104,7 @@ func TestAccountCreationDisable(t *testing.T) {
 		assert.Equal(t, nil, err)
 
 		// fail to add tx in txPool
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, errUndefinedTxType, err)
 
 		// fail to execute tx
@@ -171,7 +171,7 @@ func TestContractDeployWithDisabledAddress(t *testing.T) {
 				assert.Equal(t, nil, err)
 			}
 			// fail to add tx in txPool
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrHumanReadableNotSupported, err)
 
 			// fail to execute tx
@@ -196,7 +196,7 @@ func TestContractDeployWithDisabledAddress(t *testing.T) {
 				assert.Equal(t, nil, err)
 			}
 			// fail to add tx in txPool
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, kerrors.ErrInvalidContractAddress, err)
 
 			// fail to execute tx

--- a/tests/transaction_validation_test.go
+++ b/tests/transaction_validation_test.go
@@ -153,7 +153,7 @@ func TestValidatingUnavailableContractExecution(t *testing.T) {
 	{
 		tx, _ := genSmartContractExecution(t, signer, reservoir, contract, nil, gasPrice)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, nil, err)
 	}
 
@@ -161,7 +161,7 @@ func TestValidatingUnavailableContractExecution(t *testing.T) {
 	{
 		tx, _ := genSmartContractExecution(t, signer, reservoir, invalidContract, nil, gasPrice)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, kerrors.ErrNotProgramAccount, err)
 	}
 
@@ -169,7 +169,7 @@ func TestValidatingUnavailableContractExecution(t *testing.T) {
 	{
 		tx, _ := genSmartContractExecution(t, signer, reservoir, EOA, nil, gasPrice)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, kerrors.ErrNotProgramAccount, err)
 	}
 

--- a/tests/tx_cancel_test.go
+++ b/tests/tx_cancel_test.go
@@ -83,7 +83,7 @@ func TestTxCancel(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued := txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -115,7 +115,7 @@ func TestTxCancel(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued = txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -141,7 +141,7 @@ func TestTxCancel(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued := txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -167,7 +167,7 @@ func TestTxCancel(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued := txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -234,7 +234,7 @@ func TestTxFeeDelegatedCancel(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued := txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -266,7 +266,7 @@ func TestTxFeeDelegatedCancel(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued = txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -296,7 +296,7 @@ func TestTxFeeDelegatedCancel(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued := txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -326,7 +326,7 @@ func TestTxFeeDelegatedCancel(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued := txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -393,7 +393,7 @@ func TestTxFeeDelegatedCancelWithRatio(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued := txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -425,7 +425,7 @@ func TestTxFeeDelegatedCancelWithRatio(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued = txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -456,7 +456,7 @@ func TestTxFeeDelegatedCancelWithRatio(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued := txpool.Content()
 		assert.Equal(t, 0, len(queued))
@@ -487,7 +487,7 @@ func TestTxFeeDelegatedCancelWithRatio(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		txpool.AddRemotes(txs)
+		txpool.AddRemotesSync(txs)
 
 		pending, queued := txpool.Content()
 		assert.Equal(t, 0, len(queued))

--- a/tests/tx_fee_ratio_range_test.go
+++ b/tests/tx_fee_ratio_range_test.go
@@ -163,7 +163,7 @@ func testTxFeeRatioRange(t *testing.T, feeRatio types.FeeRatio, expected error) 
 		err = tx.SignFeePayerWithKeys(signer, reservoir2.Keys)
 		assert.Equal(t, nil, err)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, expected, err)
 
 		reservoir.Nonce += 1
@@ -192,7 +192,7 @@ func testTxFeeRatioRange(t *testing.T, feeRatio types.FeeRatio, expected error) 
 		err = tx.SignFeePayerWithKeys(signer, reservoir2.Keys)
 		assert.Equal(t, nil, err)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, expected, err)
 
 		reservoir.Nonce += 1
@@ -218,7 +218,7 @@ func testTxFeeRatioRange(t *testing.T, feeRatio types.FeeRatio, expected error) 
 		err = tx.SignFeePayerWithKeys(signer, reservoir2.Keys)
 		assert.Equal(t, nil, err)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, expected, err)
 
 		reservoir.Nonce += 1
@@ -249,7 +249,7 @@ func testTxFeeRatioRange(t *testing.T, feeRatio types.FeeRatio, expected error) 
 		err = tx.SignFeePayerWithKeys(signer, reservoir2.Keys)
 		assert.Equal(t, nil, err)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, expected, err)
 
 		reservoir.Nonce += 1
@@ -278,7 +278,7 @@ func testTxFeeRatioRange(t *testing.T, feeRatio types.FeeRatio, expected error) 
 		err = tx.SignFeePayerWithKeys(signer, reservoir2.Keys)
 		assert.Equal(t, nil, err)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, expected, err)
 
 		reservoir.Nonce += 1
@@ -303,7 +303,7 @@ func testTxFeeRatioRange(t *testing.T, feeRatio types.FeeRatio, expected error) 
 		err = tx.SignFeePayerWithKeys(signer, reservoir2.Keys)
 		assert.Equal(t, nil, err)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, expected, err)
 
 		reservoir.Nonce += 1

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -218,7 +218,7 @@ func TestValidationPoolInsert(t *testing.T) {
 				assert.Equal(t, nil, err)
 			}
 
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, expectedErr, err)
 			if expectedErr == nil {
 				reservoir.Nonce += 1
@@ -343,7 +343,7 @@ func TestValidationPoolInsertMagma(t *testing.T) {
 				assert.Equal(t, nil, err)
 			}
 
-			err = txpool.AddRemote(tx)
+			err = txpool.AddRemoteSync(tx)
 			assert.Equal(t, expectedErr, err)
 			if expectedErr == nil {
 				reservoir.Nonce += 1
@@ -658,7 +658,7 @@ func TestValidationInvalidSig(t *testing.T) {
 
 			if tx != nil {
 				// For tx pool validation test
-				err = txpool.AddRemote(tx)
+				err = txpool.AddRemoteSync(tx)
 				assert.Equal(t, expectedErr, err)
 
 				// For block tx validation test
@@ -783,7 +783,7 @@ func TestLegacyTxFromNonLegacyAcc(t *testing.T) {
 	err = tx.SignWithKeys(signer, reservoir.Keys)
 	assert.Equal(t, nil, err)
 
-	err = txpool.AddRemote(tx)
+	err = txpool.AddRemoteSync(tx)
 	assert.Equal(t, types.ErrSender(kerrors.ErrLegacyTransactionMustBeWithLegacyKey), err)
 }
 
@@ -923,7 +923,7 @@ func TestInvalidBalance(t *testing.T) {
 				err = tx.SignWithKeys(signer, testAcc.Keys)
 				assert.Equal(t, nil, err)
 
-				err = txpool.AddRemote(tx)
+				err = txpool.AddRemoteSync(tx)
 				assert.Equal(t, blockchain.ErrInsufficientFundsFrom, err)
 			}
 
@@ -948,7 +948,7 @@ func TestInvalidBalance(t *testing.T) {
 
 				// Since `txpool.AddRemote` does not make a block,
 				// the sender can send txs to txpool in multiple times (by the for loop) with limited KLAY.
-				err = txpool.AddRemote(tx)
+				err = txpool.AddRemoteSync(tx)
 				assert.Equal(t, nil, err)
 				testAcc.AddNonce()
 			}
@@ -974,7 +974,7 @@ func TestInvalidBalance(t *testing.T) {
 					tx.SignFeePayerWithKeys(signer, reservoir.Keys)
 					assert.Equal(t, nil, err)
 
-					err = txpool.AddRemote(tx)
+					err = txpool.AddRemoteSync(tx)
 					assert.Equal(t, blockchain.ErrInsufficientFundsFrom, err)
 				}
 			}
@@ -997,7 +997,7 @@ func TestInvalidBalance(t *testing.T) {
 				tx.SignFeePayerWithKeys(signer, testAcc.Keys)
 				assert.Equal(t, nil, err)
 
-				err = txpool.AddRemote(tx)
+				err = txpool.AddRemoteSync(tx)
 				assert.Equal(t, blockchain.ErrInsufficientFundsFeePayer, err)
 			}
 
@@ -1022,7 +1022,7 @@ func TestInvalidBalance(t *testing.T) {
 
 					// Since `txpool.AddRemote` does not make a block,
 					// the sender can send txs to txpool in multiple times (by the for loop) with limited KLAY.
-					err = txpool.AddRemote(tx)
+					err = txpool.AddRemoteSync(tx)
 					assert.Equal(t, nil, err)
 					testAcc.AddNonce()
 				}
@@ -1048,7 +1048,7 @@ func TestInvalidBalance(t *testing.T) {
 
 				// Since `txpool.AddRemote` does not make a block,
 				// the sender can send txs to txpool in multiple times (by the for loop) with limited KLAY.
-				err = txpool.AddRemote(tx)
+				err = txpool.AddRemoteSync(tx)
 				assert.Equal(t, nil, err)
 				reservoir.AddNonce()
 			}
@@ -1083,7 +1083,7 @@ func TestInvalidBalance(t *testing.T) {
 				tx.SignFeePayerWithKeys(signer, reservoir.Keys)
 				assert.Equal(t, nil, err)
 
-				err = txpool.AddRemote(tx)
+				err = txpool.AddRemoteSync(tx)
 				assert.Equal(t, blockchain.ErrInsufficientFundsFrom, err)
 			}
 
@@ -1108,7 +1108,7 @@ func TestInvalidBalance(t *testing.T) {
 				tx.SignFeePayerWithKeys(signer, testAcc.Keys)
 				assert.Equal(t, nil, err)
 
-				err = txpool.AddRemote(tx)
+				err = txpool.AddRemoteSync(tx)
 				assert.Equal(t, blockchain.ErrInsufficientFundsFeePayer, err)
 			}
 
@@ -1142,7 +1142,7 @@ func TestInvalidBalance(t *testing.T) {
 
 				// Since `txpool.AddRemote` does not make a block,
 				// the sender can send txs to txpool in multiple times (by the for loop) with limited KLAY.
-				err = txpool.AddRemote(tx)
+				err = txpool.AddRemoteSync(tx)
 				assert.Equal(t, nil, err)
 				testAcc.AddNonce()
 			}
@@ -1170,7 +1170,7 @@ func TestInvalidBalance(t *testing.T) {
 
 				// Since `txpool.AddRemote` does not make a block,
 				// the sender can send txs to txpool in multiple times (by the for loop) with limited KLAY.
-				err = txpool.AddRemote(tx)
+				err = txpool.AddRemoteSync(tx)
 				assert.Equal(t, nil, err)
 				reservoir.AddNonce()
 			}
@@ -1708,7 +1708,7 @@ func TestValidationTxSizeAfterRLP(t *testing.T) {
 			err = rlp.DecodeBytes(encodedTx, newTx)
 
 			// test for tx pool insert validation
-			err = txpool.AddRemote(newTx)
+			err = txpool.AddRemoteSync(newTx)
 			assert.Equal(t, blockchain.ErrOversizedData, err)
 		}
 
@@ -1752,7 +1752,7 @@ func TestValidationTxSizeAfterRLP(t *testing.T) {
 			err = rlp.DecodeBytes(encodedTx, newTx)
 
 			// test for tx pool insert validation
-			err = txpool.AddRemote(newTx)
+			err = txpool.AddRemoteSync(newTx)
 			assert.Equal(t, nil, err)
 			reservoir.AddNonce()
 		}
@@ -1854,7 +1854,7 @@ func TestValidationPoolResetAfterSenderKeyChange(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, nil, err)
 		reservoir.AddNonce()
 	}
@@ -1877,7 +1877,7 @@ func TestValidationPoolResetAfterSenderKeyChange(t *testing.T) {
 			assert.Equal(t, nil, err)
 		}
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		if err != nil {
 			fmt.Println(tx)
 			statedb, _ := bcdata.bc.State()
@@ -2030,7 +2030,7 @@ func TestValidationPoolResetAfterFeePayerKeyChange(t *testing.T) {
 
 		txs = append(txs, tx)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, nil, err)
 		feePayer.AddNonce()
 	}
@@ -2054,7 +2054,7 @@ func TestValidationPoolResetAfterFeePayerKeyChange(t *testing.T) {
 		tx.SignFeePayerWithKeys(signer, feePayer.Keys)
 		assert.Equal(t, nil, err)
 
-		err = txpool.AddRemote(tx)
+		err = txpool.AddRemoteSync(tx)
 		assert.Equal(t, nil, err)
 		reservoir.AddNonce()
 	}


### PR DESCRIPTION
## Proposed changes

- This PR is derived from https://github.com/ethereum/go-ethereum/issues/19192 
- Before the change, in the txpool loop, the `reset` was synchronous with txpool loop. However, in the newly modified part, the `reset` part is executed in the background goroutine. I considered it safe because the vulnarable part is protected by txpool.mu (because of that, the parallel processing became less effective)
- In essence, the **purpose** of this PR is to serialize the event processing. Without serialization, sometimes the event processing gets blocked temporarily, which could lead to potential memory leak.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
