### PR TITLE
Add cool time in TestClientReconnect

### DIFF
--- a/networks/rpc/client_test.go
+++ b/networks/rpc/client_test.go
@@ -527,13 +527,15 @@ func TestClientReconnect(t *testing.T) {
 	// Shut down the server and try calling again. It shouldn't work.
 	l1.Close()
 	s1.Stop()
+
+	// Allow for some cool down time so we can listen on the same address again.
+	time.Sleep(2 * time.Second)
+
+	// Try calling again. It shouldn't work.
 	if err := client.CallContext(ctx, &resp, "service_echo", "", 2, nil); err == nil {
 		t.Error("successful call while the server is down")
 		t.Logf("resp: %#v", resp)
 	}
-
-	// Allow for some cool down time so we can listen on the same address again.
-	time.Sleep(2 * time.Second)
 
 	// Start it up again and call again. The connection should be reestablished.
 	// We spawn multiple calls here to check whether this hangs somehow.
@@ -554,6 +556,7 @@ func TestClientReconnect(t *testing.T) {
 	errcount := 0
 	for i := 0; i < cap(errors); i++ {
 		if err = <-errors; err != nil {
+			fmt.Println(err)
 			errcount++
 		}
 	}


### PR DESCRIPTION
## Proposed changes
- sometimes TestClientReconnect testcase failed in CI process
- rearrange server shutdown cooltime in TestClientReconnect(similar to geth)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
