### PR TITLE
api: add debug_tracecall

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -282,7 +282,7 @@ type CallArgs struct {
 	Input                hexutil.Bytes   `json:"input"`
 }
 
-func (args *CallArgs) data() []byte {
+func (args *CallArgs) Payload() []byte {
 	if args.Input != nil {
 		return args.Input
 	}
@@ -311,7 +311,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	// this makes sure resources are cleaned up.
 	defer cancel()
 
-	intrinsicGas, err := types.IntrinsicGas(args.data(), nil, args.To == nil, b.ChainConfig().Rules(header.Number))
+	intrinsicGas, err := types.IntrinsicGas(args.Payload(), nil, args.To == nil, b.ChainConfig().Rules(header.Number))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -709,5 +709,5 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 	// if args.AccessList != nil {
 	//	 accessList = *args.AccessList
 	// }
-	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, args.data(), false, intrinsicGas), nil
+	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, args.Payload(), false, intrinsicGas), nil
 }

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -27,8 +27,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/klaytn/klaytn/node/cn/filters"
-
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/types/account"
@@ -39,6 +37,7 @@ import (
 	"github.com/klaytn/klaytn/common/math"
 	"github.com/klaytn/klaytn/log"
 	"github.com/klaytn/klaytn/networks/rpc"
+	"github.com/klaytn/klaytn/node/cn/filters"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 )
@@ -282,7 +281,7 @@ type CallArgs struct {
 	Input                hexutil.Bytes   `json:"input"`
 }
 
-func (args *CallArgs) Payload() []byte {
+func (args *CallArgs) InputData() []byte {
 	if args.Input != nil {
 		return args.Input
 	}
@@ -311,7 +310,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	// this makes sure resources are cleaned up.
 	defer cancel()
 
-	intrinsicGas, err := types.IntrinsicGas(args.Payload(), nil, args.To == nil, b.ChainConfig().Rules(header.Number))
+	intrinsicGas, err := types.IntrinsicGas(args.InputData(), nil, args.To == nil, b.ChainConfig().Rules(header.Number))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -709,5 +708,5 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 	// if args.AccessList != nil {
 	//	 accessList = *args.AccessList
 	// }
-	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, args.Payload(), false, intrinsicGas), nil
+	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, args.InputData(), false, intrinsicGas), nil
 }

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -793,6 +793,12 @@ web3._extend({
 			inputFormatter: [null, null]
 		}),
 		new web3._extend.Method({
+			name: 'traceCall',
+			call: 'debug_traceCall',
+			params: 3,
+			inputFormatter: [null, null, null]
+		}),
+		new web3._extend.Method({
 			name: 'preimage',
 			call: 'debug_preimage',
 			params: 1,

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -855,7 +855,7 @@ func (api *API) TraceCall(ctx context.Context, args klaytnapi.CallArgs, blockNrO
 	}
 
 	// Execute the trace
-	intrinsicGas, err := types.IntrinsicGas(args.Payload(), nil, args.To == nil, api.backend.ChainConfig().Rules(block.Number()))
+	intrinsicGas, err := types.IntrinsicGas(args.InputData(), nil, args.To == nil, api.backend.ChainConfig().Rules(block.Number()))
 	if err != nil {
 		return nil, err
 	}

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -818,6 +818,64 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 	return api.traceTx(ctx, msg, vmctx, statedb, config)
 }
 
+// TraceCall lets you trace a given klay_call. It collects the structured logs
+// created during the execution of EVM if the given transaction was added on
+// top of the provided block and returns them as a JSON object.
+func (api *API) TraceCall(ctx context.Context, args klaytnapi.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceConfig) (interface{}, error) {
+	if !api.unsafeTrace {
+		if atomic.LoadInt32(&heavyAPIRequestCount) >= HeavyAPIRequestLimit {
+			return nil, fmt.Errorf("heavy debug api requests exceed the limit: %d", int64(HeavyAPIRequestLimit))
+		}
+		atomic.AddInt32(&heavyAPIRequestCount, 1)
+		defer atomic.AddInt32(&heavyAPIRequestCount, -1)
+	}
+	// Try to retrieve the specified block
+	var (
+		err   error
+		block *types.Block
+	)
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		block, err = api.blockByHash(ctx, hash)
+	} else if number, ok := blockNrOrHash.Number(); ok {
+		block, err = api.blockByNumber(ctx, number)
+	} else {
+		return nil, errors.New("invalid arguments; neither block nor hash specified")
+	}
+	if err != nil {
+		return nil, err
+	}
+	// try to recompute the state
+	reexec := defaultTraceReexec
+	if config != nil && config.Reexec != nil {
+		reexec = *config.Reexec
+	}
+	statedb, err := api.backend.StateAtBlock(ctx, block, reexec, nil, true, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute the trace
+	intrinsicGas, err := types.IntrinsicGas(args.Payload(), nil, args.To == nil, api.backend.ChainConfig().Rules(block.Number()))
+	if err != nil {
+		return nil, err
+	}
+	basefee := new(big.Int).SetUint64(params.ZeroBaseFee)
+	if block.Header().BaseFee != nil {
+		basefee = block.Header().BaseFee
+	}
+	gasCap := uint64(0)
+	if rpcGasCap := api.backend.RPCGasCap(); rpcGasCap != nil {
+		gasCap = rpcGasCap.Uint64()
+	}
+	msg, err := args.ToMessage(gasCap, basefee, intrinsicGas)
+	if err != nil {
+		return nil, err
+	}
+	vmctx := blockchain.NewEVMContext(msg, block.Header(), newChainContext(ctx, api.backend), nil)
+
+	return api.traceTx(ctx, msg, vmctx, statedb, config)
+}
+
 // traceTx configures a new tracer according to the provided configuration, and
 // executes the given message in the provided environment. The return value will
 // be tracer dependent.

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -194,7 +194,7 @@ func TestTraceCall(t *testing.T) {
 	genBlocks := 10
 	signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
 	api := NewAPI(newTestBackend(t, genBlocks, genesis, func(i int, b *blockchain.BlockGen) {
-		// Transfer from account[0] to account[1]
+		// Transfer from account[1] to account[0]
 		//    value: 1000 peb
 		//    fee:   0 peb
 		tx, err := types.SignTx(types.NewTransaction(uint64(i), accounts[0].addr, big.NewInt(1000), params.TxGas, big.NewInt(0), nil), signer, accounts[1].key)

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -292,23 +292,8 @@ func TestTraceCall(t *testing.T) {
 	}
 	for _, testspec := range testSuite {
 		result, err := api.TraceCall(context.Background(), testspec.call, rpc.BlockNumberOrHash{BlockNumber: &testspec.blockNumber}, testspec.config)
-		if testspec.expectErr != nil {
-			if err == nil {
-				t.Errorf("Expect error %v, get nothing", testspec.expectErr)
-				continue
-			}
-			if !reflect.DeepEqual(err, testspec.expectErr) {
-				t.Errorf("Error mismatch, want %v, get %v", testspec.expectErr, err)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("Expect no error, get %v", err)
-				continue
-			}
-			if !reflect.DeepEqual(result, testspec.expect) {
-				t.Errorf("Result mismatch, want %v, get %v", testspec.expect, result)
-			}
-		}
+		assert.Equal(t, err, testspec.expectErr)
+		assert.Equal(t, result, testspec.expect)
 	}
 }
 

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -187,9 +187,9 @@ func TestTraceCall(t *testing.T) {
 	// Initialize test accounts
 	accounts := newAccounts(3)
 	genesis := &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
-		accounts[0].addr: {Balance: big.NewInt(params.KLAY)},
-		accounts[1].addr: {Balance: big.NewInt(params.KLAY)},
-		accounts[2].addr: {Balance: big.NewInt(params.KLAY)},
+		accounts[0].addr: {Balance: big.NewInt(0)},
+		accounts[1].addr: {Balance: big.NewInt(1000 * 10)},
+		accounts[2].addr: {Balance: big.NewInt(0)},
 	}}
 	genBlocks := 10
 	signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
@@ -197,7 +197,7 @@ func TestTraceCall(t *testing.T) {
 		// Transfer from account[0] to account[1]
 		//    value: 1000 peb
 		//    fee:   0 peb
-		tx, err := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, big.NewInt(0), nil), signer, accounts[0].key)
+		tx, err := types.SignTx(types.NewTransaction(uint64(i), accounts[0].addr, big.NewInt(1000), params.TxGas, big.NewInt(0), nil), signer, accounts[1].key)
 		assert.NoError(t, err)
 		b.AddTx(tx)
 	}))
@@ -218,13 +218,8 @@ func TestTraceCall(t *testing.T) {
 				Value: (hexutil.Big)(*big.NewInt(1000)),
 			},
 			config:    nil,
-			expectErr: nil,
-			expect: &klaytnapi.ExecutionResult{
-				Gas:         params.TxGas,
-				Failed:      false,
-				ReturnValue: "",
-				StructLogs:  []klaytnapi.StructLogRes{},
-			},
+			expectErr: errors.New("tracing failed: insufficient balance for transfer"),
+			expect:    nil,
 		},
 		// Standard JSON trace upon the head, plain transfer.
 		{

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/consensus"
 	"github.com/klaytn/klaytn/consensus/gxhash"
 	"github.com/klaytn/klaytn/crypto"
@@ -43,6 +44,7 @@ import (
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/klaytn/klaytn/storage/statedb"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -179,136 +181,136 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 	return nil, vm.Context{}, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
 }
 
-// TODO-tracer: implement TraceCall
-//func TestTraceCall(t *testing.T) {
-//	t.Parallel()
-//
-//	// Initialize test accounts
-//	accounts := newAccounts(3)
-//	genesis := &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
-//		accounts[0].addr: {Balance: big.NewInt(params.KLAY)},
-//		accounts[1].addr: {Balance: big.NewInt(params.KLAY)},
-//		accounts[2].addr: {Balance: big.NewInt(params.KLAY)},
-//	}}
-//	genBlocks := 10
-//	signer := types.HomesteadSigner{}
-//	api := NewAPI(newTestBackend(t, genBlocks, genesis, func(i int, b *blockchain.BlockGen) {
-//		// Transfer from account[0] to account[1]
-//		//    value: 1000 peb
-//		//    fee:   0 peb
-//		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, big.NewInt(0), nil), signer, accounts[0].key)
-//		b.AddTx(tx)
-//	}))
-//
-//	var testSuite = []struct {
-//		blockNumber rpc.BlockNumber
-//		call        klaytnapi.CallArgs
-//		config      *TraceConfig
-//		expectErr   error
-//		expect      interface{}
-//	}{
-//		// Standard JSON trace upon the genesis, plain transfer.
-//		{
-//			blockNumber: rpc.BlockNumber(0),
-//			call: klaytnapi.CallArgs{
-//				From:  accounts[0].addr,
-//				To:    &accounts[1].addr,
-//				Value: (hexutil.Big)(*big.NewInt(1000)),
-//			},
-//			config:    nil,
-//			expectErr: nil,
-//			expect: &klaytnapi.ExecutionResult{
-//				Gas:         params.TxGas,
-//				Failed:      false,
-//				ReturnValue: "",
-//				StructLogs:  []klaytnapi.StructLogRes{},
-//			},
-//		},
-//		// Standard JSON trace upon the head, plain transfer.
-//		{
-//			blockNumber: rpc.BlockNumber(genBlocks),
-//			call: klaytnapi.CallArgs{
-//				From:  accounts[0].addr,
-//				To:    &accounts[1].addr,
-//				Value: (hexutil.Big)(*big.NewInt(1000)),
-//			},
-//			config:    nil,
-//			expectErr: nil,
-//			expect: &klaytnapi.ExecutionResult{
-//				Gas:         params.TxGas,
-//				Failed:      false,
-//				ReturnValue: "",
-//				StructLogs:  []klaytnapi.StructLogRes{},
-//			},
-//		},
-//		// Standard JSON trace upon the non-existent block, error expects
-//		{
-//			blockNumber: rpc.BlockNumber(genBlocks + 1),
-//			call: klaytnapi.CallArgs{
-//				From:  accounts[0].addr,
-//				To:    &accounts[1].addr,
-//				Value: (hexutil.Big)(*big.NewInt(1000)),
-//			},
-//			config:    nil,
-//			expectErr: fmt.Errorf("the block does not exist (block number: %d)", genBlocks+1),
-//			expect:    nil,
-//		},
-//		// Standard JSON trace upon the latest block
-//		{
-//			blockNumber: rpc.LatestBlockNumber,
-//			call: klaytnapi.CallArgs{
-//				From:  accounts[0].addr,
-//				To:    &accounts[1].addr,
-//				Value: (hexutil.Big)(*big.NewInt(1000)),
-//			},
-//			config:    nil,
-//			expectErr: nil,
-//			expect: &klaytnapi.ExecutionResult{
-//				Gas:         params.TxGas,
-//				Failed:      false,
-//				ReturnValue: "",
-//				StructLogs:  []klaytnapi.StructLogRes{},
-//			},
-//		},
-//		// Standard JSON trace upon the pending block
-//		{
-//			blockNumber: rpc.PendingBlockNumber,
-//			call: klaytnapi.CallArgs{
-//				From:  accounts[0].addr,
-//				To:    &accounts[1].addr,
-//				Value: (hexutil.Big)(*big.NewInt(1000)),
-//			},
-//			config:    nil,
-//			expectErr: nil,
-//			expect: &klaytnapi.ExecutionResult{
-//				Gas:         params.TxGas,
-//				Failed:      false,
-//				ReturnValue: "",
-//				StructLogs:  []klaytnapi.StructLogRes{},
-//			},
-//		},
-//	}
-//	for _, testspec := range testSuite {
-//		result, err := api.TraceCall(context.Background(), testspec.call, rpc.BlockNumberOrHash{BlockNumber: &testspec.blockNumber}, testspec.config)
-//		if testspec.expectErr != nil {
-//			if err == nil {
-//				t.Errorf("Expect error %v, get nothing", testspec.expectErr)
-//				continue
-//			}
-//			if !reflect.DeepEqual(err, testspec.expectErr) {
-//				t.Errorf("Error mismatch, want %v, get %v", testspec.expectErr, err)
-//			}
-//		} else {
-//			if err != nil {
-//				t.Errorf("Expect no error, get %v", err)
-//				continue
-//			}
-//			if !reflect.DeepEqual(result, testspec.expect) {
-//				t.Errorf("Result mismatch, want %v, get %v", testspec.expect, result)
-//			}
-//		}
-//	}
-//}
+func TestTraceCall(t *testing.T) {
+	t.Parallel()
+
+	// Initialize test accounts
+	accounts := newAccounts(3)
+	genesis := &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
+		accounts[0].addr: {Balance: big.NewInt(params.KLAY)},
+		accounts[1].addr: {Balance: big.NewInt(params.KLAY)},
+		accounts[2].addr: {Balance: big.NewInt(params.KLAY)},
+	}}
+	genBlocks := 10
+	signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
+	api := NewAPI(newTestBackend(t, genBlocks, genesis, func(i int, b *blockchain.BlockGen) {
+		// Transfer from account[0] to account[1]
+		//    value: 1000 peb
+		//    fee:   0 peb
+		tx, err := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, big.NewInt(0), nil), signer, accounts[0].key)
+		assert.NoError(t, err)
+		b.AddTx(tx)
+	}))
+
+	testSuite := []struct {
+		blockNumber rpc.BlockNumber
+		call        klaytnapi.CallArgs
+		config      *TraceConfig
+		expectErr   error
+		expect      interface{}
+	}{
+		// Standard JSON trace upon the genesis, plain transfer.
+		{
+			blockNumber: rpc.BlockNumber(0),
+			call: klaytnapi.CallArgs{
+				From:  accounts[0].addr,
+				To:    &accounts[1].addr,
+				Value: (hexutil.Big)(*big.NewInt(1000)),
+			},
+			config:    nil,
+			expectErr: nil,
+			expect: &klaytnapi.ExecutionResult{
+				Gas:         params.TxGas,
+				Failed:      false,
+				ReturnValue: "",
+				StructLogs:  []klaytnapi.StructLogRes{},
+			},
+		},
+		// Standard JSON trace upon the head, plain transfer.
+		{
+			blockNumber: rpc.BlockNumber(genBlocks),
+			call: klaytnapi.CallArgs{
+				From:  accounts[0].addr,
+				To:    &accounts[1].addr,
+				Value: (hexutil.Big)(*big.NewInt(1000)),
+			},
+			config:    nil,
+			expectErr: nil,
+			expect: &klaytnapi.ExecutionResult{
+				Gas:         params.TxGas,
+				Failed:      false,
+				ReturnValue: "",
+				StructLogs:  []klaytnapi.StructLogRes{},
+			},
+		},
+		// Standard JSON trace upon the non-existent block, error expects
+		{
+			blockNumber: rpc.BlockNumber(genBlocks + 1),
+			call: klaytnapi.CallArgs{
+				From:  accounts[0].addr,
+				To:    &accounts[1].addr,
+				Value: (hexutil.Big)(*big.NewInt(1000)),
+			},
+			config:    nil,
+			expectErr: fmt.Errorf("the block does not exist (block number: %d)", genBlocks+1),
+			expect:    nil,
+		},
+		// Standard JSON trace upon the latest block
+		{
+			blockNumber: rpc.LatestBlockNumber,
+			call: klaytnapi.CallArgs{
+				From:  accounts[0].addr,
+				To:    &accounts[1].addr,
+				Value: (hexutil.Big)(*big.NewInt(1000)),
+			},
+			config:    nil,
+			expectErr: nil,
+			expect: &klaytnapi.ExecutionResult{
+				Gas:         params.TxGas,
+				Failed:      false,
+				ReturnValue: "",
+				StructLogs:  []klaytnapi.StructLogRes{},
+			},
+		},
+		// Standard JSON trace upon the pending block
+		{
+			blockNumber: rpc.PendingBlockNumber,
+			call: klaytnapi.CallArgs{
+				From:  accounts[0].addr,
+				To:    &accounts[1].addr,
+				Value: (hexutil.Big)(*big.NewInt(1000)),
+			},
+			config:    nil,
+			expectErr: nil,
+			expect: &klaytnapi.ExecutionResult{
+				Gas:         params.TxGas,
+				Failed:      false,
+				ReturnValue: "",
+				StructLogs:  []klaytnapi.StructLogRes{},
+			},
+		},
+	}
+	for _, testspec := range testSuite {
+		result, err := api.TraceCall(context.Background(), testspec.call, rpc.BlockNumberOrHash{BlockNumber: &testspec.blockNumber}, testspec.config)
+		if testspec.expectErr != nil {
+			if err == nil {
+				t.Errorf("Expect error %v, get nothing", testspec.expectErr)
+				continue
+			}
+			if !reflect.DeepEqual(err, testspec.expectErr) {
+				t.Errorf("Error mismatch, want %v, get %v", testspec.expectErr, err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Expect no error, get %v", err)
+				continue
+			}
+			if !reflect.DeepEqual(result, testspec.expect) {
+				t.Errorf("Result mismatch, want %v, get %v", testspec.expect, result)
+			}
+		}
+	}
+}
 
 func TestTraceTransaction(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Proposed changes
This PR adds new api `debug_tracecall`.
It allows tracing on a specific block if callArgs is provided.

traceCall tested on local network
```
> debug.traceCall({from: klay.accounts[0], to: "0xB2da01761B494F5F257fD3bA626fBAbFaE104313", input: "0x6057361d0000000000000000000000000000000000000000000000000000000000000003"}, klay.blockNumber, {tracer:"revertTracer"})
"input was three"
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/klaytn/klaytn/issues/1870

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
