### PR TITLE
evm: add eip-3860(limit and meter initcode)

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -64,6 +64,10 @@ var (
 	// ErrAlreadyNonceExistInPool is returned if there is another tx with the same nonce in the tx pool.
 	ErrAlreadyNonceExistInPool = errors.New("there is another tx which has the same nonce in the tx pool")
 
+	// ErrMaxInitCodeSizeExceeded is returned if creation transaction provides the init code bigger
+	// than init code size limit.
+	ErrMaxInitCodeSizeExceeded = errors.New("max initcode size exceeded")
+
 	// ErrInsufficientFunds is returned if the total cost of executing a transaction
 	// is higher than the balance of the user's account.
 	ErrInsufficientFunds = errors.New("insufficient funds for gas * price + value")

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -713,15 +713,11 @@ func (self *StateDB) createObjectWithMap(addr common.Address, accountType accoun
 }
 
 // CreateAccount explicitly creates a state object. If a state object with the address
-// already exists the balance is carried over to the new account.
-//
-// CreateAccount is called during the EVM CREATE operation. The situation might arise that
-// a contract does the following:
-//
-//  1. sends funds to sha(account ++ (nonce + 1))
-//  2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
-//
+// already exists, the balance is carried over to the new account.
 // Carrying over the balance ensures that Ether doesn't disappear.
+//
+// CreateAccount is currently used for test code only. Instead,
+// use CreateEOA, CreateSmartContractAccount, or CreateSmartContractAccountWithKey to create a typed account.
 func (self *StateDB) CreateAccount(addr common.Address) {
 	new, prev := self.createObject(addr)
 	if prev != nil {

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -718,8 +718,8 @@ func (self *StateDB) createObjectWithMap(addr common.Address, accountType accoun
 // CreateAccount is called during the EVM CREATE operation. The situation might arise that
 // a contract does the following:
 //
-//   1. sends funds to sha(account ++ (nonce + 1))
-//   2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
+//  1. sends funds to sha(account ++ (nonce + 1))
+//  2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
 //
 // Carrying over the balance ensures that Ether doesn't disappear.
 func (self *StateDB) CreateAccount(addr common.Address) {

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -557,7 +557,7 @@ func IntrinsicGasPayload(gas uint64, data []byte, isContractCreation bool, rules
 			return 0, kerrors.ErrOutOfGas
 		}
 		if isContractCreation && rules.IsMantle {
-			lenWords := toWordSize(uint64(len(data)))
+			lenWords := toWordSize(length)
 			if (math.MaxUint64-gas)/params.InitCodeWordGas < lenWords {
 				return 0, kerrors.ErrOutOfGas
 			}

--- a/blockchain/types/tx_internal_data_chain_data_anchoring.go
+++ b/blockchain/types/tx_internal_data_chain_data_anchoring.go
@@ -26,6 +26,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 )
@@ -260,7 +261,7 @@ func (t *TxInternalDataChainDataAnchoring) SetSignature(s TxSignatures) {
 func (t *TxInternalDataChainDataAnchoring) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxChainDataAnchoringGas
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_chain_data_anchoring.go
+++ b/blockchain/types/tx_internal_data_chain_data_anchoring.go
@@ -261,7 +261,9 @@ func (t *TxInternalDataChainDataAnchoring) SetSignature(s TxSignatures) {
 func (t *TxInternalDataChainDataAnchoring) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxChainDataAnchoringGas
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	// ChainDataAnchoring does not have Recipient, but it is not contract deployment transaction type.
+	// So, isContractCreation is explicitly set as false.
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, false, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 )
@@ -295,7 +296,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoring) RecoverFeePayerPubkey(txh
 func (t *TxInternalDataFeeDelegatedChainDataAnchoring) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxChainDataAnchoringGas + params.TxGasFeeDelegated
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring.go
@@ -296,7 +296,9 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoring) RecoverFeePayerPubkey(txh
 func (t *TxInternalDataFeeDelegatedChainDataAnchoring) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxChainDataAnchoringGas + params.TxGasFeeDelegated
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	// ChainDataAnchoring does not have Recipient, but it is not contract deployment transaction type.
+	// So, isContractCreation is explicitly set as false.
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, false, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
@@ -320,7 +320,9 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) RecoverFeePayerP
 func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxChainDataAnchoringGas + params.TxGasFeeDelegatedWithRatio
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	// ChainDataAnchoring does not have Recipient, but it is not contract deployment transaction type.
+	// So, isContractCreation is explicitly set as false.
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, false, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_chain_data_anchoring_with_ratio.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 )
@@ -319,7 +320,7 @@ func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) RecoverFeePayerP
 func (t *TxInternalDataFeeDelegatedChainDataAnchoringWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxChainDataAnchoringGas + params.TxGasFeeDelegatedWithRatio
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -307,7 +308,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeploy) IntrinsicGas(currentBloc
 		gas += params.TxGasHumanReadable
 	}
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
@@ -308,7 +308,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeploy) IntrinsicGas(currentBloc
 		gas += params.TxGasHumanReadable
 	}
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, true, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
@@ -328,7 +328,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeployWithRatio) IntrinsicGas(cu
 		gas += params.TxGasHumanReadable
 	}
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, true, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
@@ -28,6 +28,7 @@ import (
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -327,7 +328,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeployWithRatio) IntrinsicGas(cu
 		gas += params.TxGasHumanReadable
 	}
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution.go
@@ -274,7 +274,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractExecution) String() string {
 func (t *TxInternalDataFeeDelegatedSmartContractExecution) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractExecution + params.TxGasFeeDelegated
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, false, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -273,7 +274,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractExecution) String() string {
 func (t *TxInternalDataFeeDelegatedSmartContractExecution) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractExecution + params.TxGasFeeDelegated
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution_with_ratio.go
@@ -294,7 +294,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractExecutionWithRatio) String() str
 func (t *TxInternalDataFeeDelegatedSmartContractExecutionWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractExecution + params.TxGasFeeDelegatedWithRatio
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, false, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_execution_with_ratio.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -293,7 +294,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractExecutionWithRatio) String() str
 func (t *TxInternalDataFeeDelegatedSmartContractExecutionWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractExecution + params.TxGasFeeDelegatedWithRatio
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -273,7 +274,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferMemo) RecoverFeePayerPubkey(txha
 
 func (t *TxInternalDataFeeDelegatedValueTransferMemo) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasValueTransfer + params.TxGasFeeDelegated
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo.go
@@ -274,7 +274,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferMemo) RecoverFeePayerPubkey(txha
 
 func (t *TxInternalDataFeeDelegatedValueTransferMemo) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasValueTransfer + params.TxGasFeeDelegated
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, false, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo_with_ratio.go
@@ -294,7 +294,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferMemoWithRatio) RecoverFeePayerPu
 
 func (t *TxInternalDataFeeDelegatedValueTransferMemoWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasValueTransfer + params.TxGasFeeDelegatedWithRatio
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, false, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo_with_ratio.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -293,7 +294,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferMemoWithRatio) RecoverFeePayerPu
 
 func (t *TxInternalDataFeeDelegatedValueTransferMemoWithRatio) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasValueTransfer + params.TxGasFeeDelegatedWithRatio
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_smart_contract_deploy.go
@@ -272,7 +272,8 @@ func (t *TxInternalDataSmartContractDeploy) IntrinsicGas(currentBlockNumber uint
 	if t.HumanReadable {
 		gas += params.TxGasHumanReadable
 	}
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, true, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_smart_contract_deploy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -271,8 +272,7 @@ func (t *TxInternalDataSmartContractDeploy) IntrinsicGas(currentBlockNumber uint
 	if t.HumanReadable {
 		gas += params.TxGasHumanReadable
 	}
-
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_smart_contract_execution.go
+++ b/blockchain/types/tx_internal_data_smart_contract_execution.go
@@ -26,6 +26,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -238,7 +239,7 @@ func (t *TxInternalDataSmartContractExecution) String() string {
 func (t *TxInternalDataSmartContractExecution) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractExecution
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_smart_contract_execution.go
+++ b/blockchain/types/tx_internal_data_smart_contract_execution.go
@@ -239,7 +239,7 @@ func (t *TxInternalDataSmartContractExecution) String() string {
 func (t *TxInternalDataSmartContractExecution) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasContractExecution
 
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, false, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_value_transfer_memo.go
+++ b/blockchain/types/tx_internal_data_value_transfer_memo.go
@@ -26,6 +26,7 @@ import (
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto/sha3"
+	"github.com/klaytn/klaytn/fork"
 	"github.com/klaytn/klaytn/kerrors"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -238,7 +239,7 @@ func (t *TxInternalDataValueTransferMemo) SetSignature(s TxSignatures) {
 
 func (t *TxInternalDataValueTransferMemo) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasValueTransfer
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload)
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/types/tx_internal_data_value_transfer_memo.go
+++ b/blockchain/types/tx_internal_data_value_transfer_memo.go
@@ -239,7 +239,7 @@ func (t *TxInternalDataValueTransferMemo) SetSignature(s TxSignatures) {
 
 func (t *TxInternalDataValueTransferMemo) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
 	gas := params.TxGasValueTransfer
-	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, t.GetRecipient() == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	gasPayloadWithGas, err := IntrinsicGasPayload(gas, t.Payload, false, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -28,6 +28,8 @@ import (
 // defined jump tables are not polluted.
 func EnableEIP(eipNum int, jt *JumpTable) error {
 	switch eipNum {
+	case 3860:
+		enable3860(jt)
 	case 3855:
 		enable3855(jt)
 	case 4399:
@@ -207,4 +209,11 @@ func enable3855(jt *JumpTable) {
 func opPush0(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	stack.push(new(big.Int))
 	return nil, nil
+}
+
+// enable3860 enables "EIP-3860: Limit and meter initcode"
+// https://eips.ethereum.org/EIPS/eip-3860
+func enable3860(jt *JumpTable) {
+	jt[CREATE].dynamicGas = gasCreateEip3860
+	jt[CREATE2].dynamicGas = gasCreate2Eip3860
 }

--- a/blockchain/vm/gas_table.go
+++ b/blockchain/vm/gas_table.go
@@ -121,19 +121,19 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	}
 }
 
-//  0. If *gasleft* is less than or equal to 2300, fail the current call.
-//  1. If current value equals new value (this is a no-op), SLOAD_GAS is deducted.
-//  2. If current value does not equal new value:
-//     2.1. If original value equals current value (this storage slot has not been changed by the current execution context):
-//     2.1.1. If original value is 0, SSTORE_SET_GAS (20K) gas is deducted.
-//     2.1.2. Otherwise, SSTORE_RESET_GAS gas is deducted. If new value is 0, add SSTORE_CLEARS_SCHEDULE to refund counter.
-//     2.2. If original value does not equal current value (this storage slot is dirty), SLOAD_GAS gas is deducted. Apply both of the following clauses:
-//     2.2.1. If original value is not 0:
-//     2.2.1.1. If current value is 0 (also means that new value is not 0), subtract SSTORE_CLEARS_SCHEDULE gas from refund counter.
-//     2.2.1.2. If new value is 0 (also means that current value is not 0), add SSTORE_CLEARS_SCHEDULE gas to refund counter.
-//     2.2.2. If original value equals new value (this storage slot is reset):
-//     2.2.2.1. If original value is 0, add SSTORE_SET_GAS - SLOAD_GAS to refund counter.
-//     2.2.2.2. Otherwise, add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter.
+// 0. If *gasleft* is less than or equal to 2300, fail the current call.
+// 1. If current value equals new value (this is a no-op), SLOAD_GAS is deducted.
+// 2. If current value does not equal new value:
+//  2.1. If original value equals current value (this storage slot has not been changed by the current execution context):
+//   2.1.1. If original value is 0, SSTORE_SET_GAS (20K) gas is deducted.
+//   2.1.2. Otherwise, SSTORE_RESET_GAS gas is deducted. If new value is 0, add SSTORE_CLEARS_SCHEDULE to refund counter.
+//  2.2. If original value does not equal current value (this storage slot is dirty), SLOAD_GAS gas is deducted. Apply both of the following clauses:
+//   2.2.1. If original value is not 0:
+//    2.2.1.1. If current value is 0 (also means that new value is not 0), subtract SSTORE_CLEARS_SCHEDULE gas from refund counter.
+//    2.2.1.2. If new value is 0 (also means that current value is not 0), add SSTORE_CLEARS_SCHEDULE gas to refund counter.
+//   2.2.2. If original value equals new value (this storage slot is reset):
+//    2.2.2.1. If original value is 0, add SSTORE_SET_GAS - SLOAD_GAS to refund counter.
+//    2.2.2.2. Otherwise, add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter.
 func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	// If we fail the minimum gas availability invariant, fail (0)
 	if contract.Gas <= params.SstoreSentryGasEIP2200 {

--- a/blockchain/vm/gas_table.go
+++ b/blockchain/vm/gas_table.go
@@ -121,19 +121,19 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	}
 }
 
-// 0. If *gasleft* is less than or equal to 2300, fail the current call.
-// 1. If current value equals new value (this is a no-op), SLOAD_GAS is deducted.
-// 2. If current value does not equal new value:
-//   2.1. If original value equals current value (this storage slot has not been changed by the current execution context):
+//  0. If *gasleft* is less than or equal to 2300, fail the current call.
+//  1. If current value equals new value (this is a no-op), SLOAD_GAS is deducted.
+//  2. If current value does not equal new value:
+//     2.1. If original value equals current value (this storage slot has not been changed by the current execution context):
 //     2.1.1. If original value is 0, SSTORE_SET_GAS (20K) gas is deducted.
 //     2.1.2. Otherwise, SSTORE_RESET_GAS gas is deducted. If new value is 0, add SSTORE_CLEARS_SCHEDULE to refund counter.
-//   2.2. If original value does not equal current value (this storage slot is dirty), SLOAD_GAS gas is deducted. Apply both of the following clauses:
+//     2.2. If original value does not equal current value (this storage slot is dirty), SLOAD_GAS gas is deducted. Apply both of the following clauses:
 //     2.2.1. If original value is not 0:
-//       2.2.1.1. If current value is 0 (also means that new value is not 0), subtract SSTORE_CLEARS_SCHEDULE gas from refund counter.
-//       2.2.1.2. If new value is 0 (also means that current value is not 0), add SSTORE_CLEARS_SCHEDULE gas to refund counter.
+//     2.2.1.1. If current value is 0 (also means that new value is not 0), subtract SSTORE_CLEARS_SCHEDULE gas from refund counter.
+//     2.2.1.2. If new value is 0 (also means that current value is not 0), add SSTORE_CLEARS_SCHEDULE gas to refund counter.
 //     2.2.2. If original value equals new value (this storage slot is reset):
-//       2.2.2.1. If original value is 0, add SSTORE_SET_GAS - SLOAD_GAS to refund counter.
-//       2.2.2.2. Otherwise, add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter.
+//     2.2.2.1. If original value is 0, add SSTORE_SET_GAS - SLOAD_GAS to refund counter.
+//     2.2.2.2. Otherwise, add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter.
 func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	// If we fail the minimum gas availability invariant, fail (0)
 	if contract.Gas <= params.SstoreSentryGasEIP2200 {
@@ -253,6 +253,40 @@ func gasCreate2(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memoryS
 		return 0, errGasUintOverflow
 	}
 	if gas, overflow = math.SafeAdd(gas, wordGas); overflow {
+		return 0, errGasUintOverflow
+	}
+	return gas, nil
+}
+
+func gasCreateEip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	gas, err := memoryGasCost(mem, memorySize)
+	if err != nil {
+		return 0, err
+	}
+	size, overflow := bigUint64(stack.Back(2))
+	if overflow || size > params.MaxInitCodeSize {
+		return 0, errGasUintOverflow
+	}
+	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
+	moreGas := params.InitCodeWordGas * ((size + 31) / 32)
+	if gas, overflow = math.SafeAdd(gas, moreGas); overflow {
+		return 0, errGasUintOverflow
+	}
+	return gas, nil
+}
+
+func gasCreate2Eip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	gas, err := memoryGasCost(mem, memorySize)
+	if err != nil {
+		return 0, err
+	}
+	size, overflow := bigUint64(stack.Back(2))
+	if overflow || size > params.MaxInitCodeSize {
+		return 0, errGasUintOverflow
+	}
+	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
+	moreGas := (params.InitCodeWordGas + params.Sha3WordGas) * ((size + 31) / 32)
+	if gas, overflow = math.SafeAdd(gas, moreGas); overflow {
 		return 0, errGasUintOverflow
 	}
 	return gas, nil

--- a/blockchain/vm/gas_table_test.go
+++ b/blockchain/vm/gas_table_test.go
@@ -21,8 +21,10 @@
 package vm
 
 import (
+	"bytes"
 	"math"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/klaytn/klaytn/blockchain/state"
@@ -133,6 +135,77 @@ func TestEIP2200(t *testing.T) {
 		}
 		if refund := vmenv.StateDB.GetRefund(); refund != tt.refund {
 			t.Errorf("test %d: gas refund mismatch: have %v, want %v", i, refund, tt.refund)
+		}
+	}
+}
+
+var createGasTests = []struct {
+	code       string
+	eip3860    bool
+	gasUsed    uint64
+	minimumGas uint64
+}{
+	// legacy create(0, 0, 0xc000) without eip3860
+	{"0x61C00060006000f0" + "600052" + "60206000F3", false, 41237, 41237},
+	// create2(0, 0, 0xc001, 0) without eip3860
+	{"0x600061C00160006000f5" + "600052" + "60206000F3", false, 50471, 50471},
+	// legacy create(0, 0, 0xc000), with eip3860
+	{"0x61C00060006000f0" + "600052" + "60206000F3", true, 44309, 44309},
+	// create2(0, 0, 0xc001, 0) (too large), with eip3860
+	{"0x600061C00160006000f5" + "600052" + "60206000F3", true, 32012, 100_000},
+	// create2(0, 0, 0xc000, 0)
+	// This case is trying to deploy code at (within) the limit
+	{"0x600061C00060006000f5" + "600052" + "60206000F3", true, 53528, 53528},
+	// create2(0, 0, 0xc001, 0)
+	// This case is trying to deploy code exceeding the limit
+	{"0x600061C00160006000f5" + "600052" + "60206000F3", true, 32024, 100000},
+}
+
+func TestCreateGas(t *testing.T) {
+	for i, tt := range createGasTests {
+		gasUsed := uint64(0)
+		doCheck := func(testGas int) bool {
+			address := common.BytesToAddress([]byte("contract"))
+			statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+			statedb.CreateSmartContractAccount(address, params.CodeFormatEVM, params.Rules{IsIstanbul: true})
+			statedb.SetCode(address, hexutil.MustDecode(tt.code))
+			statedb.Finalise(true, false)
+
+			vmctx := Context{
+				CanTransfer: func(StateDB, common.Address, *big.Int) bool { return true },
+				Transfer:    func(StateDB, common.Address, common.Address, *big.Int) {},
+			}
+			config := Config{}
+			if tt.eip3860 {
+				config.ExtraEips = []int{3860}
+			}
+
+			vmenv := NewEVM(vmctx, statedb, params.AllGxhashProtocolChanges, &config)
+			startGas := uint64(testGas)
+			ret, gas, err := vmenv.Call(AccountRef(common.Address{}), address, nil, startGas, new(big.Int))
+			if err != nil {
+				return false
+			}
+			gasUsed = startGas - gas
+
+			if len(ret) != 32 {
+				t.Fatalf("test %d: expected 32 bytes returned, have %d", i, len(ret))
+			}
+			if bytes.Equal(ret, make([]byte, 32)) {
+				// Failure
+				return false
+			}
+			return true
+		}
+		minGas := sort.Search(100_000, doCheck)
+		if uint64(minGas) != tt.minimumGas {
+			t.Fatalf("test %d: min gas error, want %d, have %d", i, tt.minimumGas, minGas)
+		}
+		// If the deployment succeeded, we also check the gas used
+		if minGas < 100_000 {
+			if gasUsed != tt.gasUsed {
+				t.Errorf("test %d: gas used mismatch: have %v, want %v", i, gasUsed, tt.gasUsed)
+			}
 		}
 	}
 }

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -75,6 +75,7 @@ func newMantleInstructionSet() JumpTable {
 	instructionSet := newKoreInstructionSet()
 
 	enable3855(&instructionSet) // PUSH0 opcode
+	enable3860(&instructionSet) // EIP-3860: limit and meter initcode
 	return instructionSet
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -42,6 +42,7 @@ const (
 	CallStipend           uint64 = 2300  // Free gas given at beginning of call.                                // G_callstipend
 	Sha3Gas               uint64 = 30    // Once per SHA3 operation.                                                 // G_sha3
 	Sha3WordGas           uint64 = 6     // Once per word of the SHA3 operation's data.                              // G_sha3word
+	InitCodeWordGas       uint64 = 2     // Once per word of the init code when creating a contract.				 // G_InitCodeWord
 	SstoreResetGas        uint64 = 5000  // Once per SSTORE operation if the zeroness changes from zero.             // G_sreset
 	SstoreClearGas        uint64 = 5000  // Once per SSTORE operation if the zeroness doesn't change.                // G_sreset
 	SstoreRefundGas       uint64 = 15000 // Once per SSTORE operation if the zeroness changes to zero.               // R_sclear
@@ -144,7 +145,9 @@ const (
 	CallCreateDepth uint64 = 1024  // Maximum depth of call/create stack.
 	StackLimit      uint64 = 1024  // Maximum size of VM stack allowed.
 
-	MaxCodeSize = 24576 // Maximum bytecode to permit for a contract
+	// eip-3860: limit and meter initcode (Shanghai)
+	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
+	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
 
 	// istanbul BFT
 	BFTMaximumExtraDataSize uint64 = 65 // Maximum size extra data may be after Genesis.

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -106,6 +106,8 @@ func TestGasCalculation(t *testing.T) {
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().KoreCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().MantleCompatibleBlock = big.NewInt(0)
 	prof.Profile("main_init_blockchain", time.Now().Sub(start))
 
 	defer bcdata.Shutdown()

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -819,7 +819,7 @@ func genMapForDeploy(from TestAccount, to TestAccount, gasPrice *big.Int, txType
 	intrinsicGas := getIntrinsicGas(txType)
 	intrinsicGas += uint64(0x175fd)
 
-	gasPayloadWithGas, err := types.IntrinsicGasPayload(intrinsicGas, common.FromHex(code))
+	gasPayloadWithGas, err := types.IntrinsicGasPayload(intrinsicGas, common.FromHex(code), true, params.Rules{IsMantle: true})
 	if err != nil {
 		return nil, 0
 	}
@@ -854,7 +854,7 @@ func genMapForExecution(from TestAccount, to TestAccount, gasPrice *big.Int, txT
 	intrinsicGas := getIntrinsicGas(txType)
 	intrinsicGas += uint64(0x9ec4)
 
-	gasPayloadWithGas, err := types.IntrinsicGasPayload(intrinsicGas, data)
+	gasPayloadWithGas, err := types.IntrinsicGasPayload(intrinsicGas, data, false, params.Rules{IsMantle: false})
 	if err != nil {
 		return nil, 0
 	}


### PR DESCRIPTION
## Proposed changes
This PR brings [eip-3860](https://eips.ethereum.org/EIPS/eip-3860). It limits the size of initcode to 2*MaxContrctCodeSize(24576), and increases and meters the deployment gas. Initcode is the code that generates the runtime bytecode. When deploying a contract, the initcode is contained in the data field. Then constructor is executed, and then only runtime bytecode is stored in the blockchain.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
