### PR TITLE
Set a blocknumber of Baobab ShanghaiCompatible Hardfork

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -82,7 +82,7 @@ var (
 		KoreCompatibleBlock:      big.NewInt(111736800),
 		Kip103CompatibleBlock:    big.NewInt(119145600),
 		Kip103ContractAddress:    common.HexToAddress("0xD5ad6D61Dd87EdabE2332607C328f5cc96aeCB95"),
-		ShanghaiCompatibleBlock:  nil,
+		ShanghaiCompatibleBlock:  big.NewInt(131608000),
 		DeriveShaImpl:            2,
 		Governance: &GovernanceConfig{
 			GoverningNode:  common.HexToAddress("0x99fb17d324fa0e07f23b49d09028ac0919414db6"),


### PR DESCRIPTION
## Proposed changes

- Set a blocknumber of Baobab ShanghaiCompatible Hardfork
- [baobab 131608000 = 2023-08-28 10:30 KST](https://baobab.scope.klaytn.com/blockCount/131608000)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
