### PR TITLE
KIP-103 code uses PendingContractCaller with intermediate state

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -63,6 +63,7 @@ type BlockchainContractCaller struct {
 
 // This nil assignment ensures at compile time that BlockchainContractCaller implements bind.ContractCaller.
 var _ bind.ContractCaller = (*BlockchainContractCaller)(nil)
+var _ bind.PendingContractCaller = (*BlockchainContractCaller)(nil)
 
 func NewBlockchainContractCaller(bc BlockChainForCaller) *BlockchainContractCaller {
 	return &BlockchainContractCaller{

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -510,7 +510,7 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 	if chain.Config().IsKIP103ForkBlock(header.Number) {
 		// RebalanceTreasury can modify the global state (state),
 		// so the existing state db should be used to apply the rebalancing result.
-		c := backends.NewBlockchainContractCaller(chain)
+		c := backends.NewBlockchainPendingContractCaller(chain, header, state)
 		result, err := RebalanceTreasury(state, chain, header, c)
 		if err != nil {
 			logger.Error("failed to execute treasury rebalancing (KIP-103). State not changed", "err", err)

--- a/consensus/istanbul/backend/kip103_test.go
+++ b/consensus/istanbul/backend/kip103_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/accounts/abi"
+	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/contracts/kip103"
@@ -24,8 +25,14 @@ type mockKip103ContractCaller struct {
 	retMap     map[string][]interface{}
 }
 
+var _ (bind.PendingContractCaller) = (*mockKip103ContractCaller)(nil)
+
 func (caller *mockKip103ContractCaller) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
 	return []byte(kip103.TreasuryRebalanceBinRuntime), nil
+}
+
+func (caller *mockKip103ContractCaller) PendingCodeAt(ctx context.Context, contract common.Address) ([]byte, error) {
+	return caller.CodeAt(ctx, contract, nil)
 }
 
 func (caller *mockKip103ContractCaller) CallContract(ctx context.Context, call klaytn.CallMsg, blockNumber *big.Int) ([]byte, error) {
@@ -40,6 +47,10 @@ func (caller *mockKip103ContractCaller) CallContract(ctx context.Context, call k
 
 	mockRet := caller.retMap[mockKey]
 	return caller.abi.Methods[funcName].Outputs.Pack(mockRet...)
+}
+
+func (caller *mockKip103ContractCaller) PendingCallContract(ctx context.Context, call klaytn.CallMsg) ([]byte, error) {
+	return caller.CallContract(ctx, call, nil)
 }
 
 func TestRebalanceTreasury(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

Alternative fix to #1923.
- accounts/abi/bind/backends/blockchain.go
  BlockchainContractCaller implements PendingContractCaller
- consensus/istanbul/backend/engine.go
  Pass `header` and `state` to the PendingContractCaller as `pendingHeader` and `pendingState`.
- consensus/istanbul/backend/kip103.go
  Use `CallOpts{Pending: true}` at contract call sites

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments