### PR TITLE
tracer: introduce heavy debug api limiter

### DIFF
--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -55,6 +55,7 @@ import (
 	"github.com/klaytn/klaytn/node"
 	"github.com/klaytn/klaytn/node/cn"
 	"github.com/klaytn/klaytn/node/cn/filters"
+	"github.com/klaytn/klaytn/node/cn/tracers"
 	"github.com/klaytn/klaytn/node/sc"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
@@ -651,6 +652,8 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 
 	// disable unsafe debug APIs
 	cfg.DisableUnsafeDebug = ctx.Bool(UnsafeDebugDisableFlag.Name)
+	cfg.StateRegenerationTimeLimit = ctx.Duration(StateRegenerationTimeLimitFlag.Name)
+	tracers.HeavyAPIRequestLimit = int32(ctx.Int(HeavyDebugRequestLimitFlag.Name))
 
 	// Override any default configs for hard coded network.
 	// TODO-Klaytn-Bootnode: Discuss and add `baobab` test network's genesis block

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -266,6 +266,8 @@ var FlagGroups = []FlagGroup{
 			RPCConcurrencyLimit,
 			RPCNonEthCompatibleFlag,
 			UnsafeDebugDisableFlag,
+			HeavyDebugRequestLimitFlag,
+			StateRegenerationTimeLimitFlag,
 			IPCDisabledFlag,
 			IPCPathFlag,
 			WSEnabledFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -900,9 +900,24 @@ var (
 	}
 	UnsafeDebugDisableFlag = &cli.BoolFlag{
 		Name:    "rpc.unsafe-debug.disable",
-		Usage:   "Disable unsafe debug APIs (traceTransaction, writeXXX, ...).",
+		Usage:   "Disable unsafe debug APIs (traceTransaction, traceChain, ...).",
 		Aliases: []string{"http-rpc.unsafe-debug.disable"},
 		EnvVars: []string{"KLAYTN_RPC_UNSAFE_DEBUG_DISABLE"},
+	}
+	// TODO-klaytn: Consider limiting the non-debug heavy apis.
+	HeavyDebugRequestLimitFlag = &cli.IntFlag{
+		Name:    "rpc.unsafe-debug.heavy-debug.requestlimit",
+		Usage:   "Limit the maximum number of heavy debug api requests. Works with unsafe-debug only.",
+		Value:   50,
+		Aliases: []string{},
+		EnvVars: []string{"KLAYTN_RPC_UNSAFE_DEBUG_HEAVY_DEBUG_REQUEST_LIMIT"},
+	}
+	StateRegenerationTimeLimitFlag = &cli.DurationFlag{
+		Name:    "rpc.unsafe-debug.state-regeneration.timelimit",
+		Usage:   "Limit the state regeneration time. Works with unsafe-debug only.",
+		Value:   60 * time.Second,
+		Aliases: []string{},
+		EnvVars: []string{"KLAYTN_RPC_UNSAFE_DEBUG_STATE_REGENERATION_TIME_LIMIT"},
 	}
 
 	// Network Settings

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -906,14 +906,14 @@ var (
 	}
 	// TODO-klaytn: Consider limiting the non-debug heavy apis.
 	HeavyDebugRequestLimitFlag = &cli.IntFlag{
-		Name:    "rpc.unsafe-debug.heavy-debug.requestlimit",
+		Name:    "rpc.unsafe-debug.heavy-debug.request-limit",
 		Usage:   "Limit the maximum number of heavy debug api requests. Works with unsafe-debug only.",
 		Value:   50,
 		Aliases: []string{},
 		EnvVars: []string{"KLAYTN_RPC_UNSAFE_DEBUG_HEAVY_DEBUG_REQUEST_LIMIT"},
 	}
 	StateRegenerationTimeLimitFlag = &cli.DurationFlag{
-		Name:    "rpc.unsafe-debug.state-regeneration.timelimit",
+		Name:    "rpc.unsafe-debug.state-regeneration.time-limit",
 		Usage:   "Limit the state regeneration time. Works with unsafe-debug only.",
 		Value:   60 * time.Second,
 		Aliases: []string{},

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -295,6 +295,8 @@ var CommonRPCFlags = []cli.Flag{
 	altsrc.NewIntFlag(RPCIdleTimeoutFlag),
 	altsrc.NewIntFlag(RPCExecutionTimeoutFlag),
 	altsrc.NewBoolFlag(UnsafeDebugDisableFlag),
+	altsrc.NewIntFlag(HeavyDebugRequestLimitFlag),
+	altsrc.NewDurationFlag(StateRegenerationTimeLimitFlag),
 }
 
 var BNFlags = []cli.Flag{

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -185,7 +185,8 @@ type Config struct {
 	RPCTxFeeCap float64
 
 	// Disable option for unsafe debug APIs
-	DisableUnsafeDebug bool `toml:",omitempty"`
+	DisableUnsafeDebug         bool          `toml:",omitempty"`
+	StateRegenerationTimeLimit time.Duration `toml:",omitempty"`
 }
 
 type configMarshaling struct {


### PR DESCRIPTION
## Proposed changes

When disable-unsafe-trace is true, the following restrictions are newly added
- set the number of the heavy debug api request limit.
  - heavy debug api list: TraceBlockByNumber, TraceBlockByHash, TraceBlock, TraceBadBlock, TraceTransaction 
  - considered two types of implementation when it exceeds limitation: semaphore, rate limiting. Here, chose rate limiting.
- limit the state regeneration time: default value is 60s
- set `traceBlockByNumberRange` and `traceChain` as unsafe-debug api

Meanwhile, non-debug heavy apis aren't considered yet. There's some candidates (ex. estimateGas) but needs some more investigation.

If you want to modify the new limits, configure ADDITIONAL at kend.conf as below. Those flags only work with unsafe-debug.disable.
```
ADDITIONAL=" --rpc.unsafe-debug.disable --rpc.unsafe-debug.heavy-debug.request-limit 50 --rpc.unsafe-debug.state-regeneration.time-limit 60s"
```

Test result
Set `debug.request-limit` as 2 and set `state-regeneration.time-limit` as 5s
```
# tests the state regeneration time limit
[root@test-machine ~]# ./traceBlockByNumber-76767677.sh
Elapsed time: 0 seconds
Elapsed time: 1 seconds
Elapsed time: 2 seconds
Elapsed time: 3 seconds
Elapsed time: 4 seconds
Elapsed time: 5 seconds
Elapsed time: 6 seconds
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"this request has queried old states too long since it exceeds the state regeneration time limit(5s)"}}
Elapsed time: 7 seconds
[root@ip-10-117-2-145 ~]# ./traceBlockByNumber-76767677.sh
...(repeat 6 times)
[root@ip-10-117-2-145 ~]# ./traceBlockByNumber-76767677.sh 
Elapsed time: 0 seconds
Elapsed time: 1 seconds
Elapsed time: 2 seconds
Elapsed time: 3 seconds
Elapsed time: 4 seconds
Elapsed time: 5 seconds
Elapsed time: 6 seconds
{"jsonrpc":"2.0","id":1,"result":[{"txHash":"0xc4c5ca9ff430e94d7f357602bace4c96d01cb0c5968dfd0f362f9c8b9854eaa7","result":{"gas":31000,"failed":false,"returnValue":"","structLogs":[]}},{"txHash":"0xa0527cee1e9d9375ae2aeca5130d...]
```
```
# test the heavy-debug request limit - execute six debug_traceBlockByNumber call concurrently.
# only first two calls are executed and the other calls are rejected
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"heavy debug api requests exceed the limit: 2"}}
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"heavy debug api requests exceed the limit: 2"}}
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"heavy debug api requests exceed the limit: 2"}}
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"heavy debug api requests exceed the limit: 2"}}
{"jsonrpc":"2.0","id":1,"result":[...]}
{"jsonrpc":"2.0","id":1,"result":[...]}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
