### PR TITLE
Added more flags to resolve high memory consumption

### DIFF
--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -534,6 +534,8 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 	cfg.RocksDBConfig.BottommostCompressionType = ctx.String(RocksDBBottommostCompressionTypeFlag.Name)
 	cfg.RocksDBConfig.FilterPolicy = ctx.String(RocksDBFilterPolicyFlag.Name)
 	cfg.RocksDBConfig.DisableMetrics = ctx.Bool(RocksDBDisableMetricsFlag.Name)
+	cfg.RocksDBConfig.MaxOpenFiles = ctx.Int(RocksDBMaxOpenFilesFlag.Name)
+	cfg.RocksDBConfig.CacheIndexAndFilter = ctx.Bool(RocksDBCacheIndexAndFilterFlag.Name)
 
 	cfg.DynamoDBConfig.TableName = ctx.String(DynamoDBTableNameFlag.Name)
 	cfg.DynamoDBConfig.Region = ctx.String(DynamoDBRegionFlag.Name)

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -100,6 +100,8 @@ var FlagGroups = []FlagGroup{
 			RocksDBBottommostCompressionTypeFlag,
 			RocksDBFilterPolicyFlag,
 			RocksDBDisableMetricsFlag,
+			RocksDBMaxOpenFilesFlag,
+			RocksDBCacheIndexAndFilterFlag,
 			DynamoDBTableNameFlag,
 			DynamoDBRegionFlag,
 			DynamoDBIsProvisionedFlag,
@@ -183,6 +185,8 @@ var FlagGroups = []FlagGroup{
 			DstRocksDBBottommostCompressionTypeFlag,
 			DstRocksDBFilterPolicyFlag,
 			DstRocksDBDisableMetricsFlag,
+			DstRocksDBMaxOpenFilesFlag,
+			DstRocksDBCacheIndexAndFilterFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -360,7 +360,7 @@ var (
 	}
 	RocksDBMaxOpenFilesFlag = &cli.IntFlag{
 		Name:    "db.rocksdb.max-open-files",
-		Usage:   "Set RocksDB max open files. (-1: unlimited, or the value should be greater than 16)",
+		Usage:   "Set RocksDB max open files. (the value should be greater than 16)",
 		Value:   database.GetDefaultRocksDBConfig().MaxOpenFiles,
 		EnvVars: []string{"KLAYTN_DB_ROCKSDB_MAX_OPEN_FILES"},
 	}
@@ -1636,7 +1636,7 @@ var (
 	}
 	DstRocksDBMaxOpenFilesFlag = &cli.IntFlag{
 		Name:    "db.dst.rocksdb.max-open-files",
-		Usage:   "Set RocksDB max open files. (-1: unlimited, or the value should be greater than 16)",
+		Usage:   "Set RocksDB max open files. (the value should be greater than 16)",
 		Value:   database.GetDefaultRocksDBConfig().MaxOpenFiles,
 		Aliases: []string{"migration.dst.db.rocksdb.max-open-files"},
 		EnvVars: []string{"KLAYTN_DB_DST_ROCKSDB_MAX_OPEN_FILES"},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -358,6 +358,17 @@ var (
 		Usage:   "Disable RocksDB metrics",
 		EnvVars: []string{"KLAYTN_DB_ROCKSDB_DISABLE_METRICS"},
 	}
+	RocksDBMaxOpenFilesFlag = &cli.IntFlag{
+		Name:    "db.rocksdb.max-open-files",
+		Usage:   "Set RocksDB max open files. (-1: unlimited, or the value should be greater than 16)",
+		Value:   database.GetDefaultRocksDBConfig().MaxOpenFiles,
+		EnvVars: []string{"KLAYTN_DB_ROCKSDB_MAX_OPEN_FILES"},
+	}
+	RocksDBCacheIndexAndFilterFlag = &cli.BoolFlag{
+		Name:    "db.rocksdb.cache-index-and-filter",
+		Usage:   "Use block cache for index and filter blocks.",
+		EnvVars: []string{"KLAYTN_DB_ROCKSDB_CACHE_INDEX_AND_FILTER"},
+	}
 	DynamoDBTableNameFlag = &cli.StringFlag{
 		Name:    "db.dynamo.tablename",
 		Usage:   "Specifies DynamoDB table name. This is mandatory to use dynamoDB. (Set dbtype to use DynamoDBS3)",
@@ -1622,6 +1633,19 @@ var (
 		Usage:   "Disable RocksDB metrics",
 		Aliases: []string{"migration.dst.db.rocksdb.disable-metrics"},
 		EnvVars: []string{"KLAYTN_DB_DST_ROCKSDB_DISABLE_METRICS"},
+	}
+	DstRocksDBMaxOpenFilesFlag = &cli.IntFlag{
+		Name:    "db.dst.rocksdb.max-open-files",
+		Usage:   "Set RocksDB max open files. (-1: unlimited, or the value should be greater than 16)",
+		Value:   database.GetDefaultRocksDBConfig().MaxOpenFiles,
+		Aliases: []string{"migration.dst.db.rocksdb.max-open-files"},
+		EnvVars: []string{"KLAYTN_DB_DST_ROCKSDB_MAX_OPEN_FILES"},
+	}
+	DstRocksDBCacheIndexAndFilterFlag = &cli.BoolFlag{
+		Name:    "db.dst.rocksdb.cache-index-and-filter",
+		Usage:   "Use block cache for index and filter blocks.",
+		Aliases: []string{"migration.dst.db.rocksdb.cache-index-and-filter"},
+		EnvVars: []string{"KLAYTN_DB_DST_ROCKSDB_CACHE_INDEX_AND_FILTER"},
 	}
 
 	// Config

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -65,6 +65,8 @@ var (
 			utils.RocksDBCompressionTypeFlag,
 			utils.RocksDBBottommostCompressionTypeFlag,
 			utils.RocksDBDisableMetricsFlag,
+			utils.RocksDBMaxOpenFilesFlag,
+			utils.RocksDBCacheIndexAndFilterFlag,
 			utils.OverwriteGenesisFlag,
 			utils.LivePruningFlag,
 		},
@@ -169,6 +171,8 @@ func initGenesis(ctx *cli.Context) error {
 			CompressionType:           ctx.String(utils.RocksDBCompressionTypeFlag.Name),
 			BottommostCompressionType: ctx.String(utils.RocksDBBottommostCompressionTypeFlag.Name),
 			FilterPolicy:              ctx.String(utils.RocksDBFilterPolicyFlag.Name),
+			MaxOpenFiles:              ctx.Int(utils.RocksDBMaxOpenFilesFlag.Name),
+			CacheIndexAndFilter:       ctx.Bool(utils.RocksDBCacheIndexAndFilterFlag.Name),
 		}
 	}
 

--- a/cmd/utils/nodecmd/migrationcmd.go
+++ b/cmd/utils/nodecmd/migrationcmd.go
@@ -122,6 +122,8 @@ func createDBConfigForMigration(ctx *cli.Context) (*database.DBConfig, *database
 			CompressionType:           ctx.String(utils.RocksDBCompressionTypeFlag.Name),
 			BottommostCompressionType: ctx.String(utils.RocksDBBottommostCompressionTypeFlag.Name),
 			FilterPolicy:              ctx.String(utils.RocksDBFilterPolicyFlag.Name),
+			MaxOpenFiles:              ctx.Int(utils.RocksDBMaxOpenFilesFlag.Name),
+			CacheIndexAndFilter:       ctx.Bool(utils.RocksDBCacheIndexAndFilterFlag.Name),
 		},
 	}
 	if len(srcDBC.DBType) == 0 { // changed to invalid type
@@ -157,6 +159,8 @@ func createDBConfigForMigration(ctx *cli.Context) (*database.DBConfig, *database
 			CompressionType:           ctx.String(utils.DstRocksDBCompressionTypeFlag.Name),
 			BottommostCompressionType: ctx.String(utils.DstRocksDBBottommostCompressionTypeFlag.Name),
 			FilterPolicy:              ctx.String(utils.DstRocksDBFilterPolicyFlag.Name),
+			MaxOpenFiles:              ctx.Int(utils.DstRocksDBMaxOpenFilesFlag.Name),
+			CacheIndexAndFilter:       ctx.Bool(utils.DstRocksDBCacheIndexAndFilterFlag.Name),
 		},
 	}
 	if len(dstDBC.DBType) == 0 { // changed to invalid type

--- a/cmd/utils/nodecmd/snapshot.go
+++ b/cmd/utils/nodecmd/snapshot.go
@@ -122,6 +122,8 @@ func getConfig(ctx *cli.Context) *database.DBConfig {
 			CompressionType:           ctx.String(utils.RocksDBCompressionTypeFlag.Name),
 			BottommostCompressionType: ctx.String(utils.RocksDBBottommostCompressionTypeFlag.Name),
 			FilterPolicy:              ctx.String(utils.RocksDBFilterPolicyFlag.Name),
+			MaxOpenFiles:              ctx.Int(utils.RocksDBMaxOpenFilesFlag.Name),
+			CacheIndexAndFilter:       ctx.Bool(utils.RocksDBCacheIndexAndFilterFlag.Name),
 		},
 	}
 }

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -203,6 +203,8 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewStringFlag(RocksDBBottommostCompressionTypeFlag),
 	altsrc.NewStringFlag(RocksDBFilterPolicyFlag),
 	altsrc.NewBoolFlag(RocksDBDisableMetricsFlag),
+	altsrc.NewIntFlag(RocksDBMaxOpenFilesFlag),
+	altsrc.NewBoolFlag(RocksDBCacheIndexAndFilterFlag),
 	altsrc.NewStringFlag(DynamoDBTableNameFlag),
 	altsrc.NewStringFlag(DynamoDBRegionFlag),
 	altsrc.NewBoolFlag(DynamoDBIsProvisionedFlag),
@@ -492,6 +494,8 @@ var SnapshotFlags = []cli.Flag{
 	altsrc.NewStringFlag(RocksDBCompressionTypeFlag),
 	altsrc.NewStringFlag(RocksDBBottommostCompressionTypeFlag),
 	altsrc.NewBoolFlag(RocksDBDisableMetricsFlag),
+	altsrc.NewIntFlag(RocksDBMaxOpenFilesFlag),
+	altsrc.NewBoolFlag(RocksDBCacheIndexAndFilterFlag),
 }
 
 var DBMigrationSrcFlags = []cli.Flag{
@@ -514,6 +518,8 @@ var DBMigrationSrcFlags = []cli.Flag{
 	altsrc.NewStringFlag(RocksDBCompressionTypeFlag),
 	altsrc.NewStringFlag(RocksDBBottommostCompressionTypeFlag),
 	altsrc.NewBoolFlag(RocksDBDisableMetricsFlag),
+	altsrc.NewIntFlag(RocksDBMaxOpenFilesFlag),
+	altsrc.NewBoolFlag(RocksDBCacheIndexAndFilterFlag),
 }
 
 var DBMigrationDstFlags = []cli.Flag{
@@ -535,6 +541,8 @@ var DBMigrationDstFlags = []cli.Flag{
 	altsrc.NewStringFlag(DstRocksDBCompressionTypeFlag),
 	altsrc.NewStringFlag(DstRocksDBBottommostCompressionTypeFlag),
 	altsrc.NewStringFlag(DstRocksDBFilterPolicyFlag),
+	altsrc.NewIntFlag(DstRocksDBMaxOpenFilesFlag),
+	altsrc.NewBoolFlag(DstRocksDBCacheIndexAndFilterFlag),
 }
 
 var ChainDataFetcherFlags = []cli.Flag{

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -404,11 +404,7 @@ func getDBEntryConfig(originalDBC *DBConfig, i DBEntryType, dbDir string) *DBCon
 	if newDBC.RocksDBConfig != nil {
 		newRocksDBConfig := *originalDBC.RocksDBConfig
 		newRocksDBConfig.CacheSize = originalDBC.RocksDBConfig.CacheSize * uint64(ratio) / 100
-		if originalDBC.RocksDBConfig.MaxOpenFiles == -1 {
-			newRocksDBConfig.MaxOpenFiles = originalDBC.RocksDBConfig.MaxOpenFiles
-		} else {
-			newRocksDBConfig.MaxOpenFiles = originalDBC.RocksDBConfig.MaxOpenFiles * ratio / 100
-		}
+		newRocksDBConfig.MaxOpenFiles = originalDBC.RocksDBConfig.MaxOpenFiles * ratio / 100
 		newDBC.RocksDBConfig = &newRocksDBConfig
 	}
 

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -404,6 +404,11 @@ func getDBEntryConfig(originalDBC *DBConfig, i DBEntryType, dbDir string) *DBCon
 	if newDBC.RocksDBConfig != nil {
 		newRocksDBConfig := *originalDBC.RocksDBConfig
 		newRocksDBConfig.CacheSize = originalDBC.RocksDBConfig.CacheSize * uint64(ratio) / 100
+		if originalDBC.RocksDBConfig.MaxOpenFiles == -1 {
+			newRocksDBConfig.MaxOpenFiles = originalDBC.RocksDBConfig.MaxOpenFiles
+		} else {
+			newRocksDBConfig.MaxOpenFiles = originalDBC.RocksDBConfig.MaxOpenFiles * ratio / 100
+		}
 		newDBC.RocksDBConfig = &newRocksDBConfig
 	}
 

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -74,7 +74,7 @@ var (
 	signer types.Signer
 )
 
-var addRocksdb = false
+var addRocksDB = false
 
 func init() {
 	GetOpenFilesLimit()
@@ -94,7 +94,7 @@ func init() {
 		dbConfigs = append(dbConfigs, bc)
 		dbConfigs = append(dbConfigs, &badgerConfig)
 		dbConfigs = append(dbConfigs, &memoryConfig)
-		if addRocksdb {
+		if addRocksDB {
 			dbConfigs = append(dbConfigs, &rockdbConfig)
 		}
 	}

--- a/storage/database/rocksdb_database.go
+++ b/storage/database/rocksdb_database.go
@@ -110,7 +110,7 @@ func NewRocksDB(path string, config *RocksDBConfig) (*rocksDB, error) {
 		logger.Warn("Cache size too small, increasing to minimum recommended", "oldCacheSize", config.CacheSize, "newCacheSize", minCacheSizeForRocksDB)
 		config.CacheSize = minCacheSizeForRocksDB
 	}
-	if config.MaxOpenFiles >= 0 && config.MaxOpenFiles < minOpenFilesForRocksDB {
+	if config.MaxOpenFiles < minOpenFilesForRocksDB {
 		logger.Warn("Max open files too small, increasing to minimum recommended", "oldMaxOpenFiles", config.MaxOpenFiles, "newMaxOpenFiles", minOpenFilesForRocksDB)
 		config.MaxOpenFiles = minOpenFilesForRocksDB
 	}
@@ -123,8 +123,6 @@ func NewRocksDB(path string, config *RocksDBConfig) (*rocksDB, error) {
 	if cacheIndexAndFilter := config.CacheIndexAndFilter; cacheIndexAndFilter {
 		bbto.SetCacheIndexAndFilterBlocks(cacheIndexAndFilter)
 		bbto.SetPinL0FilterAndIndexBlocksInCache(cacheIndexAndFilter)
-	} else if config.MaxOpenFiles == -1 {
-		logger.Warn("Use caching index and filter blocks or limit max open files to avoid memory explosion")
 	}
 
 	policy := filterPolicyStrToNative(config.FilterPolicy)

--- a/storage/database/rocksdb_database.go
+++ b/storage/database/rocksdb_database.go
@@ -107,9 +107,11 @@ func NewRocksDB(path string, config *RocksDBConfig) (*rocksDB, error) {
 
 	// Ensure we have some minimal caching and file guarantees
 	if config.CacheSize < minCacheSizeForRocksDB {
+		logger.Warn("Cache size too small, increasing to minimum recommended", "oldCacheSize", config.CacheSize, "newCacheSize", minCacheSizeForRocksDB)
 		config.CacheSize = minCacheSizeForRocksDB
 	}
 	if config.MaxOpenFiles >= 0 && config.MaxOpenFiles < minOpenFilesForRocksDB {
+		logger.Warn("Max open files too small, increasing to minimum recommended", "oldMaxOpenFiles", config.MaxOpenFiles, "newMaxOpenFiles", minOpenFilesForRocksDB)
 		config.MaxOpenFiles = minOpenFilesForRocksDB
 	}
 

--- a/storage/database/rocksdb_database.go
+++ b/storage/database/rocksdb_database.go
@@ -245,7 +245,9 @@ func (i *rdbIter) Key() []byte {
 	if i.first {
 		return nil
 	}
-	return i.iter.Key().Data()
+	key := i.iter.Key()
+	defer key.Free()
+	return key.Data()
 }
 
 // Value returns the value of the current key/value pair, or nil if done. The
@@ -255,7 +257,9 @@ func (i *rdbIter) Value() []byte {
 	if i.first {
 		return nil
 	}
-	return i.iter.Value().Data()
+	val := i.iter.Value()
+	defer val.Free()
+	return val.Data()
 }
 
 // Release releases associated resources. Release should always succeed and can

--- a/storage/database/rocksdb_database_config.go
+++ b/storage/database/rocksdb_database_config.go
@@ -17,8 +17,11 @@
 package database
 
 const (
-	defaultRocksDBCacheSize = 2 // 2MB
-	defaultBitsPerKey       = 10
+	defaultRocksDBCacheSize    = 2 // 2MB
+	defaultBitsPerKey          = 10
+	minCacheSizeForRocksDB     = 16
+	defaultOpenFilesForRocksDB = 1024
+	minOpenFilesForRocksDB     = 16
 )
 
 var properties = []string{
@@ -71,6 +74,8 @@ type RocksDBConfig struct {
 	CompressionType           string
 	BottommostCompressionType string
 	FilterPolicy              string
+	MaxOpenFiles              int
+	CacheIndexAndFilter       bool
 }
 
 func GetDefaultRocksDBConfig() *RocksDBConfig {
@@ -82,5 +87,7 @@ func GetDefaultRocksDBConfig() *RocksDBConfig {
 		BottommostCompressionType: "zstd",
 		FilterPolicy:              "ribbon",
 		DisableMetrics:            false,
+		MaxOpenFiles:              defaultOpenFilesForRocksDB,
+		CacheIndexAndFilter:       true,
 	}
 }

--- a/storage/database/rocksdb_database_test.go
+++ b/storage/database/rocksdb_database_test.go
@@ -26,7 +26,7 @@ import (
 
 func init() {
 	testDatabases = append(testDatabases, newTestRocksDB)
-	addRocksdb = true
+	addRocksDB = true
 }
 
 func newTestRocksDB() (Database, func(), string) {

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -70,11 +70,18 @@ func newShardedDB(dbc *DBConfig, et DBEntryType, numShards uint) (*shardedDB, er
 	sdbBatchTaskCh := make(chan sdbBatchTask, numShards*2)
 	sdbLevelDBCacheSize := dbc.LevelDBCacheSize / int(numShards)
 	sdbOpenFilesLimit := dbc.OpenFilesLimit / int(numShards)
+	sdbRocksDBCacheSize := GetDefaultRocksDBConfig().CacheSize / uint64(numShards)
+	if dbc.RocksDBConfig != nil {
+		sdbRocksDBCacheSize = dbc.RocksDBConfig.CacheSize / uint64(numShards)
+	}
 	for i := 0; i < int(numShards); i++ {
 		copiedDBC := *dbc
 		copiedDBC.Dir = path.Join(copiedDBC.Dir, strconv.Itoa(i))
 		copiedDBC.LevelDBCacheSize = sdbLevelDBCacheSize
 		copiedDBC.OpenFilesLimit = sdbOpenFilesLimit
+		if copiedDBC.RocksDBConfig != nil {
+			copiedDBC.RocksDBConfig.CacheSize = sdbRocksDBCacheSize
+		}
 
 		db, err := newDatabase(&copiedDBC, et)
 		if err != nil {

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -71,8 +71,14 @@ func newShardedDB(dbc *DBConfig, et DBEntryType, numShards uint) (*shardedDB, er
 	sdbLevelDBCacheSize := dbc.LevelDBCacheSize / int(numShards)
 	sdbOpenFilesLimit := dbc.OpenFilesLimit / int(numShards)
 	sdbRocksDBCacheSize := GetDefaultRocksDBConfig().CacheSize / uint64(numShards)
+	sdbRocksDBMaxOpenFiles := GetDefaultRocksDBConfig().MaxOpenFiles / int(numShards)
 	if dbc.RocksDBConfig != nil {
 		sdbRocksDBCacheSize = dbc.RocksDBConfig.CacheSize / uint64(numShards)
+		if dbc.RocksDBConfig.MaxOpenFiles == -1 {
+			sdbRocksDBMaxOpenFiles = dbc.RocksDBConfig.MaxOpenFiles
+		} else {
+			sdbRocksDBMaxOpenFiles = dbc.RocksDBConfig.MaxOpenFiles / int(numShards)
+		}
 	}
 	for i := 0; i < int(numShards); i++ {
 		copiedDBC := *dbc
@@ -81,6 +87,7 @@ func newShardedDB(dbc *DBConfig, et DBEntryType, numShards uint) (*shardedDB, er
 		copiedDBC.OpenFilesLimit = sdbOpenFilesLimit
 		if copiedDBC.RocksDBConfig != nil {
 			copiedDBC.RocksDBConfig.CacheSize = sdbRocksDBCacheSize
+			copiedDBC.RocksDBConfig.MaxOpenFiles = sdbRocksDBMaxOpenFiles
 		}
 
 		db, err := newDatabase(&copiedDBC, et)

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -74,11 +74,7 @@ func newShardedDB(dbc *DBConfig, et DBEntryType, numShards uint) (*shardedDB, er
 	sdbRocksDBMaxOpenFiles := GetDefaultRocksDBConfig().MaxOpenFiles / int(numShards)
 	if dbc.RocksDBConfig != nil {
 		sdbRocksDBCacheSize = dbc.RocksDBConfig.CacheSize / uint64(numShards)
-		if dbc.RocksDBConfig.MaxOpenFiles == -1 {
-			sdbRocksDBMaxOpenFiles = dbc.RocksDBConfig.MaxOpenFiles
-		} else {
-			sdbRocksDBMaxOpenFiles = dbc.RocksDBConfig.MaxOpenFiles / int(numShards)
-		}
+		sdbRocksDBMaxOpenFiles = dbc.RocksDBConfig.MaxOpenFiles / int(numShards)
 	}
 	for i := 0; i < int(numShards); i++ {
 		copiedDBC := *dbc


### PR DESCRIPTION
## Proposed changes

### Introduced two flags
- `MaxOpenFiles` and `CacheIndexAndFilter` flags are added
- RocksDB used extra memory for index and filter blocks other than block cache.
  - `MaxOpenFiles` controls the number of index/filter blocks by limiting this number.
  - `CacheIndexAndFilter` uses block cache instead of using extra.

ref: https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB#indexes-and-filter-blocks


### Minor fixes
- Free key/value of iterator
- Rebalance cache size of sharded database

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
