### PR TITLE
added no chain reader error on GetConsensusInfo method

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -758,6 +758,10 @@ func (sb *backend) GetConsensusInfo(block *types.Block) (consensus.ConsensusInfo
 		return consensus.ConsensusInfo{}, err
 	}
 
+	if sb.chain == nil {
+		return consensus.ConsensusInfo{}, errNoChainReader
+	}
+
 	// get the snapshot of the previous block.
 	parentHash := block.ParentHash()
 	snap, err := sb.snapshot(sb.chain, blockNumber-1, parentHash, nil, false)


### PR DESCRIPTION
## Proposed changes

- This PR protects panic issue when `GetConsensusInfo` method is called before `ChainReader` is set on `backend`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

