### PR TITLE
KIP-111 Prune obsolete trie nodes

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -251,8 +251,8 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 		cacheConfig:        cacheConfig,
 		db:                 db,
 		triegc:             prque.New(),
-		chBlock:            make(chan gcBlock, 1000),
-		chPrune:            make(chan uint64, 1000),
+		chBlock:            make(chan gcBlock, 2048), // downloader.maxResultsProcess
+		chPrune:            make(chan uint64, 2048),  // downloader.maxResultsProcess
 		stateCache:         state.NewDatabaseWithNewCache(db, cacheConfig.TrieNodeCacheConfig),
 		quit:               make(chan struct{}),
 		futureBlocks:       futureBlocks,

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -107,9 +107,10 @@ const (
 )
 
 const (
-	DefaultTriesInMemory = 128
-	DefaultBlockInterval = 128
-	MaxPrefetchTxs       = 20000
+	DefaultTriesInMemory        = 128
+	DefaultBlockInterval        = 128
+	DefaultLivePruningRetention = 172800
+	MaxPrefetchTxs              = 20000
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	// Changelog:
@@ -127,6 +128,7 @@ type CacheConfig struct {
 	CacheSize            int                          // Size of in-memory cache of a trie (MiB) to flush matured singleton trie nodes to disk
 	BlockInterval        uint                         // Block interval to flush the trie. Each interval state trie will be flushed into disk
 	TriesInMemory        uint64                       // Maximum number of recent state tries according to its block number
+	LivePruningRetention uint64                       // Number of blocks before trie nodes in pruning marks to be deleted. If zero, obsolete nodes are not deleted.
 	SenderTxHashIndexing bool                         // Enables saving senderTxHash to txHash mapping information to database and cache
 	TrieNodeCacheConfig  *statedb.TrieNodeCacheConfig // Configures trie node cache
 	SnapshotCacheSize    int                          // Memory allowance (MB) to use for caching snapshot entries in memory
@@ -161,6 +163,7 @@ type BlockChain struct {
 	snaps   *snapshot.Tree     // Snapshot tree for fast trie leaf access
 	triegc  *prque.Prque       // Priority queue mapping block numbers to tries to gc
 	chBlock chan gcBlock       // chPushBlockGCPrque is a channel for delivering the gc item to gc loop.
+	chPrune chan uint64        // chPrune is a channel for delivering the current block number for pruning loop.
 
 	hc            *HeaderChain
 	rmLogsFeed    event.Feed
@@ -224,13 +227,14 @@ type prefetchTx struct {
 func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig *params.ChainConfig, engine consensus.Engine, vmConfig vm.Config) (*BlockChain, error) {
 	if cacheConfig == nil {
 		cacheConfig = &CacheConfig{
-			ArchiveMode:         false,
-			CacheSize:           512,
-			BlockInterval:       DefaultBlockInterval,
-			TriesInMemory:       DefaultTriesInMemory,
-			TrieNodeCacheConfig: statedb.GetEmptyTrieNodeCacheConfig(),
-			SnapshotCacheSize:   512,
-			SnapshotAsyncGen:    true,
+			ArchiveMode:          false,
+			CacheSize:            512,
+			BlockInterval:        DefaultBlockInterval,
+			TriesInMemory:        DefaultTriesInMemory,
+			LivePruningRetention: DefaultLivePruningRetention,
+			TrieNodeCacheConfig:  statedb.GetEmptyTrieNodeCacheConfig(),
+			SnapshotCacheSize:    512,
+			SnapshotAsyncGen:     true,
 		}
 	}
 
@@ -248,6 +252,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 		db:                 db,
 		triegc:             prque.New(),
 		chBlock:            make(chan gcBlock, 1000),
+		chPrune:            make(chan uint64, 1000),
 		stateCache:         state.NewDatabaseWithNewCache(db, cacheConfig.TrieNodeCacheConfig),
 		quit:               make(chan struct{}),
 		futureBlocks:       futureBlocks,
@@ -353,6 +358,7 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 	// Take ownership of this particular state
 	go bc.update()
 	bc.gcCachedNodeLoop()
+	bc.pruneTrieNodeLoop()
 	bc.restartStateMigration()
 
 	if cacheConfig.TrieNodeCacheConfig.DumpPeriodically() {
@@ -685,6 +691,18 @@ func (bc *BlockChain) State() (*state.StateDB, error) {
 // StateAt returns a new mutable state based on a particular point in time.
 func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
 	return state.New(root, bc.stateCache, bc.snaps, nil)
+}
+
+// PrunableStateAt returns a new mutable state based on a particular point in time.
+// If live pruning is enabled on the databse, and num is nonzero, then trie will mark obsolete nodes for pruning.
+func (bc *BlockChain) PrunableStateAt(root common.Hash, num uint64) (*state.StateDB, error) {
+	if bc.db.ReadPruningEnabled() && bc.cacheConfig.LivePruningRetention != 0 {
+		return state.New(root, bc.stateCache, bc.snaps, &statedb.TrieOpts{
+			PruningBlockNumber: num,
+		})
+	} else {
+		return bc.StateAt(root)
+	}
 }
 
 // StateAtWithPersistent returns a new mutable state based on a particular point in time with persistent trie nodes.
@@ -1335,8 +1353,8 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 					logger.Error("Error from trieDB.Cap by state migration", "err", err)
 				}
 			}
-
 			bc.lastCommittedBlock = block.NumberU64()
+			bc.chPrune <- block.NumberU64()
 		}
 
 		bc.chBlock <- gcBlock{root, block.NumberU64()}
@@ -1390,6 +1408,41 @@ func (bc *BlockChain) gcCachedNodeLoop() {
 					cnt++
 				}
 				logger.Debug("GC cached node", "currentBlk", blkNum, "chosenBlk", chosen, "deferenceCnt", cnt)
+			case <-bc.quit:
+				return
+			}
+		}
+	}()
+}
+
+func (bc *BlockChain) pruneTrieNodeLoop() {
+	// ReadPruningMarks(1, limit) is very slow because it iterates over the most of MiscDB.
+	// ReadPruningMarks(start, limit) is much faster because it only iterates a small range.
+	startNum := uint64(1)
+
+	bc.wg.Add(1)
+	go func() {
+		defer bc.wg.Done()
+		for {
+			select {
+			case num := <-bc.chPrune:
+				if !bc.db.ReadPruningEnabled() || bc.cacheConfig.LivePruningRetention == 0 {
+					continue
+				}
+				if num <= bc.cacheConfig.LivePruningRetention {
+					continue
+				}
+				limit := num - bc.cacheConfig.LivePruningRetention // Prune [1, latest - retention]
+
+				startTime := time.Now()
+				marks := bc.db.ReadPruningMarks(startNum, limit+1)
+				bc.db.PruneTrieNodes(marks)
+				bc.db.DeletePruningMarks(marks)
+
+				logger.Info("Pruned trie nodes", "number", num, "start", startNum, "limit", limit,
+					"count", len(marks), "elapsed", time.Since(startTime))
+
+				startNum = limit + 1
 			case <-bc.quit:
 				return
 			}
@@ -1918,7 +1971,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 			return i, events, coalescedLogs, err
 		}
 
-		stateDB, err := bc.StateAt(parent.Root())
+		stateDB, err := bc.PrunableStateAt(parent.Root(), parent.NumberU64())
 		if err != nil {
 			return i, events, coalescedLogs, err
 		}

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/klaytn/klaytn/consensus"
 	"github.com/klaytn/klaytn/consensus/gxhash"
 	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 	"github.com/klaytn/klaytn/storage"
@@ -48,6 +49,7 @@ import (
 	"github.com/klaytn/klaytn/storage/statedb"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // So we can deterministically seed different blockchains
@@ -1259,6 +1261,75 @@ func TestTrieForkGC(t *testing.T) {
 	}
 	if len(chain.stateCache.TrieDB().Nodes()) > 0 {
 		t.Fatalf("stale tries still alive after garbase collection")
+	}
+}
+
+// Tests that State pruning indeed deletes obsolete trie nodes.
+func TestStatePruning(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlInfo)
+	var (
+		db      = database.NewMemoryDBManager()
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2   = common.HexToAddress("0xaaaa")
+
+		gspec = &Genesis{
+			Config: params.TestChainConfig,
+			Alloc:  GenesisAlloc{addr1: {Balance: big.NewInt(10000000000000)}},
+		}
+		genesis = gspec.MustCommit(db)
+		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
+		engine  = gxhash.NewFaker()
+
+		// Latest `retention` blocks survive.
+		// Blocks 1..7 are pruned, blocks 8..10 are kept.
+		retention = uint64(3)
+		numBlocks = 10
+		pruneNum  = uint64(numBlocks) - retention
+	)
+
+	db.WritePruningEnabled() // Enable pruning on database by writing the flag at genesis
+	cacheConfig := &CacheConfig{
+		ArchiveMode:          false,
+		CacheSize:            512,
+		BlockInterval:        1, // Write frequently to test pruning
+		TriesInMemory:        DefaultTriesInMemory,
+		LivePruningRetention: retention, // Enable pruning on blockchain by setting it nonzero
+		TrieNodeCacheConfig:  statedb.GetEmptyTrieNodeCacheConfig(),
+	}
+	blockchain, _ := NewBlockChain(db, cacheConfig, gspec.Config, engine, vm.Config{})
+	defer blockchain.Stop()
+
+	chain, _ := GenerateChain(gspec.Config, genesis, engine, db, numBlocks, func(i int, gen *BlockGen) {
+		tx, _ := types.SignTx(types.NewTransaction(
+			gen.TxNonce(addr1), addr2, common.Big1, 21000, common.Big1, nil), signer, key1)
+		gen.AddTx(tx)
+	})
+	if _, err := blockchain.InsertChain(chain); err != nil {
+		t.Fatalf("failed to insert chain: %v", err)
+	}
+	assert.Equal(t, uint64(numBlocks), blockchain.CurrentBlock().NumberU64())
+
+	// Give some time for pruning loop to run
+	time.Sleep(100 * time.Millisecond)
+
+	// Genesis block always survives
+	state, err := blockchain.StateAt(genesis.Root())
+	assert.Nil(t, err)
+	assert.NotZero(t, state.GetBalance(addr1).Uint64())
+
+	// Pruned blocks should be inaccessible.
+	for num := uint64(1); num <= pruneNum; num++ {
+		_, err := blockchain.StateAt(blockchain.GetBlockByNumber(num).Root())
+		assert.IsType(t, &statedb.MissingNodeError{}, err, num)
+	}
+
+	// Recent unpruned blocks should be accessible.
+	for num := pruneNum + 1; num < uint64(numBlocks); num++ {
+		state, err := blockchain.StateAt(blockchain.GetBlockByNumber(num).Root())
+		require.Nil(t, err, num)
+		assert.NotZero(t, state.GetBalance(addr1).Uint64())
+		assert.NotZero(t, state.GetBalance(addr2).Uint64())
 	}
 }
 

--- a/blockchain/state/state_object.go
+++ b/blockchain/state/state_object.go
@@ -130,7 +130,8 @@ func newObject(db *StateDB, address common.Address, data account.Account) *state
 
 // EncodeRLP implements rlp.Encoder.
 func (c *stateObject) EncodeRLP(w io.Writer) error {
-	serializer := account.NewAccountSerializerWithAccount(c.account)
+	// State objects are RLP encoded with ExtHash preserved.
+	serializer := account.NewAccountSerializerExtWithAccount(c.account)
 	return rlp.Encode(w, serializer)
 }
 

--- a/blockchain/state/state_object.go
+++ b/blockchain/state/state_object.go
@@ -35,7 +35,6 @@ import (
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/rlp"
-	"github.com/klaytn/klaytn/storage/statedb"
 )
 
 var emptyCodeHash = crypto.Keccak256(nil)
@@ -158,7 +157,7 @@ func (c *stateObject) touch() {
 }
 
 func (c *stateObject) openStorageTrie(hash common.ExtHash, db Database) (Trie, error) {
-	return db.OpenStorageTrie(hash, &statedb.TrieOpts{Prefetching: c.db.prefetching})
+	return db.OpenStorageTrie(hash, c.db.trieOpts)
 }
 
 func (c *stateObject) getStorageTrie(db Database) Trie {

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -60,8 +60,9 @@ var (
 // StateDBs within the Klaytn protocol are used to cache stateObjects from Merkle Patricia Trie
 // and mediate the operations to them.
 type StateDB struct {
-	db   Database
-	trie Trie
+	db       Database
+	trie     Trie
+	trieOpts *statedb.TrieOpts
 
 	snaps         *snapshot.Tree
 	snap          snapshot.Snapshot
@@ -125,6 +126,7 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree, opts *statedb.Trie
 	sdb := &StateDB{
 		db:                       db,
 		trie:                     tr,
+		trieOpts:                 opts,
 		snaps:                    snaps,
 		stateObjects:             make(map[common.Address]*stateObject),
 		stateObjectsDirtyStorage: make(map[common.Address]struct{}),
@@ -171,7 +173,7 @@ func (self *StateDB) Error() error {
 // Reset clears out all ephemeral state objects from the state db, but keeps
 // the underlying state trie to avoid reloading data for the next operations.
 func (self *StateDB) Reset(root common.Hash) error {
-	tr, err := self.db.OpenTrie(root, nil)
+	tr, err := self.db.OpenTrie(root, self.trieOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -540,6 +540,7 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 	common.DefaultCacheType = common.CacheType(ctx.GlobalInt(CacheTypeFlag.Name))
 	cfg.TrieBlockInterval = ctx.GlobalUint(TrieBlockIntervalFlag.Name)
 	cfg.TriesInMemory = ctx.GlobalUint64(TriesInMemoryFlag.Name)
+	cfg.LivePruning = ctx.GlobalBool(LivePruningFlag.Name)
 	cfg.LivePruningRetention = ctx.GlobalUint64(LivePruningRetentionFlag.Name)
 
 	if ctx.GlobalIsSet(CacheScaleFlag.Name) {

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -540,6 +540,7 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 	common.DefaultCacheType = common.CacheType(ctx.GlobalInt(CacheTypeFlag.Name))
 	cfg.TrieBlockInterval = ctx.GlobalUint(TrieBlockIntervalFlag.Name)
 	cfg.TriesInMemory = ctx.GlobalUint64(TriesInMemoryFlag.Name)
+	cfg.LivePruningRetention = ctx.GlobalUint64(LivePruningRetentionFlag.Name)
 
 	if ctx.GlobalIsSet(CacheScaleFlag.Name) {
 		common.CacheScale = ctx.GlobalInt(CacheScaleFlag.Name)

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -176,6 +176,8 @@ var FlagGroups = []FlagGroup{
 			TrieMemoryCacheSizeFlag,
 			TrieBlockIntervalFlag,
 			TriesInMemoryFlag,
+			LivePruningFlag,
+			LivePruningRetentionFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -351,6 +351,17 @@ var (
 		Value:  blockchain.DefaultTriesInMemory,
 		EnvVar: "KLAYTN_STATE_TRIES_IN_MEMORY",
 	}
+	LivePruningFlag = cli.BoolFlag{
+		Name:   "state.live-pruning",
+		Usage:  "Enable trie live pruning",
+		EnvVar: "KLAYTN_STATE_LIVE_PRUNING",
+	}
+	LivePruningRetentionFlag = cli.Uint64Flag{
+		Name:   "state.live-pruning-retention",
+		Usage:  "Number of blocks from the latest block that are not to be pruned",
+		Value:  blockchain.DefaultLivePruningRetention,
+		EnvVar: "KLAYTN_STATE_LIVE_PRUNING_RETENTION",
+	}
 	CacheTypeFlag = cli.IntFlag{
 		Name:   "cache.type",
 		Usage:  "Cache Type: 0=LRUCache, 1=LRUShardCache, 2=FIFOCache",

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -133,6 +133,7 @@ func initGenesis(ctx *cli.Context) error {
 	singleDB := ctx.GlobalIsSet(utils.SingleDBFlag.Name)
 	numStateTrieShards := ctx.GlobalUint(utils.NumStateTrieShardsFlag.Name)
 	overwriteGenesis := ctx.GlobalBool(utils.OverwriteGenesisFlag.Name)
+	livePruning := ctx.GlobalBool(utils.LivePruningFlag.Name)
 
 	dbtype := database.DBType(ctx.GlobalString(utils.DbTypeFlag.Name)).ToValid()
 	if len(dbtype) == 0 {
@@ -175,9 +176,9 @@ func initGenesis(ctx *cli.Context) error {
 		}
 
 		// Write the live pruning flag to database
-		if ctx.Bool(utils.LivePruningFlag.Name) {
+		if livePruning {
 			chainDB.WritePruningEnabled()
-			logger.Info("Live pruning enabled")
+			logger.Info("Enabling live pruning")
 		}
 
 		logger.Info("Successfully wrote genesis state", "database", name, "hash", hash.String())

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -58,6 +58,7 @@ var (
 			utils.LevelDBCompressionTypeFlag,
 			utils.DataDirFlag,
 			utils.OverwriteGenesisFlag,
+			utils.LivePruningFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
@@ -171,6 +172,12 @@ func initGenesis(ctx *cli.Context) error {
 		gov := governance.NewMixedEngineNoInit(genesis.Config, chainDB)
 		if err := gov.WriteGovernance(0, govSet, governance.NewGovernanceSet()); err != nil {
 			logger.Crit("Failed to write governance items", "err", err)
+		}
+
+		// Write the live pruning flag to database
+		if ctx.Bool(utils.LivePruningFlag.Name) {
+			chainDB.WritePruningEnabled()
+			logger.Info("Live pruning enabled")
 		}
 
 		logger.Info("Successfully wrote genesis state", "database", name, "hash", hash.String())

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -156,6 +156,7 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewIntFlag(utils.TrieMemoryCacheSizeFlag),
 	altsrc.NewUintFlag(utils.TrieBlockIntervalFlag),
 	altsrc.NewUint64Flag(utils.TriesInMemoryFlag),
+	altsrc.NewBoolFlag(utils.LivePruningFlag),
 	altsrc.NewUint64Flag(utils.LivePruningRetentionFlag),
 	altsrc.NewIntFlag(utils.CacheTypeFlag),
 	altsrc.NewIntFlag(utils.CacheScaleFlag),

--- a/cmd/utils/nodecmd/nodeflags.go
+++ b/cmd/utils/nodecmd/nodeflags.go
@@ -156,6 +156,7 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewIntFlag(utils.TrieMemoryCacheSizeFlag),
 	altsrc.NewUintFlag(utils.TrieBlockIntervalFlag),
 	altsrc.NewUint64Flag(utils.TriesInMemoryFlag),
+	altsrc.NewUint64Flag(utils.LivePruningRetentionFlag),
 	altsrc.NewIntFlag(utils.CacheTypeFlag),
 	altsrc.NewIntFlag(utils.CacheScaleFlag),
 	altsrc.NewStringFlag(utils.CacheUsageLevelFlag),

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -281,7 +281,8 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	}
 	// Live pruning is enabled according to the flag in database
 	// regardless of the command line flag --state.live-pruning
-	if chainDB.ReadPruningEnabled() {
+	// But live pruning is disabled when --state.live-pruning-retention 0
+	if chainDB.ReadPruningEnabled() && config.LivePruningRetention != 0 {
 		logger.Info("Live pruning is enabled")
 	}
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -253,9 +253,15 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	var (
 		vmConfig    = config.getVMConfig()
 		cacheConfig = &blockchain.CacheConfig{
-			ArchiveMode: config.NoPruning, CacheSize: config.TrieCacheSize,
-			BlockInterval: config.TrieBlockInterval, TriesInMemory: config.TriesInMemory,
-			TrieNodeCacheConfig: &config.TrieNodeCacheConfig, SenderTxHashIndexing: config.SenderTxHashIndexing, SnapshotCacheSize: config.SnapshotCacheSize, SnapshotAsyncGen: config.SnapshotAsyncGen,
+			ArchiveMode:          config.NoPruning,
+			CacheSize:            config.TrieCacheSize,
+			BlockInterval:        config.TrieBlockInterval,
+			TriesInMemory:        config.TriesInMemory,
+			LivePruningRetention: config.LivePruningRetention,
+			TrieNodeCacheConfig:  &config.TrieNodeCacheConfig,
+			SenderTxHashIndexing: config.SenderTxHashIndexing,
+			SnapshotCacheSize:    config.SnapshotCacheSize,
+			SnapshotAsyncGen:     config.SnapshotAsyncGen,
 		}
 	)
 

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -122,6 +122,7 @@ type Config struct {
 	TrieTimeout          time.Duration
 	TrieBlockInterval    uint
 	TriesInMemory        uint64
+	LivePruning          bool
 	LivePruningRetention uint64
 	SenderTxHashIndexing bool
 	ParallelDBWrite      bool

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -45,15 +45,16 @@ var logger = log.NewModuleLogger(log.NodeCN)
 // GetDefaultConfig returns default settings for use on the Klaytn main net.
 func GetDefaultConfig() *Config {
 	return &Config{
-		SyncMode:            downloader.FullSync,
-		NetworkId:           params.CypressNetworkId,
-		LevelDBCacheSize:    768,
-		TrieCacheSize:       512,
-		TrieTimeout:         5 * time.Minute,
-		TrieBlockInterval:   blockchain.DefaultBlockInterval,
-		TrieNodeCacheConfig: *statedb.GetEmptyTrieNodeCacheConfig(),
-		TriesInMemory:       blockchain.DefaultTriesInMemory,
-		GasPrice:            big.NewInt(18 * params.Ston),
+		SyncMode:             downloader.FullSync,
+		NetworkId:            params.CypressNetworkId,
+		LevelDBCacheSize:     768,
+		TrieCacheSize:        512,
+		TrieTimeout:          5 * time.Minute,
+		TrieBlockInterval:    blockchain.DefaultBlockInterval,
+		TrieNodeCacheConfig:  *statedb.GetEmptyTrieNodeCacheConfig(),
+		TriesInMemory:        blockchain.DefaultTriesInMemory,
+		LivePruningRetention: blockchain.DefaultLivePruningRetention,
+		GasPrice:             big.NewInt(18 * params.Ston),
 
 		TxPool: blockchain.DefaultTxPoolConfig,
 		GPO: gasprice.Config{
@@ -121,6 +122,7 @@ type Config struct {
 	TrieTimeout          time.Duration
 	TrieBlockInterval    uint
 	TriesInMemory        uint64
+	LivePruningRetention uint64
 	SenderTxHashIndexing bool
 	ParallelDBWrite      bool
 	TrieNodeCacheConfig  statedb.TrieNodeCacheConfig

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1873,6 +1873,7 @@ func (dbm *databaseManager) PutTrieNodeToBatch(batch Batch, hash common.ExtHash,
 	}
 }
 
+// DeleteTrieNode deletes a trie node having a specific hash. It is used only for testing.
 func (dbm *databaseManager) DeleteTrieNode(hash common.ExtHash) {
 	if err := dbm.getDatabase(StateTrieDB).Delete(TrieNodeKey(hash)); err != nil {
 		logger.Crit("Failed to delete trie node", "err", err)

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -521,6 +521,53 @@ func TestDBManager_TrieNode(t *testing.T) {
 	}
 }
 
+func TestDBManager_PruningMarks(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
+	for _, dbm := range dbManagers {
+		if dbm.GetMiscDB().Type() == BadgerDB {
+			continue // badgerDB doesn't support NewIterator, so cannot test ReadPruningMarks.
+		}
+
+		assert.False(t, dbm.ReadPruningEnabled())
+		dbm.WritePruningEnabled()
+		assert.True(t, dbm.ReadPruningEnabled())
+		dbm.DeletePruningEnabled()
+		assert.False(t, dbm.ReadPruningEnabled())
+
+		var (
+			node1 = hash1.Extend()
+			node2 = hash2.Extend()
+			node3 = hash3.Extend()
+			node4 = hash4.Extend()
+			value = []byte("value")
+		)
+
+		dbm.WriteTrieNode(node1, value)
+		dbm.WriteTrieNode(node2, value)
+		dbm.WriteTrieNode(node3, value)
+		dbm.WriteTrieNode(node4, value)
+		dbm.WritePruningMarks([]PruningMark{
+			{100, node1}, {200, node2}, {300, node3}, {400, node4},
+		})
+
+		marks := dbm.ReadPruningMarks(300, 0)
+		assert.Equal(t, []PruningMark{{300, node3}, {400, node4}}, marks)
+		marks = dbm.ReadPruningMarks(0, 300)
+		assert.Equal(t, []PruningMark{{100, node1}, {200, node2}}, marks)
+
+		dbm.PruneTrieNodes(marks) // delete node1, node2
+		has := func(hash common.ExtHash) bool { ok, _ := dbm.HasTrieNode(hash); return ok }
+		assert.False(t, has(node1))
+		assert.False(t, has(node2))
+		assert.True(t, has(node3))
+		assert.True(t, has(node4))
+
+		dbm.DeletePruningMarks(marks)
+		marks = dbm.ReadPruningMarks(0, 0)
+		assert.Equal(t, []PruningMark{{300, node3}, {400, node4}}, marks)
+	}
+}
+
 // TestDBManager_TxLookupEntry tests read, write and delete operations of TxLookupEntries.
 func TestDBManager_TxLookupEntry(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -466,8 +466,13 @@ func (db *Database) insertPreimage(hash common.Hash, preimage []byte) {
 	db.preimagesSize += common.StorageSize(common.HashLength + len(preimage))
 }
 
-func (db *Database) insertPruningMark(mark database.PruningMark) {
-	db.pruningMarks = append(db.pruningMarks, mark)
+// insertPruningMark writes a new pruning mark to the memory database.
+// Note, this method assumes that the database's lock is held!
+func (db *Database) insertPruningMark(hash common.ExtHash, blockNum uint64) {
+	db.pruningMarks = append(db.pruningMarks, database.PruningMark{
+		Number: blockNum,
+		Hash:   hash,
+	})
 }
 
 // getCachedNode finds an encoded node in the trie node cache if enabled.

--- a/storage/statedb/errors.go
+++ b/storage/statedb/errors.go
@@ -40,3 +40,4 @@ func (err *MissingNodeError) Error() string {
 }
 
 var ErrZeroHashNode = errors.New("cannot retrieve a node which has 0x00 hash value")
+var ErrPruningDisabled = errors.New("pruning is disabled on database")

--- a/storage/statedb/iterator_test.go
+++ b/storage/statedb/iterator_test.go
@@ -141,15 +141,17 @@ func TestNodeIteratorCoverage(t *testing.T) {
 
 // NodeIterator yields exact same result for Trie and StroageTrie
 func TestNodeIteratorStorageTrie(t *testing.T) {
-	triedb := NewDatabase(database.NewMemoryDBManager())
+	dbm := database.NewMemoryDBManager()
+	dbm.WritePruningEnabled()
+	triedb := NewDatabase(dbm)
 
-	trie1, _ := NewTrie(common.Hash{}, triedb, &TrieOpts{Pruning: true})
+	trie1, _ := NewTrie(common.Hash{}, triedb, nil)
 	hashes1 := make(map[common.Hash]struct{})
 	for it := trie1.NodeIterator(nil); it.Next(true); {
 		hashes1[it.Hash()] = struct{}{}
 	}
 
-	trie2, _ := NewStorageTrie(common.ExtHash{}, triedb, &TrieOpts{Pruning: true})
+	trie2, _ := NewStorageTrie(common.ExtHash{}, triedb, nil)
 	hashes2 := make(map[common.Hash]struct{})
 	for it := trie2.NodeIterator(nil); it.Next(true); {
 		hashes2[it.Hash()] = struct{}{}

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -678,6 +678,21 @@ func (mr *MockBlockChainMockRecorder) Processor() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Processor", reflect.TypeOf((*MockBlockChain)(nil).Processor))
 }
 
+// PrunableStateAt mocks base method.
+func (m *MockBlockChain) PrunableStateAt(arg0 common.Hash, arg1 uint64) (*state.StateDB, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrunableStateAt", arg0, arg1)
+	ret0, _ := ret[0].(*state.StateDB)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PrunableStateAt indicates an expected call of PrunableStateAt.
+func (mr *MockBlockChainMockRecorder) PrunableStateAt(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrunableStateAt", reflect.TypeOf((*MockBlockChain)(nil).PrunableStateAt), arg0, arg1)
+}
+
 // ResetWithGenesisBlock mocks base method.
 func (m *MockBlockChain) ResetWithGenesisBlock(arg0 *types.Block) error {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -271,6 +271,7 @@ type BlockChain interface {
 	Processor() blockchain.Processor
 	BadBlocks() ([]blockchain.BadBlockArgs, error)
 	StateAt(root common.Hash) (*state.StateDB, error)
+	PrunableStateAt(root common.Hash, num uint64) (*state.StateDB, error)
 	StateAtWithPersistent(root common.Hash) (*state.StateDB, error)
 	StateAtWithGCLock(root common.Hash) (*state.StateDB, error)
 	Export(w io.Writer) error

--- a/work/worker.go
+++ b/work/worker.go
@@ -478,7 +478,7 @@ func (self *worker) push(work *Task) {
 
 // makeCurrent creates a new environment for the current cycle.
 func (self *worker) makeCurrent(parent *types.Block, header *types.Header) error {
-	stateDB, err := self.chain.StateAt(parent.Root())
+	stateDB, err := self.chain.PrunableStateAt(parent.Root(), parent.NumberU64())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

See [KIP-111](https://github.com/ethan-kr/kips/blob/main/KIPs/kip-111.md) for the background.

Usage:

```bash
# init custom genesis and sync
kcn init --state.live-pruning genesis.json
kcn   # after init, --state.live-pruning is optional

# cypress sync
ken --state.live-pruning  # first run, when database is clean.
ken   # from the second run, --state.live-pruning is optional

# temporarily disable live pruning
ken --state.live-pruning-retention 0
```

Changes:

- New database schema
  - (MiscDB) `PruningEnabled: ["PruningEnabled"] -> true` is a database-stored flag that tells the trie nodes are in prunable format (i.e. with ExtHash).
  - (MiscDB) `PruningMark: ["Pruning-" + blockNum + ExtHash] -> true` marks an obsolete trie node that's not yet deleted.

- New CLI flags
  - `kcn init --state.live-pruning`
    - if specified, write PruningEnabled to database.
  - `kcn --state.live-pruning`
    - if specified and database is clean, write PruningEnabled to database.
    - After the first writing PruningEnabled, this flag becomes optional.
  - `kcn --state.live-pruning-retention <172800>`
    - Number of blocks to keep obsolete nodes before deleting. Defaults to 2 days (172800).
    - Set 0 to disable live pruning.
    - Ignored if the database has pruning disabled.

- New struct fields
	```
	cn.Config.LivePruning
	cn.Config.LivePruningRetention
	blockchain.CacheConfig.LivePruningRetention
	statedb.TrieOpts.PruningBlockNumber uint64        // replaces  TrieOpts.Pruning bool
	```

- Pruning actions
  - `Trie.insert` and `Trie.delete` marks obsolete nodes as PruningMarks, only if:
    - PruningEnabled in database AND
    - The Trie is created with `PruningBlockNumber != 0` (i.e. through `PrunableStateAt()`)
  - `blockchain.insertChain` uses `PrunableStateAt()`
  - `worker.makeCurrent` uses `PrunableStateAt()`
  - `blockchain.writeStateTrie` asynchronously deletes trie nodes according to PruningMarks.

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments