### PR TITLE
Add common EstimateGas

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -94,7 +94,7 @@ func (b *BlockchainContractCaller) CallContract(ctx context.Context, call klaytn
 		return nil, err
 	}
 	if len(res.Revert()) > 0 {
-		return nil, newRevertError(res)
+		return nil, blockchain.NewRevertError(res)
 	}
 	return res.Return(), res.Unwrap()
 }

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -502,7 +502,7 @@ func TestSimulatedBackend_EstimateGas(t *testing.T) {
 				t.Fatalf("Expect error, want %v, got %v", c.expectError, err)
 			}
 			if c.expectData != nil {
-				if err, ok := err.(*revertError); !ok {
+				if err, ok := err.(*blockchain.RevertError); !ok {
 					t.Fatalf("Expect revert error, got %T", err)
 				} else if !reflect.DeepEqual(err.ErrorData(), c.expectData) {
 					t.Fatalf("Error data mismatch, want %v, got %v", c.expectData, err.ErrorData())
@@ -1023,7 +1023,7 @@ func TestSimulatedBackend_CallContractRevert(t *testing.T) {
 				t.Errorf("result from %v was not nil: %v", key, res)
 			}
 			if val != nil {
-				rerr, ok := err.(*revertError)
+				rerr, ok := err.(*blockchain.RevertError)
 				if !ok {
 					t.Errorf("expect revert error")
 				}

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -617,7 +617,7 @@ func (api *EthereumAPI) Call(ctx context.Context, args EthTransactionArgs, block
 	}
 
 	if len(result.Revert()) > 0 {
-		return nil, newRevertError(result)
+		return nil, blockchain.NewRevertError(result)
 	}
 	return result.Return(), result.Unwrap()
 }
@@ -1620,24 +1620,18 @@ func EthDoCall(ctx context.Context, b Backend, args EthTransactionArgs, blockNrO
 }
 
 func EthDoEstimateGas(ctx context.Context, b Backend, args EthTransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, gasCap uint64) (hexutil.Uint64, error) {
-	// Binary search the gas requirement, as it may be higher than the amount used
-	var (
-		lo  uint64 = params.TxGas - 1
-		hi  uint64 = params.UpperGasLimit
-		cap uint64
-	)
 	// Use zero address if sender unspecified.
 	if args.From == nil {
 		args.From = new(common.Address)
 	}
-	// Determine the highest gas limit can be used during the estimation.
-	if args.Gas != nil && uint64(*args.Gas) >= params.TxGas {
-		hi = uint64(*args.Gas)
+
+	var gasLimit uint64
+	if args.Gas != nil {
+		gasLimit = uint64(*args.Gas)
 	} else {
-		// Ethereum set hi as gas ceiling of the block but,
-		// there is no actual gas limit in Klaytn, so we set it as params.UpperGasLimit.
-		hi = params.UpperGasLimit
+		gasLimit = 0
 	}
+
 	// Normalize the max fee per gas the call is willing to spend.
 	var feeCap *big.Int
 	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
@@ -1649,39 +1643,11 @@ func EthDoEstimateGas(ctx context.Context, b Backend, args EthTransactionArgs, b
 	} else {
 		feeCap = common.Big0
 	}
-	// recap the highest gas limit with account's available balance.
-	if feeCap.BitLen() != 0 {
-		state, _, err := b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-		if err != nil {
-			return 0, err
-		}
-		balance := state.GetBalance(*args.From) // from can't be nil
-		available := new(big.Int).Set(balance)
-		if args.Value != nil {
-			if args.Value.ToInt().Cmp(available) >= 0 {
-				return 0, errors.New("insufficient funds for transfer")
-			}
-			available.Sub(available, args.Value.ToInt())
-		}
-		allowance := new(big.Int).Div(available, feeCap)
-
-		// If the allowance is larger than maximum uint64, skip checking
-		if allowance.IsUint64() && hi > allowance.Uint64() {
-			transfer := args.Value
-			if transfer == nil {
-				transfer = new(hexutil.Big)
-			}
-			logger.Warn("Gas estimation capped by limited funds", "original", hi, "balance", balance,
-				"sent", transfer.ToInt(), "maxFeePerGas", feeCap, "fundable", allowance)
-			hi = allowance.Uint64()
-		}
+	state, _, err := b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if err != nil {
+		return 0, err
 	}
-	// Recap the highest gas allowance with specified gascap.
-	if gasCap != 0 && hi > gasCap {
-		logger.Warn("Caller gas above allowance, capping", "requested", hi, "cap", gasCap)
-		hi = gasCap
-	}
-	cap = hi
+	balance := state.GetBalance(*args.From) // from can't be nil
 
 	executable := func(gas uint64) (bool, *blockchain.ExecutionResult, error) {
 		args.Gas = (*hexutil.Uint64)(&gas)
@@ -1697,38 +1663,7 @@ func EthDoEstimateGas(ctx context.Context, b Backend, args EthTransactionArgs, b
 		return result.Failed(), result, nil
 	}
 
-	// Execute the binary search and hone in on an executable gas limit
-	for lo+1 < hi {
-		mid := (hi + lo) / 2
-		failed, _, err := executable(mid)
-		if err != nil {
-			return 0, err
-		}
-
-		if failed {
-			lo = mid
-		} else {
-			hi = mid
-		}
-	}
-	// Reject the transaction as invalid if it still fails at the highest allowance
-	if hi == cap {
-		failed, result, err := executable(hi)
-		if err != nil {
-			return 0, err
-		}
-		if failed {
-			if result != nil {
-				if len(result.Revert()) > 0 && result.VmExecutionStatus != types.ReceiptStatusErrOutOfGas {
-					return 0, newRevertError(result)
-				}
-				return 0, result.Unwrap()
-			}
-			// Otherwise, the specified gas cap is too low
-			return 0, fmt.Errorf("gas required exceeds allowance (%d)", cap)
-		}
-	}
-	return hexutil.Uint64(hi), nil
+	return blockchain.DoEstimateGas(ctx, gasLimit, gasCap, args.Value.ToInt(), feeCap, balance, executable)
 }
 
 // checkTxFee is an internal function used to check whether the fee of

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1625,24 +1625,21 @@ func EthDoEstimateGas(ctx context.Context, b Backend, args EthTransactionArgs, b
 		args.From = new(common.Address)
 	}
 
-	var gasLimit uint64
+	var gasLimit uint64 = 0
 	if args.Gas != nil {
 		gasLimit = uint64(*args.Gas)
-	} else {
-		gasLimit = 0
 	}
 
 	// Normalize the max fee per gas the call is willing to spend.
-	var feeCap *big.Int
+	var feeCap *big.Int = common.Big0
 	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
 		return 0, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	} else if args.GasPrice != nil {
 		feeCap = args.GasPrice.ToInt()
 	} else if args.MaxFeePerGas != nil {
 		feeCap = args.MaxFeePerGas.ToInt()
-	} else {
-		feeCap = common.Big0
 	}
+
 	state, _, err := b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if err != nil {
 		return 0, err

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/klaytn/klaytn/consensus"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/governance"
 
@@ -20,10 +21,13 @@ import (
 	mock_accounts "github.com/klaytn/klaytn/accounts/mocks"
 	mock_api "github.com/klaytn/klaytn/api/mocks"
 	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/types/accountkey"
+	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/consensus/gxhash"
 	"github.com/klaytn/klaytn/consensus/mocks"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
@@ -2430,4 +2434,161 @@ func TestEthereumAPI_GetRawTransactionByBlockNumberAndIndex(t *testing.T) {
 	}
 
 	mockCtrl.Finish()
+}
+
+type testChainContext struct {
+	header *types.Header
+}
+
+func (mc *testChainContext) Engine() consensus.Engine {
+	return gxhash.NewFaker()
+}
+
+func (mc *testChainContext) GetHeader(common.Hash, uint64) *types.Header {
+	return mc.header
+}
+
+// revert("hello")
+//   PUSH1 73; PUSH1 12; PUSH1 0; CODECOPY // mem[0:0+73] = code[12:12+73]
+//   PUSH1 73; PUSH1 0; REVERT // revert mem[0:0+73]
+var codeRevertHello = "0x6049600c60003960496000fd08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f"
+
+func testEstimateGas(t *testing.T, mockBackend *mock_api.MockBackend, fnEstimateGas func(EthTransactionArgs) (hexutil.Uint64, error)) {
+	var (
+		// genesis
+		account1    = common.HexToAddress("0xaaaa")
+		account2    = common.HexToAddress("0xbbbb")
+		account3    = common.HexToAddress("0xcccc")
+		chainConfig = params.TestChainConfig
+		gspec       = &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
+			account1: {Balance: big.NewInt(params.KLAY * 2)},
+			account2: {Balance: big.NewInt(0)},
+			account3: {Balance: common.Big0, Code: hexutil.MustDecode(codeRevertHello)},
+		}}
+
+		// blockchain
+		dbm    = database.NewMemoryDBManager()
+		db     = state.NewDatabase(dbm)
+		block  = gspec.MustCommit(dbm)
+		header = block.Header()
+		chain  = &testChainContext{header: header}
+
+		// tx arguments
+		KLAY     = hexutil.Big(*big.NewInt(params.KLAY))
+		mKLAY    = hexutil.Big(*big.NewInt(params.KLAY / 1000))
+		gas1000  = hexutil.Uint64(1000)
+		gas40000 = hexutil.Uint64(40000)
+		baddata  = hexutil.Bytes(hexutil.MustDecode("0xdeadbeef"))
+	)
+
+	any := gomock.Any()
+	getStateAndHeader := func(...interface{}) (*state.StateDB, *types.Header, error) {
+		// Return a new state for each call because the state is modified by EstimateGas.
+		state, err := state.New(block.Root(), db, nil, nil)
+		return state, header, err
+	}
+	getEVM := func(_ context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmConfig vm.Config) (*vm.EVM, func() error, error) {
+		// Taken from node/cn/api_backend.go
+		vmError := func() error { return nil }
+		context := blockchain.NewEVMContext(msg, header, chain, nil)
+		return vm.NewEVM(context, state, chainConfig, &vmConfig), vmError, nil
+	}
+	mockBackend.EXPECT().ChainConfig().Return(chainConfig).AnyTimes()
+	mockBackend.EXPECT().RPCGasCap().Return(common.Big0).AnyTimes()
+	mockBackend.EXPECT().StateAndHeaderByNumber(any, any).DoAndReturn(getStateAndHeader).AnyTimes()
+	mockBackend.EXPECT().StateAndHeaderByNumberOrHash(any, any).DoAndReturn(getStateAndHeader).AnyTimes()
+	mockBackend.EXPECT().GetEVM(any, any, any, any, any).DoAndReturn(getEVM).AnyTimes()
+
+	testcases := []struct {
+		args      EthTransactionArgs
+		expectErr string
+		expectGas uint64
+	}{
+		{ // simple transfer
+			args: EthTransactionArgs{
+				From:  &account1,
+				To:    &account2,
+				Value: &KLAY,
+			},
+			expectGas: 21000,
+		},
+		{ // simple transfer with insufficient funds
+			args: EthTransactionArgs{
+				From:  &account2, // sender has 0 KLAY
+				To:    &account1,
+				Value: &KLAY, // transfer 1 KLAY
+			},
+			expectErr: "insufficient balance for transfer",
+		},
+		{ // simple transfer with insufficient funds with nonzero gasPrice
+			args: EthTransactionArgs{
+				From:     &account2, // sender has 0 KLAY
+				To:       &account1,
+				Value:    &KLAY, // transfer 1 KLAY
+				GasPrice: &mKLAY,
+			},
+			expectErr: "insufficient funds for transfer",
+		},
+		{ // simple transfer too high gasPrice
+			args: EthTransactionArgs{
+				From:     &account1, // sender has 2 KLAY
+				To:       &account2,
+				Value:    &KLAY,  // transfer 1 KLAY
+				GasPrice: &mKLAY, // allowance = (2 - 1) / 0.001 = 1000 gas
+			},
+			expectErr: "gas required exceeds allowance",
+		},
+		{ // empty create
+			args:      EthTransactionArgs{},
+			expectGas: 53000,
+		},
+		{ // ignore too small gasLimit
+			args: EthTransactionArgs{
+				Gas: &gas1000,
+			},
+			expectGas: 53000,
+		},
+		{ // capped by gasLimit
+			args: EthTransactionArgs{
+				Gas: &gas40000,
+			},
+			expectErr: "gas required exceeds allowance",
+		},
+		{ // fails with VM error
+			args: EthTransactionArgs{
+				From: &account1,
+				Data: &baddata,
+			},
+			expectErr: "VM error occurs while running smart contract",
+		},
+		{ // fails with contract revert
+			args: EthTransactionArgs{
+				From: &account1,
+				To:   &account3,
+				Data: &baddata,
+			},
+			expectErr: "execution reverted: hello",
+		},
+	}
+
+	for i, tc := range testcases {
+		gas, err := fnEstimateGas(tc.args)
+		t.Logf("tc[%02d] = %d %v", i, gas, err)
+		if len(tc.expectErr) > 0 {
+			require.NotNil(t, err)
+			assert.Contains(t, err.Error(), tc.expectErr, i)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectGas, uint64(gas), i)
+		}
+	}
+}
+
+func TestEthereumAPI_EstimateGas(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForEthApi(t)
+	defer mockCtrl.Finish()
+
+	testEstimateGas(t, mockBackend, func(args EthTransactionArgs) (hexutil.Uint64, error) {
+		return api.EstimateGas(context.Background(), args, nil)
+	})
 }

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -363,7 +363,7 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 	}
 
 	if len(result.Revert()) > 0 {
-		return nil, newRevertError(result)
+		return nil, blockchain.NewRevertError(result)
 	}
 	return result.Return(), result.Unwrap()
 }
@@ -387,20 +387,18 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (h
 }
 
 func (s *PublicBlockChainAPI) DoEstimateGas(ctx context.Context, b Backend, args CallArgs, gasCap *big.Int) (hexutil.Uint64, error) {
-	// Binary search the gas requirement, as it may be higher than the amount used
-	var (
-		lo  uint64 = params.TxGas - 1
-		hi  uint64
-		cap uint64
-	)
-	if uint64(args.Gas) >= params.TxGas {
-		hi = uint64(args.Gas)
+	var feeCap *big.Int
+	if args.GasPrice != nil {
+		feeCap = args.GasPrice.ToInt()
 	} else {
-		// Retrieve the current pending block to act as the gas ceiling
-		hi = params.UpperGasLimit
+		feeCap = common.Big0
 	}
-	// TODO-Klaytn: set hi value with account balance
-	cap = hi
+
+	state, _, err := b.StateAndHeaderByNumber(ctx, rpc.LatestBlockNumber)
+	if err != nil {
+		return 0, err
+	}
+	balance := state.GetBalance(args.From) // from can't be nil
 
 	// Create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (bool, *blockchain.ExecutionResult, error) {
@@ -415,37 +413,7 @@ func (s *PublicBlockChainAPI) DoEstimateGas(ctx context.Context, b Backend, args
 		return result.Failed(), result, nil
 	}
 
-	// Execute the binary search and hone in on an executable gas limit
-	for lo+1 < hi {
-		mid := (hi + lo) / 2
-		failed, _, err := executable(mid)
-		if err != nil {
-			return 0, err
-		}
-		if failed {
-			lo = mid
-		} else {
-			hi = mid
-		}
-	}
-	// Reject the transaction as invalid if it still fails at the highest allowance
-	if hi == cap {
-		failed, result, err := executable(hi)
-		if err != nil {
-			return 0, err
-		}
-		if failed {
-			if result != nil && result.VmExecutionStatus != types.ReceiptStatusErrOutOfGas {
-				if len(result.Revert()) > 0 {
-					return 0, newRevertError(result)
-				}
-				return 0, result.Unwrap()
-			}
-			// Otherwise, the specified gas cap is too low
-			return 0, fmt.Errorf("gas required exceeds allowance (%d)", cap)
-		}
-	}
-	return hexutil.Uint64(hi), nil
+	return blockchain.DoEstimateGas(ctx, uint64(args.Gas), gasCap.Uint64(), args.Value.ToInt(), feeCap, balance, executable)
 }
 
 // ExecutionResult groups all structured logs emitted by the EVM

--- a/api/api_public_blockchain_test.go
+++ b/api/api_public_blockchain_test.go
@@ -1,0 +1,62 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	mock_api "github.com/klaytn/klaytn/api/mocks"
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/params"
+)
+
+func testInitForKlayApi(t *testing.T) (*gomock.Controller, *mock_api.MockBackend, *PublicBlockChainAPI) {
+	mockCtrl := gomock.NewController(t)
+	mockBackend := mock_api.NewMockBackend(mockCtrl)
+
+	blockchain.InitDeriveSha(params.TestChainConfig)
+
+	api := NewPublicBlockChainAPI(mockBackend)
+	return mockCtrl, mockBackend, api
+}
+
+func TestKlaytnAPI_EstimateGas(t *testing.T) {
+	mockCtrl, mockBackend, api := testInitForKlayApi(t)
+	defer mockCtrl.Finish()
+
+	testEstimateGas(t, mockBackend, func(ethArgs EthTransactionArgs) (hexutil.Uint64, error) {
+		// Testcases are written in EthTransactionArgs. Convert to klay CallArgs
+		args := CallArgs{
+			From:                 ethArgs.from(),
+			To:                   ethArgs.To,
+			GasPrice:             ethArgs.GasPrice,
+			MaxFeePerGas:         ethArgs.MaxFeePerGas,
+			MaxPriorityFeePerGas: ethArgs.MaxPriorityFeePerGas,
+			Data:                 ethArgs.data(),
+		}
+		if ethArgs.Gas != nil {
+			args.Gas = *ethArgs.Gas
+		}
+		if ethArgs.Value != nil {
+			args.Value = *ethArgs.Value
+		}
+		return api.EstimateGas(context.Background(), args)
+	})
+}

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -28,11 +28,8 @@ import (
 	"math/big"
 	"reflect"
 
-	"github.com/klaytn/klaytn/accounts/abi"
-	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/types/accountkey"
-	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/params"
@@ -459,44 +456,4 @@ func (args *AccountUpdateTxArgs) toTransaction() (*types.Transaction, error) {
 	}
 
 	return tx, nil
-}
-
-// isReverted checks given error is vm.ErrExecutionReverted
-func isReverted(err error) bool {
-	if errors.Is(err, vm.ErrExecutionReverted) {
-		return true
-	}
-	return false
-}
-
-// newRevertError wraps data returned when EVM execution was reverted.
-// Make sure that data is returned when execution reverted situation.
-func newRevertError(result *blockchain.ExecutionResult) *revertError {
-	reason, errUnpack := abi.UnpackRevert(result.Revert())
-	err := errors.New("execution reverted")
-	if errUnpack == nil {
-		err = fmt.Errorf("execution reverted: %v", reason)
-	}
-	return &revertError{
-		error:  err,
-		reason: hexutil.Encode(result.Revert()),
-	}
-}
-
-// revertError is an API error that encompassas an EVM revertal with JSON error
-// code and a binary data blob.
-type revertError struct {
-	error
-	reason string // revert reason hex encoded
-}
-
-// ErrorCode returns the JSON error code for a revertal.
-// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
-func (e *revertError) ErrorCode() int {
-	return 3
-}
-
-// ErrorData returns the hex encoded revert reason.
-func (e *revertError) ErrorData() interface{} {
-	return e.reason
 }

--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -21,11 +21,16 @@
 package blockchain
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"math/big"
 
+	"github.com/klaytn/klaytn/accounts/abi"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/consensus"
 	"github.com/klaytn/klaytn/params"
 )
@@ -123,4 +128,114 @@ func CanTransfer(db vm.StateDB, addr common.Address, amount *big.Int) bool {
 func Transfer(db vm.StateDB, sender, recipient common.Address, amount *big.Int) {
 	db.SubBalance(sender, amount)
 	db.AddBalance(recipient, amount)
+}
+
+func DoEstimateGas(ctx context.Context, gasLimit, rpcGasCap uint64, txValue, gasPrice, balance *big.Int, test func(gas uint64) (bool, *ExecutionResult, error)) (hexutil.Uint64, error) {
+	// Binary search the gas requirement, as it may be higher than the amount used
+	var (
+		lo  uint64 = params.TxGas - 1
+		hi  uint64 = params.UpperGasLimit
+		cap uint64
+	)
+
+	// Initialize nil params
+	if txValue == nil {
+		txValue = big.NewInt(0)
+	}
+	if gasPrice == nil {
+		gasPrice = big.NewInt(0)
+	}
+	if balance == nil {
+		balance = big.NewInt(0)
+	}
+
+	if gasLimit >= params.TxGas {
+		hi = gasLimit
+	}
+
+	// recap the highest gas limit with account's available balance.
+	if gasPrice.BitLen() != 0 {
+		available := new(big.Int).Set(balance)
+		if txValue.Cmp(available) >= 0 {
+			return 0, errors.New("insufficient funds for transfer")
+		}
+		available.Sub(available, txValue)
+		allowance := new(big.Int).Div(available, gasPrice)
+
+		// If the allowance is larger than maximum uint64, skip checking
+		if allowance.IsUint64() && hi > allowance.Uint64() {
+			logger.Warn("Gas estimation capped by limited funds", "original", hi, "balance", balance,
+				"sent", txValue, "maxFeePerGas", gasPrice, "fundable", allowance)
+			hi = allowance.Uint64()
+		}
+	}
+	// Recap the highest gas allowance with specified gascap.
+	if rpcGasCap != 0 && hi > rpcGasCap {
+		logger.Warn("Caller gas above allowance, capping", "requested", hi, "cap", rpcGasCap)
+		hi = rpcGasCap
+	}
+	cap = hi
+
+	// Execute the binary search and hone in on an executable gas limit
+	for lo+1 < hi {
+		mid := (hi + lo) / 2
+		failed, _, err := test(mid)
+		if err != nil {
+			return 0, err
+		}
+
+		if failed {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	// Reject the transaction as invalid if it still fails at the highest allowance
+	if hi == cap {
+		failed, result, err := test(hi)
+		if err != nil {
+			return 0, err
+		}
+		if failed {
+			if result != nil && result.VmExecutionStatus != types.ReceiptStatusErrOutOfGas {
+				if len(result.Revert()) > 0 {
+					return 0, NewRevertError(result)
+				}
+				return 0, result.Unwrap()
+			}
+			// Otherwise, the specified gas cap is too low
+			return 0, fmt.Errorf("gas required exceeds allowance (%d)", cap)
+		}
+	}
+	return hexutil.Uint64(hi), nil
+}
+
+func NewRevertError(result *ExecutionResult) *RevertError {
+	reason, errUnpack := abi.UnpackRevert(result.Revert())
+	err := errors.New("execution reverted")
+	if errUnpack == nil {
+		err = fmt.Errorf("execution reverted: %v", reason)
+	}
+	return &RevertError{
+		error:  err,
+		reason: hexutil.Encode(result.Revert()),
+	}
+}
+
+// RevertError is an API error that encompassas an EVM revertal with JSON error
+// code and a binary data blob.
+type RevertError struct {
+	error
+	reason string // revert reason hex encoded
+}
+
+// ErrorCode returns the JSON error code for a revertal.
+// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+func (e *RevertError) ErrorCode() int {
+	return 3
+}
+
+// ErrorData returns the hex encoded revert reason.
+func (e *RevertError) ErrorData() interface{} {
+	return e.reason
 }


### PR DESCRIPTION
## Proposed changes

Summary
- Replace the below 3 similar implementations...
	- [`accounts/abi/bind/backends/simulated.go`](https://github.com/klaytn/klaytn/blob/dev/accounts/abi/bind/backends/simulated.go#L445) - SimulatedBackend.EstimateGas
	- [`api/api_ethereum.go`](https://github.com/klaytn/klaytn/blob/dev/api/api_ethereum.go#L1622) - api.EthDoEstimateGas (eth_estimateGas)
	- [`api/api_public_blockchain.go`](https://github.com/klaytn/klaytn/blob/dev/api/api_public_blockchain.go#L389) - api.DoEstimateGas (klay_estimateGas)
- ...with a common function.
  - [`blockchain/evm.go`](https://github.com/2dvorak/klaytn/blob/common-estimategas/blockchain/evm.go#L133) - blockchain.DoEstimateGas 

Additional changes

- Fix the OutOfGas handling in [api.EthDoEstimateGas](https://github.com/klaytn/klaytn/blob/74b5389cfdd2c5b32c975a7f6efb9d4e5eba2e3c/api/api_ethereum.go#L1725) to follow [geth](https://github.com/ethereum/go-ethereum/blob/v1.12.0/internal/ethapi/api.go#L1203).
  - Now returns the "gas required exceeds allowance" error upon `ReceiptStatusErrOutOfGas`.
- Add GasPriceCap logic to [api.DoEstimateGas](https://github.com/klaytn/klaytn/blob/v1.10.2/api/api_public_blockchain.go#L409). Clears a TODO.
  - Now returns the "insufficient funds..." error.
- Replace duplicate `revertError` structs with `blockchain.RevertError`
  - [`accounts/abi/bind/backends/simulated.go`](https://github.com/klaytn/klaytn/blob/74b5389cfdd2c5b32c975a7f6efb9d4e5eba2e3c/accounts/abi/bind/backends/simulated.go#L370)
  - [`api/tx_args.go`](https://github.com/klaytn/klaytn/blob/74b5389cfdd2c5b32c975a7f6efb9d4e5eba2e3c/api/tx_args.go#L488)
- Delete unused function `isReverted()`
- New unit tests for eth_estimateGas and klay_estimateGas

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

None

## Further comments

The actions that each implementations perform can be listed into:
- GasLimitCap: If user specified gas limit, spend gas up to it
- GasPriceCap: If user specified gas price, spend gas up to `(user balance - transferred value) / gas price`
- RpcGasCap: If node has rpc.gascap setting, spend gas up to it
- BinarySearch: Binary search the required amount of gas
- FindReason: If it fails to find the required amount of gas, find out why

| Impl | Before | After |
|------|--------|-------|
|Simulated       | GasLimitCap <br> GasPriceCap <br> BinarySearch <br> FindReason | CommonEstimateGas <br><br><br><br> |
|EthEstimateGas  | GasLimitCap <br> GasPriceCap <br> RpcGasCap <br> BinarySearch <br> FindReason | CommonEstimateGas <br><br><br><br><br> |
|KlayEstimateGas | GasLimitCap <br> BinarySearch <br> FindReason | CommonEstimateGas <br><br><br> |
|CommonEstimateGas | | GasLimitCap <br> GasPriceCap <br> RpcGasCap <br> BinarySearch <br> FindReason