### PR TITLE
Add rocksdb flag aliases

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -354,6 +354,7 @@ var (
 	RocksDBSecondaryFlag = &cli.BoolFlag{
 		Name:     "db.rocksdb.secondary",
 		Usage:    "Enable rocksdb secondary mode (read-only and catch-up with primary node dynamically)",
+		Aliases:  []string{"migration.src.db.rocksdb.secondary"},
 		EnvVars:  []string{"KLAYTN_DB_ROCKSDB_SECONDARY"},
 		Category: "DATABASE",
 	}
@@ -361,12 +362,14 @@ var (
 		Name:     "db.rocksdb.cache-size",
 		Usage:    "Size of in-memory cache in RocksDB (MiB)",
 		Value:    768,
+		Aliases:  []string{"migration.src.db.rocksdb.cache-size"},
 		EnvVars:  []string{"KLAYTN_DB_ROCKSDB_CACHE_SIZE"},
 		Category: "DATABASE",
 	}
 	RocksDBDumpMallocStatFlag = &cli.BoolFlag{
 		Name:     "db.rocksdb.dump-malloc-stat",
 		Usage:    "Enable to print memory stat together with rocksdb.stat. Works with Jemalloc only.",
+		Aliases:  []string{"migration.src.db.rocksdb.dump-malloc-stat"},
 		EnvVars:  []string{"KLAYTN_DB_ROCKSDB_DUMP_MALLOC_STAT"},
 		Category: "DATABASE",
 	}
@@ -374,6 +377,7 @@ var (
 		Name:     "db.rocksdb.compression-type",
 		Usage:    "RocksDB block compression type. Supported values are 'no', 'snappy', 'zlib', 'bz', 'lz4', 'lz4hc', 'xpress', 'zstd'",
 		Value:    database.GetDefaultRocksDBConfig().CompressionType,
+		Aliases:  []string{"migration.src.db.rocksdb.compression-type"},
 		EnvVars:  []string{"KLAYTN_DB_ROCKSDB_COMPRESSION_TYPE"},
 		Category: "DATABASE",
 	}
@@ -381,6 +385,7 @@ var (
 		Name:     "db.rocksdb.bottommost-compression-type",
 		Usage:    "RocksDB bottommost block compression type. Supported values are 'no', 'snappy', 'zlib', 'bz2', 'lz4', 'lz4hc', 'xpress', 'zstd'",
 		Value:    database.GetDefaultRocksDBConfig().BottommostCompressionType,
+		Aliases:  []string{"migration.src.db.rocksdb.bottommost-compression-type"},
 		EnvVars:  []string{"KLAYTN_DB_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE"},
 		Category: "DATABASE",
 	}
@@ -388,12 +393,14 @@ var (
 		Name:     "db.rocksdb.filter-policy",
 		Usage:    "RocksDB filter policy. Supported values are 'no', 'bloom', 'ribbon'",
 		Value:    database.GetDefaultRocksDBConfig().FilterPolicy,
+		Aliases:  []string{"migration.src.db.rocksdb.filter-policy"},
 		EnvVars:  []string{"KLAYTN_DB_ROCKSDB_FILTER_POLICY"},
 		Category: "DATABASE",
 	}
 	RocksDBDisableMetricsFlag = &cli.BoolFlag{
 		Name:     "db.rocksdb.disable-metrics",
 		Usage:    "Disable RocksDB metrics",
+		Aliases:  []string{"migration.src.db.rocksdb.disable-metrics"},
 		EnvVars:  []string{"KLAYTN_DB_ROCKSDB_DISABLE_METRICS"},
 		Category: "DATABASE",
 	}
@@ -401,12 +408,14 @@ var (
 		Name:     "db.rocksdb.max-open-files",
 		Usage:    "Set RocksDB max open files. (the value should be greater than 16)",
 		Value:    database.GetDefaultRocksDBConfig().MaxOpenFiles,
+		Aliases:  []string{"migration.src.db.rocksdb.max-open-files"},
 		EnvVars:  []string{"KLAYTN_DB_ROCKSDB_MAX_OPEN_FILES"},
 		Category: "DATABASE",
 	}
 	RocksDBCacheIndexAndFilterFlag = &cli.BoolFlag{
 		Name:     "db.rocksdb.cache-index-and-filter",
 		Usage:    "Use block cache for index and filter blocks.",
+		Aliases:  []string{"migration.src.db.rocksdb.cache-index-and-filter"},
 		EnvVars:  []string{"KLAYTN_DB_ROCKSDB_CACHE_INDEX_AND_FILTER"},
 		Category: "DATABASE",
 	}


### PR DESCRIPTION
## Proposed changes

Adds missing RocksDB flag aliases, as per https://github.com/klaytn/klaytn/pull/1918#pullrequestreview-1562472371.

> aliases only exist for "DstRocksDB*", so I'll add aliases to "RocksDB*" ...

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules