### PR TITLE
[Client] Added misconsidered error handling

### DIFF
--- a/client/klay_client.go
+++ b/client/klay_client.go
@@ -228,12 +228,10 @@ func (ec *Client) TransactionInBlock(ctx context.Context, blockHash common.Hash,
 	if err != nil {
 		return nil, err
 	}
-	if err == nil {
-		if json == nil {
-			return nil, klaytn.NotFound
-		} else if sigs := json.tx.RawSignatureValues(); sigs[0].V == nil {
-			return nil, fmt.Errorf("server returned transaction without signature")
-		}
+	if json == nil {
+		return nil, klaytn.NotFound
+	} else if sigs := json.tx.RawSignatureValues(); sigs[0].V == nil {
+		return nil, fmt.Errorf("server returned transaction without signature")
 	}
 	if json.From != nil && json.BlockHash != nil {
 		setSenderFromServer(json.tx, *json.From, *json.BlockHash)

--- a/client/klay_client.go
+++ b/client/klay_client.go
@@ -225,6 +225,9 @@ func (ec *Client) TransactionCount(ctx context.Context, blockHash common.Hash) (
 func (ec *Client) TransactionInBlock(ctx context.Context, blockHash common.Hash, index uint) (*types.Transaction, error) {
 	var json *rpcTransaction
 	err := ec.c.CallContext(ctx, &json, "klay_getTransactionByBlockHashAndIndex", blockHash, hexutil.Uint64(index))
+	if err != nil {
+		return nil, err
+	}
 	if err == nil {
 		if json == nil {
 			return nil, klaytn.NotFound


### PR DESCRIPTION

## Proposed changes

The client function `TransactionInBlock()` had not correctly handled the internal function call error.  The expected error should be `the block does not exist` or something others, but it makes a runtime panic (at L241). This PR added an early exit when the return value of the internal function call is found as an error.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
