### PR TITLE
Implement Vrank metrics and logs

### DIFF
--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -78,8 +78,8 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 		return errInvalidMessage
 	}
 
-	if Vrank != nil {
-		Vrank.AddCommit(commit, src)
+	if vrank != nil {
+		vrank.AddCommit(commit, src)
 	}
 
 	// logger.Error("receive handle commit","num", commit.View.Sequence)
@@ -154,7 +154,7 @@ func (c *core) acceptCommit(msg *message, src istanbul.Validator) error {
 	}
 
 	if c.current.Commits.Size() == 1 {
-		vrankFirstCommitArrivalTimeGauge.Update(int64(Vrank.TimeSinceStart()))
+		vrankFirstCommitArrivalTimeGauge.Update(int64(vrank.TimeSinceStart()))
 	}
 
 	return nil

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -78,6 +78,10 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 		return errInvalidMessage
 	}
 
+	if Vrank != nil {
+		Vrank.AddCommit(commit, src)
+	}
+
 	// logger.Error("receive handle commit","num", commit.View.Sequence)
 	if err := c.checkMessage(msgCommit, commit.View); err != nil {
 		// logger.Error("### istanbul/commit.go checkMessage","num",commit.View.Sequence,"err",err)
@@ -147,6 +151,10 @@ func (c *core) acceptCommit(msg *message, src istanbul.Validator) error {
 	if err := c.current.Commits.Add(msg); err != nil {
 		logger.Error("Failed to record commit message", "msg", msg, "err", err)
 		return err
+	}
+
+	if c.current.Commits.Size() == 1 {
+		vrankFirstCommitArrivalTimeGauge.Update(int64(Vrank.TimeSinceStart()))
 	}
 
 	return nil

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -153,7 +153,7 @@ func (c *core) acceptCommit(msg *message, src istanbul.Validator) error {
 		return err
 	}
 
-	if c.current.Commits.Size() == 1 {
+	if c.current.Commits.Size() == 1 && vrank != nil {
 		vrankFirstCommitArrivalTimeGauge.Update(int64(vrank.TimeSinceStart()))
 	}
 

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -194,8 +194,8 @@ func (c *core) commit() {
 			return
 		}
 
-		if Vrank != nil {
-			Vrank.HandleCommitted(proposal.Number())
+		if vrank != nil {
+			vrank.HandleCommitted(proposal.Number())
 		}
 	} else {
 		// TODO-Klaytn never happen, but if proposal is nil, mining is not working.

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -193,6 +193,10 @@ func (c *core) commit() {
 			c.sendNextRoundChange("commit failure")
 			return
 		}
+
+		if Vrank != nil {
+			Vrank.HandleCommitted(proposal.Number())
+		}
 	} else {
 		// TODO-Klaytn never happen, but if proposal is nil, mining is not working.
 		logger.Error("istanbul.core current.Proposal is NULL")

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -122,6 +122,11 @@ func (c *core) handlePreprepare(msg *message, src istanbul.Validator) error {
 				c.acceptPreprepare(preprepare)
 				c.setState(StatePrepared)
 				c.sendCommit()
+
+				if Vrank != nil {
+					Vrank.Stop()
+				}
+				Vrank = NewVrank(*c.currentView(), c.valSet.SubList(preprepare.Proposal.ParentHash(), c.currentView()))
 			} else {
 				// Send round change
 				c.sendNextRoundChange("handlePreprepare. HashLocked, but received hash is different from locked hash")
@@ -133,6 +138,11 @@ func (c *core) handlePreprepare(msg *message, src istanbul.Validator) error {
 			c.acceptPreprepare(preprepare)
 			c.setState(StatePreprepared)
 			c.sendPrepare()
+
+			if Vrank != nil {
+				Vrank.Stop()
+			}
+			Vrank = NewVrank(*c.currentView(), c.valSet.SubList(preprepare.Proposal.ParentHash(), c.currentView()))
 		}
 	}
 

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -123,10 +123,10 @@ func (c *core) handlePreprepare(msg *message, src istanbul.Validator) error {
 				c.setState(StatePrepared)
 				c.sendCommit()
 
-				if Vrank != nil {
-					Vrank.Stop()
+				if vrank != nil {
+					vrank.Log()
 				}
-				Vrank = NewVrank(*c.currentView(), c.valSet.SubList(preprepare.Proposal.ParentHash(), c.currentView()))
+				vrank = NewVrank(*c.currentView(), c.valSet.SubList(preprepare.Proposal.ParentHash(), c.currentView()))
 			} else {
 				// Send round change
 				c.sendNextRoundChange("handlePreprepare. HashLocked, but received hash is different from locked hash")
@@ -139,10 +139,10 @@ func (c *core) handlePreprepare(msg *message, src istanbul.Validator) error {
 			c.setState(StatePreprepared)
 			c.sendPrepare()
 
-			if Vrank != nil {
-				Vrank.Stop()
+			if vrank != nil {
+				vrank.Log()
 			}
-			Vrank = NewVrank(*c.currentView(), c.valSet.SubList(preprepare.Proposal.ParentHash(), c.currentView()))
+			vrank = NewVrank(*c.currentView(), c.valSet.SubList(preprepare.Proposal.ParentHash(), c.currentView()))
 		}
 	}
 

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -97,8 +97,10 @@ func (v *Vrank) HandleCommitted(blockNum *big.Int) {
 	for _, v := range v.commitArrivalTimeMap {
 		sum += int64(v)
 	}
-	avg := sum / int64(len(v.commitArrivalTimeMap))
-	vrankAvgCommitArrivalTimeWithinQuorumGauge.Update(avg)
+	if len(v.commitArrivalTimeMap) != 0 {
+		avg := sum / int64(len(v.commitArrivalTimeMap))
+		vrankAvgCommitArrivalTimeWithinQuorumGauge.Update(avg)
+	}
 }
 
 // Log logs accumulated data in a compressed form

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -43,7 +43,7 @@ var (
 	vrankAvgCommitArrivalTimeWithinQuorumGauge = metrics.NewRegisteredGauge("vrank/avg_commit_within_quorum", nil)
 	vrankLastCommitArrivalTimeGauge            = metrics.NewRegisteredGauge("vrank/last_commit", nil)
 
-	vrankDefaultThreshold = "300ms"
+	vrankDefaultThreshold = "300ms" // the time to receive 2f+1 commits in an ideal network
 
 	vrank *Vrank
 )

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -183,7 +183,7 @@ func compress(arr []int) []byte {
 	}
 
 	// pad zero to make len(arr)%4 == 0
-	for i := 0; i < 4-len(arr)%4; i++ {
+	for len(arr)%4 != 0 {
 		arr = append(arr, 0)
 	}
 

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -93,11 +93,11 @@ func (v *Vrank) HandleCommitted(blockNum *big.Int) {
 	}
 
 	vrankQuorumCommitArrivalTimeGauge.Update(int64(committedTime))
-	sum := int64(0)
-	for _, v := range v.commitArrivalTimeMap {
-		sum += int64(v)
-	}
 	if len(v.commitArrivalTimeMap) != 0 {
+		sum := int64(0)
+		for _, v := range v.commitArrivalTimeMap {
+			sum += int64(v)
+		}
 		avg := sum / int64(len(v.commitArrivalTimeMap))
 		vrankAvgCommitArrivalTimeWithinQuorumGauge.Update(avg)
 	}

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -73,13 +73,11 @@ func (v *Vrank) TimeSinceStart() time.Duration {
 	return time.Now().Sub(v.startTime)
 }
 
-func (v *Vrank) AddCommit(msg *istanbul.Subject, src istanbul.Validator) time.Duration {
+func (v *Vrank) AddCommit(msg *istanbul.Subject, src istanbul.Validator) {
 	if v.isTargetCommit(msg, src) {
 		t := v.TimeSinceStart()
 		v.commitArrivalTimeMap[src.Address()] = t
-		return t
 	}
-	return -1
 }
 
 func (v *Vrank) HandleCommitted(blockNum *big.Int) {

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -142,6 +142,9 @@ func (v *Vrank) Log() (string, []string) {
 }
 
 func (v *Vrank) isTargetCommit(msg *istanbul.Subject, src istanbul.Validator) bool {
+	if msg.View == nil || msg.View.Sequence == nil || msg.View.Round == nil {
+		return false
+	}
 	if msg.View.Cmp(&v.view) != 0 {
 		return false
 	}

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -162,7 +162,6 @@ func serialize(committee istanbul.Validators, arrivalTimeMap map[common.Address]
 	sortedCommittee := make(istanbul.Validators, len(committee))
 	copy(sortedCommittee[:], committee[:])
 	sort.Sort(sortedCommittee)
-	logger.Info("serialize", "sortedCommittee", sortedCommittee, "committee", committee)
 
 	serialized := make([]time.Duration, len(sortedCommittee))
 	for i, v := range sortedCommittee {

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -131,7 +131,11 @@ func (v *Vrank) Log() (string, []string) {
 
 	lateCommitsStrArr := encodeDurationBatch(lateCommits)
 
-	logger.Info("VRank", "bitmap", bitmap, "late", lateCommitsStrArr)
+	logger.Info("VRank", "seq", v.view.Sequence.Int64(),
+		"round", v.view.Round.Int64(),
+		"bitmap", bitmap,
+		"late", lateCommitsStrArr,
+	)
 	return bitmap, lateCommitsStrArr
 }
 

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -87,7 +87,7 @@ func (v *vrank) Stop() {
 	var (
 		serialized = serialize(v.committee, v.commitArrivalTimeMap)
 
-		assessBitmap = hex.EncodeToString(compress(assessAll(serialized, v.threshold)))
+		assessBitmap = hex.EncodeToString(compress(assessBatch(serialized, v.threshold)))
 
 		lateCommits        = make([]time.Duration, 0)
 		encodedLateCommits = make([]string, 0)
@@ -150,7 +150,7 @@ func assess(t, threshold time.Duration) int {
 	}
 }
 
-func assessAll(t []time.Duration, threshold time.Duration) []int {
+func assessBatch(t []time.Duration, threshold time.Duration) []int {
 	ret := make([]int, 0)
 	for _, v := range t {
 		ret = append(ret, assess(v, threshold))

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -143,10 +143,10 @@ func assess(t, threshold time.Duration) int {
 	}
 }
 
-func assessBatch(t []time.Duration, threshold time.Duration) []int {
+func assessBatch(ts []time.Duration, threshold time.Duration) []int {
 	ret := make([]int, 0)
-	for _, v := range t {
-		ret = append(ret, assess(v, threshold))
+	for _, t := range ts {
+		ret = append(ret, assess(t, threshold))
 	}
 	return ret
 }
@@ -183,13 +183,8 @@ func compress(arr []int) []byte {
 	}
 
 	// pad zero to make len(arr)%4 == 0
-	switch len(arr) % 4 {
-	case 1:
-		arr = append(arr, []int{0, 0, 0}...)
-	case 2:
-		arr = append(arr, []int{0, 0}...)
-	case 3:
-		arr = append(arr, []int{0}...)
+	for i := 0; i < 4-len(arr)%4; i++ {
+		arr = append(arr, 0)
 	}
 
 	ret := make([]byte, 0)

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -153,7 +153,7 @@ func (v *Vrank) isTargetCommit(msg *istanbul.Subject, src istanbul.Validator) bo
 }
 
 // assess determines if given time is early, late, or not arrived
-func assess(t, threshold time.Duration) int {
+func assess(t, threshold time.Duration) uint8 {
 	if t == vrankNotArrivedPlaceholder {
 		return vrankNotArrived
 	}
@@ -165,8 +165,8 @@ func assess(t, threshold time.Duration) int {
 	}
 }
 
-func assessBatch(ts []time.Duration, threshold time.Duration) []int {
-	ret := make([]int, len(ts))
+func assessBatch(ts []time.Duration, threshold time.Duration) []uint8 {
+	ret := make([]uint8, len(ts))
 	for i, t := range ts {
 		ret[i] = assess(t, threshold)
 	}
@@ -196,8 +196,8 @@ func serialize(committee istanbul.Validators, arrivalTimeMap map[common.Address]
 
 // compress compresses data into 2-bit bitmap
 // e.g., [1, 0, 2] => [0b01_00_10_00]
-func compress(arr []int) []byte {
-	zip := func(a, b, c, d int) byte {
+func compress(arr []uint8) []byte {
+	zip := func(a, b, c, d uint8) byte {
 		a &= 0b11
 		b &= 0b11
 		c &= 0b11

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -1,0 +1,208 @@
+package core
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"sort"
+	"time"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
+	"github.com/rcrowley/go-metrics"
+)
+
+type vrank struct {
+	startTime            time.Time
+	view                 istanbul.View
+	committee            istanbul.Validators
+	threshold            time.Duration
+	commitArrivalTimeMap map[common.Address]time.Duration
+}
+
+var (
+	// VRank metrics
+	vrankFirstCommitArrivalTimeGauge           = metrics.NewRegisteredGauge("vrank/first_commit", nil)
+	vrankQuorumCommitArrivalTimeGauge          = metrics.NewRegisteredGauge("vrank/quorum_commit", nil)
+	vrankAvgCommitArrivalTimeWithinQuorumGauge = metrics.NewRegisteredGauge("vrank/avg_commit_within_quorum", nil)
+	vrankLastCommitArrivalTimeGauge            = metrics.NewRegisteredGauge("vrank/last_commit", nil)
+
+	vrankDefaultThreshold = "300ms"
+
+	Vrank *vrank
+)
+
+const (
+	vrankArrivedEarly = iota
+	vrankArrivedLate
+	vrankNotArrived
+)
+
+const (
+	vrankNotArrivedPlaceholder = -1
+)
+
+func NewVrank(view istanbul.View, committee istanbul.Validators) *vrank {
+	threshold, _ := time.ParseDuration(vrankDefaultThreshold)
+	return &vrank{
+		startTime:            time.Now(),
+		view:                 view,
+		committee:            committee,
+		threshold:            threshold,
+		commitArrivalTimeMap: make(map[common.Address]time.Duration),
+	}
+}
+
+func (v *vrank) TimeSinceStart() time.Duration {
+	return time.Now().Sub(v.startTime)
+}
+
+func (v *vrank) AddCommit(msg *istanbul.Subject, src istanbul.Validator) {
+	if v.isTargetCommit(msg, src) {
+		v.commitArrivalTimeMap[src.Address()] = v.TimeSinceStart()
+	}
+}
+
+func (v *vrank) HandleCommitted(blockNum *big.Int) {
+	if v.view.Sequence.Cmp(blockNum) != 0 {
+		return
+	}
+
+	committedTime := v.TimeSinceStart()
+	if v.threshold > committedTime {
+		v.threshold = committedTime
+	}
+
+	vrankQuorumCommitArrivalTimeGauge.Update(int64(committedTime))
+	sum := int64(0)
+	for _, v := range v.commitArrivalTimeMap {
+		sum += int64(v)
+	}
+	avg := sum / int64(len(v.commitArrivalTimeMap))
+	vrankAvgCommitArrivalTimeWithinQuorumGauge.Update(avg)
+}
+
+// Stop logs accumulated data in a compressed form
+func (v *vrank) Stop() {
+	var (
+		serialized = serialize(v.committee, v.commitArrivalTimeMap)
+
+		assessBitmap = hex.EncodeToString(compress(assessAll(serialized, v.threshold)))
+
+		lateCommits        = make([]time.Duration, 0)
+		encodedLateCommits = make([]string, 0)
+		lastCommit         = time.Duration(0)
+	)
+
+	for _, t := range serialized {
+		if assess(t, v.threshold) == vrankArrivedLate {
+			lateCommits = append(lateCommits, t)
+		}
+	}
+
+	for _, t := range lateCommits {
+		if lastCommit < t {
+			lastCommit = t
+		}
+	}
+	if lastCommit != time.Duration(0) {
+		vrankLastCommitArrivalTimeGauge.Update(int64(lastCommit))
+	}
+
+	// encode late commits
+	// if t >
+	for _, t := range lateCommits {
+		var s string
+		if t > time.Second {
+			s = fmt.Sprintf("%.1fs", t.Seconds())
+		} else {
+			s = fmt.Sprintf("%d", t.Milliseconds())
+		}
+		encodedLateCommits = append(encodedLateCommits, s)
+	}
+
+	logger.Info("VRank",
+		"bitmap", assessBitmap,
+		"late", encodedLateCommits,
+	)
+}
+
+func (v *vrank) isTargetCommit(msg *istanbul.Subject, src istanbul.Validator) bool {
+	if msg.View.Cmp(&v.view) != 0 {
+		return false
+	}
+	_, ok := v.commitArrivalTimeMap[src.Address()]
+	if ok {
+		return false
+	}
+	return true
+}
+
+func assess(t, threshold time.Duration) int {
+	if t == vrankNotArrivedPlaceholder {
+		return vrankNotArrived
+	}
+
+	if t > threshold {
+		return vrankArrivedLate
+	} else {
+		return vrankArrivedEarly
+	}
+}
+
+func assessAll(t []time.Duration, threshold time.Duration) []int {
+	ret := make([]int, 0)
+	for _, v := range t {
+		ret = append(ret, assess(v, threshold))
+	}
+	return ret
+}
+
+func serialize(committee istanbul.Validators, arrivalTimeMap map[common.Address]time.Duration) []time.Duration {
+	sortedCommittee := make(istanbul.Validators, len(committee))
+	copy(sortedCommittee[:], committee[:])
+	sort.Sort(sortedCommittee)
+	logger.Info("serialize", "sortedCommittee", sortedCommittee, "committee", committee)
+
+	serialized := make([]time.Duration, len(sortedCommittee))
+	for i, v := range sortedCommittee {
+		val, ok := arrivalTimeMap[v.Address()]
+		if ok {
+			serialized[i] = val
+		} else {
+			serialized[i] = vrankNotArrivedPlaceholder
+		}
+
+	}
+	return serialized
+}
+
+// compress compresses data into 2-bit bitmap
+// e.g., [1, 0, 2] => [0b01_00_10_00]
+func compress(arr []int) []byte {
+	zip := func(a, b, c, d int) byte {
+		a &= 0b11
+		b &= 0b11
+		c &= 0b11
+		d &= 0b11
+		return byte(a<<6 | b<<4 | c<<2 | d<<0)
+	}
+
+	// pad zero to make len(arr)%4 == 0
+	switch len(arr) % 4 {
+	case 1:
+		arr = append(arr, []int{0, 0, 0}...)
+	case 2:
+		arr = append(arr, []int{0, 0}...)
+	case 3:
+		arr = append(arr, []int{0}...)
+	}
+
+	ret := make([]byte, 0)
+
+	for i := 0; i < len(arr)/4; i++ {
+		chunk := arr[4*i : 4*(i+1)]
+		ret = append(ret, zip(chunk[0], chunk[1], chunk[2], chunk[3]))
+	}
+	return ret
+}

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -1,3 +1,19 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
 package core
 
 import (

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -152,7 +152,8 @@ func assessBatch(ts []time.Duration, threshold time.Duration) []int {
 }
 
 // serialize serializes arrivalTime hashmap into array.
-// It needs to be deterministic, so the order of array is equal to that of sorted committee.
+// If committee is sorted, we can simply figure out the validator position in the output array
+// by sorting the output of `klay.getCommittee()`
 func serialize(committee istanbul.Validators, arrivalTimeMap map[common.Address]time.Duration) []time.Duration {
 	sortedCommittee := make(istanbul.Validators, len(committee))
 	copy(sortedCommittee[:], committee[:])

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -166,9 +166,9 @@ func assess(t, threshold time.Duration) int {
 }
 
 func assessBatch(ts []time.Duration, threshold time.Duration) []int {
-	ret := make([]int, 0)
-	for _, t := range ts {
-		ret = append(ret, assess(t, threshold))
+	ret := make([]int, len(ts))
+	for i, t := range ts {
+		ret[i] = assess(t, threshold)
 	}
 	return ret
 }
@@ -210,11 +210,11 @@ func compress(arr []int) []byte {
 		arr = append(arr, 0)
 	}
 
-	ret := make([]byte, 0)
+	ret := make([]byte, len(arr)/4)
 
 	for i := 0; i < len(arr)/4; i++ {
 		chunk := arr[4*i : 4*(i+1)]
-		ret = append(ret, zip(chunk[0], chunk[1], chunk[2], chunk[3]))
+		ret[i] = zip(chunk[0], chunk[1], chunk[2], chunk[3])
 	}
 	return ret
 }

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVrankCompress(t *testing.T) {
+	tcs := []struct {
+		input    []int
+		expected []byte
+	}{
+		{
+			input:    []int{2},
+			expected: []byte{0b10_000000},
+		},
+		{
+			input:    []int{2, 1},
+			expected: []byte{0b10_01_0000},
+		},
+		{
+			input:    []int{0, 2, 1},
+			expected: []byte{0b00_10_01_00},
+		},
+		{
+			input:    []int{0, 2, 1, 1},
+			expected: []byte{0b00_10_01_01},
+		},
+		{
+			input:    []int{1, 2, 1, 2, 1},
+			expected: []byte{0b01_10_01_10, 0b01_000000},
+		},
+		{
+			input:    []int{1, 2, 1, 2, 1, 2},
+			expected: []byte{0b01_10_01_10, 0b01_10_0000},
+		},
+		{
+			input:    []int{1, 2, 1, 2, 1, 2, 1},
+			expected: []byte{0b01_10_01_10, 0b01_10_01_00},
+		},
+		{
+			input:    []int{1, 2, 1, 2, 1, 2, 0, 2},
+			expected: []byte{0b01_10_01_10, 0b01_10_00_10},
+		},
+		{
+			input:    []int{1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1},
+			expected: []byte{0b01011010, 0b01011010, 0b01011010, 0b01011010, 0b01010000},
+		},
+	}
+	for i, tc := range tcs {
+		assert.Equal(t, compress(tc.input), tc.expected, "tc %d failed", i)
+	}
+}

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -63,9 +63,9 @@ func TestVrank(t *testing.T) {
 		expectedLateCommits = append(expectedLateCommits, vrank.commitArrivalTimeMap[committee[i].Address()])
 	}
 
-	bitmap, late := vrank.Log()
+	bitmap, late := vrank.Bitmap(), vrank.LateCommits()
 	assert.Equal(t, hex.EncodeToString(compress(expectedAssessList)), bitmap)
-	assert.Equal(t, encodeDurationBatch(expectedLateCommits), late)
+	assert.Equal(t, expectedLateCommits, late)
 }
 
 func TestVrankAssessBatch(t *testing.T) {

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -58,9 +58,9 @@ func TestVrank(t *testing.T) {
 	}
 	vrank.HandleCommitted(view.Sequence)
 	for i := quorum; i < N; i++ {
-		t := vrank.AddCommit(msg, committee[i])
+		vrank.AddCommit(msg, committee[i])
 		expectedAssessList = append(expectedAssessList, vrankArrivedLate)
-		expectedLateCommits = append(expectedLateCommits, t)
+		expectedLateCommits = append(expectedLateCommits, vrank.commitArrivalTimeMap[committee[i].Address()])
 	}
 
 	bitmap, late := vrank.Log()

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -1,3 +1,19 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
 package core
 
 import (

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -63,23 +63,18 @@ func TestVrankAssessBatch(t *testing.T) {
 
 func TestVrankSerialize(t *testing.T) {
 	var (
-		addrs = []common.Address{
-			common.HexToAddress("0x6666666666666666666666666666666666666666"),
-			common.HexToAddress("0x5555555555555555555555555555555555555555"),
-			common.HexToAddress("0x4444444444444444444444444444444444444444"),
-			common.HexToAddress("0x3333333333333333333333333333333333333333"),
-			common.HexToAddress("0x2222222222222222222222222222222222222222"),
-			common.HexToAddress("0x1111111111111111111111111111111111111111"),
-		}
+		N         = 6
+		addrs, _  = genValidators(N)
 		committee = genCommitteeFromAddrs(addrs)
 		timeMap   = make(map[common.Address]time.Duration)
 		expected  = make([]time.Duration, len(addrs))
 	)
 
-	for i, addr := range addrs {
+	sort.Sort(committee)
+	for i, val := range committee {
 		t := time.Duration((i * 100) * int(time.Millisecond))
-		timeMap[addr] = t
-		expected[len(expected)-1-i] = t
+		timeMap[val.Address()] = t
+		expected[i] = t
 	}
 
 	assert.Equal(t, expected, serialize(committee, timeMap))

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -2,9 +2,47 @@ package core
 
 import (
 	"testing"
+	"time"
 
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
+	"github.com/klaytn/klaytn/consensus/istanbul/validator"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestVrankAssessBatch(t *testing.T) {
+	arr := []time.Duration{0, 4, 1, vrankNotArrivedPlaceholder, 2}
+	threshold := time.Duration(2)
+	expected := []int{
+		vrankArrivedEarly, vrankArrivedLate, vrankArrivedEarly, vrankNotArrived, vrankArrivedEarly,
+	}
+	assert.Equal(t, expected, assessBatch(arr, threshold))
+}
+
+func TestVrankSerialize(t *testing.T) {
+	var (
+		addrs = []common.Address{
+			common.HexToAddress("0x6666666666666666666666666666666666666666"),
+			common.HexToAddress("0x5555555555555555555555555555555555555555"),
+			common.HexToAddress("0x4444444444444444444444444444444444444444"),
+			common.HexToAddress("0x3333333333333333333333333333333333333333"),
+			common.HexToAddress("0x2222222222222222222222222222222222222222"),
+			common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		}
+		committee = istanbul.Validators{}
+		timeMap   = make(map[common.Address]time.Duration)
+		expected  = make([]time.Duration, len(addrs))
+	)
+
+	for i, addr := range addrs {
+		committee = append(committee, validator.New(addr))
+		t := time.Duration((i * 100) * int(time.Millisecond))
+		timeMap[addr] = t
+		expected[len(expected)-1-i] = t
+	}
+
+	assert.Equal(t, expected, serialize(committee, timeMap))
+}
 
 func TestVrankCompress(t *testing.T) {
 	tcs := []struct {

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -123,6 +123,6 @@ func TestVrankCompress(t *testing.T) {
 		},
 	}
 	for i, tc := range tcs {
-		assert.Equal(t, compress(tc.input), tc.expected, "tc %d failed", i)
+		assert.Equal(t, tc.expected, compress(tc.input), "tc %d failed", i)
 	}
 }

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -24,7 +24,7 @@ func genCommitteeFromAddrs(addrs []common.Address) istanbul.Validators {
 func TestVrank(t *testing.T) {
 	var (
 		N         = 6
-		quorum    = 3
+		quorum    = 4
 		addrs, _  = genValidators(N)
 		committee = genCommitteeFromAddrs(addrs)
 		view      = istanbul.View{Sequence: big.NewInt(0), Round: big.NewInt(0)}

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -47,7 +47,7 @@ func TestVrank(t *testing.T) {
 		msg       = &istanbul.Subject{View: &view}
 		vrank     = NewVrank(view, committee)
 
-		expectedAssessList  []int
+		expectedAssessList  []uint8
 		expectedLateCommits []time.Duration
 	)
 
@@ -71,7 +71,7 @@ func TestVrank(t *testing.T) {
 func TestVrankAssessBatch(t *testing.T) {
 	arr := []time.Duration{0, 4, 1, vrankNotArrivedPlaceholder, 2}
 	threshold := time.Duration(2)
-	expected := []int{
+	expected := []uint8{
 		vrankArrivedEarly, vrankArrivedLate, vrankArrivedEarly, vrankNotArrived, vrankArrivedEarly,
 	}
 	assert.Equal(t, expected, assessBatch(arr, threshold))
@@ -98,43 +98,43 @@ func TestVrankSerialize(t *testing.T) {
 
 func TestVrankCompress(t *testing.T) {
 	tcs := []struct {
-		input    []int
+		input    []uint8
 		expected []byte
 	}{
 		{
-			input:    []int{2},
+			input:    []uint8{2},
 			expected: []byte{0b10_000000},
 		},
 		{
-			input:    []int{2, 1},
+			input:    []uint8{2, 1},
 			expected: []byte{0b10_01_0000},
 		},
 		{
-			input:    []int{0, 2, 1},
+			input:    []uint8{0, 2, 1},
 			expected: []byte{0b00_10_01_00},
 		},
 		{
-			input:    []int{0, 2, 1, 1},
+			input:    []uint8{0, 2, 1, 1},
 			expected: []byte{0b00_10_01_01},
 		},
 		{
-			input:    []int{1, 2, 1, 2, 1},
+			input:    []uint8{1, 2, 1, 2, 1},
 			expected: []byte{0b01_10_01_10, 0b01_000000},
 		},
 		{
-			input:    []int{1, 2, 1, 2, 1, 2},
+			input:    []uint8{1, 2, 1, 2, 1, 2},
 			expected: []byte{0b01_10_01_10, 0b01_10_0000},
 		},
 		{
-			input:    []int{1, 2, 1, 2, 1, 2, 1},
+			input:    []uint8{1, 2, 1, 2, 1, 2, 1},
 			expected: []byte{0b01_10_01_10, 0b01_10_01_00},
 		},
 		{
-			input:    []int{1, 2, 1, 2, 1, 2, 0, 2},
+			input:    []uint8{1, 2, 1, 2, 1, 2, 0, 2},
 			expected: []byte{0b01_10_01_10, 0b01_10_00_10},
 		},
 		{
-			input:    []int{1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1},
+			input:    []uint8{1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1},
 			expected: []byte{0b01011010, 0b01011010, 0b01011010, 0b01011010, 0b01010000},
 		},
 	}


### PR DESCRIPTION
## Proposed changes

We collect all commits between two preprepares.
```
collect      start                                     stop
---------------|--------------|------------|-------------|
state:     preprepared      prepared     commit      preprepared
```

Existing implementation discards "late commit messages" that we receive after turning into the "commit" state.
To receive those commit messages, we must define an independent data structure, hence `Vrank struct`.

#### Metrics
- target: the time elapsed between the preprepared time (start time) and the followings:
  - the first commit arrival time
  - the [2f+1]-th commit arrival time
  - the average arrival times from the first commit to the [2f+1]-th commit
  - the last commit before stop

See further comments for an examplery metric output.

#### Logs
We assess each validator in the committee by how fast it sent its commit message:
- early: received before threshold
- late: received after threshold
- not received

The threshold that divides early and late commits is defined as follows:
- threshold =  min( [2f+1]-th commit arrival time, preprepared time + 300ms )

This is logged as `bitmap`.
In addition, the arrival times of late commits are logged as `late`.

See further comments for log interpretation.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments
Example metric output:
```
klaytn_vrank_avg_commit_within_quorum 1.944361e+06
klaytn_vrank_first_commit 1.520958e+06
klaytn_vrank_last_commit 6.891958e+06
klaytn_vrank_quorum_commit 2.290458e+06
```

Example log:
```
INFO[07/21,22:12:16 +09] [25|consensus/istanbul/core/vrank.go:118]  VRank     bitmap=01 late=[2]
```
It means that the fourth validator in the committee is late, and that its arrival time is 2ms.
Interpretation of bitmap: 01 => 0x01 => 0b00_00_00_01 => fourth 2-bit is `vrankArrivedLate`, others are `vrankArrivedEarly`.

Q. Why compress the log?
A. We wanted to reduce the log size as much as possible and reduce verbosity. If the threshold is [2f+1]-th commit arrival time, the size of `late` is `f`. If the threshold is preprepared time + 300ms, the size of `late` is more than `f`.

Q. Why not use existing variables such as `consensusTimestamp`, or `currentView`?
A. They are reset at `startNewRound()`, which is called almost immediately after turning into the "commit" state.

Q. Why threshold is 300ms?
A. In an ideal network, a validator is supposed to receive 2f+1 number of commits within 300ms.