### PR TITLE
Add new error types for accounts

### DIFF
--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -378,7 +378,7 @@ func expectedTestResultForDefaultTx(accountKeyType accountkey.AccountKeyType, tx
 		if txType.IsAccountUpdate() {
 			return kerrors.ErrAccountKeyFailNotUpdatable
 		}
-		return types.ErrSender(types.ErrInvalidSigSender)
+		return types.ErrSender(types.ErrInvalidAccountKey)
 	}
 	return nil
 }
@@ -1603,14 +1603,14 @@ func TestAccountUpdateRoleBasedKey(t *testing.T) {
 		// For tx pool validation test
 		{
 			err = txpool.AddRemote(tx)
-			assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+			assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 		}
 
 		// For block tx validation test
 		{
 			receipt, err := applyTransaction(t, bcdata, tx)
 			assert.Equal(t, (*types.Receipt)(nil), receipt)
-			assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+			assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 		}
 	}
 
@@ -1632,14 +1632,14 @@ func TestAccountUpdateRoleBasedKey(t *testing.T) {
 		// For tx pool validation test
 		{
 			err = txpool.AddRemote(tx)
-			assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+			assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 		}
 
 		// For block tx validation test
 		{
 			receipt, err := applyTransaction(t, bcdata, tx)
 			assert.Equal(t, (*types.Receipt)(nil), receipt)
-			assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+			assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 		}
 	}
 
@@ -1992,13 +1992,13 @@ func TestRoleBasedKeySendTx(t *testing.T) {
 				// For tx pool validation test
 				{
 					err = txpool.AddRemote(tx)
-					assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+					assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 				}
 
 				// For block tx validation test
 				{
 					receipt, err := applyTransaction(t, bcdata, tx)
-					assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+					assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 					assert.Equal(t, (*types.Receipt)(nil), receipt)
 				}
 			}
@@ -2189,13 +2189,13 @@ func TestRoleBasedKeyFeeDelegation(t *testing.T) {
 				// For tx pool validation test
 				{
 					err = txpool.AddRemote(tx)
-					assert.Equal(t, types.ErrFeePayer(types.ErrInvalidSigFeePayer), err)
+					assert.Equal(t, types.ErrFeePayer(types.ErrInvalidAccountKey), err)
 				}
 
 				// For block tx validation test
 				{
 					receipt, err := applyTransaction(t, bcdata, tx)
-					assert.Equal(t, types.ErrFeePayer(types.ErrInvalidSigFeePayer), err)
+					assert.Equal(t, types.ErrFeePayer(types.ErrInvalidAccountKey), err)
 					assert.Equal(t, (*types.Receipt)(nil), receipt)
 				}
 			}

--- a/tests/klay_scenario_test.go
+++ b/tests/klay_scenario_test.go
@@ -675,7 +675,7 @@ func TestSmartContractSign(t *testing.T) {
 
 		receipt, err := applyTransaction(t, bcdata, tx)
 		assert.Equal(t, (*types.Receipt)(nil), receipt)
-		assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+		assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 	}
 
 	// 4. Try fee delegation. It should be failed.
@@ -701,7 +701,7 @@ func TestSmartContractSign(t *testing.T) {
 
 		receipt, err := applyTransaction(t, bcdata, tx)
 		assert.Equal(t, (*types.Receipt)(nil), receipt)
-		assert.Equal(t, types.ErrFeePayer(types.ErrInvalidSigFeePayer), err)
+		assert.Equal(t, types.ErrFeePayer(types.ErrInvalidAccountKey), err)
 	}
 }
 
@@ -1721,7 +1721,7 @@ func TestMultisigScenario(t *testing.T) {
 		assert.Equal(t, nil, err)
 
 		receipt, err := applyTransaction(t, bcdata, tx)
-		assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+		assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 		assert.Equal(t, (*types.Receipt)(nil), receipt)
 	}
 

--- a/tests/role_based_account_test.go
+++ b/tests/role_based_account_test.go
@@ -590,7 +590,7 @@ func TestAccountUpdateRoleBasedLegacy(t *testing.T) {
 
 		receipt, err := applyTransaction(t, bcdata, tx)
 		assert.Equal(t, (*types.Receipt)(nil), receipt)
-		assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+		assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 	}
 
 	// 6. Test RoleTransfer of the RoleBasedKey with invalid number of signatures
@@ -615,7 +615,7 @@ func TestAccountUpdateRoleBasedLegacy(t *testing.T) {
 
 		receipt, err := applyTransaction(t, bcdata, tx)
 		assert.Equal(t, (*types.Receipt)(nil), receipt)
-		assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+		assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 	}
 }
 
@@ -859,7 +859,7 @@ func TestAccountUpdateRoleBasedTransition(t *testing.T) {
 
 		txpool := makeTxPool(bcdata, 10)
 		err = txpool.AddRemote(tx)
-		assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+		assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 	}
 
 	// 4. Execute TxTypeAccountUpdate
@@ -904,7 +904,7 @@ func TestAccountUpdateRoleBasedTransition(t *testing.T) {
 
 		txpool := makeTxPool(bcdata, 10)
 		err = txpool.AddRemote(tx)
-		assert.Equal(t, types.ErrSender(types.ErrInvalidSigSender), err)
+		assert.Equal(t, types.ErrSender(types.ErrInvalidAccountKey), err)
 	}
 
 	// 6. Inserting a tx signed by new key into the pool. It should pass.

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -666,7 +666,7 @@ func TestValidationInvalidSig(t *testing.T) {
 
 				// For block tx validation test
 				if expectedErr == blockchain.ErrInvalidFeePayer {
-					expectedErr = types.ErrFeePayer(types.ErrInvalidSigFeePayer)
+					expectedErr = types.ErrFeePayer(types.ErrInvalidAccountKey)
 				}
 				receipt, err := applyTransaction(t, bcdata, tx)
 				assert.Equal(t, expectedErr, err)
@@ -698,7 +698,7 @@ func testInvalidSenderSig(t *testing.T, txType types.TxType, reservoir *TestAcco
 			tx.SignFeePayerWithKeys(signer, reservoir.Keys)
 			assert.Equal(t, nil, err)
 		}
-		return tx, types.ErrSender(types.ErrInvalidSigSender)
+		return tx, types.ErrSender(types.ErrInvalidAccountKey)
 	}
 	return nil, nil
 }
@@ -726,7 +726,7 @@ func testInvalidFeePayerSig(t *testing.T, txType types.TxType, reservoir *TestAc
 
 		// Look at the blockchain/types/transaction.go/ValidateFeePayer
 		// Testcases using this function should return invalid signature error
-		return tx, types.ErrFeePayer(types.ErrInvalidSigFeePayer)
+		return tx, types.ErrFeePayer(types.ErrInvalidAccountKey)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
## Proposed changes

- Leave detailed information about the situation when throwing an error.
- Introduces new error types for accounts: `ErrNotLegacyAccount` and `ErrInvalidAccountKey`
- Error situations are subdivided and an error appropriate for each is generated.
- Delete unused error types: `errNoSigner`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #1610 

## Further comments

This PR is the same as #1958.
This was rewritten because the previous PR was accidentally deleted. 
