### PR TITLE
Klaytn composite accountKey aware recoverTransaction and recoverMessage

### DIFF
--- a/api/api_private_account.go
+++ b/api/api_private_account.go
@@ -22,6 +22,7 @@ package api
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"time"
@@ -414,6 +415,11 @@ func signHash(data []byte) []byte {
 	return crypto.Keccak256([]byte(msg))
 }
 
+func ethSignHash(data []byte) []byte {
+	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(data), data)
+	return crypto.Keccak256([]byte(msg))
+}
+
 // sign is a helper function that signs a transaction with the private key of the given address.
 // If the given password isn't able to decrypt the key, it fails.
 func (s *PrivateAccountAPI) sign(addr common.Address, passwd string, tx *types.Transaction) (*types.Transaction, error) {
@@ -479,19 +485,31 @@ func (s *PrivateAccountAPI) Sign(ctx context.Context, data hexutil.Bytes, addr c
 //
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_ecRecover
 func (s *PrivateAccountAPI) EcRecover(ctx context.Context, data, sig hexutil.Bytes) (common.Address, error) {
-	if len(sig) != crypto.SignatureLength {
-		return common.Address{}, fmt.Errorf("signature must be 65 bytes long")
-	}
-	if sig[crypto.RecoveryIDOffset] != 27 && sig[crypto.RecoveryIDOffset] != 28 {
-		return common.Address{}, fmt.Errorf("invalid Klaytn signature (V is not 27 or 28)")
-	}
-	sig[crypto.RecoveryIDOffset] -= 27 // Transform yellow paper V from 27/28 to 0/1
-
-	rpk, err := crypto.SigToPub(signHash(data), sig)
+	pubkey, err := klayEthEcRecover(data, sig)
 	if err != nil {
 		return common.Address{}, err
 	}
-	return crypto.PubkeyToAddress(*rpk), nil
+	return crypto.PubkeyToAddress(*pubkey), nil
+}
+
+func klayEthEcRecover(data, sig hexutil.Bytes) (*ecdsa.PublicKey, error) {
+	if len(sig) != crypto.SignatureLength {
+		return nil, fmt.Errorf("signature must be 65 bytes long")
+	}
+	if sig[crypto.RecoveryIDOffset] != 27 && sig[crypto.RecoveryIDOffset] != 28 {
+		return nil, fmt.Errorf("invalid Klaytn signature (V is not 27 or 28)")
+	}
+	sig[crypto.RecoveryIDOffset] -= 27 // Transform yellow paper V from 27/28 to 0/1
+
+	klayRpk, klayErr := crypto.SigToPub(signHash(data), sig)
+	if klayErr == nil {
+		return klayRpk, nil
+	}
+	ethRpk, ethErr := crypto.SigToPub(ethSignHash(data), sig)
+	if ethErr == nil {
+		return ethRpk, nil
+	}
+	return nil, klayErr // klayErr has more priority
 }
 
 // SignAndSendTransaction was renamed to SendTransaction. This method is deprecated

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -573,7 +573,8 @@ func (s *PublicTransactionPoolAPI) RecoverTransaction(ctx context.Context, encod
 }
 
 func (s *PublicTransactionPoolAPI) RecoverMessage(
-	ctx context.Context, address common.Address, data, sig hexutil.Bytes, blockNumber rpc.BlockNumber) (common.Address, error) {
+	ctx context.Context, address common.Address, data, sig hexutil.Bytes, blockNumber rpc.BlockNumber,
+) (common.Address, error) {
 	pubkey, err := klayEthEcRecover(data, sig)
 	if err != nil {
 		return common.Address{}, err

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -561,7 +561,12 @@ func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, e
 		return common.Address{}, err
 	}
 
-	signer := types.MakeSigner(s.b.ChainConfig(), new(big.Int).SetUint64(blockNumber.Uint64()))
+	var signer types.Signer
+	if blockNumber == rpc.LatestBlockNumber || blockNumber == rpc.PendingBlockNumber {
+		signer = types.MakeSigner(s.b.ChainConfig(), new(big.Int).SetUint64(s.b.CurrentBlock().Number().Uint64()))
+	} else {
+		signer = types.MakeSigner(s.b.ChainConfig(), new(big.Int).SetUint64(blockNumber.Uint64()))
+	}
 	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNumber)
 	if err != nil {
 		return common.Address{}, err

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -561,17 +561,19 @@ func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, e
 		return common.Address{}, err
 	}
 
-	var signer types.Signer
+	var bn uint64
 	if blockNumber == rpc.LatestBlockNumber || blockNumber == rpc.PendingBlockNumber {
-		signer = types.MakeSigner(s.b.ChainConfig(), new(big.Int).SetUint64(s.b.CurrentBlock().Number().Uint64()))
+		bn = s.b.CurrentBlock().NumberU64()
 	} else {
-		signer = types.MakeSigner(s.b.ChainConfig(), new(big.Int).SetUint64(blockNumber.Uint64()))
+		bn = blockNumber.Uint64()
 	}
+
+	signer := types.MakeSigner(s.b.ChainConfig(), new(big.Int).SetUint64(bn))
 	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNumber)
 	if err != nil {
 		return common.Address{}, err
 	}
-	_, err = tx.ValidateSender(signer, state, blockNumber.Uint64())
+	_, err = tx.ValidateSender(signer, state, bn)
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -553,7 +553,7 @@ func resend(s *PublicTransactionPoolAPI, ctx context.Context, sendArgs NewTxArgs
 	return common.Hash{}, fmt.Errorf("Transaction %#x not found", matchTx.Hash())
 }
 
-// RecoverTransaction recovers the sender address from a signed raw transaction.
+// RecoverFromTransaction recovers the sender address from a signed raw transaction.
 // The signature is validated against the sender account's key configuration at the given block number.
 func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, encodedTx hexutil.Bytes, blockNumber rpc.BlockNumber) (common.Address, error) {
 	tx := new(types.Transaction)
@@ -573,7 +573,7 @@ func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, e
 	return signer.Sender(tx)
 }
 
-// RecoverMessage validates that the message is signed by one of the keys in the given account.
+// RecoverFromMessage validates that the message is signed by one of the keys in the given account.
 // Returns the recovered signer address, which may be different from the account address.
 func (s *PublicTransactionPoolAPI) RecoverFromMessage(
 	ctx context.Context, address common.Address, data, sig hexutil.Bytes, blockNumber rpc.BlockNumber,

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -584,7 +584,10 @@ func (s *PublicTransactionPoolAPI) RecoverMessage(
 	if err != nil {
 		return common.Address{}, err
 	}
-	if state.GetKey(address).IsContainedKey(pubkey) {
+	key := state.GetKey(address)
+	// If the key is the AccountKeyTypeLegacy, confirmation will be delegated to the user
+	// by returning the recovered address
+	if key.ValidateMember(pubkey, address) {
 		return crypto.PubkeyToAddress(*pubkey), nil
 	}
 	return common.Address{}, nil

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -555,7 +555,7 @@ func resend(s *PublicTransactionPoolAPI, ctx context.Context, sendArgs NewTxArgs
 
 // RecoverTransaction recovers the sender address from a signed raw transaction.
 // The signature is validated against the sender account's key configuration at the given block number.
-func (s *PublicTransactionPoolAPI) RecoverTransaction(ctx context.Context, encodedTx hexutil.Bytes, blockNumber rpc.BlockNumber) (common.Address, error) {
+func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, encodedTx hexutil.Bytes, blockNumber rpc.BlockNumber) (common.Address, error) {
 	tx := new(types.Transaction)
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return common.Address{}, err
@@ -575,7 +575,7 @@ func (s *PublicTransactionPoolAPI) RecoverTransaction(ctx context.Context, encod
 
 // RecoverMessage validates that the message is signed by one of the keys in the given account.
 // Returns the recovered signer address, which may be different from the account address.
-func (s *PublicTransactionPoolAPI) RecoverMessage(
+func (s *PublicTransactionPoolAPI) RecoverFromMessage(
 	ctx context.Context, address common.Address, data, sig hexutil.Bytes, blockNumber rpc.BlockNumber,
 ) (common.Address, error) {
 	pubkey, err := klayEthEcRecover(data, sig)

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -561,7 +561,7 @@ func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, e
 		return common.Address{}, err
 	}
 
-	signer := types.MakeSigner(s.b.ChainConfig(), s.b.CurrentBlock().Number())
+	signer := types.MakeSigner(s.b.ChainConfig(), new(big.Int).SetUint64(blockNumber.Uint64()))
 	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNumber)
 	if err != nil {
 		return common.Address{}, err

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -587,11 +587,10 @@ func (s *PublicTransactionPoolAPI) RecoverMessage(
 	if err != nil {
 		return common.Address{}, err
 	}
+
 	key := state.GetKey(address)
-	// If the key is the AccountKeyTypeLegacy, confirmation will be delegated to the user
-	// by returning the recovered address
 	if key.ValidateMember(pubkey, address) {
 		return crypto.PubkeyToAddress(*pubkey), nil
 	}
-	return common.Address{}, nil
+	return common.Address{}, fmt.Errorf("Invalid signature")
 }

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -553,7 +553,8 @@ func resend(s *PublicTransactionPoolAPI, ctx context.Context, sendArgs NewTxArgs
 	return common.Hash{}, fmt.Errorf("Transaction %#x not found", matchTx.Hash())
 }
 
-// This API doesn't allow rueqesters to use block hash according to ValidateSender function's parameter
+// RecoverTransaction recovers the sender address from a signed raw transaction.
+// The signature is validated against the sender account's key configuration at the given block number.
 func (s *PublicTransactionPoolAPI) RecoverTransaction(ctx context.Context, encodedTx hexutil.Bytes, blockNumber rpc.BlockNumber) (common.Address, error) {
 	tx := new(types.Transaction)
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
@@ -572,6 +573,8 @@ func (s *PublicTransactionPoolAPI) RecoverTransaction(ctx context.Context, encod
 	return signer.Sender(tx)
 }
 
+// RecoverMessage validates that the message is signed by one of the keys in the given account.
+// Returns the recovered signer address, which may be different from the account address.
 func (s *PublicTransactionPoolAPI) RecoverMessage(
 	ctx context.Context, address common.Address, data, sig hexutil.Bytes, blockNumber rpc.BlockNumber,
 ) (common.Address, error) {

--- a/blockchain/types/accountkey/account_key.go
+++ b/blockchain/types/accountkey/account_key.go
@@ -65,6 +65,9 @@ type AccountKey interface {
 	// Validate returns true if the given public keys are verifiable with the AccountKey.
 	Validate(currentBlockNumber uint64, r RoleType, recoveredKeys []*ecdsa.PublicKey, from common.Address) bool
 
+	// ValidateMember returns true if the account type contains the given public key in any part of its AccountKey.
+	ValidateMember(recoveredKey *ecdsa.PublicKey, from common.Address) bool
+
 	// DeepCopy creates a new object and copies all the attributes to the new object.
 	DeepCopy() AccountKey
 
@@ -87,8 +90,6 @@ type AccountKey interface {
 	// IsCompositeType returns true if the account type is a composite type.
 	// Composite types are AccountKeyRoleBased and AccountKeyRoleBasedRLPBytes.
 	IsCompositeType() bool
-
-	IsContainedKey(recoveredKey *ecdsa.PublicKey) bool
 }
 
 func NewAccountKey(t AccountKeyType) (AccountKey, error) {

--- a/blockchain/types/accountkey/account_key.go
+++ b/blockchain/types/accountkey/account_key.go
@@ -87,6 +87,8 @@ type AccountKey interface {
 	// IsCompositeType returns true if the account type is a composite type.
 	// Composite types are AccountKeyRoleBased and AccountKeyRoleBasedRLPBytes.
 	IsCompositeType() bool
+
+	IsContainedKey(recoveredKey *ecdsa.PublicKey) bool
 }
 
 func NewAccountKey(t AccountKeyType) (AccountKey, error) {

--- a/blockchain/types/accountkey/account_key_fail.go
+++ b/blockchain/types/accountkey/account_key_fail.go
@@ -44,7 +44,7 @@ func (a *AccountKeyFail) IsCompositeType() bool {
 }
 
 // This type of account key always return false
-func (a *AccountKeyFail) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+func (a *AccountKeyFail) ValidateMember(recoveredKey *ecdsa.PublicKey, from common.Address) bool {
 	return false
 }
 

--- a/blockchain/types/accountkey/account_key_fail.go
+++ b/blockchain/types/accountkey/account_key_fail.go
@@ -43,6 +43,11 @@ func (a *AccountKeyFail) IsCompositeType() bool {
 	return false
 }
 
+// This type of account key always return false
+func (a *AccountKeyFail) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+	return false
+}
+
 func (a *AccountKeyFail) Equal(b AccountKey) bool {
 	// This type of account key always returns false.
 	return false

--- a/blockchain/types/accountkey/account_key_legacy.go
+++ b/blockchain/types/accountkey/account_key_legacy.go
@@ -45,6 +45,11 @@ func (a *AccountKeyLegacy) IsCompositeType() bool {
 	return false
 }
 
+// AccountKeyLegacy cannot check the public key, just return address of the public key argument always
+func (a *AccountKeyLegacy) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+	return true
+}
+
 func (a *AccountKeyLegacy) Equal(b AccountKey) bool {
 	if _, ok := b.(*AccountKeyLegacy); !ok {
 		return false

--- a/blockchain/types/accountkey/account_key_legacy.go
+++ b/blockchain/types/accountkey/account_key_legacy.go
@@ -45,7 +45,9 @@ func (a *AccountKeyLegacy) IsCompositeType() bool {
 	return false
 }
 
-// AccountKeyLegacy cannot check the public key, just return false and then it will be controled by the caller.
+// Other accountKey types have the pubkey so that we can compare the pubkeys in Klaytn.
+// But AccountKeyLegacy doesn't have the pubkey so ValidateMember receives 'from' address more
+// and then checks whether the recovered pubkey's address form equals the 'from' address.
 func (a *AccountKeyLegacy) ValidateMember(recoveredKey *ecdsa.PublicKey, from common.Address) bool {
 	return from == crypto.PubkeyToAddress(*recoveredKey)
 }

--- a/blockchain/types/accountkey/account_key_legacy.go
+++ b/blockchain/types/accountkey/account_key_legacy.go
@@ -45,9 +45,9 @@ func (a *AccountKeyLegacy) IsCompositeType() bool {
 	return false
 }
 
-// AccountKeyLegacy cannot check the public key, just return address of the public key argument always
-func (a *AccountKeyLegacy) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
-	return true
+// AccountKeyLegacy cannot check the public key, just return false and then it will be controled by the caller.
+func (a *AccountKeyLegacy) ValidateMember(recoveredKey *ecdsa.PublicKey, from common.Address) bool {
+	return from == crypto.PubkeyToAddress(*recoveredKey)
 }
 
 func (a *AccountKeyLegacy) Equal(b AccountKey) bool {

--- a/blockchain/types/accountkey/account_key_nil.go
+++ b/blockchain/types/accountkey/account_key_nil.go
@@ -46,6 +46,10 @@ func (a *AccountKeyNil) IsCompositeType() bool {
 	return false
 }
 
+func (a *AccountKeyNil) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+	return false
+}
+
 func (a *AccountKeyNil) Equal(b AccountKey) bool {
 	if _, ok := b.(*AccountKeyNil); !ok {
 		return false

--- a/blockchain/types/accountkey/account_key_nil.go
+++ b/blockchain/types/accountkey/account_key_nil.go
@@ -46,7 +46,7 @@ func (a *AccountKeyNil) IsCompositeType() bool {
 	return false
 }
 
-func (a *AccountKeyNil) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+func (a *AccountKeyNil) ValidateMember(recoveredKey *ecdsa.PublicKey, from common.Address) bool {
 	return false
 }
 

--- a/blockchain/types/accountkey/account_key_public.go
+++ b/blockchain/types/accountkey/account_key_public.go
@@ -51,7 +51,7 @@ func (a *AccountKeyPublic) IsCompositeType() bool {
 	return false
 }
 
-func (a *AccountKeyPublic) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+func (a *AccountKeyPublic) ValidateMember(recoveredKey *ecdsa.PublicKey, from common.Address) bool {
 	return a.PublicKeySerializable.Equal((*PublicKeySerializable)(recoveredKey))
 }
 

--- a/blockchain/types/accountkey/account_key_public.go
+++ b/blockchain/types/accountkey/account_key_public.go
@@ -51,6 +51,10 @@ func (a *AccountKeyPublic) IsCompositeType() bool {
 	return false
 }
 
+func (a *AccountKeyPublic) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+	return a.PublicKeySerializable.Equal((*PublicKeySerializable)(recoveredKey))
+}
+
 func (a *AccountKeyPublic) DeepCopy() AccountKey {
 	return &AccountKeyPublic{
 		a.PublicKeySerializable.DeepCopy(),

--- a/blockchain/types/accountkey/account_key_role_based.go
+++ b/blockchain/types/accountkey/account_key_role_based.go
@@ -69,9 +69,9 @@ func (a *AccountKeyRoleBased) IsCompositeType() bool {
 	return true
 }
 
-func (a *AccountKeyRoleBased) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+func (a *AccountKeyRoleBased) ValidateMember(recoveredKey *ecdsa.PublicKey, from common.Address) bool {
 	for _, rk := range *a {
-		if rk.IsContainedKey(recoveredKey) {
+		if rk.ValidateMember(recoveredKey, from) {
 			return true
 		}
 	}

--- a/blockchain/types/accountkey/account_key_role_based.go
+++ b/blockchain/types/accountkey/account_key_role_based.go
@@ -69,6 +69,15 @@ func (a *AccountKeyRoleBased) IsCompositeType() bool {
 	return true
 }
 
+func (a *AccountKeyRoleBased) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+	for _, rk := range *a {
+		if rk.IsContainedKey(recoveredKey) {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *AccountKeyRoleBased) DeepCopy() AccountKey {
 	n := make(AccountKeyRoleBased, len(*a))
 

--- a/blockchain/types/accountkey/account_key_test.go
+++ b/blockchain/types/accountkey/account_key_test.go
@@ -66,7 +66,6 @@ func TestIsContainedKey(t *testing.T) {
 	for i, testcase := range testcases {
 		assert.Equal(t, testcase.result, keys[testcase.name].IsContainedKey(&testcase.recoveredKey), i)
 	}
-
 }
 
 func TestAccountKeySerialization(t *testing.T) {

--- a/blockchain/types/accountkey/account_key_test.go
+++ b/blockchain/types/accountkey/account_key_test.go
@@ -30,6 +30,45 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsContainedKey(t *testing.T) {
+	keys := map[string]AccountKey{
+		"Nil":              genAccountKeyNil(),
+		"Legacy":           genAccountKeyLegacy(),
+		"Public":           genAccountKeyPublic(),
+		"Fail":             genAccountKeyFail(),
+		"WeightedMultisig": genAccountKeyWeightedMultisig(),
+		"RoleBased":        genAccountKeyRoleBased(),
+	}
+
+	// keys of the "RoleBased"
+	tk, _ := crypto.HexToECDSA("98275a145bc1726eb0445433088f5f882f8a4a9499135239cfb4040e78991dab")
+	ak, _ := crypto.HexToECDSA("c64f2cd1196e2a1791365b00c4bc07ab8f047b73152e4617c6ed06ac221a4b0c") // multisig accountUpdate key of the role-based key
+	fk, _ := crypto.HexToECDSA("ed580f5bd71a2ee4dae5cb43e331b7d0318596e561e6add7844271ed94156b20")
+	// for test
+	testPubkey, _ := crypto.GenerateKey()
+
+	testcases := []struct {
+		name         string
+		recoveredKey ecdsa.PublicKey
+		result       bool
+	}{
+		{"Nil", testPubkey.PublicKey, false},
+		{"Legacy", testPubkey.PublicKey, true},
+		{"Public", testPubkey.PublicKey, false},
+		{"Fail", testPubkey.PublicKey, false},
+		{"WeightedMultisig", testPubkey.PublicKey, false},
+		{"RoleBased", testPubkey.PublicKey, false},
+		{"RoleBased", tk.PublicKey, true}, // even test IsContainedKey of the multisig
+		{"RoleBased", ak.PublicKey, true},
+		{"RoleBased", fk.PublicKey, true},
+	}
+
+	for i, testcase := range testcases {
+		assert.Equal(t, testcase.result, keys[testcase.name].IsContainedKey(&testcase.recoveredKey), i)
+	}
+
+}
+
 func TestAccountKeySerialization(t *testing.T) {
 	keys := []struct {
 		Name string

--- a/blockchain/types/accountkey/account_key_test.go
+++ b/blockchain/types/accountkey/account_key_test.go
@@ -30,7 +30,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsContainedKey(t *testing.T) {
+// assume that the account has already been taken from an address and state by a specific block number.
+func TestValidateMember(t *testing.T) {
 	keys := map[string]AccountKey{
 		"Nil":              genAccountKeyNil(),
 		"Legacy":           genAccountKeyLegacy(),
@@ -50,21 +51,22 @@ func TestIsContainedKey(t *testing.T) {
 	testcases := []struct {
 		name         string
 		recoveredKey ecdsa.PublicKey
+		address      common.Address
 		result       bool
 	}{
-		{"Nil", testPubkey.PublicKey, false},
-		{"Legacy", testPubkey.PublicKey, true},
-		{"Public", testPubkey.PublicKey, false},
-		{"Fail", testPubkey.PublicKey, false},
-		{"WeightedMultisig", testPubkey.PublicKey, false},
-		{"RoleBased", testPubkey.PublicKey, false},
-		{"RoleBased", tk.PublicKey, true}, // even test IsContainedKey of the multisig
-		{"RoleBased", ak.PublicKey, true},
-		{"RoleBased", fk.PublicKey, true},
+		{"Nil", testPubkey.PublicKey, common.Address{}, false},
+		{"Legacy", testPubkey.PublicKey, crypto.PubkeyToAddress(testPubkey.PublicKey), true},
+		{"Public", testPubkey.PublicKey, common.Address{}, false},
+		{"Fail", testPubkey.PublicKey, common.Address{}, false},
+		{"WeightedMultisig", testPubkey.PublicKey, common.Address{}, false},
+		{"RoleBased", testPubkey.PublicKey, common.Address{}, false},
+		{"RoleBased", tk.PublicKey, common.Address{}, true}, // even test IsContainedPubkey of the multisig
+		{"RoleBased", ak.PublicKey, common.Address{}, true},
+		{"RoleBased", fk.PublicKey, common.Address{}, true},
 	}
 
 	for i, testcase := range testcases {
-		assert.Equal(t, testcase.result, keys[testcase.name].IsContainedKey(&testcase.recoveredKey), i)
+		assert.Equal(t, testcase.result, keys[testcase.name].ValidateMember(&testcase.recoveredKey, testcase.address), i)
 	}
 }
 

--- a/blockchain/types/accountkey/account_key_weighted_multi_sig.go
+++ b/blockchain/types/accountkey/account_key_weighted_multi_sig.go
@@ -61,8 +61,8 @@ func (a *AccountKeyWeightedMultiSig) IsCompositeType() bool {
 	return false
 }
 
-func (a *AccountKeyWeightedMultiSig) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
-	return a.Keys.IsContainedKey((*PublicKeySerializable)(recoveredKey)) // temporary WeightedPublicKey
+func (a *AccountKeyWeightedMultiSig) ValidateMember(recoveredKey *ecdsa.PublicKey, from common.Address) bool {
+	return a.Keys.IsContainedPubkey((*PublicKeySerializable)(recoveredKey)) // temporary WeightedPublicKey
 }
 
 func (a *AccountKeyWeightedMultiSig) DeepCopy() AccountKey {
@@ -276,7 +276,7 @@ func (w WeightedPublicKeys) Equal(b WeightedPublicKeys) bool {
 	return true
 }
 
-func (w WeightedPublicKeys) IsContainedKey(b *PublicKeySerializable) bool {
+func (w WeightedPublicKeys) IsContainedPubkey(b *PublicKeySerializable) bool {
 	for _, wv := range w {
 		if b.Equal(wv.Key) {
 			return true

--- a/blockchain/types/accountkey/account_key_weighted_multi_sig.go
+++ b/blockchain/types/accountkey/account_key_weighted_multi_sig.go
@@ -61,6 +61,10 @@ func (a *AccountKeyWeightedMultiSig) IsCompositeType() bool {
 	return false
 }
 
+func (a *AccountKeyWeightedMultiSig) IsContainedKey(recoveredKey *ecdsa.PublicKey) bool {
+	return a.Keys.IsContainedKey((*PublicKeySerializable)(recoveredKey)) // temporary WeightedPublicKey
+}
+
 func (a *AccountKeyWeightedMultiSig) DeepCopy() AccountKey {
 	return &AccountKeyWeightedMultiSig{
 		a.Threshold, a.Keys.DeepCopy(),
@@ -270,4 +274,13 @@ func (w WeightedPublicKeys) Equal(b WeightedPublicKeys) bool {
 	}
 
 	return true
+}
+
+func (w WeightedPublicKeys) IsContainedKey(b *PublicKeySerializable) bool {
+	for _, wv := range w {
+		if b.Equal(wv.Key) {
+			return true
+		}
+	}
+	return false
 }

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -1006,6 +1006,16 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'recoverTransaction',
+			call: 'klay_recoverTransaction',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'recoverMessage',
+			call: 'klay_recoverMessage',
+			params: 4
+		}),
+		new web3._extend.Method({
 			name: 'getCypressCredit',
 			call: 'klay_getCypressCredit',
 		}),

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -1006,13 +1006,13 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
-			name: 'recoverTransaction',
-			call: 'klay_recoverTransaction',
+			name: 'recoverFromTransaction',
+			call: 'klay_recoverFromTransaction',
 			params: 2
 		}),
 		new web3._extend.Method({
-			name: 'recoverMessage',
-			call: 'klay_recoverMessage',
+			name: 'recoverFromMessage',
+			call: 'klay_recoverFromMessage',
 			params: 4
 		}),
 		new web3._extend.Method({

--- a/storage/statedb/errors.go
+++ b/storage/statedb/errors.go
@@ -39,5 +39,7 @@ func (err *MissingNodeError) Error() string {
 	return fmt.Sprintf("missing trie node %x (path %x)", err.NodeHash, err.Path)
 }
 
-var ErrZeroHashNode = errors.New("cannot retrieve a node which has 0x00 hash value")
-var ErrPruningDisabled = errors.New("pruning is disabled on database")
+var (
+	ErrZeroHashNode    = errors.New("cannot retrieve a node which has 0x00 hash value")
+	ErrPruningDisabled = errors.New("pruning is disabled on database")
+)


### PR DESCRIPTION
## Proposed changes

### Why these APIs are added or modified?
- It actually comes from SDK's requirements.
- We should offer the recovery mechanism for transactions or messages signed by accounts with composite accountKey Klaytn composite accountKey types.
- It can be implemented at the SDK level, but the SDK has to call the getAccountKey anyway (i.e. klay_getAccount RPC) to find the accountKey information.
- As a result, I think it would be better to offer these functions as Klaytn core JSON-RPC APIs

### API to be changed
- ecRecover
  - Klaytn's signMessage signs a message with `"\x19Klaytn signed message"` prefix. But many ethereum based wallet sign it with "\x19Ethereum signed message" and It bothers developers to implement recover logic personally.
  - So it is to be extended to recover both prefixes and then return true when at least one verification passes.
  - I think It doesn't matter with the replay attack since someone who has a private key of course can control other chain  that is using ecdsa mechanism.

### APIs to be added
- recoverTransaction
  - Receives
    - `an RLP encoded transaction` that includes signatures and
    - `blockNumber` for getting a specific accountKey state
  - Returns recovered `address`
  - If the sender address of the tx has composite accountKey type, it will return the sender address, not the addresses extracted from signatures.
  - If the recovery failed, it returns `0x0 address`.
- recoverMessage
  - Receives
    - `address`, `blockNumber` for getting a specific accountKey state
    - `data`, `signature`: same with ecRecover
  - Returns extracted address from the signature
    - need to discuss what to return:
      - option1 - the recovered address from the recovered public key
      - option2 - the recovered public key, to avoid confusion with the account address
  - Use-case: suppose Person A wants to sign a message with a Kaikas wallet,
    - if there is a multisig accountKey that has 3 private keys and 'A' has one of them
    - 'A' signed a message with the private key and then request it to the recoverMessage.
    - recoverMessage is going to check whether the multisig accountKey includes the key of 'A' and then it will pass.
    - As a result, recoverMessage returns the address extracted from the signature

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
