### PR TITLE
api/debug: fix the path of temporary file for checking logdir is writable

### DIFF
--- a/api/debug/flags.go
+++ b/api/debug/flags.go
@@ -319,7 +319,7 @@ func validateLogLocation(path string) error {
 		return fmt.Errorf("error creating the directory: %w", err)
 	}
 	// Check if the path is writable by trying to create a temporary file
-	tmp := filepath.Join(path, ".temp")
+	tmp := path + ".temp"
 	if f, err := os.Create(tmp); err != nil {
 		return err
 	} else {


### PR DESCRIPTION
## Proposed changes

The path of temporary file for checking the log dir is writable was configured wrong, so this PR fix it.

For example, if the log path is /var/kend/logs/kend.out, the path of temporary file is like below.
dev: `/var/kend/logs/kend.out/.temp`
PR: `/var/kend/logs/kend.out.temp`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
