### PR TITLE
bugfix: recoverFromMessage always returns klayEcRecover

### DIFF
--- a/api/api_private_account.go
+++ b/api/api_private_account.go
@@ -485,31 +485,37 @@ func (s *PrivateAccountAPI) Sign(ctx context.Context, data hexutil.Bytes, addr c
 //
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_ecRecover
 func (s *PrivateAccountAPI) EcRecover(ctx context.Context, data, sig hexutil.Bytes) (common.Address, error) {
-	pubkey, err := klayEthEcRecover(data, sig)
+	if len(sig) != crypto.SignatureLength {
+		return common.Address{}, fmt.Errorf("signature must be 65 bytes long")
+	}
+	if sig[crypto.RecoveryIDOffset] != 27 && sig[crypto.RecoveryIDOffset] != 28 {
+		return common.Address{}, fmt.Errorf("invalid Klaytn signature (V is not 27 or 28)")
+	}
+
+	// Transform yellow paper V from 27/28 to 0/1
+	sig[crypto.RecoveryIDOffset] -= 27
+
+	pubkey, err := klayEcRecover(data, sig)
 	if err != nil {
 		return common.Address{}, err
 	}
 	return crypto.PubkeyToAddress(*pubkey), nil
 }
 
-func klayEthEcRecover(data, sig hexutil.Bytes) (*ecdsa.PublicKey, error) {
-	if len(sig) != crypto.SignatureLength {
-		return nil, fmt.Errorf("signature must be 65 bytes long")
+func klayEcRecover(data, sig hexutil.Bytes) (*ecdsa.PublicKey, error) {
+	rpk, err := crypto.SigToPub(signHash(data), sig)
+	if err == nil {
+		return rpk, nil
 	}
-	if sig[crypto.RecoveryIDOffset] != 27 && sig[crypto.RecoveryIDOffset] != 28 {
-		return nil, fmt.Errorf("invalid Klaytn signature (V is not 27 or 28)")
-	}
-	sig[crypto.RecoveryIDOffset] -= 27 // Transform yellow paper V from 27/28 to 0/1
+	return nil, err // klayErr has more priority
+}
 
-	klayRpk, klayErr := crypto.SigToPub(signHash(data), sig)
-	if klayErr == nil {
-		return klayRpk, nil
+func ethEcRecover(data, sig hexutil.Bytes) (*ecdsa.PublicKey, error) {
+	rpk, err := crypto.SigToPub(ethSignHash(data), sig)
+	if err == nil {
+		return rpk, nil
 	}
-	ethRpk, ethErr := crypto.SigToPub(ethSignHash(data), sig)
-	if ethErr == nil {
-		return ethRpk, nil
-	}
-	return nil, klayErr // klayErr has more priority
+	return nil, err
 }
 
 // SignAndSendTransaction was renamed to SendTransaction. This method is deprecated

--- a/api/api_private_account.go
+++ b/api/api_private_account.go
@@ -503,19 +503,11 @@ func (s *PrivateAccountAPI) EcRecover(ctx context.Context, data, sig hexutil.Byt
 }
 
 func klayEcRecover(data, sig hexutil.Bytes) (*ecdsa.PublicKey, error) {
-	rpk, err := crypto.SigToPub(signHash(data), sig)
-	if err == nil {
-		return rpk, nil
-	}
-	return nil, err // klayErr has more priority
+	return crypto.SigToPub(signHash(data), sig)
 }
 
 func ethEcRecover(data, sig hexutil.Bytes) (*ecdsa.PublicKey, error) {
-	rpk, err := crypto.SigToPub(ethSignHash(data), sig)
-	if err == nil {
-		return rpk, nil
-	}
-	return nil, err
+	return crypto.SigToPub(ethSignHash(data), sig)
 }
 
 // SignAndSendTransaction was renamed to SendTransaction. This method is deprecated

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -601,6 +601,9 @@ func (s *PublicTransactionPoolAPI) RecoverFromMessage(
 	}
 	key := state.GetKey(address)
 
+	// We cannot identify if the signature has signed with klay or eth prefix without the signer's address.
+	// Even though a user signed message with eth prefix, it will return invalid something in klayEcRecover.
+	// We should call each rcrecover function separately and the actual result will be checked in ValidateMember.
 	var recoverErr error
 	if pubkey, err := klayEcRecover(data, sig); err == nil {
 		if key.ValidateMember(pubkey, address) {


### PR DESCRIPTION
## Proposed changes

- changes
  - existing ecrecover only covers klayEcrecover (`\x19Klaytn Signed Message` prefix case)
- fix
  - after checking both klay and eth ecrecover, return the recovered address only if either matches

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

