### PR TITLE
Replace IsSet(BoolFlag) with Bool(BoolFlag)

### DIFF
--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -277,10 +277,10 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 	case ctx.IsSet(BootnodesFlag.Name):
 		logger.Info("Customized bootnodes are set")
 		urls = strings.Split(ctx.String(BootnodesFlag.Name), ",")
-	case ctx.IsSet(CypressFlag.Name):
+	case ctx.Bool(CypressFlag.Name):
 		logger.Info("Cypress bootnodes are set")
 		urls = params.MainnetBootnodes[cfg.ConnectionType].Addrs
-	case ctx.IsSet(BaobabFlag.Name):
+	case ctx.Bool(BaobabFlag.Name):
 		logger.Info("Baobab bootnodes are set")
 		// set pre-configured bootnodes when 'baobab' option was enabled
 		urls = params.BaobabBootnodes[cfg.ConnectionType].Addrs
@@ -522,14 +522,14 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 	cfg.EnableDBPerfMetrics = !ctx.Bool(DBNoPerformanceMetricsFlag.Name)
 	cfg.LevelDBCacheSize = ctx.Int(LevelDBCacheSizeFlag.Name)
 
-	cfg.RocksDBConfig.Secondary = ctx.IsSet(RocksDBSecondaryFlag.Name)
+	cfg.RocksDBConfig.Secondary = ctx.Bool(RocksDBSecondaryFlag.Name)
 	if cfg.RocksDBConfig.Secondary {
 		cfg.FetcherDisable = true
 		cfg.DownloaderDisable = true
 		cfg.WorkerDisable = true
 	}
 	cfg.RocksDBConfig.CacheSize = ctx.Uint64(RocksDBCacheSizeFlag.Name)
-	cfg.RocksDBConfig.DumpMallocStat = ctx.IsSet(RocksDBDumpMallocStatFlag.Name)
+	cfg.RocksDBConfig.DumpMallocStat = ctx.Bool(RocksDBDumpMallocStatFlag.Name)
 	cfg.RocksDBConfig.CompressionType = ctx.String(RocksDBCompressionTypeFlag.Name)
 	cfg.RocksDBConfig.BottommostCompressionType = ctx.String(RocksDBBottommostCompressionTypeFlag.Name)
 	cfg.RocksDBConfig.FilterPolicy = ctx.String(RocksDBFilterPolicyFlag.Name)

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -130,8 +130,8 @@ func initGenesis(ctx *cli.Context) error {
 
 	// Open an initialise both full and light databases
 	stack := MakeFullNode(ctx)
-	parallelDBWrite := !ctx.IsSet(utils.NoParallelDBWriteFlag.Name)
-	singleDB := ctx.IsSet(utils.SingleDBFlag.Name)
+	parallelDBWrite := !ctx.Bool(utils.NoParallelDBWriteFlag.Name)
+	singleDB := ctx.Bool(utils.SingleDBFlag.Name)
 	numStateTrieShards := ctx.Uint(utils.NumStateTrieShardsFlag.Name)
 	overwriteGenesis := ctx.Bool(utils.OverwriteGenesisFlag.Name)
 	livePruning := ctx.Bool(utils.LivePruningFlag.Name)

--- a/cmd/utils/nodecmd/snapshot.go
+++ b/cmd/utils/nodecmd/snapshot.go
@@ -139,7 +139,7 @@ func getConfig(ctx *cli.Context) *database.DBConfig {
 
 		LevelDBCacheSize:    ctx.Int(utils.LevelDBCacheSizeFlag.Name),
 		LevelDBCompression:  database.LevelDBCompressionType(ctx.Int(utils.LevelDBCompressionTypeFlag.Name)),
-		EnableDBPerfMetrics: !ctx.IsSet(utils.DBNoPerformanceMetricsFlag.Name),
+		EnableDBPerfMetrics: !ctx.Bool(utils.DBNoPerformanceMetricsFlag.Name),
 
 		DynamoDBConfig: &database.DynamoDBConfig{
 			TableName:          ctx.String(utils.DynamoDBTableNameFlag.Name),
@@ -147,7 +147,7 @@ func getConfig(ctx *cli.Context) *database.DBConfig {
 			IsProvisioned:      ctx.Bool(utils.DynamoDBIsProvisionedFlag.Name),
 			ReadCapacityUnits:  ctx.Int64(utils.DynamoDBReadCapacityFlag.Name),
 			WriteCapacityUnits: ctx.Int64(utils.DynamoDBWriteCapacityFlag.Name),
-			PerfCheck:          !ctx.IsSet(utils.DBNoPerformanceMetricsFlag.Name),
+			PerfCheck:          !ctx.Bool(utils.DBNoPerformanceMetricsFlag.Name),
 		},
 	}
 }


### PR DESCRIPTION
## Proposed changes

- As promised in https://github.com/klaytn/klaytn/pull/1684#issuecomment-1652916772.
- Correctly read in cli.BoolFlag.
  - `ctx.IsSet()` and `ctx.Bool()` is slightly different - the two returns true and false for `--item=false` command line.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

I manually inspected every instance of `ctx.IsSet()` and the usage boils down to these cases:
1. `if IsSet( non-bool-flag ) { ... }` kept untouched.
2. `if IsSet( bool-flag ) { cfg.BoolVar = true }` is now
    `if Bool( bool-flag ) { cfg.BoolVar = true }`
    - I could have further simplified it into `cfg.BoolVar = Bool( bool-flag )`.
    - But I didn't for consistency with neighboring code lines such as in [here](https://github.com/klaytn/klaytn/blob/320554640a13fbadf12d42db0a0f91c0edc14386/cmd/utils/config.go#L829).
3. `cfg.BoolVar = IsSet( bool-flag )` is now
    `cfg.BoolVar = Bool( bool-flag )`
