### PR TITLE
params: add ethtxtype fork indicator at chainconfig.Rules

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -547,12 +547,13 @@ func (err *ConfigCompatError) Error() string {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	ChainID    *big.Int
-	IsIstanbul bool
-	IsLondon   bool
-	IsMagma    bool
-	IsKore     bool
-	IsMantle   bool
+	ChainID     *big.Int
+	IsIstanbul  bool
+	IsLondon    bool
+	IsEthTxType bool
+	IsMagma     bool
+	IsKore      bool
+	IsMantle    bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -562,12 +563,13 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		chainID = new(big.Int)
 	}
 	return Rules{
-		ChainID:    new(big.Int).Set(chainID),
-		IsIstanbul: c.IsIstanbulForkEnabled(num),
-		IsLondon:   c.IsLondonForkEnabled(num),
-		IsMagma:    c.IsMagmaForkEnabled(num),
-		IsKore:     c.IsKoreForkEnabled(num),
-		IsMantle:   c.IsMantleForkEnabled(num),
+		ChainID:     new(big.Int).Set(chainID),
+		IsIstanbul:  c.IsIstanbulForkEnabled(num),
+		IsLondon:    c.IsLondonForkEnabled(num),
+		IsEthTxType: c.IsEthTxTypeForkEnabled(num),
+		IsMagma:     c.IsMagmaForkEnabled(num),
+		IsKore:      c.IsKoreForkEnabled(num),
+		IsMantle:    c.IsMantleForkEnabled(num),
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

- added `EthTxType` fork indicator at `Rules`.
- Instead of defining seperate fork indicator variables at `Txpool` struct, this PR defines a single fork indicator variable and the type is `Rules`.
  - dev
  ```
   type TxPool struct {
       ...
       eip2718 bool
       eip1559 bool
       magma bool
    }
   ```
  - PR
  ```
   type TxPool struct {
       ...
       rules params.Rules
    }
  ```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
