### PR TITLE
Live pruning is available in archive mode

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1325,6 +1325,10 @@ func (bc *BlockChain) writeStateTrie(block *types.Block, state *state.StateDB) e
 
 		bc.checkStartStateMigration(block.NumberU64(), root)
 		bc.lastCommittedBlock = block.NumberU64()
+
+		if bc.IsLivePruningRequired() {
+			bc.chPrune <- block.NumberU64()
+		}
 	} else {
 		// Full but not archive node, do proper garbage collection
 		trieDB.ReferenceRoot(root) // metadata reference to keep trie alive

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1958,6 +1958,7 @@ func (dbm *databaseManager) ReadPruningMarks(startNumber, endNumber uint64) []Pr
 	prefix := pruningMarkPrefix
 	startKey := pruningMarkKey(PruningMark{startNumber, common.ExtHash{}})
 	it := dbm.getDatabase(MiscDB).NewIterator(prefix, startKey[len(prefix):])
+	defer it.Release()
 
 	var marks []PruningMark
 	for it.Next() {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1916,17 +1916,20 @@ func (dbm *databaseManager) WritePreimages(number uint64, preimages map[common.H
 	preimageHitCounter.Inc(int64(len(preimages)))
 }
 
+// ReadPruningEnabled reads if the live pruning flag is stored in database.
 func (dbm *databaseManager) ReadPruningEnabled() bool {
 	ok, _ := dbm.getDatabase(MiscDB).Has(pruningEnabledKey)
 	return ok
 }
 
+// WritePruningEnabled writes the live pruning flag to the database.
 func (dbm *databaseManager) WritePruningEnabled() {
 	if err := dbm.getDatabase(MiscDB).Put(pruningEnabledKey, []byte("42")); err != nil {
 		logger.Crit("Failed to store pruning enabled flag", "err", err)
 	}
 }
 
+// DeletePruningEnabled deletes the live pruning flag. It is used only for testing.
 func (dbm *databaseManager) DeletePruningEnabled() {
 	if err := dbm.getDatabase(MiscDB).Delete(pruningEnabledKey); err != nil {
 		logger.Crit("Failed to remove pruning enabled flag", "err", err)


### PR DESCRIPTION
## Proposed changes

- Enable live pruning in archive mode
  - Currently only worked in full mode. Now it also works in archive mode.
- Address some leftover comments in https://github.com/klaytn/klaytn/pull/1871.
  - Add comments to DeletePruningEnabled() that it is for testing
  - Add missing it.Release() in ReadPruningMarks()
  - Refactor bc.IsLivePruningRequired()
  - When live pruning is disabled, do not start the goroutine in pruneTrieNodeLoop

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
