### PR TITLE
Call batch.Release in pruning accessors

### DIFF
--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1936,6 +1936,7 @@ func (dbm *databaseManager) DeletePruningEnabled() {
 // WritePruningMarks writes the provided set of pruning marks to the database.
 func (dbm *databaseManager) WritePruningMarks(marks []PruningMark) {
 	batch := dbm.NewBatch(MiscDB)
+	defer batch.Release()
 	for _, mark := range marks {
 		if err := batch.Put(pruningMarkKey(mark), pruningMarkValue); err != nil {
 			logger.Crit("Failed to store trie pruning mark", "err", err)
@@ -1971,6 +1972,7 @@ func (dbm *databaseManager) ReadPruningMarks(startNumber, endNumber uint64) []Pr
 // the PruneTrieNodes or DeleteTrieNode functions.
 func (dbm *databaseManager) DeletePruningMarks(marks []PruningMark) {
 	batch := dbm.NewBatch(MiscDB)
+	defer batch.Release()
 	for _, mark := range marks {
 		if err := batch.Delete(pruningMarkKey(mark)); err != nil {
 			logger.Crit("Failed to delete trie pruning mark", "err", err)
@@ -1987,6 +1989,7 @@ func (dbm *databaseManager) DeletePruningMarks(marks []PruningMark) {
 // PruneTrieNodes deletes the trie nodes according to the provided set of pruning marks.
 func (dbm *databaseManager) PruneTrieNodes(marks []PruningMark) {
 	batch := dbm.NewBatch(StateTrieDB)
+	defer batch.Release()
 	for _, mark := range marks {
 		if err := batch.Delete(TrieNodeKey(mark.Hash)); err != nil {
 			logger.Crit("Failed to prune trie node", "err", err)


### PR DESCRIPTION
## Proposed changes

Add missing `batch.Release()` in DBManager pruning accessors.
We missed calling batch.Release() because #1871 and #1855 were merged concurrently.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
