### PR TITLE
Fix nodecmd tests

### DIFF
--- a/cmd/utils/nodecmd/accountcmd_test.go
+++ b/cmd/utils/nodecmd/accountcmd_test.go
@@ -46,8 +46,7 @@ func tmpDatadirWithKeystore(t *testing.T) string {
 }
 
 func TestAccountListEmpty(t *testing.T) {
-	datadir := tmpdir(t)
-	klay := runKlay(t, "klay-test", "account", "list", "--datadir", datadir)
+	klay := runKlay(t, "klay-test", "account", "list")
 	klay.ExpectExit()
 }
 

--- a/cmd/utils/nodecmd/accountcmd_test.go
+++ b/cmd/utils/nodecmd/accountcmd_test.go
@@ -46,7 +46,8 @@ func tmpDatadirWithKeystore(t *testing.T) string {
 }
 
 func TestAccountListEmpty(t *testing.T) {
-	klay := runKlay(t, "klay-test", "account", "list")
+	datadir := tmpdir(t)
+	klay := runKlay(t, "klay-test", "account", "list", "--datadir", datadir)
 	klay.ExpectExit()
 }
 

--- a/cmd/utils/nodecmd/consolecmd_test.go
+++ b/cmd/utils/nodecmd/consolecmd_test.go
@@ -53,15 +53,15 @@ func TestConsoleWelcome(t *testing.T) {
 	klay.SetTemplateFunc("gover", runtime.Version)
 	// TODO: Fix as in testAttachWelcome()
 	klay.SetTemplateFunc("klayver", func() string { return params.VersionWithCommit("") })
-	klay.SetTemplateFunc("niltime", func() string { return time.Unix(0, 0).Format(time.RFC1123) })
 	klay.SetTemplateFunc("apis", func() string { return ipcAPIs })
+	klay.SetTemplateFunc("datadir", func() string { return klay.Datadir })
 
 	// Verify the actual welcome message to the required template
 	klay.Expect(`
 Welcome to the Klaytn JavaScript console!
 
 instance: Klaytn/{{klayver}}/{{goos}}-{{goarch}}/{{gover}}
- datadir: {{.Datadir}}
+ datadir: {{datadir}}
  modules: {{apis}}
 
 > {{.InputLine "exit"}}
@@ -131,8 +131,6 @@ func testAttachWelcome(t *testing.T, klay *testklay, endpoint, apis string) {
 	// TODO: Fix the cmd/utils.DefaultNodeConfig() to use cmd/utils/nodecmd.gitCommit
 	// and then restore "klayver" to use gitCommit.
 	attach.SetTemplateFunc("klayver", func() string { return params.VersionWithCommit("") })
-	attach.SetTemplateFunc("rewardbase", func() string { return klay.Rewardbase })
-	attach.SetTemplateFunc("niltime", func() string { return time.Unix(0, 0).Format(time.RFC1123) })
 	attach.SetTemplateFunc("ipc", func() bool { return strings.HasPrefix(endpoint, "ipc") })
 	attach.SetTemplateFunc("datadir", func() string { return klay.Datadir })
 	attach.SetTemplateFunc("apis", func() string { return apis })

--- a/cmd/utils/nodecmd/run_test.go
+++ b/cmd/utils/nodecmd/run_test.go
@@ -90,6 +90,7 @@ func init() {
 	app.Flags = utils.AllNodeFlags()
 
 	app.Before = func(ctx *cli.Context) error {
+		MigrateGlobalFlags(ctx)
 		runtime.GOMAXPROCS(runtime.NumCPU())
 		logDir := (&node.Config{DataDir: utils.MakeDataDir(ctx)}).ResolvePath("logs")
 		debug.CreateLogDir(logDir)
@@ -153,7 +154,7 @@ func runKlay(t *testing.T, name string, args ...string) *testklay {
 	if tt.Datadir == "" {
 		tt.Datadir = tmpdir(t)
 		tt.Cleanup = func() { os.RemoveAll(tt.Datadir) }
-		args = append([]string{"-datadir", tt.Datadir}, args...)
+		args = append([]string{"--datadir", tt.Datadir}, args...)
 		// Remove the temporary datadir if something fails below.
 		defer func() {
 			if t.Failed() {


### PR DESCRIPTION
## Proposed changes

- Fix nodecmd tests related to --datadir flags.

nodecmd tests are not run by Pull-Request CI. It only runs as part of nightly-coverage CI.
To run manually,
```
cd cmd/utils/nodecmd && go test -v
```

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments