### PR TITLE
common: use crypto/rand library for random byte generation

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -21,10 +21,10 @@
 package common
 
 import (
+	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
-	"math/rand"
-	"time"
+	"io"
 )
 
 // ToHex returns the hex representation of b, prefixed with '0x'.
@@ -161,9 +161,11 @@ func TrimRightZeroes(s []byte) []byte {
 }
 
 func MakeRandomBytes(n int) []byte {
-	rand.Seed(time.Now().UTC().UnixNano())
 	s := make([]byte, n)
-	rand.Read(s)
+	_, err := io.ReadFull(rand.Reader, s)
+	if err != nil {
+		return nil
+	}
 	return s
 }
 

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -394,10 +394,10 @@ func insertRandomData(db KeyValueWriter, prefix []byte, num int) (testDataSlice,
 	ret := testDataSlice{}
 	for i := 0; i < num; i++ {
 		key := common.MakeRandomBytes(32)
+		val := append(key, key...)
 		if len(prefix) > 0 {
 			key = append(prefix, key...)
 		}
-		val := common.MakeRandomBytes(100)
 		ret = append(ret, &testData{k: key, v: val})
 
 		if err := db.Put(key, val); err != nil {


### PR DESCRIPTION
## Proposed changes
- Database testcase has been failed frequently. The reason is because`insertRandomData` generates test key,value data for batchwrite and the key can be duplicated. If the key is duplicated, the old one in batch is overwritten. However, the old one is not deleted from the expect value for the test case so validation failed.
- I have changed the rand library from math/rand to crypto/rand to reduce the collision. macos has not been failed since the math/rand implementation was different from linux.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
