### PR TITLE
Changed TryCatchUpWithPrimary method periodically

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2228,6 +2228,11 @@ func (bc *BlockChain) CurrentBlockUpdateLoop(pool *TxPool) {
 	for {
 		select {
 		case <-refresher.C:
+			if err := bc.db.TryCatchUpWithPrimary(); err != nil {
+				logger.Error("Failed to catch up with primary", "err", err)
+				continue
+			}
+
 			// Restore the last known head block
 			head := bc.db.ReadHeadBlockHash()
 			if head == (common.Hash{}) {

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -524,10 +524,13 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 	cfg.LevelDBCacheSize = ctx.Int(LevelDBCacheSizeFlag.Name)
 
 	cfg.RocksDBConfig.Secondary = ctx.Bool(RocksDBSecondaryFlag.Name)
+	cfg.RocksDBConfig.MaxOpenFiles = ctx.Int(RocksDBMaxOpenFilesFlag.Name)
 	if cfg.RocksDBConfig.Secondary {
 		cfg.FetcherDisable = true
 		cfg.DownloaderDisable = true
 		cfg.WorkerDisable = true
+		cfg.RocksDBConfig.MaxOpenFiles = -1
+		logger.Info("Secondary rocksdb is enabled, disabling fetcher, downloader, worker. MaxOpenFiles is forced to unlimited")
 	}
 	cfg.RocksDBConfig.CacheSize = ctx.Uint64(RocksDBCacheSizeFlag.Name)
 	cfg.RocksDBConfig.DumpMallocStat = ctx.Bool(RocksDBDumpMallocStatFlag.Name)
@@ -535,7 +538,6 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 	cfg.RocksDBConfig.BottommostCompressionType = ctx.String(RocksDBBottommostCompressionTypeFlag.Name)
 	cfg.RocksDBConfig.FilterPolicy = ctx.String(RocksDBFilterPolicyFlag.Name)
 	cfg.RocksDBConfig.DisableMetrics = ctx.Bool(RocksDBDisableMetricsFlag.Name)
-	cfg.RocksDBConfig.MaxOpenFiles = ctx.Int(RocksDBMaxOpenFilesFlag.Name)
 	cfg.RocksDBConfig.CacheIndexAndFilter = ctx.Bool(RocksDBCacheIndexAndFilterFlag.Name)
 
 	cfg.DynamoDBConfig.TableName = ctx.String(DynamoDBTableNameFlag.Name)

--- a/storage/database/badger_database.go
+++ b/storage/database/badger_database.go
@@ -206,6 +206,10 @@ func (bg *badgerDB) GetProperty(name string) string {
 	return ""
 }
 
+func (bg *badgerDB) TryCatchUpWithPrimary() error {
+	return nil
+}
+
 type badgerBatch struct {
 	db   *badger.DB
 	txn  *badger.Txn

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -300,6 +300,8 @@ type DBManager interface {
 	// ChainDataFetcher checkpoint function
 	WriteChainDataFetcherCheckpoint(checkpoint uint64) error
 	ReadChainDataFetcherCheckpoint() (uint64, error)
+
+	TryCatchUpWithPrimary() error
 }
 
 type DBEntryType uint8
@@ -863,6 +865,17 @@ func (dbm *databaseManager) GetSnapshotDB() Database {
 
 func (dbm *databaseManager) GetProperty(dt DBEntryType, name string) string {
 	return dbm.getDatabase(dt).GetProperty(name)
+}
+
+func (dbm *databaseManager) TryCatchUpWithPrimary() error {
+	for _, db := range dbm.dbs {
+		if db != nil {
+			if err := db.TryCatchUpWithPrimary(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (dbm *databaseManager) GetMemDB() *MemDB {

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -448,6 +448,10 @@ func (dynamo *dynamoDB) GetProperty(name string) string {
 	return ""
 }
 
+func (dynamo *dynamoDB) TryCatchUpWithPrimary() error {
+	return nil
+}
+
 func (dynamo *dynamoDB) NewIterator(prefix []byte, start []byte) Iterator {
 	// TODO-Klaytn: implement this later.
 	return nil

--- a/storage/database/interface.go
+++ b/storage/database/interface.go
@@ -80,6 +80,7 @@ type Database interface {
 	Iteratee
 
 	GetProperty(name string) string
+	TryCatchUpWithPrimary() error
 }
 
 func WriteBatches(batches ...Batch) (int, error) {

--- a/storage/database/leveldb_database.go
+++ b/storage/database/leveldb_database.go
@@ -508,6 +508,10 @@ func (db *levelDB) GetProperty(name string) string {
 	return db.GetProperty(name)
 }
 
+func (db *levelDB) TryCatchUpWithPrimary() error {
+	return nil
+}
+
 func (db *levelDB) NewBatch() Batch {
 	return &ldbBatch{b: new(leveldb.Batch), ldb: db}
 }

--- a/storage/database/memory_database.go
+++ b/storage/database/memory_database.go
@@ -198,6 +198,10 @@ func (db *MemDB) GetProperty(name string) string {
 	return ""
 }
 
+func (db *MemDB) TryCatchUpWithPrimary() error {
+	return nil
+}
+
 // keyvalue is a key-value tuple tagged with a deletion field to allow creating
 // memory-database write batches.
 type keyvalue struct {

--- a/storage/database/rocksdb_database.go
+++ b/storage/database/rocksdb_database.go
@@ -181,10 +181,6 @@ func (db *rocksDB) Put(key []byte, value []byte) error {
 }
 
 func (db *rocksDB) Has(key []byte) (bool, error) {
-	if db.config.Secondary {
-		db.db.TryCatchUpWithPrimary()
-	}
-
 	dat, err := db.db.GetBytes(db.ro, key)
 	if dat == nil || err != nil {
 		return false, err
@@ -194,9 +190,6 @@ func (db *rocksDB) Has(key []byte) (bool, error) {
 }
 
 func (db *rocksDB) Get(key []byte) ([]byte, error) {
-	if db.config.Secondary {
-		db.db.TryCatchUpWithPrimary()
-	}
 	if !db.config.DisableMetrics {
 		start := time.Now()
 		defer db.getTimer.Update(time.Since(start))
@@ -225,6 +218,10 @@ func (db *rocksDB) Delete(key []byte) error {
 
 func (db *rocksDB) GetProperty(name string) string {
 	return db.db.GetProperty(name)
+}
+
+func (db *rocksDB) TryCatchUpWithPrimary() error {
+	return db.db.TryCatchUpWithPrimary()
 }
 
 type rdbIter struct {

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -446,6 +446,15 @@ func (db *shardedDB) GetProperty(name string) string {
 	return buf.String()
 }
 
+func (db *shardedDB) TryCatchUpWithPrimary() error {
+	for _, shard := range db.shards {
+		if err := shard.TryCatchUpWithPrimary(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type shardedDBBatch struct {
 	batches    []Batch
 	numBatches uint


### PR DESCRIPTION
## Proposed changes

- `TryCatchUpWithPrimary` consumes too much resource whenever it is called on `Get`/`Has` method. So, this catchup method is moved to current block update method.
- Secondary instance must use unlimited max open files so that it is forced to set the configuration whenever it should be.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
