### PR TITLE
Fix vrank metrics and update timing

### DIFF
--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -153,9 +153,5 @@ func (c *core) acceptCommit(msg *message, src istanbul.Validator) error {
 		return err
 	}
 
-	if c.current.Commits.Size() == 1 && vrank != nil {
-		vrankFirstCommitArrivalTimeGauge.Update(int64(vrank.TimeSinceStart()))
-	}
-
 	return nil
 }

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -100,10 +100,10 @@ func (v *Vrank) HandleCommitted(blockNum *big.Int) {
 	if len(v.commitArrivalTimeMap) != 0 {
 		sum := int64(0)
 		quorumCommitTime := time.Duration(0)
-		for _, v := range v.commitArrivalTimeMap {
-			sum += int64(v)
-			if quorumCommitTime < v {
-				quorumCommitTime = v
+		for _, arrivalTime := range v.commitArrivalTimeMap {
+			sum += int64(arrivalTime)
+			if quorumCommitTime < arrivalTime {
+				quorumCommitTime = arrivalTime
 			}
 		}
 		avg := sum / int64(len(v.commitArrivalTimeMap))


### PR DESCRIPTION
## Proposed changes

* Change metrics to be same as logs by calculating values from `commitArrivalTimeMap`.
* Change update timing of metrics to prevent metric fetch timing issue.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
