### PR TITLE
Disable state migration when live pruning is enabled

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1428,11 +1428,6 @@ func (bc *BlockChain) gcCachedNodeLoop() {
 }
 
 func (bc *BlockChain) pruneTrieNodeLoop() {
-	// If live pruning is disabled, do not bother starting a goroutine.
-	if !bc.IsLivePruningRequired() {
-		return
-	}
-
 	// ReadPruningMarks(1, limit) is very slow because it iterates over the most of MiscDB.
 	// ReadPruningMarks(start, limit) is much faster because it only iterates a small range.
 	startNum := uint64(1)

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -307,6 +307,10 @@ func (bc *BlockChain) restartStateMigration() {
 
 // PrepareStateMigration sets prepareStateMigration to be called in checkStartStateMigration.
 func (bc *BlockChain) PrepareStateMigration() error {
+	if bc.db.ReadPruningEnabled() {
+		return errors.New("state migration not supported with live pruning enabled")
+	}
+
 	if bc.db.InMigration() || bc.prepareStateMigration {
 		return errors.New("migration already started")
 	}


### PR DESCRIPTION
## Proposed changes

- `admin_startStateMigration` RPC returns an error if the database has live pruning enabled.
  - State migration does not work with the ExtHash trie database.
  - State migration is unnecessary when Live Pruning is used.
- Fix `ken --state.live-pruning` flag to work
  - Reverts some change from https://github.com/klaytn/klaytn/pull/1914
  - When `bc.pruneTrieNodeLoop()` is executed, the pruning flag might not be in database just yet. For example in `cn.New()`, `NewBlockChain()` is first called and then `WritePruningEnabled()`.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
