### PR TITLE
Deprecate APIs

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -297,12 +297,6 @@ web3._extend({
 			params: 2
 		}),
 		new web3._extend.Method({
-			name: 'itemsAt',
-			call: 'governance_itemsAt',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
-		}),
-		new web3._extend.Method({
 			name: 'getParams',
 			call: 'governance_getParams',
 			params: 1,
@@ -317,12 +311,6 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'getStakingInfo',
 			call: 'governance_getStakingInfo',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
-		}),
-		new web3._extend.Method({
-			name: 'chainConfigAt',
-			call: 'governance_chainConfigAt',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
@@ -917,22 +905,10 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
-			name: 'govParamsAt',
-			call: 'klay_govParamsAt',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
-		}),
-		new web3._extend.Method({
 			name: 'getParams',
 			call: 'klay_getParams',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
-		}),
-		new web3._extend.Method({
-			name: 'chainConfigAt',
-			call: 'klay_chainConfigAt',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter],
 		}),
 		new web3._extend.Method({
 			name: 'getChainConfig',

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -886,13 +886,6 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
-			name: 'gasPriceAt',
-			call: 'klay_gasPriceAt',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter],
-			outputFormatter: web3._extend.formatters.outputBigNumberFormatter
-		}),
-		new web3._extend.Method({
 			name: 'getRewards',
 			call: 'klay_getRewards',
 			params: 1,

--- a/governance/api.go
+++ b/governance/api.go
@@ -66,27 +66,12 @@ var (
 	errInvalidUpperBound      = errors.New("upperboundbasefee cannot be set lower than lowerboundbasefee")
 )
 
-func (api *GovernanceKlayAPI) ChainConfig() *params.ChainConfig {
-	num := rpc.LatestBlockNumber
-	return getChainConfig(api.governance, &num)
-}
-
-// TODO-Klaytn-Mantle: deprecate this
-func (api *GovernanceKlayAPI) ChainConfigAt(num *rpc.BlockNumber) *params.ChainConfig {
-	return getChainConfig(api.governance, num)
-}
-
 func (api *GovernanceKlayAPI) GetChainConfig(num *rpc.BlockNumber) *params.ChainConfig {
 	return getChainConfig(api.governance, num)
 }
 
 func (api *GovernanceKlayAPI) GetStakingInfo(num *rpc.BlockNumber) (*reward.StakingInfo, error) {
 	return getStakingInfo(api.governance, num)
-}
-
-// TODO-Klaytn-Mantle: deprecate this
-func (api *GovernanceKlayAPI) GovParamsAt(num *rpc.BlockNumber) (map[string]interface{}, error) {
-	return getParams(api.governance, num)
 }
 
 func (api *GovernanceKlayAPI) GetParams(num *rpc.BlockNumber) (map[string]interface{}, error) {
@@ -355,11 +340,6 @@ func (api *GovernanceAPI) TotalVotingPower() (float64, error) {
 	return float64(api.governance.TotalVotingPower()) / 1000.0, nil
 }
 
-// TODO-Klaytn-Mantle: deprecate this
-func (api *GovernanceAPI) ItemsAt(num *rpc.BlockNumber) (map[string]interface{}, error) {
-	return getParams(api.governance, num)
-}
-
 func (api *GovernanceAPI) GetParams(num *rpc.BlockNumber) (map[string]interface{}, error) {
 	return getParams(api.governance, num)
 }
@@ -449,16 +429,6 @@ func (api *GovernanceAPI) MyVotingPower() (float64, error) {
 		return 0, errNotAvailableInThisMode
 	}
 	return float64(api.governance.MyVotingPower()) / 1000.0, nil
-}
-
-func (api *GovernanceAPI) ChainConfig() *params.ChainConfig {
-	num := rpc.LatestBlockNumber
-	return getChainConfig(api.governance, &num)
-}
-
-// TODO-Klaytn-Mantle: deprecate this
-func (api *GovernanceAPI) ChainConfigAt(num *rpc.BlockNumber) *params.ChainConfig {
-	return getChainConfig(api.governance, num)
 }
 
 func (api *GovernanceAPI) GetChainConfig(num *rpc.BlockNumber) *params.ChainConfig {


### PR DESCRIPTION
## Proposed changes

This PR is a follow-up of #1783. Please see #1783 before review.

Deprecate APIs:
- `governance_itemsAt`
- `governance_chainConfigAt`
- `governance_chainConfig`
- `klay_govParamsAt`
- `klay_chainConfigAt`
- `klay_chainConfig`
- `klay_gasPriceAt`

See further comments for replacing `klay_gasPriceAt`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

Current return value of `klay_gasPriceAt` (according to [docs](https://docs.klaytn.foundation/content/dapp/json-rpc/api-references/klay/config#klay_gaspriceat)): 
1. If baseFee is undefined in the header, it returns the unit price from the governance parameter
2. If the block is a pending block, it returns the gas price of the txpool.
3. Otherwise, it returns the base fee of the given block. 

Users can replace each usage by:
1. using `klay_getParams`
2. using `klay_gasPrice`
3. using `baseFeePerGas` field from `klay_getBlockByNumber`
