### PR TITLE
Add support for AccessList tx

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -123,8 +123,12 @@ func (b *BlockchainContractBackend) callContract(call klaytn.CallMsg, block *typ
 		return nil, err
 	}
 
+	var accessList types.AccessList
+	if call.AccessList != nil {
+		accessList = *call.AccessList
+	}
 	msg := types.NewMessage(call.From, call.To, 0, call.Value, call.Gas, call.GasPrice, call.Data,
-		false, intrinsicGas)
+		false, intrinsicGas, accessList)
 
 	evmContext := blockchain.NewEVMContext(msg, block.Header(), b.bc, nil)
 	// EVM demands the sender to have enough KLAY balance (gasPrice * gasLimit) in buyGas()

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -461,7 +461,12 @@ func (b *SimulatedBackend) callContract(_ context.Context, call klaytn.CallMsg, 
 	// Execute the call.
 	nonce := from.Nonce()
 	intrinsicGas, _ := types.IntrinsicGas(call.Data, nil, call.To == nil, b.config.Rules(block.Number()))
-	msg := types.NewMessage(call.From, call.To, nonce, call.Value, call.Gas, call.GasPrice, call.Data, true, intrinsicGas)
+
+	var accessList types.AccessList
+	if call.AccessList != nil {
+		accessList = *call.AccessList
+	}
+	msg := types.NewMessage(call.From, call.To, nonce, call.Value, call.Gas, call.GasPrice, call.Data, true, intrinsicGas, accessList)
 
 	evmContext := blockchain.NewEVMContext(msg, block.Header(), b.blockchain, nil)
 	// Create a new environment which holds all relevant information

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -279,6 +279,10 @@ type CallArgs struct {
 	Value                hexutil.Big     `json:"value"`
 	Data                 hexutil.Bytes   `json:"data"`
 	Input                hexutil.Bytes   `json:"input"`
+
+	// Introduced by AccessListTxType transaction.
+	AccessList *types.AccessList `json:"accessList,omitempty"`
+	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
 }
 
 func (args *CallArgs) InputData() []byte {
@@ -703,10 +707,9 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 		value = args.Value.ToInt()
 	}
 
-	// TODO-Klaytn: Klaytn does not support accessList yet.
-	// var accessList types.AccessList
-	// if args.AccessList != nil {
-	//	 accessList = *args.AccessList
-	// }
-	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, args.InputData(), false, intrinsicGas), nil
+	var accessList types.AccessList
+	if args.AccessList != nil {
+		accessList = *args.AccessList
+	}
+	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, args.Data, false, intrinsicGas, accessList), nil
 }

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -768,12 +768,11 @@ func (args *EthTransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int,
 	}
 	data := args.data()
 
-	// TODO-Klaytn: Klaytn does not support accessList yet.
-	// var accessList types.AccessList
-	// if args.AccessList != nil {
-	//	 accessList = *args.AccessList
-	// }
-	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, false, intrinsicGas), nil
+	var accessList types.AccessList
+	if args.AccessList != nil {
+		accessList = *args.AccessList
+	}
+	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, false, intrinsicGas, accessList), nil
 }
 
 // toTransaction converts the arguments to a transaction.

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -1087,7 +1087,7 @@ func (s *StateDB) GetContractStorageRoot(contractAddr common.Address) (common.Ex
 //
 // regards to EIP-3651:
 // - Add coinbase to access list (EIP-3651)
-func (s *StateDB) PrepareAccessList(rules params.Rules, sender, feepayer, coinbase common.Address, dst *common.Address, precompiles []common.Address) {
+func (s *StateDB) PrepareAccessList(rules params.Rules, sender, feepayer, coinbase common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList) {
 	// Clear out any leftover from previous executions
 	s.accessList = newAccessList()
 
@@ -1102,14 +1102,13 @@ func (s *StateDB) PrepareAccessList(rules params.Rules, sender, feepayer, coinba
 	for _, addr := range precompiles {
 		s.AddAddressToAccessList(addr)
 	}
-	// Uncommented below code because we do not support optional accessList yet (written at eip-2930).
 	// Optional accessList is the accessList mentioned through tx args.
-	//for _, el := range list {
-	//	s.AddAddressToAccessList(el.Address)
-	//	for _, key := range el.StorageKeys {
-	//		s.AddSlotToAccessList(el.Address, key)
-	//	}
-	//}
+	for _, el := range list {
+		s.AddAddressToAccessList(el.Address)
+		for _, key := range el.StorageKeys {
+			s.AddSlotToAccessList(el.Address, key)
+		}
+	}
 	if rules.IsShanghai {
 		s.AddAddressToAccessList(coinbase)
 	}

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -1088,29 +1088,35 @@ func (s *StateDB) GetContractStorageRoot(contractAddr common.Address) (common.Ex
 // regards to EIP-3651:
 // - Add coinbase to access list (EIP-3651)
 func (s *StateDB) PrepareAccessList(rules params.Rules, sender, feepayer, coinbase common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList) {
-	// Clear out any leftover from previous executions
-	s.accessList = newAccessList()
+	if rules.IsKore {
+		// Clear out any leftover from previous executions
+		s.accessList = newAccessList()
 
-	s.AddAddressToAccessList(sender)
-	if !common.EmptyAddress(feepayer) {
-		s.AddAddressToAccessList(feepayer)
-	}
-	if dst != nil {
-		s.AddAddressToAccessList(*dst)
-		// If it's a create-tx, the destination will be added inside evm.create
-	}
-	for _, addr := range precompiles {
-		s.AddAddressToAccessList(addr)
-	}
-	// Optional accessList is the accessList mentioned through tx args.
-	for _, el := range list {
-		s.AddAddressToAccessList(el.Address)
-		for _, key := range el.StorageKeys {
-			s.AddSlotToAccessList(el.Address, key)
+		s.AddAddressToAccessList(sender)
+		if !common.EmptyAddress(feepayer) {
+			s.AddAddressToAccessList(feepayer)
 		}
-	}
-	if rules.IsShanghai {
-		s.AddAddressToAccessList(coinbase)
+		if dst != nil {
+			s.AddAddressToAccessList(*dst)
+			// If it's a create-tx, the destination will be added inside evm.create
+		}
+		for _, addr := range precompiles {
+			s.AddAddressToAccessList(addr)
+		}
+
+		if rules.IsCancun {
+			// Optional accessList is the accessList mentioned through tx args.
+			for _, el := range list {
+				s.AddAddressToAccessList(el.Address)
+				for _, key := range el.StorageKeys {
+					s.AddSlotToAccessList(el.Address, key)
+				}
+			}
+		}
+
+		if rules.IsShanghai {
+			s.AddAddressToAccessList(coinbase)
+		}
 	}
 }
 

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -343,10 +343,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
-	if rules.IsCancun {
+	if rules.IsKore {
 		st.state.PrepareAccessList(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Coinbase, msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
-	} else if rules.IsKore {
-		st.state.PrepareAccessList(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Coinbase, msg.To(), vm.ActivePrecompiles(rules), nil)
 	}
 
 	// Check whether the init code size has been exceeded.

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -119,6 +119,8 @@ type Message interface {
 
 	// Execute performs execution of the transaction according to the transaction type.
 	Execute(vm types.VM, stateDB types.StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) ([]byte, uint64, error)
+
+	AccessList() types.AccessList
 }
 
 // ExecutionResult includes all output after executing given evm
@@ -342,7 +344,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
 	if rules.IsKore {
-		st.state.PrepareAccessList(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Coinbase, msg.To(), vm.ActivePrecompiles(rules))
+		st.state.PrepareAccessList(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Coinbase, msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
 	}
 
 	// Check whether the init code size has been exceeded.

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -343,8 +343,10 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
-	if rules.IsKore {
+	if rules.IsCancun {
 		st.state.PrepareAccessList(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Coinbase, msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
+	} else if rules.IsKore {
+		st.state.PrepareAccessList(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Coinbase, msg.To(), vm.ActivePrecompiles(rules), nil)
 	}
 
 	// Check whether the init code size has been exceeded.

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -1024,7 +1024,7 @@ func (t *TransactionsByTimeAndNonce) Pop() {
 }
 
 // NewMessage returns a `*Transaction` object with the given arguments.
-func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, checkNonce bool, intrinsicGas uint64) *Transaction {
+func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, checkNonce bool, intrinsicGas uint64, list AccessList) *Transaction {
 	transaction := &Transaction{
 		validatedIntrinsicGas: intrinsicGas,
 		validatedFeePayer:     from,
@@ -1032,8 +1032,13 @@ func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *b
 		checkNonce:            checkNonce,
 	}
 
-	internalData := newTxInternalDataLegacyWithValues(nonce, to, amount, gasLimit, gasPrice, data)
-	transaction.setDecoded(internalData, 0)
+	if list != nil {
+		internalData := newTxInternalDataEthereumAccessListWithValues(nonce, to, amount, gasLimit, gasPrice, data, list, nil)
+		transaction.setDecoded(internalData, 0)
+	} else {
+		internalData := newTxInternalDataLegacyWithValues(nonce, to, amount, gasLimit, gasPrice, data)
+		transaction.setDecoded(internalData, 0)
+	}
 
 	return transaction
 }

--- a/blockchain/types/tx_internal_data_ethereum_access_list.go
+++ b/blockchain/types/tx_internal_data_ethereum_access_list.go
@@ -132,7 +132,7 @@ func newTxInternalDataEthereumAccessListWithValues(nonce uint64, to *common.Addr
 	}
 
 	if accessList != nil {
-		copy(d.AccessList, accessList)
+		d.AccessList = append(d.AccessList, accessList...)
 	}
 
 	return d

--- a/blockchain/vm/interface.go
+++ b/blockchain/vm/interface.go
@@ -71,7 +71,7 @@ type StateDB interface {
 	// is defined according to EIP161 (balance = nonce = code = 0).
 	Empty(common.Address) bool
 
-	PrepareAccessList(rules params.Rules, sender, feePayer, coinbase common.Address, dest *common.Address, precompiles []common.Address)
+	PrepareAccessList(rules params.Rules, sender, feePayer, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
 	AddressInAccessList(addr common.Address) bool
 	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
 	// AddAddressToAccessList adds the given address to the access list. This operation is safe to perform

--- a/blockchain/vm/runtime/runtime.go
+++ b/blockchain/vm/runtime/runtime.go
@@ -117,9 +117,8 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 		sender  = vm.AccountRef(cfg.Origin)
 		rules   = cfg.ChainConfig.Rules(vmenv.BlockNumber)
 	)
-	if rules.IsKore {
-		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
-	}
+
+	cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
 	cfg.State.CreateSmartContractAccount(address, params.CodeFormatEVM, cfg.ChainConfig.Rules(cfg.BlockNumber))
 	// set the receiver's (the executing contract) code for execution.
 	cfg.State.SetCode(address, code)
@@ -151,9 +150,8 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 		sender = vm.AccountRef(cfg.Origin)
 		rules  = cfg.ChainConfig.Rules(vmenv.BlockNumber)
 	)
-	if rules.IsKore {
-		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, nil, vm.ActivePrecompiles(rules), nil)
-	}
+
+	cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, nil, vm.ActivePrecompiles(rules), nil)
 	// Call the code with the given configuration.
 	code, address, leftOverGas, err := vmenv.Create(
 		sender,
@@ -179,9 +177,8 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 		sender        = types.NewAccountRefWithFeePayer(senderAccount.Address(), senderAccount.Address())
 		rules         = cfg.ChainConfig.Rules(vmenv.BlockNumber)
 	)
-	if rules.IsKore {
-		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
-	}
+
+	cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
 	// Call the code with the given configuration.
 	ret, leftOverGas, err := vmenv.Call(
 		sender,

--- a/blockchain/vm/runtime/runtime.go
+++ b/blockchain/vm/runtime/runtime.go
@@ -118,7 +118,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 		rules   = cfg.ChainConfig.Rules(vmenv.BlockNumber)
 	)
 	if rules.IsKore {
-		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules))
+		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
 	}
 	cfg.State.CreateSmartContractAccount(address, params.CodeFormatEVM, cfg.ChainConfig.Rules(cfg.BlockNumber))
 	// set the receiver's (the executing contract) code for execution.
@@ -152,7 +152,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 		rules  = cfg.ChainConfig.Rules(vmenv.BlockNumber)
 	)
 	if rules.IsKore {
-		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, nil, vm.ActivePrecompiles(rules))
+		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, nil, vm.ActivePrecompiles(rules), nil)
 	}
 	// Call the code with the given configuration.
 	code, address, leftOverGas, err := vmenv.Create(
@@ -180,7 +180,7 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 		rules         = cfg.ChainConfig.Rules(vmenv.BlockNumber)
 	)
 	if rules.IsKore {
-		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules))
+		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
 	}
 	// Call the code with the given configuration.
 	ret, leftOverGas, err := vmenv.Call(

--- a/consensus/istanbul/backend/kip103.go
+++ b/consensus/istanbul/backend/kip103.go
@@ -42,8 +42,9 @@ func (caller *Kip103ContractCaller) CallContract(ctx context.Context, call klayt
 	// call.To: the target contract address will be assigned by `BoundContract`
 	// call.Value: nil value is acceptable for `types.NewMessage`
 	// call.Data: a proper value will be assigned by `BoundContract`
+	// No need to handle acccess list here
 	msg := types.NewMessage(call.From, call.To, caller.state.GetNonce(call.From),
-		call.Value, gasLimit, gasPrice, call.Data, false, intrinsicGas)
+		call.Value, gasLimit, gasPrice, call.Data, false, intrinsicGas, nil)
 
 	context := blockchain.NewEVMContext(msg, caller.header, caller.chain, nil)
 	context.GasPrice = gasPrice                                                  // set gasPrice again if baseFee is assigned

--- a/interfaces.go
+++ b/interfaces.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/hexutil"
 )
 
 // NotFound is returned by API methods if the requested item does not exist.
@@ -121,6 +122,10 @@ type CallMsg struct {
 	GasPrice *big.Int        // peb <-> gas exchange ratio
 	Value    *big.Int        // amount of peb sent along with the call
 	Data     []byte          // input data, usually an ABI-encoded contract method invocation
+
+	// Introduced by AccessListTxType transaction.
+	AccessList *types.AccessList `json:"accessList,omitempty"`
+	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -276,7 +276,7 @@ func (tx *stTransaction) toMessage(ps stPostState, r params.Rules) (blockchain.M
 		return nil, err
 	}
 
-	msg := types.NewMessage(from, to, tx.Nonce, value, gasLimit, tx.GasPrice, data, true, intrinsicGas)
+	msg := types.NewMessage(from, to, tx.Nonce, value, gasLimit, tx.GasPrice, data, true, intrinsicGas, nil)
 	return msg, nil
 }
 


### PR DESCRIPTION
## Proposed changes

- Although we accept `TxTypeEthereumAccessList` after EthTxType hardfork and EIP-2930 has been accounted after Kore hardfork(#1705), the provided access list is not properly handled (i.e., has no benefit using access list)
- This PR adds full support for address list

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #1850 

## Further comments
