### PR TITLE
RPC admin_exportChain accepts first, last block numbers

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -385,8 +385,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'exportChain',
 			call: 'admin_exportChain',
-			params: 1,
-			inputFormatter: [null]
+			params: 3,
+			inputFormatter: [null, web3._extend.formatters.inputBlockNumberFormatter, web3._extend.formatters.inputBlockNumberFormatter],
 		}),
 		new web3._extend.Method({
 			name: 'importChain',

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -71,12 +71,24 @@ func NewPrivateAdminAPI(cn *CN) *PrivateAdminAPI {
 	return &PrivateAdminAPI{cn: cn}
 }
 
-// ExportChain exports the current blockchain into a local file.
-func (api *PrivateAdminAPI) ExportChain(file string) (bool, error) {
+// ExportChain exports the current blockchain into a local file,
+// or a range of blocks if first and last are non-nil.
+func (api *PrivateAdminAPI) ExportChain(file string, first, last *rpc.BlockNumber) (bool, error) {
 	if _, err := os.Stat(file); err == nil {
 		// File already exists. Allowing overwrite could be a DoS vecotor,
 		// since the 'file' may point to arbitrary paths on the drive
 		return false, errors.New("location would overwrite an existing file")
+	}
+	if first == nil && last != nil {
+		return false, errors.New("last cannot be specified without first")
+	}
+	if first == nil {
+		zero := rpc.EarliestBlockNumber
+		first = &zero
+	}
+	if last == nil || *last == rpc.LatestBlockNumber {
+		head := rpc.BlockNumber(api.cn.BlockChain().CurrentBlock().NumberU64())
+		last = &head
 	}
 
 	// Make sure we can create the file to export into
@@ -93,7 +105,7 @@ func (api *PrivateAdminAPI) ExportChain(file string) (bool, error) {
 	}
 
 	// Export the blockchain
-	if err := api.cn.BlockChain().Export(writer); err != nil {
+	if err := api.cn.BlockChain().ExportN(writer, first.Uint64(), last.Uint64()); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -214,6 +214,20 @@ func (mr *MockBlockChainMockRecorder) Export(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Export", reflect.TypeOf((*MockBlockChain)(nil).Export), arg0)
 }
 
+// ExportN mocks base method.
+func (m *MockBlockChain) ExportN(arg0 io.Writer, arg1, arg2 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExportN", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ExportN indicates an expected call of ExportN.
+func (mr *MockBlockChainMockRecorder) ExportN(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportN", reflect.TypeOf((*MockBlockChain)(nil).ExportN), arg0, arg1, arg2)
+}
+
 // FastSyncCommitHead mocks base method.
 func (m *MockBlockChain) FastSyncCommitHead(arg0 common.Hash) error {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -274,6 +274,7 @@ type BlockChain interface {
 	StateAtWithPersistent(root common.Hash) (*state.StateDB, error)
 	StateAtWithGCLock(root common.Hash) (*state.StateDB, error)
 	Export(w io.Writer) error
+	ExportN(w io.Writer, first, last uint64) error
 	Engine() consensus.Engine
 	GetTxLookupInfoAndReceipt(txHash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, *types.Receipt)
 	GetTxAndLookupInfoInCache(hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64)


### PR DESCRIPTION
## Proposed changes

Following the geth change https://github.com/ethereum/go-ethereum/pull/20107,
the `admin_exportChain` RPC optionally accepts the first and last block numbers to export a range of blocks.

Console example:
```
admin.exportChain("chain01")  // entire chain
admin.exportChain("chain01", 555)   // 555 to the end
admin.exportChain("chain01", 1, 1000)   // 1 to 1000, inclusive.
```

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
