### PR TITLE
Enable SCA overwriting over EOA after Shanghai hardfork

### DIFF
--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -455,9 +455,20 @@ func (evm *EVM) create(caller types.ContractRef, codeAndHash *codeAndHash, gas u
 
 	// Ensure there's no existing contract already at the designated address
 	contractHash := evm.StateDB.GetCodeHash(address)
-	if evm.StateDB.GetNonce(address) != 0 || (contractHash != (common.Hash{}) && contractHash != emptyCodeHash) {
-		return nil, common.Address{}, 0, ErrContractAddressCollision // TODO-Klaytn-Issue615
+
+	// The early Klaytn design tried to support the account creation with a user selected address,
+	// so the account overwriting was restricted.
+	// Because the feature was postponed for long time and abused to prevent SCA creation,
+	// Klaytn enables SCA overwriting over EOA like Ethereum.
+	// NOTE: The following code should be re-considered when Klaytn enables TxTypeAccountCreation
+	if evm.chainRules.IsShanghai {
+		if evm.StateDB.GetNonce(address) != 0 || (contractHash != (common.Hash{}) && contractHash != emptyCodeHash) {
+			return nil, common.Address{}, 0, ErrContractAddressCollision
+		}
+	} else if evm.StateDB.Exist(address) {
+		return nil, common.Address{}, 0, ErrContractAddressCollision
 	}
+
 	if common.IsPrecompiledContractAddress(address) {
 		return nil, common.Address{}, gas, kerrors.ErrPrecompiledContractAddress
 	}

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -458,8 +458,8 @@ func (evm *EVM) create(caller types.ContractRef, codeAndHash *codeAndHash, gas u
 
 	// The early Klaytn design tried to support the account creation with a user selected address,
 	// so the account overwriting was restricted.
-	// Because the feature was postponed for long time and abused to prevent SCA creation,
-	// Klaytn enables SCA overwriting over EOA like Ethereum.
+	// Because the feature was postponed for a long time and the restriction can be abused to prevent SCA creation,
+	// Klaytn enables SCA overwriting over EOA like Ethereum after Shanghai compatible hardfork.
 	// NOTE: The following code should be re-considered when Klaytn enables TxTypeAccountCreation
 	if evm.chainRules.IsShanghai {
 		if evm.StateDB.GetNonce(address) != 0 || (contractHash != (common.Hash{}) && contractHash != emptyCodeHash) {

--- a/tests/init.go
+++ b/tests/init.go
@@ -39,6 +39,15 @@ var Forks = map[string]*params.ChainConfig{
 	"Constantinople": {
 		ChainID: big.NewInt(1),
 	},
+	"Shanghai": {
+		ChainID:                  big.NewInt(1),
+		IstanbulCompatibleBlock:  new(big.Int),
+		LondonCompatibleBlock:    new(big.Int),
+		EthTxTypeCompatibleBlock: new(big.Int),
+		MagmaCompatibleBlock:     new(big.Int),
+		KoreCompatibleBlock:      new(big.Int),
+		ShanghaiCompatibleBlock:  new(big.Int),
+	},
 }
 
 // UnsupportedForkError is returned when a test requests a fork that isn't implemented.

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -154,6 +154,7 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 		return nil, UnsupportedForkError{subtest.Fork}
 	}
 	vmconfig.ExtraEips = eips
+	blockchain.InitDeriveSha(config)
 	block := t.genesis(config).ToBlock(common.Hash{}, nil)
 	memDBManager := database.NewMemoryDBManager()
 	statedb := MakePreState(memDBManager, t.json.Pre)


### PR DESCRIPTION
## Proposed changes

- Since https://github.com/klaytn/klaytn/commit/d5f24d573d3ca0e68614f7224101d8cf99fa5a2a changes the semantics of EVM, Klaytn includes the change in the ShanghaiCompatible hardfork item list. 
- Enable "Shanghai" hardfork keyword in klaytn-test test cases

NOTE: This PR should be merged after merging https://github.com/klaytn/klaytn-tests/pull/10 to execute CI tests successfully. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
