### PR TITLE
Add CurrentBlock in backends.BlockChainForCaller

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -46,6 +46,7 @@ type BlockChainForCaller interface {
 	GetBlock(hash common.Hash, number uint64) *types.Block
 	State() (*state.StateDB, error)
 	StateAt(root common.Hash) (*state.StateDB, error)
+	CurrentBlock() *types.Block
 }
 
 // BlockchainContractCaller implements bind.ContractCaller, based on
@@ -123,18 +124,17 @@ func (b *BlockchainContractCaller) callContract(call klaytn.CallMsg, block *type
 }
 
 func (b *BlockchainContractCaller) getBlockAndState(num *big.Int) (*types.Block, *state.StateDB, error) {
-	var header *types.Header
+	var block *types.Block
 	if num == nil {
-		header = b.bc.CurrentHeader()
+		block = b.bc.CurrentBlock()
 	} else {
-		header = b.bc.GetHeaderByNumber(num.Uint64())
+		header := b.bc.GetHeaderByNumber(num.Uint64())
+		if header == nil {
+			return nil, nil, errBlockDoesNotExist
+		}
+		block = b.bc.GetBlock(header.Hash(), header.Number.Uint64())
 	}
 
-	if header == nil {
-		return nil, nil, errBlockDoesNotExist
-	}
-
-	block := b.bc.GetBlock(header.Hash(), header.Number.Uint64())
 	state, err := b.bc.StateAt(block.Root())
 	return block, state, err
 }

--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -134,6 +134,9 @@ func (b *BlockchainContractCaller) getBlockAndState(num *big.Int) (*types.Block,
 		}
 		block = b.bc.GetBlock(header.Hash(), header.Number.Uint64())
 	}
+	if block == nil {
+		return nil, nil, errBlockDoesNotExist
+	}
 
 	state, err := b.bc.StateAt(block.Root())
 	return block, state, err

--- a/blockchain/headerchain.go
+++ b/blockchain/headerchain.go
@@ -360,6 +360,13 @@ func (hc *HeaderChain) CurrentHeader() *types.Header {
 	return hc.currentHeader.Load().(*types.Header)
 }
 
+// CurrentBlock is added because HeaderChain is sometimes used as
+// type consensus.ChainReader and consensus.ChainReader interface has CurrentBlock.
+// However CurrentBlock is not supported in HeaderChain so this function just panics.
+func (hc *HeaderChain) CurrentBlock() *types.Block {
+	panic("CurrentBlock not supported for HeaderChain")
+}
+
 // SetCurrentHeader sets the current head header of the canonical chain.
 func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
 	hc.chainDB.WriteHeadHeaderHash(head.Hash())

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -40,6 +40,9 @@ type ChainReader interface {
 	// CurrentHeader retrieves the current header from the local chain.
 	CurrentHeader() *types.Header
 
+	// CurrentBlock revrieves the current block from the local chain.
+	CurrentBlock() *types.Block
+
 	// Engine retrieves the header chain's consensus engine.
 	Engine() Engine
 

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -58,6 +58,7 @@ type blockChain interface {
 	GetBlock(hash common.Hash, number uint64) *types.Block
 	GetHeaderByNumber(number uint64) *types.Header
 	State() (*state.StateDB, error)
+	CurrentBlock() *types.Block
 
 	blockchain.ChainContext
 }


### PR DESCRIPTION
## Proposed changes

- `CurrentHeader()` may mismatch with `CurrentBlock()` (see #1766).
- So add `CurrentBlock()` in `backends.BlockChainForCaller` to replace `CurrentHeader()`
- Following interfaces or structs have direct/indirect dependency with `backends.BlockChainForCaller` so also added `CurrentBlock()` to them
   - `reward.blockChain` is used as `backends.BlockChainForCaller`
   - `consensus.ChainReader` is used as `backends.BlockChainForCaller`
   - `blockchain.HeaderChain` is used as `consensus.ChainReader`
      - Since `HeaderChain` does not have blocks, its implementation of `CurrentBlock` immediately panics

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- See [this comment](https://github.com/klaytn/klaytn/pull/1828#discussion_r1265122596) in #1828 

## Further comments

None
