### PR TITLE
Update circleci to use go 1.20.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
       - run:
           name: "Install golangci-lint"
           command: |
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.0
   pre-build:
     description: "before build, set version"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ executors:
   test-executor:
     working_directory: /go/src/github.com/klaytn/klaytn
     docker:
-      - image: klaytn/build_base:1.2-go.1.18-solc0.8.13
+      - image: klaytn/build_base:1.2-go.1.20.6-solc0.8.13
   test-others-executor:
     working_directory: /go/src/github.com/klaytn/klaytn
     docker:
-      - image: klaytn/build_base:1.2-go.1.18-solc0.8.13
+      - image: klaytn/build_base:1.2-go.1.20.6-solc0.8.13
       - image: localstack/localstack:0.13.0
       - image: circleci/redis:6.0.8-alpine
       - name: zookeeper
@@ -42,11 +42,11 @@ executors:
   rpm-executor:
     working_directory: /go/src/github.com/klaytn/klaytn
     docker:
-      - image: klaytn/circleci-rpmbuild:1.18
+      - image: klaytn/circleci-rpmbuild:1.20.6
   default:
     working_directory: ~/go/src/github.com/klaytn/klaytn
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.20.6
 
 commands:
   install-netcat:
@@ -64,9 +64,9 @@ commands:
       - run:
           name: "Install golang on machine"
           command: | 
-            curl -O https://dl.google.com/go/go1.18.<< parameters.os-network >>.tar.gz
-            mkdir $HOME/go1.18
-            tar -C $HOME/go1.18 -xzf go1.18.<< parameters.os-network >>.tar.gz
+            curl -O https://dl.google.com/go/go1.20.6.<< parameters.os-network >>.tar.gz
+            mkdir $HOME/go1.20.6
+            tar -C $HOME/go1.20.6 -xzf go1.20.6.<< parameters.os-network >>.tar.gz
   install-golangci-lint:
     steps:
       - run:
@@ -80,7 +80,7 @@ commands:
           name: "set variables"
           command: |
             export GOPATH=~/go
-            export PATH=$HOME/go1.18/go/bin:$PATH
+            export PATH=$HOME/go1.20.6/go/bin:$PATH
             pat="^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+.*"
 
             if [[ $CIRCLE_TAG =~ $pat ]]; then
@@ -106,7 +106,7 @@ commands:
           name: "build and packaging"
           command: |
             export GOPATH=~/go
-            export PATH=$HOME/go1.18/go/bin:$PATH
+            export PATH=$HOME/go1.20.6/go/bin:$PATH
             make all
             for item in kcn kpn ken kscn kspn ksen kbn kgen homi; do
               ./build/package-tar.sh << parameters.baobab >> << parameters.os-network >> $item
@@ -122,7 +122,7 @@ commands:
           name: "upload S3 repo"
           command: |
             export GOPATH=~/go
-            export PATH=$HOME/go1.18/go/bin:$PATH
+            export PATH=$HOME/go1.20.6/go/bin:$PATH
             KLAYTN_VERSION=$(go run build/rpm/main.go version)
             for item in << parameters.item >>; do aws s3 cp packages/${item}-*.tar.gz s3://$FRONTEND_BUCKET/packages/klaytn/$KLAYTN_VERSION/; done
   rpm-tagging:
@@ -329,7 +329,7 @@ jobs:
       - run:
           name: "Build"
           command: |
-            export PATH=$HOME/go1.18/go/bin:$PATH
+            export PATH=$HOME/go1.20.6/go/bin:$PATH
             make fmt
             make all
 

--- a/blockchain/types/transaction_signing_test.go
+++ b/blockchain/types/transaction_signing_test.go
@@ -358,10 +358,12 @@ func TestValidateTransaction(t *testing.T) {
 	for _, fn := range testfns {
 		fnname := getFunctionName(fn)
 		fnname = fnname[strings.LastIndex(fnname, ".")+1:]
-		t.Run(fnname, func(t *testing.T) {
+		testFunc := func(t *testing.T) {
 			t.Parallel()
 			fn(t)
-		})
+		}
+
+		t.Run(fnname, testFunc)
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

- Upgrade CircleCi to use new image of build_base:1.2-go.1.20.6-solc0.8.13 and golang 1.20.6

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
