### PR TITLE
Revert "Replace Kip103ContractCaller by BlockchainContractCaller"

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -510,7 +509,7 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 	if chain.Config().IsKIP103ForkBlock(header.Number) {
 		// RebalanceTreasury can modify the global state (state),
 		// so the existing state db should be used to apply the rebalancing result.
-		c := backends.NewBlockchainContractCaller(chain)
+		c := &Kip103ContractCaller{state, chain, header}
 		result, err := RebalanceTreasury(state, chain, header, c)
 		if err != nil {
 			logger.Error("failed to execute treasury rebalancing (KIP-103). State not changed", "err", err)

--- a/consensus/istanbul/backend/kip103.go
+++ b/consensus/istanbul/backend/kip103.go
@@ -1,12 +1,16 @@
 package backend
 
 import (
+	"context"
 	"errors"
 	"math/big"
 
+	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/state"
 	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/consensus"
 	"github.com/klaytn/klaytn/contracts/kip103"
@@ -16,6 +20,38 @@ var (
 	errNotEnoughRetiredBal = errors.New("the sum of retired accounts' balance is smaller than the distributing amount")
 	errNotProperStatus     = errors.New("cannot read a proper status value")
 )
+
+// Kip103ContractCaller is an implementation of contractCaller only for KIP-103.
+// The caller interacts with a KIP-103 contract on a read only basis.
+type Kip103ContractCaller struct {
+	state  *state.StateDB        // the state that is under process
+	chain  consensus.ChainReader // chain containing the blockchain information
+	header *types.Header         // the header of a new block that is under process
+}
+
+func (caller *Kip103ContractCaller) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	return caller.state.GetCode(contract), nil
+}
+
+func (caller *Kip103ContractCaller) CallContract(ctx context.Context, call klaytn.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	gasPrice := big.NewInt(0) // execute call regardless of the balance of the sender
+	gasLimit := uint64(1e8)   // enough gas limit to execute kip103 contract functions
+	intrinsicGas := uint64(0) // read operation doesn't require intrinsicGas
+
+	// call.From: zero address will be assigned if nothing is specified
+	// call.To: the target contract address will be assigned by `BoundContract`
+	// call.Value: nil value is acceptable for `types.NewMessage`
+	// call.Data: a proper value will be assigned by `BoundContract`
+	msg := types.NewMessage(call.From, call.To, caller.state.GetNonce(call.From),
+		call.Value, gasLimit, gasPrice, call.Data, false, intrinsicGas)
+
+	context := blockchain.NewEVMContext(msg, caller.header, caller.chain, nil)
+	context.GasPrice = gasPrice                                                  // set gasPrice again if baseFee is assigned
+	evm := vm.NewEVM(context, caller.state, caller.chain.Config(), &vm.Config{}) // no additional vm config required
+
+	result, err := blockchain.ApplyMessage(evm, msg)
+	return result.Return(), err
+}
 
 type kip103result struct {
 	Retired map[common.Address]*big.Int `json:"retired"`


### PR DESCRIPTION
## Proposed changes

This reverts commit 15fb12bd2c70c2e6124c75053b96a6b8acc1dcb4.

BlockchainContractCaller as-is was not appropriate to substitute Kip103ContractCaller.
- Kip103ContractCaller, in its implementation, increments the `caller.From` nonce in `CallContract`
- BlockchainContractCaller does not
- This difference caused the Baobab sync test failure.

This PR revives Kip103ContractCaller as a quick fix.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
