### PR TITLE
Add account subcommands for BLS key handling

### DIFF
--- a/accounts/keystore/key2335.go
+++ b/accounts/keystore/key2335.go
@@ -1,0 +1,95 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// Modified by Prysmatic Labs 2018
+// Modified by the klaytn Authors 2023
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package keystore
+
+import (
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/klaytn/klaytn/crypto/bls"
+	"github.com/pborman/uuid"
+	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
+)
+
+// KeyEIP2335 is a decrypted BLS12-381 keypair.
+type KeyEIP2335 struct {
+	ID uuid.UUID // Version 4 "random" for unique id not derived from key data
+
+	PublicKey bls.PublicKey // Represents the public key of the user.
+	SecretKey bls.SecretKey // Represents the private key of the user.
+}
+
+type encryptedKeyEIP2335JSON struct {
+	PublicKey string                 `json:"publickey"`
+	Crypto    map[string]interface{} `json:"crypto"`
+	ID        string                 `json:"id"`
+}
+
+// NewKeyEIP2335 creates a new EIP-2335 keystore Key type using a BLS private key.
+func NewKeyEIP2335(blsKey bls.SecretKey) *KeyEIP2335 {
+	return &KeyEIP2335{
+		ID:        uuid.NewRandom(),
+		PublicKey: blsKey.PublicKey(),
+		SecretKey: blsKey,
+	}
+}
+
+// DecryptKeyEIP2335 decrypts a key from an EIP-2335 JSON blob, returning the BLS private key.
+func DecryptKeyEIP2335(keyJSON []byte, password string) (*KeyEIP2335, error) {
+	k := new(encryptedKeyEIP2335JSON)
+	if err := json.Unmarshal(keyJSON, k); err != nil {
+		return nil, err
+	}
+
+	decryptor := keystorev4.New()
+	keyBytes, err := decryptor.Decrypt(k.Crypto, password)
+	if err != nil {
+		return nil, err
+	}
+
+	secretKey, err := bls.SecretKeyFromBytes(keyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KeyEIP2335{
+		ID:        uuid.Parse(k.ID),
+		PublicKey: secretKey.PublicKey(),
+		SecretKey: secretKey,
+	}, nil
+}
+
+// EncryptKeyEIP2335 encrypts a BLS key using the specified scrypt parameters into a JSON
+// blob that can be decrypted later on.
+func EncryptKeyEIP2335(key *KeyEIP2335, password string, scryptN, scryptP int) ([]byte, error) {
+	keyBytes := key.SecretKey.Marshal()
+	encryptor := keystorev4.New()
+	cryptoObj, err := encryptor.Encrypt(keyBytes, password)
+	if err != nil {
+		return nil, err
+	}
+
+	encryptedJSON := encryptedKeyEIP2335JSON{
+		hex.EncodeToString(key.PublicKey.Marshal()),
+		cryptoObj,
+		key.ID.String(),
+	}
+	return json.Marshal(encryptedJSON)
+}

--- a/accounts/keystore/key2335.go
+++ b/accounts/keystore/key2335.go
@@ -22,6 +22,7 @@ package keystore
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 
 	"github.com/klaytn/klaytn/crypto/bls"
 	"github.com/pborman/uuid"
@@ -39,7 +40,7 @@ type KeyEIP2335 struct {
 type encryptedKeyEIP2335JSON struct {
 	PublicKey string                 `json:"publickey"`
 	Crypto    map[string]interface{} `json:"crypto"`
-	ID        string                 `json:"id"`
+	ID        string                 `json:"uuid"`
 }
 
 // NewKeyEIP2335 creates a new EIP-2335 keystore Key type using a BLS private key.
@@ -58,6 +59,11 @@ func DecryptKeyEIP2335(keyJSON []byte, password string) (*KeyEIP2335, error) {
 		return nil, err
 	}
 
+	id := uuid.Parse(k.ID)
+	if id == nil {
+		return nil, errors.New("Invalid UUID")
+	}
+
 	decryptor := keystorev4.New()
 	keyBytes, err := decryptor.Decrypt(k.Crypto, password)
 	if err != nil {
@@ -70,7 +76,7 @@ func DecryptKeyEIP2335(keyJSON []byte, password string) (*KeyEIP2335, error) {
 	}
 
 	return &KeyEIP2335{
-		ID:        uuid.Parse(k.ID),
+		ID:        id,
 		PublicKey: secretKey.PublicKey(),
 		SecretKey: secretKey,
 	}, nil

--- a/accounts/keystore/key2335_test.go
+++ b/accounts/keystore/key2335_test.go
@@ -1,3 +1,19 @@
+// Copyright 2018 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
 package keystore
 
 import (

--- a/accounts/keystore/key2335_test.go
+++ b/accounts/keystore/key2335_test.go
@@ -16,17 +16,17 @@ func TestEncryptDecryptEIP2335(t *testing.T) {
 	sk, err := bls.RandKey()
 	require.Nil(t, err)
 
-	plain1 := NewKeyEIP2335(sk)
+	plain := NewKeyEIP2335(sk)
 
-	encrypted, err := EncryptKeyEIP2335(plain1, password, LightScryptN, LightScryptP)
+	encrypted, err := EncryptKeyEIP2335(plain, password, LightScryptN, LightScryptP)
 	require.Nil(t, err)
 
-	plain2, err := DecryptKeyEIP2335(encrypted, password)
+	decrypted, err := DecryptKeyEIP2335(encrypted, password)
 	require.Nil(t, err)
 
-	assert.Equal(t, plain1.ID, plain2.ID)
-	assert.Equal(t, plain1.SecretKey.Marshal(), plain2.SecretKey.Marshal())
-	assert.Equal(t, plain1.PublicKey.Marshal(), plain2.PublicKey.Marshal())
+	assert.Equal(t, plain.ID, decrypted.ID)
+	assert.Equal(t, plain.SecretKey.Marshal(), decrypted.SecretKey.Marshal())
+	assert.Equal(t, plain.PublicKey.Marshal(), decrypted.PublicKey.Marshal())
 }
 
 func TestDecryptEIP2335(t *testing.T) {

--- a/accounts/keystore/key2335_test.go
+++ b/accounts/keystore/key2335_test.go
@@ -1,0 +1,50 @@
+package keystore
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/crypto/bls"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptDecryptEIP2335(t *testing.T) {
+	password := "password"
+	sk, err := bls.RandKey()
+	require.Nil(t, err)
+
+	plain1 := NewKeyEIP2335(sk)
+
+	encrypted, err := EncryptKeyEIP2335(plain1, password, LightScryptN, LightScryptP)
+	require.Nil(t, err)
+
+	plain2, err := DecryptKeyEIP2335(encrypted, password)
+	require.Nil(t, err)
+
+	assert.Equal(t, plain1.ID, plain2.ID)
+	assert.Equal(t, plain1.SecretKey.Marshal(), plain2.SecretKey.Marshal())
+	assert.Equal(t, plain1.PublicKey.Marshal(), plain2.PublicKey.Marshal())
+}
+
+func TestDecryptEIP2335(t *testing.T) {
+	var (
+		// https://eips.ethereum.org/EIPS/eip-2335 test vectors
+		passwordBytes, _ = os.ReadFile("testdata/eip2335_password.txt")
+		password         = strings.TrimSpace(string(passwordBytes))
+		keyBytes         = hexutil.MustDecode("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")
+
+		scryptJSON, _ = os.ReadFile("testdata/eip2335_scrypt.json")
+		pbkdf2JSON, _ = os.ReadFile("testdata/eip2335_pbkdf2.json")
+	)
+
+	k, err := DecryptKeyEIP2335(scryptJSON, password)
+	require.Nil(t, err)
+	assert.Equal(t, keyBytes, k.SecretKey.Marshal())
+
+	k, err = DecryptKeyEIP2335(pbkdf2JSON, password)
+	require.Nil(t, err)
+	assert.Equal(t, keyBytes, k.SecretKey.Marshal())
+}

--- a/accounts/keystore/testdata/eip2335_password.txt
+++ b/accounts/keystore/testdata/eip2335_password.txt
@@ -1,0 +1,1 @@
+testpassword🔑

--- a/accounts/keystore/testdata/eip2335_pbkdf2.json
+++ b/accounts/keystore/testdata/eip2335_pbkdf2.json
@@ -1,0 +1,31 @@
+{
+    "crypto": {
+        "kdf": {
+            "function": "pbkdf2",
+            "params": {
+                "dklen": 32,
+                "c": 262144,
+                "prf": "hmac-sha256",
+                "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+            },
+            "message": ""
+        },
+        "checksum": {
+            "function": "sha256",
+            "params": {},
+            "message": "8a9f5d9912ed7e75ea794bc5a89bca5f193721d30868ade6f73043c6ea6febf1"
+        },
+        "cipher": {
+            "function": "aes-128-ctr",
+            "params": {
+                "iv": "264daa3f303d7259501c93d997d84fe6"
+            },
+            "message": "cee03fde2af33149775b7223e7845e4fb2c8ae1792e5f99fe9ecf474cc8c16ad"
+        }
+    },
+    "description": "This is a test keystore that uses PBKDF2 to secure the secret.",
+    "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
+    "path": "m/12381/60/0/0",
+    "uuid": "64625def-3331-4eea-ab6f-782f3ed16a83",
+    "version": 4
+}

--- a/accounts/keystore/testdata/eip2335_scrypt.json
+++ b/accounts/keystore/testdata/eip2335_scrypt.json
@@ -1,0 +1,32 @@
+{
+    "crypto": {
+        "kdf": {
+            "function": "scrypt",
+            "params": {
+                "dklen": 32,
+                "n": 262144,
+                "p": 1,
+                "r": 8,
+                "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+            },
+            "message": ""
+        },
+        "checksum": {
+            "function": "sha256",
+            "params": {},
+            "message": "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484"
+        },
+        "cipher": {
+            "function": "aes-128-ctr",
+            "params": {
+                "iv": "264daa3f303d7259501c93d997d84fe6"
+            },
+            "message": "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f"
+        }
+    },
+    "description": "This is a test keystore that uses scrypt to secure the secret.",
+    "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
+    "path": "m/12381/60/3141592653/589793238",
+    "uuid": "1d85ae20-35c5-4611-98e8-aa14a633906f",
+    "version": 4
+}

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -257,10 +257,8 @@ func LoadBlsNodeKey(ctx *cli.Context) (bls.SecretKey, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(content) > 64 {
-			content = content[:64]
-		}
-		blsBytes, err := hex.DecodeString(string(content))
+		str := strings.TrimSpace(string(content))
+		blsBytes, err := hex.DecodeString(str)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1124,6 +1124,27 @@ var (
 		EnvVars:  []string{"KLAYTN_NODEKEYHEX"},
 		Category: "NETWORK",
 	}
+	BlsNodeKeyFileFlag = &cli.StringFlag{
+		Name:     "bls-nodekey",
+		Usage:    "Consensus BLS node key file",
+		Aliases:  []string{"p2p.bls-node-key"},
+		EnvVars:  []string{"KLAYTN_BLS_NODEKEY"},
+		Category: "NETWORK",
+	}
+	BlsNodeKeyHexFlag = &cli.StringFlag{
+		Name:     "bls-nodekeyhex",
+		Usage:    "Consensus BLS node key in hex (for testing)",
+		Aliases:  []string{"p2p.bls-node-key-hex"},
+		EnvVars:  []string{"KLAYTN_BLS_NODEKEYHEX"},
+		Category: "NETWORK",
+	}
+	BlsNodeKeystoreFileFlag = &cli.StringFlag{
+		Name:     "bls-nodekeystore",
+		Usage:    "Consensus BLS node keystore JSON file",
+		Aliases:  []string{"p2p.bls-node-keystore"},
+		EnvVars:  []string{"KLAYTN_BLS_NODEKEYSTORE"},
+		Category: "NETWORK",
+	}
 	NATFlag = &cli.StringFlag{
 		Name:     "nat",
 		Usage:    "NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)",

--- a/cmd/utils/nodecmd/accountcmd.go
+++ b/cmd/utils/nodecmd/accountcmd.go
@@ -90,7 +90,7 @@ The account is saved in encrypted format, you are prompted for a passphrase.
 
 You must remember this passphrase to unlock your account in the future.
 
-For non-interactive use the passphrase can be specified with the ---password flag:
+For non-interactive use the passphrase can be specified with the --password flag:
 
 Note, this is meant to be used for testing only, it is a bad idea to save your
 password to file or expose in any other way.
@@ -115,7 +115,7 @@ for a passphrase to unlock the account and another to save the updated file.
 This same command can therefore be used to migrate an account of a deprecated
 format to the newest format or change the password for an account.
 
-For non-interactive use the passphrase can be specified with the ---password flag:
+For non-interactive use the passphrase can be specified with the --password flag:
 
 Since only one password can be given, only format update can be performed,
 changing your password is only possible interactively.

--- a/cmd/utils/nodecmd/accountcmd.go
+++ b/cmd/utils/nodecmd/accountcmd.go
@@ -176,13 +176,13 @@ The input must be one of the following:
 EXAMPLES
 
 # Print public key info of the BLS key derived from the EC nodekey
-kcn acount bls-info --nodekey /var/kcnd/data/nodekey
+kcn account bls-info --nodekey /var/kcnd/data/nodekey
 
 # Print public key info of the saved BLS key
-kcn acount bls-info --bls-nodekey /var/kcnd/data/bls-nodekey
+kcn account bls-info --bls-nodekey /var/kcnd/data/bls-nodekey
 
 # Print public key info of the BLS key inside EIP-2335 keystore
-kcn acount bls-info --bls-nodekeystore blskey.json
+kcn account bls-info --bls-nodekeystore blskey.json
 `,
 		},
 		{

--- a/cmd/utils/nodecmd/accountcmd_test.go
+++ b/cmd/utils/nodecmd/accountcmd_test.go
@@ -272,3 +272,32 @@ Fatal: None of the listed files could be unlocked.
 `)
 	klay.ExpectExit()
 }
+
+func TestBlsInfoPrintOnly(t *testing.T) {
+	klay := runKlay(t, "klay-test", "account", "bls-info",
+		"--nodekeyhex", "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+	defer klay.ExpectExit()
+
+	klay.ExpectRegexp(`{"pop":"[0-9a-f]{192}","pub":"[0-9a-f]{96}"}\s*$`)
+}
+
+func TestBlsDecrypt(t *testing.T) {
+	jsonPath := "../../../accounts/keystore/testdata/eip2335_scrypt.json"
+	passwordPath := "../../../accounts/keystore/testdata/eip2335_password.txt"
+
+	klay := runKlay(t, "klay-test", "account", "bls-decrypt",
+		"--bls-nodekeystore", jsonPath, "--password", passwordPath)
+	defer klay.ExpectExit()
+
+	klay.ExpectRegexp(`000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f\s*$`)
+}
+
+func TestBlsEncrypt(t *testing.T) {
+	klay := runKlay(t, "klay-test", "account", "bls-encrypt",
+		"--bls-nodekeyhex", "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")
+	defer klay.ExpectExit()
+
+	klay.InputLine("1234") // Enter password
+	klay.InputLine("1234") // Confirm password
+	klay.ExpectRegexp(`{"publickey":"[0-9a-f]{96}","crypto":{.*},"id":".*"}\s*$`)
+}

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -35,6 +35,7 @@ type (
 // Such naming should provide compatiblity with prysm code snippets,
 // in case prysm code snippets are integrated to klaytn.
 //
+// ikm -> SK:  GenerateKey
 // ()  -> SK:  RandKey
 // b32 -> SK:  SecretKeyFromBytes
 // b48 -> PK:  PublicKeyFromBytes
@@ -51,6 +52,15 @@ type (
 //
 // Sign(SK, msg) -> Sig
 // VerifySignature(b96, msg, PK) -> ok, err
+// PopProve(SK) -> Proof
+// PoPVerify(PK, Proof) -> ok, err
+
+// GenerateKey generates a BLS secret key from the initial key material (IKM).
+// It is deterministic process. Same IKM yields the same secret key.
+// It can convert an existing EC private key to BLS secret key.
+func GenerateKey(ikm []byte) (SecretKey, error) {
+	return blst.GenerateKey(ikm)
+}
 
 // RandKey generates a random BLS secret key.
 func RandKey() (SecretKey, error) {
@@ -124,4 +134,19 @@ func VerifySignature(sig []byte, msg [32]byte, pk PublicKey) (bool, error) {
 // VerifyMultipleSignatures verifies multiple signatures for distinct messages securely.
 func VerifyMultipleSignatures(sigs [][]byte, msgs [][32]byte, pubKeys []PublicKey) (bool, error) {
 	return blst.VerifyMultipleSignatures(sigs, msgs, pubKeys)
+}
+
+// PopProve calculates the proof-of-possession for the secret key,
+// which is the signature with its public key as message.
+func PopProve(sk SecretKey) Signature {
+	// draft-irtf-cfrg-bls-signature-05 section 3.3.2. PopProve
+	msg := sk.PublicKey().Marshal()
+	return blst.Sign(sk, msg)
+}
+
+// PopVerify verifies the proof-of-possession for the public key.
+func PopVerify(pk PublicKey, proof Signature) bool {
+	// draft-irtf-cfrg-bls-signature-05 section 3.3.3. PopVerify
+	msg := pk.Marshal()
+	return blst.Verify(proof, msg, pk)
 }

--- a/crypto/bls/bls_test.go
+++ b/crypto/bls/bls_test.go
@@ -87,3 +87,21 @@ func TestMultipleVerify(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, ok)
 }
+
+func TestPop(t *testing.T) {
+	var (
+		sk1, _ = RandKey()
+		sk2, _ = RandKey()
+
+		pk1 = sk1.PublicKey()
+		pk2 = sk2.PublicKey()
+
+		pop1 = PopProve(sk1)
+		pop2 = PopProve(sk2)
+	)
+
+	assert.True(t, PopVerify(pk1, pop1))
+	assert.True(t, PopVerify(pk2, pop2))
+	assert.False(t, PopVerify(pk1, pop2))
+	assert.False(t, PopVerify(pk2, pop1))
+}

--- a/crypto/bls/blst/secret_key.go
+++ b/crypto/bls/blst/secret_key.go
@@ -28,10 +28,11 @@ type secretKey struct {
 	p *blstSecretKey
 }
 
-func RandKey() (types.SecretKey, error) {
-	ikm := make([]byte, 32)
-	if _, err := rand.Read(ikm); err != nil {
-		return nil, err
+func GenerateKey(ikm []byte) (types.SecretKey, error) {
+	// draft-irtf-cfrg-bls-signature-05 section 2.3. KeyGen
+	// requires that IKM MUST be at least 32 bytes long, but it MAY be longer.
+	if len(ikm) < 32 {
+		return nil, types.ErrSecretKeyGen
 	}
 
 	p := blst.KeyGen(ikm)
@@ -39,6 +40,14 @@ func RandKey() (types.SecretKey, error) {
 		return nil, types.ErrSecretKeyGen
 	}
 	return &secretKey{p: p}, nil
+}
+
+func RandKey() (types.SecretKey, error) {
+	ikm := make([]byte, 32)
+	if _, err := rand.Read(ikm); err != nil {
+		return nil, err
+	}
+	return GenerateKey(ikm)
 }
 
 func SecretKeyFromBytes(b []byte) (types.SecretKey, error) {

--- a/crypto/bls/blst/secret_key_test.go
+++ b/crypto/bls/blst/secret_key_test.go
@@ -24,9 +24,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// https://github.com/ethereum/bls12-381-tests
-// sign/sign_case_142f678a8d05fcd1.json
-var testSecretKeyBytes = common.FromHex("0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138")
+var (
+	// https://github.com/ethereum/bls12-381-tests
+	// sign/sign_case_142f678a8d05fcd1.json
+	testSecretKeyBytes = common.FromHex("0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138")
+
+	// Standard test mnemonic test..junk
+	testEcPrivateKeyBytes = common.FromHex("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+)
+
+func TestGenerateKey(t *testing.T) {
+	sk1, err := GenerateKey(testEcPrivateKeyBytes)
+	assert.Nil(t, err)
+
+	sk2, err := GenerateKey(testEcPrivateKeyBytes)
+	assert.Nil(t, err)
+
+	// GenerateKey is deterministic
+	assert.Equal(t, sk1.Marshal(), sk2.Marshal())
+}
 
 func TestRandKey(t *testing.T) {
 	sk, err := RandKey()

--- a/crypto/bls/blst/signature.go
+++ b/crypto/bls/blst/signature.go
@@ -40,6 +40,7 @@ func SignatureFromBytes(b []byte) (types.Signature, error) {
 	}
 
 	p := new(blstSignature).Uncompress(b)
+	// Do not check for infinity since an aggregated signature could be infinite.
 	if p == nil || !p.SigValidate(false) {
 		return nil, types.ErrSignatureUnmarshal
 	}
@@ -83,6 +84,7 @@ func MultipleSignaturesFromBytes(bs [][]byte) ([]types.Signature, error) {
 		p := batchPs[i]
 		b := batchBytes[i]
 
+		// Do not check for infinity since an aggregated signature could be infinite.
 		if p == nil || !p.SigValidate(false) {
 			return nil, types.ErrSignatureUnmarshal
 		}

--- a/go.mod
+++ b/go.mod
@@ -56,9 +56,9 @@ require (
 	github.com/urfave/cli/v2 v2.25.7
 	github.com/valyala/fasthttp v1.34.0
 	go.uber.org/zap v1.13.0
-	golang.org/x/crypto v0.1.0
+	golang.org/x/crypto v0.6.0
 	golang.org/x/net v0.7.0
-	golang.org/x/sys v0.5.0
+	golang.org/x/sys v0.10.0
 	golang.org/x/tools v0.2.0
 	google.golang.org/grpc v1.53.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.42.0
@@ -122,6 +122,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/tinylib/msgp v1.1.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.uber.org/atomic v1.5.0 // indirect
 	go.uber.org/multierr v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -503,6 +503,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.34.0 h1:d3AAQJ2DRcxJYHm7OXNXtXt2as1vMDfxeIcFvhmGGm4=
 github.com/valyala/fasthttp v1.34.0/go.mod h1:epZA5N+7pY6ZaEKRmstzOuYJx9HI8DI1oaCGZpdH4h0=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
+github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1 h1:9j7bpwjT9wmwBb54ZkBhTm1uNIlFFcCJXefd/YskZPw=
+github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1/go.mod h1:+tI1VD76E1WINI+Nstg7RVGpUolL5ql10nu2YztMO/4=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
@@ -547,6 +549,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
+golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -670,6 +674,8 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
## Proposed changes

3 new subcommands under `ken account`, preparing for [KIP-113 BLS public key registry](https://github.com/klaytn/kips/blob/main/KIPs/kip-113.md) and [KIP-114 signature based random](https://github.com/klaytn/kips/blob/main/KIPs/kip-114.md). These new command will be primarily used by the Consensus Node (CN) operators.

#### Expected use

CN operators can prepare their BLS private keys in one of the two methods.

1. Derive from existing ECDSA key (`nodekey`). The operator simply has to submit the BLS public key info to KIP-113 registy. The public key info can be obtained via `ken account bls-info --nodekey <nodekey>` command.
2. Generate and import independent BLS key. The operator can choose to use external tools such as [staking-deposit-cli](https://github.com/ethereum/staking-deposit-cli) to generate an independent BLS private key. The generated EIP-2335 keystore can be imported using the `ken account bls-decrypt --bls-nodekeystore <json> > <blsnodekey>` command. Then the operator shall submit the BLS public key info with `ken account bls-info --bls-nodekey <blsnodekey>` command.

#### New CLI flags

```
--bls-nodekey         file containing 32-byte BLS private key. Analogous to --nodekey
--bls-nodekeyhex      hex string of 32-byte BLS private key. Analogous to --nodekeyhex
--bls-nodekeystore    EIP-2335 keystore file
```

#### `ken account bls-info`

```
   Calculate BLS public key info (the public key and proof-of-possession)
   then prints to STDOUT.

   The input must be one of the following:

   (1) A 32-byte raw EC private key (--nodekey, --nodekeyhex)
       In this case the EC private key is first derived to a BLS private key,
       then the BLS public key info is calculated.
   (2) A 32-byte raw BLS private key (--bls-nodekey, --bls-nodekeyhex)
   (3) An encrypted BLS keystore JSON (--bls-nodekeystore)

   EXAMPLES

   # Print public key info of the BLS key derived from the EC nodekey
   kcn account bls-info --nodekey /var/kcnd/data/nodekey

   # Print public key info of the saved BLS key
   kcn account bls-info --bls-nodekey /var/kcnd/data/bls-nodekey

   # Print public key info of the BLS key inside EIP-2335 keystore
   kcn account bls-info --bls-nodekeystore blskey.json
```

#### `ken account bls-decrypt`

```
   Decrypt an EIP-2335 keystore JSON and prints the raw BLS private key to STDOUT.

   EXAMPLES

   # Import the BLS private key from an existing EIP-2335 keystore file
   kcn account bls-decrypt --bls-nodekeystore blskey.json --password pw.txt > /var/kcnd/data/bls-nodekey
```

#### `ken account bls-encrypt`

```
   Encrypt a BLS private key to an EIP-2335 keystore JSON and prints to STDOUT.

   The input must be one of the following:

   (1) A 32-byte raw EC private key (--nodekey, --nodekeyhex).
       In this case the EC private key is first derived to a BLS private key, then encrypted.
   (2) A 32-byte raw BLS private key (--bls-nodekey, --bls-nodekeyhex)

   EXAMPLES

   # Store a backup BLS private key as an EIP-2335 keystore file
   kcn account bls-encrypt --bls-nodekey /var/kcnd/data/bls-nodekey --password pw.txt > bls-keystore.json

   # Change the password of an EIP-2335 keystore
   kcn account bls-encrypt \
     --bls-nodekeyhex $(kcn account bls-decrypt --bls-nodekeystore blskey.json --password pw1.txt) \
     --password pw2.txt > blskey.json
```

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments