### PR TITLE
Fix nil pointer dereference during GetConsensusInfo API execution

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -80,7 +80,7 @@ func (api *API) GetValidators(number *rpc.BlockNumber) ([]common.Address, error)
 
 	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64()-1, header.ParentHash, nil, false)
 	if err != nil {
-		logger.Error("Failed to get snapshot.", "hash", snap.Hash, "err", err)
+		logger.Error("Failed to get snapshot.", "blockNum", blockNumber, "err", err)
 		return nil, err
 	}
 	return snap.validators(), nil
@@ -105,7 +105,7 @@ func (api *API) GetValidatorsAtHash(hash common.Hash) ([]common.Address, error) 
 
 	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64()-1, header.ParentHash, nil, false)
 	if err != nil {
-		logger.Error("Failed to get snapshot.", "hash", snap.Hash, "err", err)
+		logger.Error("Failed to get snapshot.", "blockNum", blockNumber, "err", err)
 		return nil, errInternalError
 	}
 	return snap.validators(), nil
@@ -122,14 +122,14 @@ func (api *API) GetDemoteValidators(number *rpc.BlockNumber) ([]common.Address, 
 	if blockNumber == 0 {
 		snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil, false)
 		if err != nil {
-			logger.Error("Failed to get snapshot.", "hash", snap.Hash, "err", err)
+			logger.Error("Failed to get snapshot.", "blockNum", blockNumber, "err", err)
 			return nil, err
 		}
 		return snap.demotedValidators(), nil
 	} else {
 		snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64()-1, header.ParentHash, nil, false)
 		if err != nil {
-			logger.Error("Failed to get snapshot.", "hash", snap.Hash, "err", err)
+			logger.Error("Failed to get snapshot.", "blockNum", blockNumber, "err", err)
 			return nil, err
 		}
 		return snap.demotedValidators(), nil
@@ -147,14 +147,14 @@ func (api *API) GetDemotedValidatorsAtHash(hash common.Hash) ([]common.Address, 
 	if blockNumber == 0 {
 		snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil, false)
 		if err != nil {
-			logger.Error("Failed to get snapshot.", "hash", snap.Hash, "err", err)
+			logger.Error("Failed to get snapshot.", "blockNum", blockNumber, "err", err)
 			return nil, err
 		}
 		return snap.demotedValidators(), nil
 	} else {
 		snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64()-1, header.ParentHash, nil, false)
 		if err != nil {
-			logger.Error("Failed to get snapshot.", "hash", snap.Hash, "err", err)
+			logger.Error("Failed to get snapshot.", "blockNum", blockNumber, "err", err)
 			return nil, err
 		}
 		return snap.demotedValidators(), nil
@@ -229,7 +229,7 @@ func (api *APIExtension) GetCouncil(number *rpc.BlockNumber) ([]common.Address, 
 
 	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64()-1, header.ParentHash, nil, false)
 	if err != nil {
-		logger.Error("Failed to get snapshot.", "hash", snap.Hash, "err", err)
+		logger.Error("Failed to get snapshot.", "blockNum", blockNumber, "err", err)
 		return nil, err
 	}
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -762,7 +762,7 @@ func (sb *backend) GetConsensusInfo(block *types.Block) (consensus.ConsensusInfo
 	parentHash := block.ParentHash()
 	snap, err := sb.snapshot(sb.chain, blockNumber-1, parentHash, nil, false)
 	if err != nil {
-		logger.Error("Failed to get snapshot.", "hash", snap.Hash, "err", err)
+		logger.Error("Failed to get snapshot.", "blockNum", blockNumber, "err", err)
 		return consensus.ConsensusInfo{}, errInternalError
 	}
 


### PR DESCRIPTION
## Proposed changes

When `snapshot` returns an error, `snap` becomes `nil`. So, the current log message trying to print `snap.hash` can cause a nil pointer dereference panic during the GetConsensusInfo API execution. 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
