### PR TITLE
Rename Live Pruning related symbols

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -707,7 +707,7 @@ func (bc *BlockChain) PrunableStateAt(root common.Hash, num uint64) (*state.Stat
 
 // StateAtWithPersistent returns a new mutable state based on a particular point in time with persistent trie nodes.
 func (bc *BlockChain) StateAtWithPersistent(root common.Hash) (*state.StateDB, error) {
-	exist := bc.stateCache.TrieDB().DoesExistNodeInPersistent(root.ExtendLegacy())
+	exist := bc.stateCache.TrieDB().DoesExistNodeInPersistent(root.ExtendZero())
 	if !exist {
 		return nil, ErrNotExistNode
 	}
@@ -718,7 +718,7 @@ func (bc *BlockChain) StateAtWithPersistent(root common.Hash) (*state.StateDB, e
 func (bc *BlockChain) StateAtWithGCLock(root common.Hash) (*state.StateDB, error) {
 	bc.RLockGCCachedNode()
 
-	exist := bc.stateCache.TrieDB().DoesExistCachedNode(root.ExtendLegacy())
+	exist := bc.stateCache.TrieDB().DoesExistCachedNode(root.ExtendZero())
 	if !exist {
 		bc.RUnlockGCCachedNode()
 		return nil, ErrNotExistNode
@@ -997,7 +997,7 @@ func (bc *BlockChain) GetLogsByHash(hash common.Hash) [][]*types.Log {
 // either from ephemeral in-memory cache, or from persistent storage.
 // Cannot retrieve nodes keyed with ExtHash
 func (bc *BlockChain) TrieNode(hash common.Hash) ([]byte, error) {
-	return bc.stateCache.TrieDB().Node(hash.ExtendLegacy())
+	return bc.stateCache.TrieDB().Node(hash.ExtendZero())
 }
 
 // ContractCode retrieves a blob of data associated with a contract hash

--- a/blockchain/state/iterator.go
+++ b/blockchain/state/iterator.go
@@ -198,7 +198,7 @@ func CheckStateConsistencyParallel(oldDB Database, newDB Database, root common.H
 		return errors.WithMessage(err, "can not open newDB trie")
 	}
 	// get children hash
-	children, err := oldDB.TrieDB().NodeChildren(root.ExtendLegacy()) // does not work with Online Pruning
+	children, err := oldDB.TrieDB().NodeChildren(root.ExtendLegacy()) // does not work with Live Pruning
 	if err != nil {
 		logger.Error("cannot start CheckStateConsistencyParallel", "err", err)
 		return errors.WithMessage(err, "cannot get children before consistency check")
@@ -247,7 +247,7 @@ func CheckStateConsistencyParallel(oldDB Database, newDB Database, root common.H
 
 // concurrentIterator checks the consistency of all state/storage trie of given two state database
 // and pass the result via the channel. The 'root' here can be a subtrie root.
-// Does not work with Online Pruning.
+// Does not work with Live Pruning.
 func concurrentIterator(oldDB Database, newDB Database, root common.ExtHash, quit chan struct{}, resultCh chan struct{}, finishCh chan error) (resultErr error) {
 	defer func() {
 		finishCh <- resultErr

--- a/blockchain/state/iterator.go
+++ b/blockchain/state/iterator.go
@@ -198,7 +198,7 @@ func CheckStateConsistencyParallel(oldDB Database, newDB Database, root common.H
 		return errors.WithMessage(err, "can not open newDB trie")
 	}
 	// get children hash
-	children, err := oldDB.TrieDB().NodeChildren(root.ExtendLegacy()) // does not work with Live Pruning
+	children, err := oldDB.TrieDB().NodeChildren(root.ExtendZero()) // does not work with Live Pruning
 	if err != nil {
 		logger.Error("cannot start CheckStateConsistencyParallel", "err", err)
 		return errors.WithMessage(err, "cannot get children before consistency check")

--- a/blockchain/state/iterator_test.go
+++ b/blockchain/state/iterator_test.go
@@ -50,7 +50,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 	// Cross check the iterated hashes and the database/nodepool content
 	// (TrieDB.Node + ContractCode) contains all iterated hashes
 	for itHash := range iterated {
-		_, err1 := db.TrieDB().Node(itHash.ExtendLegacy())
+		_, err1 := db.TrieDB().Node(itHash.ExtendZero())
 		_, err2 := db.ContractCode(itHash)
 		if err1 != nil && err2 != nil { // both failed
 			t.Errorf("failed to retrieve reported node %x", itHash)

--- a/blockchain/state/statedb_test.go
+++ b/blockchain/state/statedb_test.go
@@ -257,7 +257,7 @@ func TestPruningRoot(t *testing.T) {
 	root := makeState(db)
 	stateDB, _ := New(root, db, nil, nil)
 	storageRoot, _ := stateDB.GetContractStorageRoot(addr)
-	assert.True(t, storageRoot.IsLegacy())
+	assert.True(t, storageRoot.IsZeroExtended())
 
 	// When pruning is enabled, storage root is nonzero-extended.
 	dbm = database.NewMemoryDBManager()
@@ -267,7 +267,7 @@ func TestPruningRoot(t *testing.T) {
 	root = makeState(db)
 	stateDB, _ = New(root, db, nil, nil) // Reopen trie to check the account stored in disk.
 	storageRoot, _ = stateDB.GetContractStorageRoot(addr)
-	assert.False(t, storageRoot.IsLegacy())
+	assert.False(t, storageRoot.IsZeroExtended())
 }
 
 // A snapshotTest checks that reverting StateDB snapshots properly undoes all changes

--- a/blockchain/state/sync_test.go
+++ b/blockchain/state/sync_test.go
@@ -147,7 +147,7 @@ func checkStateAccounts(t *testing.T, newDB database.DBManager, root common.Hash
 
 // checkTrieConsistency checks that all nodes in a (sub-)trie are indeed present.
 func checkTrieConsistency(db database.DBManager, root common.Hash) error {
-	if v, _ := db.ReadTrieNode(root.ExtendLegacy()); v == nil { // only works with hash32
+	if v, _ := db.ReadTrieNode(root.ExtendZero()); v == nil { // only works with hash32
 		return nil // Consider a non existent state consistent.
 	}
 	trie, err := statedb.NewTrie(root, statedb.NewDatabase(db), nil)
@@ -163,7 +163,7 @@ func checkTrieConsistency(db database.DBManager, root common.Hash) error {
 // checkStateConsistency checks that all data of a state root is present.
 func checkStateConsistency(db database.DBManager, root common.Hash) error {
 	// Create and iterate a state trie rooted in a sub-node
-	if _, err := db.ReadTrieNode(root.ExtendLegacy()); err != nil { // only works with hash32
+	if _, err := db.ReadTrieNode(root.ExtendZero()); err != nil { // only works with hash32
 		return nil // Consider a non existent state consistent.
 	}
 	state, err := New(root, NewDatabase(db), nil, nil)
@@ -273,7 +273,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 	for len(hashQueue)+len(pathQueue) > 0 {
 		results := make([]statedb.SyncResult, len(hashQueue)+len(pathQueue))
 		for i, hash := range hashQueue {
-			data, err := srcState.TrieDB().Node(hash.ExtendLegacy())
+			data, err := srcState.TrieDB().Node(hash.ExtendZero())
 			if err != nil {
 				data, err = srcState.ContractCode(hash)
 			}
@@ -375,7 +375,7 @@ func TestCheckStateConsistencyMissNode(t *testing.T) {
 		if !common.EmptyHash(it.Hash) {
 			var (
 				codehash = it.Hash
-				nodehash = it.Hash.ExtendLegacy()
+				nodehash = it.Hash.ExtendZero()
 				data     []byte
 				code     = isCode(it.Hash)
 				err      error
@@ -437,7 +437,7 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 		// Sync only half of the scheduled nodes
 		results := make([]statedb.SyncResult, len(queue)/2+1)
 		for i, hash := range queue[:len(results)] {
-			data, err := srcState.TrieDB().Node(hash.ExtendLegacy())
+			data, err := srcState.TrieDB().Node(hash.ExtendZero())
 			if err != nil {
 				data, err = srcState.ContractCode(hash)
 			}
@@ -494,7 +494,7 @@ func testIterativeRandomStateSync(t *testing.T, count int) {
 		// Fetch all the queued nodes in a random order
 		results := make([]statedb.SyncResult, 0, len(queue))
 		for hash := range queue {
-			data, err := srcState.TrieDB().Node(hash.ExtendLegacy())
+			data, err := srcState.TrieDB().Node(hash.ExtendZero())
 			if err != nil {
 				data, err = srcState.ContractCode(hash)
 			}
@@ -553,7 +553,7 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 		for hash := range queue {
 			delete(queue, hash)
 
-			data, err := srcState.TrieDB().Node(hash.ExtendLegacy())
+			data, err := srcState.TrieDB().Node(hash.ExtendZero())
 			if err != nil {
 				data, err = srcState.ContractCode(hash)
 			}
@@ -627,7 +627,7 @@ func TestIncompleteStateSync(t *testing.T) {
 		// Fetch a batch of state nodes
 		results := make([]statedb.SyncResult, len(queue))
 		for i, hash := range queue {
-			data, err := srcState.TrieDB().Node(hash.ExtendLegacy())
+			data, err := srcState.TrieDB().Node(hash.ExtendZero())
 			if err != nil {
 				data, err = srcState.ContractCode(hash)
 			}
@@ -672,7 +672,7 @@ func TestIncompleteStateSync(t *testing.T) {
 			code     = isCode(hash)
 			val      []byte
 			codehash = hash
-			nodehash = hash.ExtendLegacy()
+			nodehash = hash.ExtendZero()
 		)
 		if code {
 			val = dstDb.ReadCode(codehash)

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -64,7 +64,7 @@ func (bc *BlockChain) concurrentRead(db state.Database, quitCh chan struct{}, ha
 		case <-quitCh:
 			return
 		case hash := <-hashCh:
-			data, err := db.TrieDB().NodeFromOld(hash.ExtendLegacy())
+			data, err := db.TrieDB().NodeFromOld(hash.ExtendZero())
 			if err != nil {
 				data, err = db.ContractCode(hash)
 			}
@@ -489,7 +489,7 @@ func (bc *BlockChain) StartWarmUp() error {
 		return err
 	}
 	// retrieve children nodes of state trie root node
-	children, err := db.TrieDB().NodeChildren(block.Root().ExtendLegacy())
+	children, err := db.TrieDB().NodeChildren(block.Root().ExtendZero())
 	if err != nil {
 		return err
 	}
@@ -532,7 +532,7 @@ func (bc *BlockChain) StartCollectingTrieStats(contractAddr common.Address) erro
 	}
 	db := state.NewDatabaseWithExistingCache(bc.db, cache)
 
-	startNode := block.Root().ExtendLegacy()
+	startNode := block.Root().ExtendZero()
 	// If the contractAddr is given, start collecting stats from the root of storage trie
 	if !common.EmptyAddress(contractAddr) {
 		var err error

--- a/blockchain/types/account/account_test.go
+++ b/blockchain/types/account/account_test.go
@@ -207,7 +207,7 @@ func TestSmartContractAccountExt(t *testing.T) {
 		scaLegacyRLP = "0x02f84dc98212348256788001c0a000112233445566778899aabbccddeeff00112233445566778899aabbccddeeffa0aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd10"
 		scaLegacy    = &SmartContractAccount{
 			AccountCommon: commonFields,
-			storageRoot:   hash.ExtendLegacy(),
+			storageRoot:   hash.ExtendZero(),
 			codeHash:      codehash,
 			codeInfo:      codeinfo,
 		}

--- a/blockchain/types/account/smart_contract_account.go
+++ b/blockchain/types/account/smart_contract_account.go
@@ -92,7 +92,7 @@ func newSmartContractAccountWithMap(values map[AccountValueKeyType]interface{}) 
 	}
 
 	if v, ok := values[AccountValueKeyStorageRoot].(common.Hash); ok {
-		sca.storageRoot = v.ExtendLegacy()
+		sca.storageRoot = v.ExtendZero()
 	}
 	if v, ok := values[AccountValueKeyStorageRoot].(common.ExtHash); ok {
 		sca.storageRoot = v
@@ -129,7 +129,7 @@ func (sca *SmartContractAccount) toSerializableExt() *smartContractAccountSerial
 
 func (sca *SmartContractAccount) fromSerializable(o *smartContractAccountSerializable) {
 	sca.AccountCommon.fromSerializable(o.CommonSerializable)
-	sca.storageRoot = o.StorageRoot.ExtendLegacy()
+	sca.storageRoot = o.StorageRoot.ExtendZero()
 	sca.codeHash = o.CodeHash
 	sca.codeInfo = o.CodeInfo
 }
@@ -208,7 +208,7 @@ func (sca *SmartContractAccount) UnmarshalJSON(b []byte) error {
 	sca.balance = (*big.Int)(serialized.Balance)
 	sca.humanReadable = serialized.HumanReadable
 	sca.key = serialized.Key.GetKey()
-	sca.storageRoot = serialized.StorageRoot.ExtendLegacy() // API inputs should contain merkle hash
+	sca.storageRoot = serialized.StorageRoot.ExtendZero() // API inputs should contain merkle hash
 	sca.codeHash = serialized.CodeHash
 	sca.codeInfo = params.NewCodeInfo(serialized.CodeFormat, serialized.VmVersion)
 

--- a/blockchain/types/account/smart_contract_account.go
+++ b/blockchain/types/account/smart_contract_account.go
@@ -146,7 +146,7 @@ func (sca *SmartContractAccount) EncodeRLP(w io.Writer) error {
 }
 
 func (sca *SmartContractAccount) EncodeRLPExt(w io.Writer) error {
-	if sca.storageRoot.IsLegacy() {
+	if sca.storageRoot.IsZeroExtended() {
 		return rlp.Encode(w, sca.toSerializable())
 	} else {
 		return rlp.Encode(w, sca.toSerializableExt())

--- a/cmd/utils/nodecmd/snapshot.go
+++ b/cmd/utils/nodecmd/snapshot.go
@@ -215,7 +215,7 @@ func traceTrie(ctx *cli.Context) error {
 	trieDB := sdb.Database().TrieDB()
 
 	// Get root-node childrens to create goroutine by number of childrens
-	children, err := trieDB.NodeChildren(root.ExtendLegacy())
+	children, err := trieDB.NodeChildren(root.ExtendZero())
 	if err != nil {
 		return fmt.Errorf("Fail get childrens of root : %v", err)
 	}

--- a/common/types.go
+++ b/common/types.go
@@ -196,7 +196,7 @@ type (
 // Otherwise, this function panics.
 func BytesToExtHash(b []byte) (eh ExtHash) {
 	if len(b) == 0 || len(b) == HashLength {
-		return BytesToHash(b).ExtendLegacy()
+		return BytesToHash(b).ExtendZero()
 	} else if len(b) == ExtHashLength {
 		eh.SetBytes(b)
 		return eh
@@ -313,9 +313,9 @@ func (h Hash) Extend() ExtHash {
 	return eh
 }
 
-// ExtendLegacy converts Hash to ExtHash by attaching the zero counter.
+// ExtendZero converts Hash to ExtHash by attaching the zero counter.
 // Zero counters are attached to hashes of Trie nodes in the legacy trie database
-func (h Hash) ExtendLegacy() ExtHash {
+func (h Hash) ExtendZero() ExtHash {
 	return h.extend(extHashZeroCounter)
 }
 

--- a/common/types.go
+++ b/common/types.go
@@ -52,9 +52,9 @@ var (
 var (
 	lastPrecompiledContractAddressHex = hexutil.MustDecode("0x00000000000000000000000000000000000003FF")
 
-	// extHashLastCounter is the counter used to generate the nonce for the ExtHash.
+	// extHashLastCounter is the counter used to generate the counter for the ExtHash.
 	// It starts off the most significant 7 bytes of the timestamp in nanoseconds at program startup.
-	// It increments every time a new ExtHash nonce is generated.
+	// It increments every time a new ExtHash counter is generated.
 	//                      [b1 b2 b3 b4 b5 b6 b7 b8] = UnixNano()
 	// extHashLastCounter = [00 b1 b2 b3 b4 b5 b6 b7]
 	// nextCounter        =    [b1 b2 b3 b4 b5 b6 b7]
@@ -191,7 +191,7 @@ type (
 )
 
 // BytesToExtHash converts the byte array b to ExtHash.
-// If len(b) is 0 or 32, then b is interpreted as a Hash and extended with LegacyNonce.
+// If len(b) is 0 or 32, then b is interpreted as a Hash and zero-extended.
 // If len(b) is 39, then b is interpreted as an ExtHash.
 // Otherwise, this function panics.
 func BytesToExtHash(b []byte) (eh ExtHash) {
@@ -316,7 +316,8 @@ func (h Hash) Extend() ExtHash {
 }
 
 // ExtendZero converts Hash to ExtHash by attaching the zero counter.
-// Zero counters are attached to hashes of Trie nodes in the legacy trie database
+// A zero counter is attached to a 32-byte Hash of Trie nodes,
+// later to be unextended back to a Hash.
 func (h Hash) ExtendZero() ExtHash {
 	return h.extend(extHashZeroCounter)
 }

--- a/common/types.go
+++ b/common/types.go
@@ -183,7 +183,7 @@ func (h UnprefixedHash) MarshalText() ([]byte, error) {
 type (
 	// ExtHash is an extended hash composed of a 32 byte Hash and a 7 byte Nonce.
 	// ExtHash is used as the reference of Merkle Patricia Trie nodes to enable
-	// the KIP-111 online state database pruning. The Hash component shall represent
+	// the KIP-111 live state database pruning. The Hash component shall represent
 	// the merkle hash of the node and the Nonce component shall differentiate
 	// nodes with the same merkle hash.
 	ExtHash      [ExtHashLength]byte

--- a/common/types.go
+++ b/common/types.go
@@ -281,7 +281,9 @@ func (eh ExtHash) Counter() (counter ExtHashCounter) {
 	return counter
 }
 
-func (eh ExtHash) IsLegacy() bool {
+// IsZeroExtended returns true if the counter component of an ExtHash is zero.
+// A zero counter signifies that the ExtHash is actually a Hash.
+func (eh ExtHash) IsZeroExtended() bool {
 	return bytes.Equal(eh.Counter().Bytes(), extHashZeroCounter[:])
 }
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -72,30 +72,30 @@ func TestBytesConversion(t *testing.T) {
 func TestExtHash(t *testing.T) {
 	var (
 		sHash      = "0x1122334411223344112233441122334411223344112233441122334411223344"
-		nNonce     = uint64(0xccccddddeeee01)
-		sNonce     = "0xccccddddeeee01"
+		nCounter   = uint64(0xccccddddeeee01)
+		sCounter   = "0xccccddddeeee01"
 		sExtHash   = "0x1122334411223344112233441122334411223344112233441122334411223344ccccddddeeee01"
 		sExtHash2  = "0x1122334411223344112233441122334411223344112233441122334411223344ccccddddeeee02"
 		sExtLegacy = "0x112233441122334411223344112233441122334411223344112233441122334400000000000000"
 		sEmpty     = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000"
 		bHash      = hexutil.MustDecode(sHash)
-		bNonce     = hexutil.MustDecode(sNonce)
+		bCounter   = hexutil.MustDecode(sCounter)
 		bExtHash   = hexutil.MustDecode(sExtHash)
 	)
 
 	h := BytesToHash(bHash)
-	nonce := BytesToExtHashNonce(bNonce)
-	eh := h.extend(nonce)
+	counter := BytesToExtHashCounter(bCounter)
+	eh := h.extend(counter)
 
 	// ExtHash methods
 	assert.Equal(t, bExtHash, eh.Bytes())
 	assert.Equal(t, sExtHash, eh.Hex())
-	assert.Equal(t, nonce, eh.Nonce())
+	assert.Equal(t, counter, eh.Counter())
 
 	assert.Equal(t, sEmpty, BytesToExtHash(nil).Hex())
 	assert.Equal(t, sExtLegacy, BytesToExtHash(bHash).Hex())
 	assert.Equal(t, sExtHash, BytesToExtHash(bExtHash).Hex())
-	assert.Equal(t, sNonce, BytesToExtHashNonce(bNonce).Hex())
+	assert.Equal(t, sCounter, BytesToExtHashCounter(bCounter).Hex())
 
 	assert.Equal(t, sExtHash, HexToExtHash(sExtHash).Hex())
 	assert.Equal(t, sExtLegacy, HexToExtHash(sHash).Hex())
@@ -103,7 +103,7 @@ func TestExtHash(t *testing.T) {
 	// Hash <-> ExtHash
 	assert.Equal(t, h, eh.Unextend())
 	assert.Equal(t, sExtLegacy, h.ExtendLegacy().Hex())
-	ResetExtHashCounterForTest(nNonce - 1)
+	ResetExtHashCounterForTest(nCounter - 1)
 	assert.Equal(t, sExtHash, h.Extend().Hex())
 	assert.Equal(t, sExtHash2, h.Extend().Hex())
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -102,17 +102,17 @@ func TestExtHash(t *testing.T) {
 
 	// Hash <-> ExtHash
 	assert.Equal(t, h, eh.Unextend())
-	assert.Equal(t, sExtLegacy, h.ExtendLegacy().Hex())
+	assert.Equal(t, sExtLegacy, h.ExtendZero().Hex())
 	ResetExtHashCounterForTest(nCounter - 1)
 	assert.Equal(t, sExtHash, h.Extend().Hex())
 	assert.Equal(t, sExtHash2, h.Extend().Hex())
 
 	// Predicates
 	assert.False(t, eh.IsLegacy())
-	assert.True(t, h.ExtendLegacy().IsLegacy())
+	assert.True(t, h.ExtendZero().IsLegacy())
 
 	assert.False(t, EmptyExtHash(eh))
-	assert.True(t, EmptyExtHash(Hash{}.ExtendLegacy()))
+	assert.True(t, EmptyExtHash(Hash{}.ExtendZero()))
 	assert.True(t, EmptyExtHash(ExtHash{}))
 }
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -108,8 +108,8 @@ func TestExtHash(t *testing.T) {
 	assert.Equal(t, sExtHash2, h.Extend().Hex())
 
 	// Predicates
-	assert.False(t, eh.IsLegacy())
-	assert.True(t, h.ExtendZero().IsLegacy())
+	assert.False(t, eh.IsZeroExtended())
+	assert.True(t, h.ExtendZero().IsZeroExtended())
 
 	assert.False(t, EmptyExtHash(eh))
 	assert.True(t, EmptyExtHash(Hash{}.ExtendZero()))

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -149,7 +149,7 @@ func newTester() *downloadTester {
 		peerMissingStates: make(map[string]map[common.Hash]bool),
 	}
 	tester.stateDb = localdb
-	tester.stateDb.WriteTrieNode(genesis.Root().ExtendLegacy(), []byte{0x00})
+	tester.stateDb.WriteTrieNode(genesis.Root().ExtendZero(), []byte{0x00})
 
 	tester.downloader = New(FullSync, tester.stateDb, statedb.NewSyncBloom(1, tester.stateDb.GetMemDB()), new(event.TypeMux), tester, nil, tester.dropPeer, uint64(istanbul.WeightedRandom))
 
@@ -348,7 +348,7 @@ func (dl *downloadTester) CurrentBlock() *types.Block {
 
 	for i := len(dl.ownHashes) - 1; i >= 0; i-- {
 		if block := dl.ownBlocks[dl.ownHashes[i]]; block != nil {
-			if has, _ := dl.stateDb.HasTrieNode(block.Root().ExtendLegacy()); has {
+			if has, _ := dl.stateDb.HasTrieNode(block.Root().ExtendZero()); has {
 				return block
 			}
 		}
@@ -430,7 +430,7 @@ func (dl *downloadTester) InsertChain(blocks types.Blocks) (int, error) {
 	for i, block := range blocks {
 		if parent, ok := dl.ownBlocks[block.ParentHash()]; !ok {
 			return i, fmt.Errorf("InsertChain: unknown parent at position %d / %d", i, len(blocks))
-		} else if has, _ := dl.stateDb.HasTrieNode(parent.Root().ExtendLegacy()); !has {
+		} else if has, _ := dl.stateDb.HasTrieNode(parent.Root().ExtendZero()); !has {
 			return i, fmt.Errorf("InsertChain: unknown parent state %x", parent.Root())
 		}
 		if _, ok := dl.ownHeaders[block.Hash()]; !ok {
@@ -438,7 +438,7 @@ func (dl *downloadTester) InsertChain(blocks types.Blocks) (int, error) {
 			dl.ownHeaders[block.Hash()] = block.Header()
 		}
 		dl.ownBlocks[block.Hash()] = block
-		dl.stateDb.WriteTrieNode(block.Root().ExtendLegacy(), []byte{0x00})
+		dl.stateDb.WriteTrieNode(block.Root().ExtendZero(), []byte{0x00})
 		dl.ownChainTd[block.Hash()] = new(big.Int).Add(dl.ownChainTd[block.ParentHash()], block.BlockScore())
 	}
 	return len(blocks), nil
@@ -734,7 +734,7 @@ func (dlp *downloadTesterPeer) RequestNodeData(hashes []common.Hash) error {
 
 	results := make([][]byte, 0, len(hashes))
 	for _, hash := range hashes {
-		if data, err := dlp.dl.peerDb.ReadTrieNode(hash.ExtendLegacy()); err == nil {
+		if data, err := dlp.dl.peerDb.ReadTrieNode(hash.ExtendZero()); err == nil {
 			if !dlp.dl.peerMissingStates[dlp.id][hash] {
 				results = append(results, data)
 			}

--- a/snapshot/generate_test.go
+++ b/snapshot/generate_test.go
@@ -467,7 +467,7 @@ func TestGenerateCorruptAccountTrie(t *testing.T) {
 	// Delete an account trie leaf and ensure the generator chokes
 	// TODO-Klaytn-Snapshot put propoer block number
 	triedb.Commit(common.HexToHash("0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978"), false, 0)
-	diskdb.DeleteTrieNode(common.HexToHash("0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7").ExtendLegacy())
+	diskdb.DeleteTrieNode(common.HexToHash("0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7").ExtendZero())
 
 	snap := generateSnapshot(diskdb, triedb, 16, common.HexToHash("0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978"))
 	select {
@@ -531,7 +531,7 @@ func TestGenerateMissingStorageTrie(t *testing.T) {
 	triedb.Commit(common.HexToHash("0xa2282b99de1fc11e32d26bee37707ef49a6978b2d375796a1b026a497193a2ef"), false, 0)
 
 	// Delete a storage trie root and ensure the generator chokes
-	diskdb.DeleteTrieNode(common.HexToHash("0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67").ExtendLegacy())
+	diskdb.DeleteTrieNode(common.HexToHash("0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67").ExtendZero())
 
 	snap := generateSnapshot(diskdb, triedb, 16, common.HexToHash("0xa2282b99de1fc11e32d26bee37707ef49a6978b2d375796a1b026a497193a2ef"))
 	select {
@@ -594,7 +594,7 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 	triedb.Commit(common.HexToHash("0x4a651234bc4b8c7462b5ad4eb95bbb724eb636fed72bb5278d886f9ea4c345f8"), false, 0)
 
 	// Delete a storage trie leaf and ensure the generator chokes
-	diskdb.DeleteTrieNode(common.HexToHash("0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371").ExtendLegacy())
+	diskdb.DeleteTrieNode(common.HexToHash("0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371").ExtendZero())
 
 	snap := generateSnapshot(diskdb, triedb, 16, common.HexToHash("0x4a651234bc4b8c7462b5ad4eb95bbb724eb636fed72bb5278d886f9ea4c345f8"))
 	select {

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -461,7 +461,7 @@ func TestDBManager_IstanbulSnapshot(t *testing.T) {
 func TestDBManager_TrieNode(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 	var (
-		key1  = hash1.ExtendLegacy()
+		key1  = hash1.ExtendZero()
 		key2  = hash2.Extend()
 		node1 = hash1[:]
 		node2 = hash2[:]

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -270,7 +270,7 @@ func databaseDirKey(dbEntryType uint64) []byte {
 
 // TrieNodeKey = if Legacy, hash32. Otherwise, exthash
 func TrieNodeKey(hash common.ExtHash) []byte {
-	if hash.IsLegacy() {
+	if hash.IsZeroExtended() {
 		return hash.Unextend().Bytes()
 	} else {
 		return hash.Bytes()

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -644,7 +644,7 @@ func (db *Database) ReferenceRoot(root common.Hash) {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	db.reference(root.ExtendLegacy(), common.ExtHash{})
+	db.reference(root.ExtendZero(), common.ExtHash{})
 }
 
 // Reference adds a new reference from a parent node to a child node.
@@ -691,7 +691,7 @@ func (db *Database) Dereference(root common.Hash) {
 	defer db.lock.Unlock()
 
 	nodes, storage, start := len(db.nodes), db.nodesSize, time.Now()
-	db.dereference(root.ExtendLegacy(), common.ExtHash{})
+	db.dereference(root.ExtendZero(), common.ExtHash{})
 
 	db.gcnodes += uint64(nodes - len(db.nodes))
 	db.gcsize += storage - db.nodesSize
@@ -902,7 +902,7 @@ func (db *Database) concurrentCommit(hash common.ExtHash, resultCh chan<- commit
 //
 // As a side effect, all pre-images accumulated up to this point are also written.
 func (db *Database) Commit(root common.Hash, report bool, blockNum uint64) error {
-	hash := root.ExtendLegacy()
+	hash := root.ExtendZero()
 	// Create a database batch to flush persistent data out. It is important that
 	// outside code doesn't see an inconsistent state (referenced data removed from
 	// memory cache during commit but not yet in persistent database). This is ensured

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -27,8 +27,8 @@ import (
 var (
 	childHash     = common.HexToHash("1341655") // 20190805 in hexadecimal
 	parentHash    = common.HexToHash("1343A3F") // 20199999 in hexadecimal
-	childExtHash  = childHash.ExtendLegacy()
-	parentExtHash = parentHash.ExtendLegacy()
+	childExtHash  = childHash.ExtendZero()
+	parentExtHash = parentHash.ExtendZero()
 )
 
 func TestDatabase_Reference(t *testing.T) {

--- a/storage/statedb/hasher.go
+++ b/storage/statedb/hasher.go
@@ -287,7 +287,7 @@ func unextendNode(original node, preserveExtHash bool) node {
 		return stored
 	case hashNode:
 		exthash := common.BytesToExtHash(n)
-		if exthash.IsLegacy() { // Always unextend ExtHashLegacy
+		if exthash.IsZeroExtended() { // Always unextend ExtHashLegacy
 			return hashNode(exthash.Unextend().Bytes())
 		} else if !preserveExtHash { // It's ExtHash and not preserving ExtHash (for merkle hash)
 			return hashNode(exthash.Unextend().Bytes())

--- a/storage/statedb/hasher.go
+++ b/storage/statedb/hasher.go
@@ -261,7 +261,7 @@ func (h *hasher) makeHashNode(data []byte, onRoot bool) hashNode {
 	if h.pruning && (h.storageRoot || !onRoot) {
 		return hash.Extend().Bytes()
 	} else {
-		return hash.ExtendLegacy().Bytes()
+		return hash.ExtendZero().Bytes()
 	}
 }
 

--- a/storage/statedb/iterator_test.go
+++ b/storage/statedb/iterator_test.go
@@ -115,7 +115,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 	// Cross check the hashes and the database itself
 	// db.Node contains all iterated hashes
 	for itHash := range iterated {
-		if _, err := db.Node(itHash.ExtendLegacy()); err != nil {
+		if _, err := db.Node(itHash.ExtendZero()); err != nil {
 			t.Errorf("failed to retrieve reported node %x: %v", itHash, err)
 		}
 	}
@@ -437,7 +437,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 		triedb.Commit(root, true, 0)
 	}
 	barNodeHash := common.HexToHash("05041990364eb72fcb1127652ce40d8bab765f2bfe53225b1170d276cc101c2e")
-	nodehash := barNodeHash.ExtendLegacy()
+	nodehash := barNodeHash.ExtendZero()
 	var (
 		barNodeBlob []byte
 		barNodeObj  *cachedNode

--- a/storage/statedb/proof.go
+++ b/storage/statedb/proof.go
@@ -122,7 +122,7 @@ func VerifyProof(rootHash common.Hash, key []byte, proofDB database.DBManager) (
 	key = keybytesToHex(key)
 	wantHash := rootHash
 	for i := 0; ; i++ {
-		buf, _ := proofDB.ReadTrieNode(wantHash.ExtendLegacy()) // only works with hash32
+		buf, _ := proofDB.ReadTrieNode(wantHash.ExtendZero()) // only works with hash32
 		if buf == nil {
 			return nil, fmt.Errorf("proof node %d (hash %064x) missing", i, wantHash), i
 		}
@@ -165,7 +165,7 @@ func proofToPath(rootHash common.Hash, root node, key []byte, proofDb ProofDBRea
 	// If the root node is empty, resolve it first.
 	// Root node must be included in the proof.
 	if root == nil {
-		n, err := resolveNode(rootHash.ExtendLegacy())
+		n, err := resolveNode(rootHash.ExtendZero())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -184,7 +184,7 @@ func (s *TrieSync) AddSubTrie(root common.Hash, path []byte, depth int, parent c
 		// Bloom filter says this might be a duplicate, double check.
 		// If database says yes, then at least the trie node is present
 		// and we hold the assumption that it's NOT legacy contract code.
-		if ok, _ := s.database.HasTrieNode(root.ExtendLegacy()); ok {
+		if ok, _ := s.database.HasTrieNode(root.ExtendZero()); ok {
 			logger.Debug("skip write sub-trie", "root", root.String())
 			return
 		}
@@ -346,7 +346,7 @@ func (s *TrieSync) Commit(dbw database.Batch) (int, error) {
 	written := 0
 	// Dump the membatch into a database dbw
 	for key, value := range s.membatch.nodes {
-		if err := dbw.Put(database.TrieNodeKey(key.ExtendLegacy()), value); err != nil { // only works with hash32
+		if err := dbw.Put(database.TrieNodeKey(key.ExtendZero()), value); err != nil { // only works with hash32
 			return written, err
 		}
 		if s.bloom != nil {
@@ -459,7 +459,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 					paths = append(paths, hexToKeybytes(child.path[:2*common.HashLength]))
 					paths = append(paths, hexToKeybytes(child.path[2*common.HashLength:]))
 				}
-				if err := req.callback(paths, child.path, node, req.hash.ExtendLegacy(), child.depth); err != nil {
+				if err := req.callback(paths, child.path, node, req.hash.ExtendZero(), child.depth); err != nil {
 					return nil, err
 				}
 			}
@@ -480,7 +480,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 				// Bloom filter says this might be a duplicate, double check.
 				// If database says yes, then at least the trie node is present
 				// and we hold the assumption that it's NOT legacy contract code.
-				if ok, _ := s.database.HasTrieNode(hash.ExtendLegacy()); ok {
+				if ok, _ := s.database.HasTrieNode(hash.ExtendZero()); ok {
 					continue
 				}
 				// False positive, bump fault meter

--- a/storage/statedb/sync_test.go
+++ b/storage/statedb/sync_test.go
@@ -133,7 +133,7 @@ func trieSyncLoop(t *testing.T, count int, srcTrie *SecureTrie, sched *TrieSync,
 	for len(hashQueue)+len(pathQueue) > 0 {
 		results := make([]SyncResult, len(hashQueue)+len(pathQueue))
 		for i, hash := range hashQueue {
-			data, err := srcDB.Node(hash.ExtendLegacy())
+			data, err := srcDB.Node(hash.ExtendZero())
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for hash %x: %v", hash, err)
 			}
@@ -241,7 +241,7 @@ func TestIterativeDelayedTrieSync(t *testing.T) {
 		// Sync only half of the scheduled nodes
 		results := make([]SyncResult, len(queue)/2+1)
 		for i, hash := range queue[:len(results)] {
-			data, err := srcDb.Node(hash.ExtendLegacy())
+			data, err := srcDb.Node(hash.ExtendZero())
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
@@ -289,7 +289,7 @@ func testIterativeRandomTrieSync(t *testing.T, count int) {
 		// Fetch all the queued nodes in a random order
 		results := make([]SyncResult, 0, len(queue))
 		for hash := range queue {
-			data, err := srcDb.Node(hash.ExtendLegacy())
+			data, err := srcDb.Node(hash.ExtendZero())
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
@@ -337,7 +337,7 @@ func TestIterativeRandomDelayedTrieSync(t *testing.T) {
 		// Sync only half of the scheduled nodes, even those in random order
 		results := make([]SyncResult, 0, len(queue)/2+1)
 		for hash := range queue {
-			data, err := srcDb.Node(hash.ExtendLegacy())
+			data, err := srcDb.Node(hash.ExtendZero())
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
@@ -389,7 +389,7 @@ func TestDuplicateAvoidanceTrieSync(t *testing.T) {
 	for len(queue) > 0 {
 		results := make([]SyncResult, len(queue))
 		for i, hash := range queue {
-			data, err := srcDb.Node(hash.ExtendLegacy())
+			data, err := srcDb.Node(hash.ExtendZero())
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
@@ -435,7 +435,7 @@ func TestIncompleteTrieSync(t *testing.T) {
 		// Fetch a batch of trie nodes
 		results := make([]SyncResult, len(queue))
 		for i, hash := range queue {
-			data, err := srcDb.Node(hash.ExtendLegacy())
+			data, err := srcDb.Node(hash.ExtendZero())
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
@@ -467,7 +467,7 @@ func TestIncompleteTrieSync(t *testing.T) {
 	}
 	// Sanity check that removing any node from the database is detected
 	for _, hash := range added[1:] {
-		nodehash := hash.ExtendLegacy()
+		nodehash := hash.ExtendZero()
 		value, _ := dbm.ReadTrieNode(nodehash)
 
 		dbm.DeleteTrieNode(nodehash)
@@ -496,7 +496,7 @@ func TestSyncOrdering(t *testing.T) {
 	for len(queue) > 0 {
 		results := make([]SyncResult, len(queue))
 		for i, hash := range queue {
-			data, err := srcDb.Node(hash.ExtendLegacy())
+			data, err := srcDb.Node(hash.ExtendZero())
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -91,7 +91,7 @@ func (t *Trie) newFlag() nodeFlag {
 // NewTrie will panic if db is nil and returns a MissingNodeError if root does
 // not exist in the database. Accessing the trie loads nodes from db on demand.
 func NewTrie(root common.Hash, db *Database, opts *TrieOpts) (*Trie, error) {
-	return newTrie(root.ExtendLegacy(), db, opts, false)
+	return newTrie(root.ExtendZero(), db, opts, false)
 }
 
 // NewStorageTrie creates a storage trie with an existing root node from db.
@@ -588,7 +588,7 @@ func (t *Trie) CommitExt(onleaf LeafCallback) (root common.ExtHash, err error) {
 
 func (t *Trie) hashRoot(db *Database, onleaf LeafCallback) (common.ExtHash, node) {
 	if t.root == nil {
-		return emptyRoot.ExtendLegacy(), nil
+		return emptyRoot.ExtendZero(), nil
 	}
 	h := newHasher(&hasherOpts{
 		onleaf:      onleaf,

--- a/storage/statedb/trie_test.go
+++ b/storage/statedb/trie_test.go
@@ -123,7 +123,7 @@ func testMissingNode(t *testing.T, memonly bool) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	hash := common.HexToHash("0xe1d943cc8f061a0c0b98162830b970395ac9315654824bf21b73b891365262f9").ExtendLegacy()
+	hash := common.HexToHash("0xe1d943cc8f061a0c0b98162830b970395ac9315654824bf21b73b891365262f9").ExtendZero()
 	if memonly {
 		delete(triedb.nodes, hash)
 	} else {

--- a/storage/statedb/trie_test.go
+++ b/storage/statedb/trie_test.go
@@ -337,20 +337,20 @@ func TestStorageTrie(t *testing.T) {
 	// non-pruning storage trie returns Legacy ExtHash for root
 	trie := newStorageTrie(false)
 	root := trie.HashExt()
-	assert.True(t, root.IsLegacy())
+	assert.True(t, root.IsZeroExtended())
 
 	trie = newStorageTrie(false)
 	root, _ = trie.CommitExt(nil)
-	assert.True(t, root.IsLegacy())
+	assert.True(t, root.IsZeroExtended())
 
 	// pruning storage trie returns non-Legacy ExtHash for root
 	trie = newStorageTrie(true)
 	root = trie.HashExt()
-	assert.False(t, root.IsLegacy())
+	assert.False(t, root.IsZeroExtended())
 
 	trie = newStorageTrie(true)
 	root, _ = trie.CommitExt(nil)
-	assert.False(t, root.IsLegacy())
+	assert.False(t, root.IsZeroExtended())
 }
 
 func TestPruningByUpdate(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

Rename KIP-111 Live Pruning related functions and variables for clarity.
- Online Pruning -> Live Pruning
- ExtHashNonce -> ExtHashCounter
- ExtendLegacy -> ExtendZero
- IsLegacy -> IsZeroExtended

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
