### PR TITLE
System contract registry accessors

### DIFF
--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -767,7 +767,13 @@ func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common
 			cb(key, value)
 			continue
 		}
-		cb(key, common.BytesToHash(it.Value))
+		enc := it.Value
+		if len(enc) > 0 {
+			_, content, _, _ := rlp.Split(enc)
+			cb(key, common.BytesToHash(content))
+		} else {
+			cb(key, common.Hash{})
+		}
 	}
 }
 

--- a/blockchain/system/constant.go
+++ b/blockchain/system/constant.go
@@ -1,0 +1,47 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"errors"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/hexutil"
+	contracts "github.com/klaytn/klaytn/contracts/system_contracts"
+	"github.com/klaytn/klaytn/log"
+)
+
+var (
+	logger = log.NewModuleLogger(log.Blockchain)
+
+	// Canonical system contract names registered in Registry.
+	AddressBookName = "AddressBook"
+
+	AllContractNames = []string{
+		AddressBookName,
+	}
+
+	// Some system contracts are allocated at special addresses.
+	RegistryAddr = common.HexToAddress("0x0000000000000000000000000000000000000401")
+
+	// System contract binaries to be injected at hardfork or used in testing.
+	RegistryCode     = hexutil.MustDecode("0x" + contracts.RegistryBinRuntime)
+	RegistryMockCode = hexutil.MustDecode("0x" + contracts.RegistryMockBinRuntime)
+
+	// Errors
+	ErrRegistryNotInstalled = errors.New("Registry contract not installed")
+)

--- a/blockchain/system/doc.go
+++ b/blockchain/system/doc.go
@@ -1,0 +1,25 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+/*
+Package system deals with system contracts in Klaytn.
+System contracts are smart contracts that affects the protocol.
+
+- Registry: Stores the canonical system contract addresses.
+
+*/

--- a/blockchain/system/registry.go
+++ b/blockchain/system/registry.go
@@ -1,0 +1,49 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/blockchain/state"
+	"github.com/klaytn/klaytn/common"
+	contracts "github.com/klaytn/klaytn/contracts/system_contracts"
+)
+
+func InstallRegistry(state *state.StateDB) error {
+	return state.SetCode(RegistryAddr, RegistryCode)
+}
+
+func ReadRegistryActiveAddr(backend bind.ContractCaller, name string, num *big.Int) (common.Address, error) {
+	caller, err := contracts.NewIRegistryCaller(RegistryAddr, backend)
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	code, err := backend.CodeAt(context.Background(), RegistryAddr, nil)
+	if err != nil {
+		return common.Address{}, err
+	} else if code == nil {
+		return common.Address{}, ErrRegistryNotInstalled
+	}
+
+	opts := &bind.CallOpts{BlockNumber: num}
+	addr, err := caller.GetActiveContract(opts, name)
+	return addr, err
+}

--- a/blockchain/system/registry.go
+++ b/blockchain/system/registry.go
@@ -26,6 +26,55 @@ import (
 	contracts "github.com/klaytn/klaytn/contracts/system_contracts"
 )
 
+type RegistryRecord struct {
+	Addr       common.Address
+	Activation *big.Int
+}
+
+type AllocRegistryInit struct {
+	Records map[string][]RegistryRecord
+	Names   []string
+	Owner   common.Address
+}
+
+// Create storage state from the given initial values.
+// The storage slots are calculated according to the solidity layout rule.
+// https://docs.soliditylang.org/en/v1.8.20/internals/layout_in_storage.html
+func AllocRegistry(init *AllocRegistryInit) map[common.Hash]common.Hash {
+	storage := make(map[common.Hash]common.Hash)
+
+	// slot[0]: mapping(string => Record[]) records;
+	// - records[x].length @ Hash(x, 0)
+	// - records[x][i].addr @ Hash(Hash(x, 0)) + (2*i)
+	// - records[x][i].activation @ Hash(Hash(x, 0)) + (2*i + 1)
+	for name, records := range init.Records {
+		arraySlot := calcMappingSlot(0, name)
+		storage[arraySlot] = lpad32(len(records))
+
+		for i, record := range records {
+			addrSlot := calcArraySlot(arraySlot, 2, i, 0)
+			activationSlot := calcArraySlot(arraySlot, 2, i, 1)
+
+			storage[addrSlot] = lpad32(record.Addr)
+			storage[activationSlot] = lpad32(record.Activation)
+		}
+	}
+
+	// slot[1]: string[] names;
+	// - names.length @ 1
+	// - names[i] @ Hash(1) + i
+	storage[lpad32(1)] = lpad32(len(init.Names))
+	for i, name := range init.Names {
+		nameSlot := calcArraySlot(1, 1, i, 0)
+		storage[nameSlot] = encodeShortString(name)
+	}
+
+	// slot[2]: address _owner;
+	storage[lpad32(2)] = lpad32(init.Owner)
+
+	return storage
+}
+
 func InstallRegistry(state *state.StateDB) error {
 	return state.SetCode(RegistryAddr, RegistryCode)
 }

--- a/blockchain/system/registry.go
+++ b/blockchain/system/registry.go
@@ -39,7 +39,7 @@ type AllocRegistryInit struct {
 
 // Create storage state from the given initial values.
 // The storage slots are calculated according to the solidity layout rule.
-// https://docs.soliditylang.org/en/v1.8.20/internals/layout_in_storage.html
+// https://docs.soliditylang.org/en/v0.8.20/internals/layout_in_storage.html
 func AllocRegistry(init *AllocRegistryInit) map[common.Hash]common.Hash {
 	storage := make(map[common.Hash]common.Hash)
 	if init == nil {

--- a/blockchain/system/registry.go
+++ b/blockchain/system/registry.go
@@ -31,7 +31,7 @@ func InstallRegistry(state *state.StateDB) error {
 }
 
 func ReadRegistryActiveAddr(backend bind.ContractCaller, name string, num *big.Int) (common.Address, error) {
-	caller, err := contracts.NewIRegistryCaller(RegistryAddr, backend)
+	caller, err := contracts.NewRegistryCaller(RegistryAddr, backend)
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -39,11 +39,11 @@ func ReadRegistryActiveAddr(backend bind.ContractCaller, name string, num *big.I
 	code, err := backend.CodeAt(context.Background(), RegistryAddr, nil)
 	if err != nil {
 		return common.Address{}, err
-	} else if code == nil {
+	}
+	if code == nil {
 		return common.Address{}, ErrRegistryNotInstalled
 	}
 
 	opts := &bind.CallOpts{BlockNumber: num}
-	addr, err := caller.GetActiveContract(opts, name)
-	return addr, err
+	return caller.GetActiveContract(opts, name)
 }

--- a/blockchain/system/registry.go
+++ b/blockchain/system/registry.go
@@ -41,10 +41,10 @@ type AllocRegistryInit struct {
 // The storage slots are calculated according to the solidity layout rule.
 // https://docs.soliditylang.org/en/v0.8.20/internals/layout_in_storage.html
 func AllocRegistry(init *AllocRegistryInit) map[common.Hash]common.Hash {
-	storage := make(map[common.Hash]common.Hash)
 	if init == nil {
-		return storage
+		return nil
 	}
+	storage := make(map[common.Hash]common.Hash)
 
 	// slot[0]: mapping(string => Record[]) records;
 	// - records[x].length @ Hash(x, 0)

--- a/blockchain/system/registry.go
+++ b/blockchain/system/registry.go
@@ -45,5 +45,5 @@ func ReadRegistryActiveAddr(backend bind.ContractCaller, name string, num *big.I
 	}
 
 	opts := &bind.CallOpts{BlockNumber: num}
-	return caller.GetActiveContract(opts, name)
+	return caller.GetActiveAddr(opts, name)
 }

--- a/blockchain/system/registry_test.go
+++ b/blockchain/system/registry_test.go
@@ -61,11 +61,11 @@ func TestAllocRegistry(t *testing.T) {
 	// 1. Create storage with AllocRegistry
 	allocStorage := AllocRegistry(&AllocRegistryInit{
 		Records: map[string][]RegistryRecord{
-			"AcmeContract": []RegistryRecord{
+			"AcmeContract": {
 				{common.HexToAddress("0xaaaa"), big.NewInt(0x1234)},
 				{common.HexToAddress("0xbbbb"), big.NewInt(0x5678)},
 			},
-			"TestContract": []RegistryRecord{
+			"TestContract": {
 				{common.HexToAddress("0xcccc"), big.NewInt(0x9999)},
 			},
 		},

--- a/blockchain/system/registry_test.go
+++ b/blockchain/system/registry_test.go
@@ -43,8 +43,9 @@ func TestSystemRegistry(t *testing.T) {
 	assert.Equal(t, common.Address{}, addr)
 
 	// Register a record
-	contract, _ := contracts.NewRegistryMockTransactor(RegistryAddr, backend)
-	contract.Register(sender, recordName, recordAddr)
+	contract, err := contracts.NewRegistryMockTransactor(RegistryAddr, backend)
+	_, err = contract.Register(sender, recordName, recordAddr, common.Big1)
+	assert.Nil(t, err)
 	backend.Commit()
 
 	// With the record

--- a/blockchain/system/registry_test.go
+++ b/blockchain/system/registry_test.go
@@ -1,0 +1,54 @@
+package system
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/common"
+	contracts "github.com/klaytn/klaytn/contracts/system_contracts"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSystemRegistry(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlInfo)
+	var (
+		senderKey, _ = crypto.GenerateKey()
+		sender       = bind.NewKeyedTransactor(senderKey)
+		senderAddr   = sender.From
+
+		alloc = blockchain.GenesisAlloc{
+			senderAddr: {
+				Balance: big.NewInt(params.KLAY),
+			},
+			RegistryAddr: {
+				Code:    RegistryMockCode,
+				Balance: common.Big0,
+			},
+		}
+		backend = backends.NewSimulatedBackend(alloc)
+
+		recordName = "AcmeContract"
+		recordAddr = common.HexToAddress("0xaaaa")
+	)
+
+	// Without a record
+	addr, err := ReadRegistryActiveAddr(backend, recordName, common.Big0)
+	assert.Nil(t, err)
+	assert.Equal(t, common.Address{}, addr)
+
+	// Register a record
+	contract, _ := contracts.NewRegistryMockTransactor(RegistryAddr, backend)
+	contract.Register(sender, recordName, recordAddr)
+	backend.Commit()
+
+	// With the record
+	addr, err = ReadRegistryActiveAddr(backend, recordName, common.Big1)
+	assert.Nil(t, err)
+	assert.Equal(t, recordAddr, addr)
+}

--- a/blockchain/system/storage.go
+++ b/blockchain/system/storage.go
@@ -1,0 +1,125 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"math/big"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/crypto"
+)
+
+// Calculate the contract storage slot for a mapping element.
+// Returns keccak256(h(key) . base) where h() differs by the key type.
+//
+// "The value corresponding to a mapping key k is located at keccak256(h(k) . p)
+// where . is concatenation and h is a function that is applied to the key depending
+// on its type"
+//
+// The baseSlot (p) can be of type:
+// - *big.Int or common.Hash to represent a slot index
+//
+// The key can be of type:
+// - *big.Int to represent Solidity uint8..uint256
+// - common.Address to represent Solidity address
+// - common.Hash to represent Solidity bytes1..bytes32, or another slot index
+// - []byte to represent Solidity bytes
+// - string to represent Solidity string
+//
+// See https://docs.soliditylang.org/en/v0.8.20/internals/layout_in_storage.html
+func calcMappingSlot(baseSlot, key interface{}) common.Hash {
+	baseBytes := lpad32(baseSlot).Bytes()
+
+	var keyBytes []byte
+	switch v := key.(type) {
+	// For bytes and string types, h(k) = k, unpadded.
+	case []byte:
+		keyBytes = v
+	case string:
+		keyBytes = []byte(v)
+	// For value types, h(k) = lpad32(k)
+	default:
+		keyBytes = lpad32(key).Bytes()
+	}
+
+	return crypto.Keccak256Hash(append(keyBytes, baseBytes...))
+}
+
+// Calculate the contract storage slot for a dynamic array element.
+// Returns keccak256(base) + (elemSize * index + offset)
+//
+// The baseSlot (p) can be of type:
+// - *big.Int or common.Hash to represent a slot index
+//
+// "Array data is located starting at keccak256(p) and it is laid out in the same way
+// as statically-sized array data would: One element after the other"
+//
+// See https://docs.soliditylang.org/en/v0.8.20/internals/layout_in_storage.html
+func calcArraySlot(baseSlot interface{}, elemSize, index, offset int) common.Hash {
+	baseBytes := lpad32(baseSlot).Bytes()
+	baseHash := crypto.Keccak256Hash(baseBytes)
+
+	slot := new(big.Int).SetBytes(baseHash.Bytes())
+
+	mult := new(big.Int).Mul(
+		big.NewInt(int64(elemSize)),
+		big.NewInt(int64(index)))
+	slot.Add(slot, mult) // slot += size * index
+
+	slot.Add(slot, big.NewInt(int64(offset))) // slot += offset
+
+	return common.BytesToHash(slot.Bytes())
+}
+
+// Pad Solidity "value types" to 32 bytes.
+// Only a few value types are implemented here.
+// See https://docs.soliditylang.org/en/v0.8.20/types.html
+func lpad32(value interface{}) common.Hash {
+	switch v := value.(type) {
+	case int:
+		return common.BytesToHash(big.NewInt(int64(v)).Bytes())
+	case uint64:
+		return common.BytesToHash(big.NewInt(int64(v)).Bytes())
+	case *big.Int:
+		return common.BytesToHash(v.Bytes())
+	case common.Address:
+		return common.BytesToHash(v.Bytes())
+	case common.Hash:
+		return v
+	default:
+		logger.Crit("not a slot value type", "value", value)
+		return common.Hash{}
+	}
+}
+
+// Pad a dynamic string to a single slot.
+// Only strings at most 31 bytes long are implemented here.
+// See https://docs.soliditylang.org/en/v0.8.20/internals/layout_in_storage.html
+func encodeShortString(s string) common.Hash {
+	if len(s) > 31 {
+		logger.Crit("encoding more than 31 byte string is not implemented")
+		return common.Hash{}
+	}
+
+	// "In particular: if the data is at most 31 bytes long,
+	// the elements are stored in the higher-order bytes (left aligned)
+	// and the lowest-order byte stores the value length * 2."
+	b := make([]byte, 32)
+	copy(b, []byte(s))
+	b[31] = byte(len(s)) * 2
+	return common.BytesToHash(b)
+}

--- a/blockchain/system/storage_test.go
+++ b/blockchain/system/storage_test.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"testing"
+
+	"github.com/klaytn/klaytn/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStorageCalc(t *testing.T) {
+	assert.Equal(t,
+		common.HexToHash("0000000000000000000000000000000000000000000000000000000000001234"),
+		lpad32(0x1234))
+	assert.Equal(t,
+		common.HexToHash("41636d65436f6e74726163740000000000000000000000000000000000000018"),
+		encodeShortString("AcmeContract"))
+}

--- a/contracts/generate.go
+++ b/contracts/generate.go
@@ -30,6 +30,8 @@ package contracts
 
 //go:generate abigen --sol ./kip103/TreasuryRebalance.sol --pkg kip103 --out ./kip103/TreasuryRebalance.go
 
+//go:generate abigen --sol ./system_contracts/all.sol --pkg system_contracts --out ./system_contracts/all.go
+
 //`credit.sol` was compiled by solidity@0.4.24.
 // This code data was included in cypress genesis file.
 ////go:generate abigen --sol ./cypress/credit.sol --pkg cypress --out ./cypress/credit.go

--- a/contracts/system_contracts/all.go
+++ b/contracts/system_contracts/all.go
@@ -4,11 +4,11 @@
 package system_contracts
 
 import (
+	"errors"
 	"math/big"
 	"strings"
 
 	"github.com/klaytn/klaytn"
-	"github.com/klaytn/klaytn/accounts/abi"
 	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -17,6 +17,7 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var (
+	_ = errors.New
 	_ = big.NewInt
 	_ = strings.NewReader
 	_ = klaytn.NotFound
@@ -26,16 +27,26 @@ var (
 	_ = event.NewSubscription
 )
 
+// IRegistryMetaData contains all meta data concerning the IRegistry contract.
+var IRegistryMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	Sigs: map[string]string{
+		"e2693e3f": "getActiveAddr(string)",
+		"4622ab03": "names(uint256)",
+		"3b51650d": "records(string,uint256)",
+	},
+}
+
 // IRegistryABI is the input ABI used to generate the binding from.
-const IRegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
+// Deprecated: Use IRegistryMetaData.ABI instead.
+var IRegistryABI = IRegistryMetaData.ABI
 
 // IRegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
 const IRegistryBinRuntime = ``
 
 // IRegistryFuncSigs maps the 4-byte function signature to its string representation.
-var IRegistryFuncSigs = map[string]string{
-	"e2693e3f": "getActiveAddr(string)",
-}
+// Deprecated: Use IRegistryMetaData.Sigs instead.
+var IRegistryFuncSigs = IRegistryMetaData.Sigs
 
 // IRegistry is an auto generated Go binding around a Klaytn contract.
 type IRegistry struct {
@@ -134,11 +145,11 @@ func NewIRegistryFilterer(address common.Address, filterer bind.ContractFilterer
 
 // bindIRegistry binds a generic wrapper to an already deployed contract.
 func bindIRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := abi.JSON(strings.NewReader(IRegistryABI))
+	parsed, err := IRegistryMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and
@@ -205,28 +216,105 @@ func (_IRegistry *IRegistryCallerSession) GetActiveAddr(name string) (common.Add
 	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.CallOpts, name)
 }
 
-// RegistryABI is the input ABI used to generate the binding from.
-const RegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
-
-// RegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
-const RegistryBinRuntime = `608060405234801561001057600080fd5b506004361061002b5760003560e01c8063e2693e3f14610030575b600080fd5b61004361003e3660046100b6565b61005f565b6040516001600160a01b03909116815260200160405180910390f35b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b6000602082840312156100c857600080fd5b813567ffffffffffffffff808211156100e057600080fd5b818401915084601f8301126100f457600080fd5b813581811115610106576101066100a0565b604051601f8201601f19908116603f0116810190838211818310171561012e5761012e6100a0565b8160405282815287602084870101111561014757600080fd5b82602086016020830137600092810160200192909252509594505050505056fea26469706673582212202baebcbf67ab9b5cbd8fc6dcc00c381bef5833202c81d669604bbe8d34bc7bb764736f6c63430008110033`
-
-// RegistryFuncSigs maps the 4-byte function signature to its string representation.
-var RegistryFuncSigs = map[string]string{
-	"e2693e3f": "getActiveAddr(string)",
+// Names is a free data retrieval call binding the contract method 0x4622ab03.
+//
+// Solidity: function names(uint256 ) view returns(string)
+func (_IRegistry *IRegistryCaller) Names(opts *bind.CallOpts, arg0 *big.Int) (string, error) {
+	var (
+		ret0 = new(string)
+	)
+	out := ret0
+	err := _IRegistry.contract.Call(opts, out, "names", arg0)
+	return *ret0, err
 }
 
+// Names is a free data retrieval call binding the contract method 0x4622ab03.
+//
+// Solidity: function names(uint256 ) view returns(string)
+func (_IRegistry *IRegistrySession) Names(arg0 *big.Int) (string, error) {
+	return _IRegistry.Contract.Names(&_IRegistry.CallOpts, arg0)
+}
+
+// Names is a free data retrieval call binding the contract method 0x4622ab03.
+//
+// Solidity: function names(uint256 ) view returns(string)
+func (_IRegistry *IRegistryCallerSession) Names(arg0 *big.Int) (string, error) {
+	return _IRegistry.Contract.Names(&_IRegistry.CallOpts, arg0)
+}
+
+// Records is a free data retrieval call binding the contract method 0x3b51650d.
+//
+// Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
+func (_IRegistry *IRegistryCaller) Records(opts *bind.CallOpts, arg0 string, arg1 *big.Int) (struct {
+	Addr       common.Address
+	Activation *big.Int
+}, error) {
+	ret := new(struct {
+		Addr       common.Address
+		Activation *big.Int
+	})
+	out := ret
+	err := _IRegistry.contract.Call(opts, out, "records", arg0, arg1)
+	return *ret, err
+}
+
+// Records is a free data retrieval call binding the contract method 0x3b51650d.
+//
+// Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
+func (_IRegistry *IRegistrySession) Records(arg0 string, arg1 *big.Int) (struct {
+	Addr       common.Address
+	Activation *big.Int
+}, error) {
+	return _IRegistry.Contract.Records(&_IRegistry.CallOpts, arg0, arg1)
+}
+
+// Records is a free data retrieval call binding the contract method 0x3b51650d.
+//
+// Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
+func (_IRegistry *IRegistryCallerSession) Records(arg0 string, arg1 *big.Int) (struct {
+	Addr       common.Address
+	Activation *big.Int
+}, error) {
+	return _IRegistry.Contract.Records(&_IRegistry.CallOpts, arg0, arg1)
+}
+
+// RegistryMetaData contains all meta data concerning the Registry contract.
+var RegistryMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	Sigs: map[string]string{
+		"e2693e3f": "getActiveAddr(string)",
+		"4622ab03": "names(uint256)",
+		"3b51650d": "records(string,uint256)",
+	},
+	Bin: "0x608060405234801561001057600080fd5b5061040e806100206000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d146100465780634622ab031461007d578063e2693e3f1461009d575b600080fd5b6100596100543660046102ad565b6100c8565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102f2565b61011d565b604051610074919061030b565b6100b06100ab366004610360565b6101c9565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100f357600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061012d57600080fd5b9060005260206000200160009150905080546101489061039d565b80601f01602080910402602001604051908101604052809291908181526020018280546101749061039d565b80156101c15780601f10610196576101008083540402835291602001916101c1565b820191906000526020600020905b8154815290600101906020018083116101a457829003601f168201915b505050505081565b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023157600080fd5b813567ffffffffffffffff8082111561024c5761024c61020a565b604051601f8301601f19908116603f011681019082821181831017156102745761027461020a565b8160405283815286602085880101111561028d57600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c057600080fd5b823567ffffffffffffffff8111156102d757600080fd5b6102e385828601610220565b95602094909401359450505050565b60006020828403121561030457600080fd5b5035919050565b600060208083528351808285015260005b818110156103385785810183015185820160400152820161031c565b8181111561034a576000604083870101525b50601f01601f1916929092016040019392505050565b60006020828403121561037257600080fd5b813567ffffffffffffffff81111561038957600080fd5b61039584828501610220565b949350505050565b600181811c908216806103b157607f821691505b602082108114156103d257634e487b7160e01b600052602260045260246000fd5b5091905056fea2646970667358221220e26a575b63762d698eb6e82f6fd9cac682122d4874acca851d6e8e9f20ac556d64736f6c634300080b0033",
+}
+
+// RegistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use RegistryMetaData.ABI instead.
+var RegistryABI = RegistryMetaData.ABI
+
+// RegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const RegistryBinRuntime = `608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d146100465780634622ab031461007d578063e2693e3f1461009d575b600080fd5b6100596100543660046102ad565b6100c8565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102f2565b61011d565b604051610074919061030b565b6100b06100ab366004610360565b6101c9565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100f357600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061012d57600080fd5b9060005260206000200160009150905080546101489061039d565b80601f01602080910402602001604051908101604052809291908181526020018280546101749061039d565b80156101c15780601f10610196576101008083540402835291602001916101c1565b820191906000526020600020905b8154815290600101906020018083116101a457829003601f168201915b505050505081565b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023157600080fd5b813567ffffffffffffffff8082111561024c5761024c61020a565b604051601f8301601f19908116603f011681019082821181831017156102745761027461020a565b8160405283815286602085880101111561028d57600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c057600080fd5b823567ffffffffffffffff8111156102d757600080fd5b6102e385828601610220565b95602094909401359450505050565b60006020828403121561030457600080fd5b5035919050565b600060208083528351808285015260005b818110156103385785810183015185820160400152820161031c565b8181111561034a576000604083870101525b50601f01601f1916929092016040019392505050565b60006020828403121561037257600080fd5b813567ffffffffffffffff81111561038957600080fd5b61039584828501610220565b949350505050565b600181811c908216806103b157607f821691505b602082108114156103d257634e487b7160e01b600052602260045260246000fd5b5091905056fea2646970667358221220e26a575b63762d698eb6e82f6fd9cac682122d4874acca851d6e8e9f20ac556d64736f6c634300080b0033`
+
+// RegistryFuncSigs maps the 4-byte function signature to its string representation.
+// Deprecated: Use RegistryMetaData.Sigs instead.
+var RegistryFuncSigs = RegistryMetaData.Sigs
+
 // RegistryBin is the compiled bytecode used for deploying new contracts.
-var RegistryBin = "0x608060405234801561001057600080fd5b5061019d806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063e2693e3f14610030575b600080fd5b61004361003e3660046100b6565b61005f565b6040516001600160a01b03909116815260200160405180910390f35b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b6000602082840312156100c857600080fd5b813567ffffffffffffffff808211156100e057600080fd5b818401915084601f8301126100f457600080fd5b813581811115610106576101066100a0565b604051601f8201601f19908116603f0116810190838211818310171561012e5761012e6100a0565b8160405282815287602084870101111561014757600080fd5b82602086016020830137600092810160200192909252509594505050505056fea26469706673582212202baebcbf67ab9b5cbd8fc6dcc00c381bef5833202c81d669604bbe8d34bc7bb764736f6c63430008110033"
+// Deprecated: Use RegistryMetaData.Bin instead.
+var RegistryBin = RegistryMetaData.Bin
 
 // DeployRegistry deploys a new Klaytn contract, binding an instance of Registry to it.
 func DeployRegistry(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Registry, error) {
-	parsed, err := abi.JSON(strings.NewReader(RegistryABI))
+	parsed, err := RegistryMetaData.GetAbi()
 	if err != nil {
 		return common.Address{}, nil, nil, err
 	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
 
-	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(RegistryBin), backend)
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(RegistryBin), backend)
 	if err != nil {
 		return common.Address{}, nil, nil, err
 	}
@@ -330,11 +418,11 @@ func NewRegistryFilterer(address common.Address, filterer bind.ContractFilterer)
 
 // bindRegistry binds a generic wrapper to an already deployed contract.
 func bindRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := abi.JSON(strings.NewReader(RegistryABI))
+	parsed, err := RegistryMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and
@@ -401,30 +489,107 @@ func (_Registry *RegistryCallerSession) GetActiveAddr(name string) (common.Addre
 	return _Registry.Contract.GetActiveAddr(&_Registry.CallOpts, name)
 }
 
-// RegistryMockABI is the input ABI used to generate the binding from.
-const RegistryMockABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
-
-// RegistryMockBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
-const RegistryMockBinRuntime = `608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d14610046578063d393c8711461007d578063e2693e3f14610092575b600080fd5b6100596100543660046102b6565b6100bd565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102fb565b610112565b005b6100a56100a0366004610361565b610181565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100e857600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600083604051610122919061039e565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b600080600083604051610194919061039e565b90815260405190819003602001902054905060008190036101b85750600092915050565b6000836040516101c8919061039e565b9081526040519081900360200190206101e26001836103cd565b815481106101f2576101f26103f4565b60009182526020909120600290910201546001600160a01b03169392505050565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023a57600080fd5b813567ffffffffffffffff8082111561025557610255610213565b604051601f8301601f19908116603f0116810190828211818310171561027d5761027d610213565b8160405283815286602085880101111561029657600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c957600080fd5b823567ffffffffffffffff8111156102e057600080fd5b6102ec85828601610229565b95602094909401359450505050565b60008060006060848603121561031057600080fd5b833567ffffffffffffffff81111561032757600080fd5b61033386828701610229565b93505060208401356001600160a01b038116811461035057600080fd5b929592945050506040919091013590565b60006020828403121561037357600080fd5b813567ffffffffffffffff81111561038a57600080fd5b61039684828501610229565b949350505050565b6000825160005b818110156103bf57602081860181015185830152016103a5565b506000920191825250919050565b818103818111156103ee57634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea26469706673582212205fe32fa81ee789c8e1f6cf6e001eeea21e25ad22870152e09ff2b670f942aa8c64736f6c63430008110033`
-
-// RegistryMockFuncSigs maps the 4-byte function signature to its string representation.
-var RegistryMockFuncSigs = map[string]string{
-	"e2693e3f": "getActiveAddr(string)",
-	"3b51650d": "records(string,uint256)",
-	"d393c871": "register(string,address,uint256)",
+// Names is a free data retrieval call binding the contract method 0x4622ab03.
+//
+// Solidity: function names(uint256 ) view returns(string)
+func (_Registry *RegistryCaller) Names(opts *bind.CallOpts, arg0 *big.Int) (string, error) {
+	var (
+		ret0 = new(string)
+	)
+	out := ret0
+	err := _Registry.contract.Call(opts, out, "names", arg0)
+	return *ret0, err
 }
 
+// Names is a free data retrieval call binding the contract method 0x4622ab03.
+//
+// Solidity: function names(uint256 ) view returns(string)
+func (_Registry *RegistrySession) Names(arg0 *big.Int) (string, error) {
+	return _Registry.Contract.Names(&_Registry.CallOpts, arg0)
+}
+
+// Names is a free data retrieval call binding the contract method 0x4622ab03.
+//
+// Solidity: function names(uint256 ) view returns(string)
+func (_Registry *RegistryCallerSession) Names(arg0 *big.Int) (string, error) {
+	return _Registry.Contract.Names(&_Registry.CallOpts, arg0)
+}
+
+// Records is a free data retrieval call binding the contract method 0x3b51650d.
+//
+// Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
+func (_Registry *RegistryCaller) Records(opts *bind.CallOpts, arg0 string, arg1 *big.Int) (struct {
+	Addr       common.Address
+	Activation *big.Int
+}, error) {
+	ret := new(struct {
+		Addr       common.Address
+		Activation *big.Int
+	})
+	out := ret
+	err := _Registry.contract.Call(opts, out, "records", arg0, arg1)
+	return *ret, err
+}
+
+// Records is a free data retrieval call binding the contract method 0x3b51650d.
+//
+// Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
+func (_Registry *RegistrySession) Records(arg0 string, arg1 *big.Int) (struct {
+	Addr       common.Address
+	Activation *big.Int
+}, error) {
+	return _Registry.Contract.Records(&_Registry.CallOpts, arg0, arg1)
+}
+
+// Records is a free data retrieval call binding the contract method 0x3b51650d.
+//
+// Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
+func (_Registry *RegistryCallerSession) Records(arg0 string, arg1 *big.Int) (struct {
+	Addr       common.Address
+	Activation *big.Int
+}, error) {
+	return _Registry.Contract.Records(&_Registry.CallOpts, arg0, arg1)
+}
+
+// RegistryMockMetaData contains all meta data concerning the RegistryMock contract.
+var RegistryMockMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Sigs: map[string]string{
+		"e2693e3f": "getActiveAddr(string)",
+		"4622ab03": "names(uint256)",
+		"3b51650d": "records(string,uint256)",
+		"d393c871": "register(string,address,uint256)",
+		"f2fde38b": "transferOwnership(address)",
+	},
+	Bin: "0x608060405234801561001057600080fd5b50610720806100206000396000f3fe608060405234801561001057600080fd5b50600436106100575760003560e01c80633b51650d1461005c5780634622ab0314610093578063d393c871146100b3578063e2693e3f146100c8578063f2fde38b146100f3575b600080fd5b61006f61006a3660046104cb565b610123565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100a66100a1366004610510565b610178565b60405161008a9190610559565b6100c66100c13660046105a8565b610224565b005b6100db6100d63660046105ff565b6102fb565b6040516001600160a01b03909116815260200161008a565b6100c661010136600461063c565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b8151602081840181018051600082529282019185019190912091905280548290811061014e57600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061018857600080fd5b9060005260206000200160009150905080546101a39061065e565b80601f01602080910402602001604051908101604052809291908181526020018280546101cf9061065e565b801561021c5780601f106101f15761010080835404028352916020019161021c565b820191906000526020600020905b8154815290600101906020018083116101ff57829003601f168201915b505050505081565b6000836040516102349190610693565b9081526040519081900360200190205461028c57600180548082018255600091909152835161028a917fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60190602086019061038f565b505b60008360405161029c9190610693565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b60008060008360405161030e9190610693565b9081526040519081900360200190205490508061032e5750600092915050565b60008360405161033e9190610693565b9081526040519081900360200190206103586001836106af565b81548110610368576103686106d4565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b82805461039b9061065e565b90600052602060002090601f0160209004810192826103bd5760008555610403565b82601f106103d657805160ff1916838001178555610403565b82800160010185558215610403579182015b828111156104035782518255916020019190600101906103e8565b5061040f929150610413565b5090565b5b8082111561040f5760008155600101610414565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261044f57600080fd5b813567ffffffffffffffff8082111561046a5761046a610428565b604051601f8301601f19908116603f0116810190828211818310171561049257610492610428565b816040528381528660208588010111156104ab57600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156104de57600080fd5b823567ffffffffffffffff8111156104f557600080fd5b6105018582860161043e565b95602094909401359450505050565b60006020828403121561052257600080fd5b5035919050565b60005b8381101561054457818101518382015260200161052c565b83811115610553576000848401525b50505050565b6020815260008251806020840152610578816040850160208701610529565b601f01601f19169190910160400192915050565b80356001600160a01b03811681146105a357600080fd5b919050565b6000806000606084860312156105bd57600080fd5b833567ffffffffffffffff8111156105d457600080fd5b6105e08682870161043e565b9350506105ef6020850161058c565b9150604084013590509250925092565b60006020828403121561061157600080fd5b813567ffffffffffffffff81111561062857600080fd5b6106348482850161043e565b949350505050565b60006020828403121561064e57600080fd5b6106578261058c565b9392505050565b600181811c9082168061067257607f821691505b6020821081141561038957634e487b7160e01b600052602260045260246000fd5b600082516106a5818460208701610529565b9190910192915050565b6000828210156106cf57634e487b7160e01b600052601160045260246000fd5b500390565b634e487b7160e01b600052603260045260246000fdfea26469706673582212207c642130a3785d0c34f24c86b872c3271bfc8012eb6d21a3a27b0b1ec3b2660c64736f6c634300080b0033",
+}
+
+// RegistryMockABI is the input ABI used to generate the binding from.
+// Deprecated: Use RegistryMockMetaData.ABI instead.
+var RegistryMockABI = RegistryMockMetaData.ABI
+
+// RegistryMockBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const RegistryMockBinRuntime = `608060405234801561001057600080fd5b50600436106100575760003560e01c80633b51650d1461005c5780634622ab0314610093578063d393c871146100b3578063e2693e3f146100c8578063f2fde38b146100f3575b600080fd5b61006f61006a3660046104cb565b610123565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100a66100a1366004610510565b610178565b60405161008a9190610559565b6100c66100c13660046105a8565b610224565b005b6100db6100d63660046105ff565b6102fb565b6040516001600160a01b03909116815260200161008a565b6100c661010136600461063c565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b8151602081840181018051600082529282019185019190912091905280548290811061014e57600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061018857600080fd5b9060005260206000200160009150905080546101a39061065e565b80601f01602080910402602001604051908101604052809291908181526020018280546101cf9061065e565b801561021c5780601f106101f15761010080835404028352916020019161021c565b820191906000526020600020905b8154815290600101906020018083116101ff57829003601f168201915b505050505081565b6000836040516102349190610693565b9081526040519081900360200190205461028c57600180548082018255600091909152835161028a917fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60190602086019061038f565b505b60008360405161029c9190610693565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b60008060008360405161030e9190610693565b9081526040519081900360200190205490508061032e5750600092915050565b60008360405161033e9190610693565b9081526040519081900360200190206103586001836106af565b81548110610368576103686106d4565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b82805461039b9061065e565b90600052602060002090601f0160209004810192826103bd5760008555610403565b82601f106103d657805160ff1916838001178555610403565b82800160010185558215610403579182015b828111156104035782518255916020019190600101906103e8565b5061040f929150610413565b5090565b5b8082111561040f5760008155600101610414565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261044f57600080fd5b813567ffffffffffffffff8082111561046a5761046a610428565b604051601f8301601f19908116603f0116810190828211818310171561049257610492610428565b816040528381528660208588010111156104ab57600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156104de57600080fd5b823567ffffffffffffffff8111156104f557600080fd5b6105018582860161043e565b95602094909401359450505050565b60006020828403121561052257600080fd5b5035919050565b60005b8381101561054457818101518382015260200161052c565b83811115610553576000848401525b50505050565b6020815260008251806020840152610578816040850160208701610529565b601f01601f19169190910160400192915050565b80356001600160a01b03811681146105a357600080fd5b919050565b6000806000606084860312156105bd57600080fd5b833567ffffffffffffffff8111156105d457600080fd5b6105e08682870161043e565b9350506105ef6020850161058c565b9150604084013590509250925092565b60006020828403121561061157600080fd5b813567ffffffffffffffff81111561062857600080fd5b6106348482850161043e565b949350505050565b60006020828403121561064e57600080fd5b6106578261058c565b9392505050565b600181811c9082168061067257607f821691505b6020821081141561038957634e487b7160e01b600052602260045260246000fd5b600082516106a5818460208701610529565b9190910192915050565b6000828210156106cf57634e487b7160e01b600052601160045260246000fd5b500390565b634e487b7160e01b600052603260045260246000fdfea26469706673582212207c642130a3785d0c34f24c86b872c3271bfc8012eb6d21a3a27b0b1ec3b2660c64736f6c634300080b0033`
+
+// RegistryMockFuncSigs maps the 4-byte function signature to its string representation.
+// Deprecated: Use RegistryMockMetaData.Sigs instead.
+var RegistryMockFuncSigs = RegistryMockMetaData.Sigs
+
 // RegistryMockBin is the compiled bytecode used for deploying new contracts.
-var RegistryMockBin = "0x608060405234801561001057600080fd5b50610440806100206000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d14610046578063d393c8711461007d578063e2693e3f14610092575b600080fd5b6100596100543660046102b6565b6100bd565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102fb565b610112565b005b6100a56100a0366004610361565b610181565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100e857600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600083604051610122919061039e565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b600080600083604051610194919061039e565b90815260405190819003602001902054905060008190036101b85750600092915050565b6000836040516101c8919061039e565b9081526040519081900360200190206101e26001836103cd565b815481106101f2576101f26103f4565b60009182526020909120600290910201546001600160a01b03169392505050565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023a57600080fd5b813567ffffffffffffffff8082111561025557610255610213565b604051601f8301601f19908116603f0116810190828211818310171561027d5761027d610213565b8160405283815286602085880101111561029657600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c957600080fd5b823567ffffffffffffffff8111156102e057600080fd5b6102ec85828601610229565b95602094909401359450505050565b60008060006060848603121561031057600080fd5b833567ffffffffffffffff81111561032757600080fd5b61033386828701610229565b93505060208401356001600160a01b038116811461035057600080fd5b929592945050506040919091013590565b60006020828403121561037357600080fd5b813567ffffffffffffffff81111561038a57600080fd5b61039684828501610229565b949350505050565b6000825160005b818110156103bf57602081860181015185830152016103a5565b506000920191825250919050565b818103818111156103ee57634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea26469706673582212205fe32fa81ee789c8e1f6cf6e001eeea21e25ad22870152e09ff2b670f942aa8c64736f6c63430008110033"
+// Deprecated: Use RegistryMockMetaData.Bin instead.
+var RegistryMockBin = RegistryMockMetaData.Bin
 
 // DeployRegistryMock deploys a new Klaytn contract, binding an instance of RegistryMock to it.
 func DeployRegistryMock(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *RegistryMock, error) {
-	parsed, err := abi.JSON(strings.NewReader(RegistryMockABI))
+	parsed, err := RegistryMockMetaData.GetAbi()
 	if err != nil {
 		return common.Address{}, nil, nil, err
 	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
 
-	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(RegistryMockBin), backend)
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(RegistryMockBin), backend)
 	if err != nil {
 		return common.Address{}, nil, nil, err
 	}
@@ -528,11 +693,11 @@ func NewRegistryMockFilterer(address common.Address, filterer bind.ContractFilte
 
 // bindRegistryMock binds a generic wrapper to an already deployed contract.
 func bindRegistryMock(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := abi.JSON(strings.NewReader(RegistryMockABI))
+	parsed, err := RegistryMockMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and
@@ -599,6 +764,32 @@ func (_RegistryMock *RegistryMockCallerSession) GetActiveAddr(name string) (comm
 	return _RegistryMock.Contract.GetActiveAddr(&_RegistryMock.CallOpts, name)
 }
 
+// Names is a free data retrieval call binding the contract method 0x4622ab03.
+//
+// Solidity: function names(uint256 ) view returns(string)
+func (_RegistryMock *RegistryMockCaller) Names(opts *bind.CallOpts, arg0 *big.Int) (string, error) {
+	var (
+		ret0 = new(string)
+	)
+	out := ret0
+	err := _RegistryMock.contract.Call(opts, out, "names", arg0)
+	return *ret0, err
+}
+
+// Names is a free data retrieval call binding the contract method 0x4622ab03.
+//
+// Solidity: function names(uint256 ) view returns(string)
+func (_RegistryMock *RegistryMockSession) Names(arg0 *big.Int) (string, error) {
+	return _RegistryMock.Contract.Names(&_RegistryMock.CallOpts, arg0)
+}
+
+// Names is a free data retrieval call binding the contract method 0x4622ab03.
+//
+// Solidity: function names(uint256 ) view returns(string)
+func (_RegistryMock *RegistryMockCallerSession) Names(arg0 *big.Int) (string, error) {
+	return _RegistryMock.Contract.Names(&_RegistryMock.CallOpts, arg0)
+}
+
 // Records is a free data retrieval call binding the contract method 0x3b51650d.
 //
 // Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
@@ -654,4 +845,25 @@ func (_RegistryMock *RegistryMockSession) Register(name string, addr common.Addr
 // Solidity: function register(string name, address addr, uint256 activation) returns()
 func (_RegistryMock *RegistryMockTransactorSession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
 	return _RegistryMock.Contract.Register(&_RegistryMock.TransactOpts, name, addr, activation)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_RegistryMock *RegistryMockTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _RegistryMock.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_RegistryMock *RegistryMockSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _RegistryMock.Contract.TransferOwnership(&_RegistryMock.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_RegistryMock *RegistryMockTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _RegistryMock.Contract.TransferOwnership(&_RegistryMock.TransactOpts, newOwner)
 }

--- a/contracts/system_contracts/all.go
+++ b/contracts/system_contracts/all.go
@@ -1,0 +1,647 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package system_contracts
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/klaytn/klaytn"
+	"github.com/klaytn/klaytn/accounts/abi"
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = klaytn.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// IRegistryABI is the input ABI used to generate the binding from.
+const IRegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
+
+// IRegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const IRegistryBinRuntime = ``
+
+// IRegistryFuncSigs maps the 4-byte function signature to its string representation.
+var IRegistryFuncSigs = map[string]string{
+	"080d5721": "getActiveContract(string)",
+}
+
+// IRegistry is an auto generated Go binding around a Klaytn contract.
+type IRegistry struct {
+	IRegistryCaller     // Read-only binding to the contract
+	IRegistryTransactor // Write-only binding to the contract
+	IRegistryFilterer   // Log filterer for contract events
+}
+
+// IRegistryCaller is an auto generated read-only Go binding around a Klaytn contract.
+type IRegistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IRegistryTransactor is an auto generated write-only Go binding around a Klaytn contract.
+type IRegistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IRegistryFilterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type IRegistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IRegistrySession is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type IRegistrySession struct {
+	Contract     *IRegistry        // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IRegistryCallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type IRegistryCallerSession struct {
+	Contract *IRegistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts    // Call options to use throughout this session
+}
+
+// IRegistryTransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type IRegistryTransactorSession struct {
+	Contract     *IRegistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
+}
+
+// IRegistryRaw is an auto generated low-level Go binding around a Klaytn contract.
+type IRegistryRaw struct {
+	Contract *IRegistry // Generic contract binding to access the raw methods on
+}
+
+// IRegistryCallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type IRegistryCallerRaw struct {
+	Contract *IRegistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IRegistryTransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type IRegistryTransactorRaw struct {
+	Contract *IRegistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIRegistry creates a new instance of IRegistry, bound to a specific deployed contract.
+func NewIRegistry(address common.Address, backend bind.ContractBackend) (*IRegistry, error) {
+	contract, err := bindIRegistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IRegistry{IRegistryCaller: IRegistryCaller{contract: contract}, IRegistryTransactor: IRegistryTransactor{contract: contract}, IRegistryFilterer: IRegistryFilterer{contract: contract}}, nil
+}
+
+// NewIRegistryCaller creates a new read-only instance of IRegistry, bound to a specific deployed contract.
+func NewIRegistryCaller(address common.Address, caller bind.ContractCaller) (*IRegistryCaller, error) {
+	contract, err := bindIRegistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IRegistryCaller{contract: contract}, nil
+}
+
+// NewIRegistryTransactor creates a new write-only instance of IRegistry, bound to a specific deployed contract.
+func NewIRegistryTransactor(address common.Address, transactor bind.ContractTransactor) (*IRegistryTransactor, error) {
+	contract, err := bindIRegistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IRegistryTransactor{contract: contract}, nil
+}
+
+// NewIRegistryFilterer creates a new log filterer instance of IRegistry, bound to a specific deployed contract.
+func NewIRegistryFilterer(address common.Address, filterer bind.ContractFilterer) (*IRegistryFilterer, error) {
+	contract, err := bindIRegistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IRegistryFilterer{contract: contract}, nil
+}
+
+// bindIRegistry binds a generic wrapper to an already deployed contract.
+func bindIRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(IRegistryABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IRegistry *IRegistryRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _IRegistry.Contract.IRegistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IRegistry *IRegistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IRegistry.Contract.IRegistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IRegistry *IRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IRegistry.Contract.IRegistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IRegistry *IRegistryCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _IRegistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IRegistry *IRegistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IRegistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IRegistry *IRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IRegistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+//
+// Solidity: function getActiveContract(string name) view returns(address)
+func (_IRegistry *IRegistryCaller) GetActiveContract(opts *bind.CallOpts, name string) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _IRegistry.contract.Call(opts, out, "getActiveContract", name)
+	return *ret0, err
+}
+
+// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+//
+// Solidity: function getActiveContract(string name) view returns(address)
+func (_IRegistry *IRegistrySession) GetActiveContract(name string) (common.Address, error) {
+	return _IRegistry.Contract.GetActiveContract(&_IRegistry.CallOpts, name)
+}
+
+// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+//
+// Solidity: function getActiveContract(string name) view returns(address)
+func (_IRegistry *IRegistryCallerSession) GetActiveContract(name string) (common.Address, error) {
+	return _IRegistry.Contract.GetActiveContract(&_IRegistry.CallOpts, name)
+}
+
+// RegistryABI is the input ABI used to generate the binding from.
+const RegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
+
+// RegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const RegistryBinRuntime = `608060405234801561001057600080fd5b506004361061002b5760003560e01c8063080d572114610030575b600080fd5b61004361003e3660046100b6565b61005f565b6040516001600160a01b03909116815260200160405180910390f35b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b6000602082840312156100c857600080fd5b813567ffffffffffffffff808211156100e057600080fd5b818401915084601f8301126100f457600080fd5b813581811115610106576101066100a0565b604051601f8201601f19908116603f0116810190838211818310171561012e5761012e6100a0565b8160405282815287602084870101111561014757600080fd5b82602086016020830137600092810160200192909252509594505050505056fea26469706673582212201b2ec5ac3f64bc0b73fe2515f6c12d958b63dbd7387cae5d88affc9c69b01e5664736f6c63430008110033`
+
+// RegistryFuncSigs maps the 4-byte function signature to its string representation.
+var RegistryFuncSigs = map[string]string{
+	"080d5721": "getActiveContract(string)",
+}
+
+// RegistryBin is the compiled bytecode used for deploying new contracts.
+var RegistryBin = "0x608060405234801561001057600080fd5b5061019d806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063080d572114610030575b600080fd5b61004361003e3660046100b6565b61005f565b6040516001600160a01b03909116815260200160405180910390f35b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b6000602082840312156100c857600080fd5b813567ffffffffffffffff808211156100e057600080fd5b818401915084601f8301126100f457600080fd5b813581811115610106576101066100a0565b604051601f8201601f19908116603f0116810190838211818310171561012e5761012e6100a0565b8160405282815287602084870101111561014757600080fd5b82602086016020830137600092810160200192909252509594505050505056fea26469706673582212201b2ec5ac3f64bc0b73fe2515f6c12d958b63dbd7387cae5d88affc9c69b01e5664736f6c63430008110033"
+
+// DeployRegistry deploys a new Klaytn contract, binding an instance of Registry to it.
+func DeployRegistry(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Registry, error) {
+	parsed, err := abi.JSON(strings.NewReader(RegistryABI))
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(RegistryBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Registry{RegistryCaller: RegistryCaller{contract: contract}, RegistryTransactor: RegistryTransactor{contract: contract}, RegistryFilterer: RegistryFilterer{contract: contract}}, nil
+}
+
+// Registry is an auto generated Go binding around a Klaytn contract.
+type Registry struct {
+	RegistryCaller     // Read-only binding to the contract
+	RegistryTransactor // Write-only binding to the contract
+	RegistryFilterer   // Log filterer for contract events
+}
+
+// RegistryCaller is an auto generated read-only Go binding around a Klaytn contract.
+type RegistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RegistryTransactor is an auto generated write-only Go binding around a Klaytn contract.
+type RegistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RegistryFilterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type RegistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RegistrySession is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type RegistrySession struct {
+	Contract     *Registry         // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// RegistryCallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type RegistryCallerSession struct {
+	Contract *RegistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts   // Call options to use throughout this session
+}
+
+// RegistryTransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type RegistryTransactorSession struct {
+	Contract     *RegistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// RegistryRaw is an auto generated low-level Go binding around a Klaytn contract.
+type RegistryRaw struct {
+	Contract *Registry // Generic contract binding to access the raw methods on
+}
+
+// RegistryCallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type RegistryCallerRaw struct {
+	Contract *RegistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// RegistryTransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type RegistryTransactorRaw struct {
+	Contract *RegistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewRegistry creates a new instance of Registry, bound to a specific deployed contract.
+func NewRegistry(address common.Address, backend bind.ContractBackend) (*Registry, error) {
+	contract, err := bindRegistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Registry{RegistryCaller: RegistryCaller{contract: contract}, RegistryTransactor: RegistryTransactor{contract: contract}, RegistryFilterer: RegistryFilterer{contract: contract}}, nil
+}
+
+// NewRegistryCaller creates a new read-only instance of Registry, bound to a specific deployed contract.
+func NewRegistryCaller(address common.Address, caller bind.ContractCaller) (*RegistryCaller, error) {
+	contract, err := bindRegistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryCaller{contract: contract}, nil
+}
+
+// NewRegistryTransactor creates a new write-only instance of Registry, bound to a specific deployed contract.
+func NewRegistryTransactor(address common.Address, transactor bind.ContractTransactor) (*RegistryTransactor, error) {
+	contract, err := bindRegistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryTransactor{contract: contract}, nil
+}
+
+// NewRegistryFilterer creates a new log filterer instance of Registry, bound to a specific deployed contract.
+func NewRegistryFilterer(address common.Address, filterer bind.ContractFilterer) (*RegistryFilterer, error) {
+	contract, err := bindRegistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryFilterer{contract: contract}, nil
+}
+
+// bindRegistry binds a generic wrapper to an already deployed contract.
+func bindRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(RegistryABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Registry *RegistryRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Registry.Contract.RegistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Registry *RegistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Registry.Contract.RegistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Registry *RegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Registry.Contract.RegistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Registry *RegistryCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Registry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Registry *RegistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Registry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Registry *RegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Registry.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+//
+// Solidity: function getActiveContract(string name) view returns(address)
+func (_Registry *RegistryCaller) GetActiveContract(opts *bind.CallOpts, name string) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _Registry.contract.Call(opts, out, "getActiveContract", name)
+	return *ret0, err
+}
+
+// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+//
+// Solidity: function getActiveContract(string name) view returns(address)
+func (_Registry *RegistrySession) GetActiveContract(name string) (common.Address, error) {
+	return _Registry.Contract.GetActiveContract(&_Registry.CallOpts, name)
+}
+
+// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+//
+// Solidity: function getActiveContract(string name) view returns(address)
+func (_Registry *RegistryCallerSession) GetActiveContract(name string) (common.Address, error) {
+	return _Registry.Contract.GetActiveContract(&_Registry.CallOpts, name)
+}
+
+// RegistryMockABI is the input ABI used to generate the binding from.
+const RegistryMockABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+
+// RegistryMockBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const RegistryMockBinRuntime = `608060405234801561001057600080fd5b50600436106100415760003560e01c8063080d5721146100465780631e59c52914610075578063541e771d1461008a575b600080fd5b6100596100543660046101d5565b6100be565b6040516001600160a01b03909116815260200160405180910390f35b610088610083366004610212565b6100ee565b005b6100596100983660046101d5565b80516020818301810180516000825292820191909301209152546001600160a01b031681565b600080826040516100cf9190610270565b908152604051908190036020019020546001600160a01b031692915050565b806000836040516100ff9190610270565b90815260405190819003602001902080546001600160a01b03929092166001600160a01b03199092169190911790555050565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261015957600080fd5b813567ffffffffffffffff8082111561017457610174610132565b604051601f8301601f19908116603f0116810190828211818310171561019c5761019c610132565b816040528381528660208588010111156101b557600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000602082840312156101e757600080fd5b813567ffffffffffffffff8111156101fe57600080fd5b61020a84828501610148565b949350505050565b6000806040838503121561022557600080fd5b823567ffffffffffffffff81111561023c57600080fd5b61024885828601610148565b92505060208301356001600160a01b038116811461026557600080fd5b809150509250929050565b6000825160005b818110156102915760208186018101518583015201610277565b50600092019182525091905056fea26469706673582212200be7666a50b9065e81c071c025510f3e57b6e8294690ac5940a1c711cf00340b64736f6c63430008110033`
+
+// RegistryMockFuncSigs maps the 4-byte function signature to its string representation.
+var RegistryMockFuncSigs = map[string]string{
+	"080d5721": "getActiveContract(string)",
+	"541e771d": "records(string)",
+	"1e59c529": "register(string,address)",
+}
+
+// RegistryMockBin is the compiled bytecode used for deploying new contracts.
+var RegistryMockBin = "0x608060405234801561001057600080fd5b506102d5806100206000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c8063080d5721146100465780631e59c52914610075578063541e771d1461008a575b600080fd5b6100596100543660046101d5565b6100be565b6040516001600160a01b03909116815260200160405180910390f35b610088610083366004610212565b6100ee565b005b6100596100983660046101d5565b80516020818301810180516000825292820191909301209152546001600160a01b031681565b600080826040516100cf9190610270565b908152604051908190036020019020546001600160a01b031692915050565b806000836040516100ff9190610270565b90815260405190819003602001902080546001600160a01b03929092166001600160a01b03199092169190911790555050565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261015957600080fd5b813567ffffffffffffffff8082111561017457610174610132565b604051601f8301601f19908116603f0116810190828211818310171561019c5761019c610132565b816040528381528660208588010111156101b557600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000602082840312156101e757600080fd5b813567ffffffffffffffff8111156101fe57600080fd5b61020a84828501610148565b949350505050565b6000806040838503121561022557600080fd5b823567ffffffffffffffff81111561023c57600080fd5b61024885828601610148565b92505060208301356001600160a01b038116811461026557600080fd5b809150509250929050565b6000825160005b818110156102915760208186018101518583015201610277565b50600092019182525091905056fea26469706673582212200be7666a50b9065e81c071c025510f3e57b6e8294690ac5940a1c711cf00340b64736f6c63430008110033"
+
+// DeployRegistryMock deploys a new Klaytn contract, binding an instance of RegistryMock to it.
+func DeployRegistryMock(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *RegistryMock, error) {
+	parsed, err := abi.JSON(strings.NewReader(RegistryMockABI))
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(RegistryMockBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &RegistryMock{RegistryMockCaller: RegistryMockCaller{contract: contract}, RegistryMockTransactor: RegistryMockTransactor{contract: contract}, RegistryMockFilterer: RegistryMockFilterer{contract: contract}}, nil
+}
+
+// RegistryMock is an auto generated Go binding around a Klaytn contract.
+type RegistryMock struct {
+	RegistryMockCaller     // Read-only binding to the contract
+	RegistryMockTransactor // Write-only binding to the contract
+	RegistryMockFilterer   // Log filterer for contract events
+}
+
+// RegistryMockCaller is an auto generated read-only Go binding around a Klaytn contract.
+type RegistryMockCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RegistryMockTransactor is an auto generated write-only Go binding around a Klaytn contract.
+type RegistryMockTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RegistryMockFilterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type RegistryMockFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RegistryMockSession is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type RegistryMockSession struct {
+	Contract     *RegistryMock     // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// RegistryMockCallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type RegistryMockCallerSession struct {
+	Contract *RegistryMockCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts       // Call options to use throughout this session
+}
+
+// RegistryMockTransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type RegistryMockTransactorSession struct {
+	Contract     *RegistryMockTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts       // Transaction auth options to use throughout this session
+}
+
+// RegistryMockRaw is an auto generated low-level Go binding around a Klaytn contract.
+type RegistryMockRaw struct {
+	Contract *RegistryMock // Generic contract binding to access the raw methods on
+}
+
+// RegistryMockCallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type RegistryMockCallerRaw struct {
+	Contract *RegistryMockCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// RegistryMockTransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type RegistryMockTransactorRaw struct {
+	Contract *RegistryMockTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewRegistryMock creates a new instance of RegistryMock, bound to a specific deployed contract.
+func NewRegistryMock(address common.Address, backend bind.ContractBackend) (*RegistryMock, error) {
+	contract, err := bindRegistryMock(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryMock{RegistryMockCaller: RegistryMockCaller{contract: contract}, RegistryMockTransactor: RegistryMockTransactor{contract: contract}, RegistryMockFilterer: RegistryMockFilterer{contract: contract}}, nil
+}
+
+// NewRegistryMockCaller creates a new read-only instance of RegistryMock, bound to a specific deployed contract.
+func NewRegistryMockCaller(address common.Address, caller bind.ContractCaller) (*RegistryMockCaller, error) {
+	contract, err := bindRegistryMock(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryMockCaller{contract: contract}, nil
+}
+
+// NewRegistryMockTransactor creates a new write-only instance of RegistryMock, bound to a specific deployed contract.
+func NewRegistryMockTransactor(address common.Address, transactor bind.ContractTransactor) (*RegistryMockTransactor, error) {
+	contract, err := bindRegistryMock(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryMockTransactor{contract: contract}, nil
+}
+
+// NewRegistryMockFilterer creates a new log filterer instance of RegistryMock, bound to a specific deployed contract.
+func NewRegistryMockFilterer(address common.Address, filterer bind.ContractFilterer) (*RegistryMockFilterer, error) {
+	contract, err := bindRegistryMock(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryMockFilterer{contract: contract}, nil
+}
+
+// bindRegistryMock binds a generic wrapper to an already deployed contract.
+func bindRegistryMock(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(RegistryMockABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_RegistryMock *RegistryMockRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _RegistryMock.Contract.RegistryMockCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_RegistryMock *RegistryMockRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _RegistryMock.Contract.RegistryMockTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_RegistryMock *RegistryMockRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _RegistryMock.Contract.RegistryMockTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_RegistryMock *RegistryMockCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _RegistryMock.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_RegistryMock *RegistryMockTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _RegistryMock.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_RegistryMock *RegistryMockTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _RegistryMock.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+//
+// Solidity: function getActiveContract(string name) view returns(address)
+func (_RegistryMock *RegistryMockCaller) GetActiveContract(opts *bind.CallOpts, name string) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _RegistryMock.contract.Call(opts, out, "getActiveContract", name)
+	return *ret0, err
+}
+
+// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+//
+// Solidity: function getActiveContract(string name) view returns(address)
+func (_RegistryMock *RegistryMockSession) GetActiveContract(name string) (common.Address, error) {
+	return _RegistryMock.Contract.GetActiveContract(&_RegistryMock.CallOpts, name)
+}
+
+// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+//
+// Solidity: function getActiveContract(string name) view returns(address)
+func (_RegistryMock *RegistryMockCallerSession) GetActiveContract(name string) (common.Address, error) {
+	return _RegistryMock.Contract.GetActiveContract(&_RegistryMock.CallOpts, name)
+}
+
+// Records is a free data retrieval call binding the contract method 0x541e771d.
+//
+// Solidity: function records(string ) view returns(address)
+func (_RegistryMock *RegistryMockCaller) Records(opts *bind.CallOpts, arg0 string) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _RegistryMock.contract.Call(opts, out, "records", arg0)
+	return *ret0, err
+}
+
+// Records is a free data retrieval call binding the contract method 0x541e771d.
+//
+// Solidity: function records(string ) view returns(address)
+func (_RegistryMock *RegistryMockSession) Records(arg0 string) (common.Address, error) {
+	return _RegistryMock.Contract.Records(&_RegistryMock.CallOpts, arg0)
+}
+
+// Records is a free data retrieval call binding the contract method 0x541e771d.
+//
+// Solidity: function records(string ) view returns(address)
+func (_RegistryMock *RegistryMockCallerSession) Records(arg0 string) (common.Address, error) {
+	return _RegistryMock.Contract.Records(&_RegistryMock.CallOpts, arg0)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x1e59c529.
+//
+// Solidity: function register(string name, address addr) returns()
+func (_RegistryMock *RegistryMockTransactor) Register(opts *bind.TransactOpts, name string, addr common.Address) (*types.Transaction, error) {
+	return _RegistryMock.contract.Transact(opts, "register", name, addr)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x1e59c529.
+//
+// Solidity: function register(string name, address addr) returns()
+func (_RegistryMock *RegistryMockSession) Register(name string, addr common.Address) (*types.Transaction, error) {
+	return _RegistryMock.Contract.Register(&_RegistryMock.TransactOpts, name, addr)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x1e59c529.
+//
+// Solidity: function register(string name, address addr) returns()
+func (_RegistryMock *RegistryMockTransactorSession) Register(name string, addr common.Address) (*types.Transaction, error) {
+	return _RegistryMock.Contract.Register(&_RegistryMock.TransactOpts, name, addr)
+}

--- a/contracts/system_contracts/all.go
+++ b/contracts/system_contracts/all.go
@@ -27,14 +27,14 @@ var (
 )
 
 // IRegistryABI is the input ABI used to generate the binding from.
-const IRegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
+const IRegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
 
 // IRegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
 const IRegistryBinRuntime = ``
 
 // IRegistryFuncSigs maps the 4-byte function signature to its string representation.
 var IRegistryFuncSigs = map[string]string{
-	"080d5721": "getActiveContract(string)",
+	"e2693e3f": "getActiveAddr(string)",
 }
 
 // IRegistry is an auto generated Go binding around a Klaytn contract.
@@ -179,45 +179,45 @@ func (_IRegistry *IRegistryTransactorRaw) Transact(opts *bind.TransactOpts, meth
 	return _IRegistry.Contract.contract.Transact(opts, method, params...)
 }
 
-// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getActiveContract(string name) view returns(address)
-func (_IRegistry *IRegistryCaller) GetActiveContract(opts *bind.CallOpts, name string) (common.Address, error) {
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_IRegistry *IRegistryCaller) GetActiveAddr(opts *bind.CallOpts, name string) (common.Address, error) {
 	var (
 		ret0 = new(common.Address)
 	)
 	out := ret0
-	err := _IRegistry.contract.Call(opts, out, "getActiveContract", name)
+	err := _IRegistry.contract.Call(opts, out, "getActiveAddr", name)
 	return *ret0, err
 }
 
-// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getActiveContract(string name) view returns(address)
-func (_IRegistry *IRegistrySession) GetActiveContract(name string) (common.Address, error) {
-	return _IRegistry.Contract.GetActiveContract(&_IRegistry.CallOpts, name)
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_IRegistry *IRegistrySession) GetActiveAddr(name string) (common.Address, error) {
+	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.CallOpts, name)
 }
 
-// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getActiveContract(string name) view returns(address)
-func (_IRegistry *IRegistryCallerSession) GetActiveContract(name string) (common.Address, error) {
-	return _IRegistry.Contract.GetActiveContract(&_IRegistry.CallOpts, name)
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_IRegistry *IRegistryCallerSession) GetActiveAddr(name string) (common.Address, error) {
+	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.CallOpts, name)
 }
 
 // RegistryABI is the input ABI used to generate the binding from.
-const RegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
+const RegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
 
 // RegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
-const RegistryBinRuntime = `608060405234801561001057600080fd5b506004361061002b5760003560e01c8063080d572114610030575b600080fd5b61004361003e3660046100b6565b61005f565b6040516001600160a01b03909116815260200160405180910390f35b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b6000602082840312156100c857600080fd5b813567ffffffffffffffff808211156100e057600080fd5b818401915084601f8301126100f457600080fd5b813581811115610106576101066100a0565b604051601f8201601f19908116603f0116810190838211818310171561012e5761012e6100a0565b8160405282815287602084870101111561014757600080fd5b82602086016020830137600092810160200192909252509594505050505056fea26469706673582212201b2ec5ac3f64bc0b73fe2515f6c12d958b63dbd7387cae5d88affc9c69b01e5664736f6c63430008110033`
+const RegistryBinRuntime = `608060405234801561001057600080fd5b506004361061002b5760003560e01c8063e2693e3f14610030575b600080fd5b61004361003e3660046100b6565b61005f565b6040516001600160a01b03909116815260200160405180910390f35b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b6000602082840312156100c857600080fd5b813567ffffffffffffffff808211156100e057600080fd5b818401915084601f8301126100f457600080fd5b813581811115610106576101066100a0565b604051601f8201601f19908116603f0116810190838211818310171561012e5761012e6100a0565b8160405282815287602084870101111561014757600080fd5b82602086016020830137600092810160200192909252509594505050505056fea26469706673582212202baebcbf67ab9b5cbd8fc6dcc00c381bef5833202c81d669604bbe8d34bc7bb764736f6c63430008110033`
 
 // RegistryFuncSigs maps the 4-byte function signature to its string representation.
 var RegistryFuncSigs = map[string]string{
-	"080d5721": "getActiveContract(string)",
+	"e2693e3f": "getActiveAddr(string)",
 }
 
 // RegistryBin is the compiled bytecode used for deploying new contracts.
-var RegistryBin = "0x608060405234801561001057600080fd5b5061019d806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063080d572114610030575b600080fd5b61004361003e3660046100b6565b61005f565b6040516001600160a01b03909116815260200160405180910390f35b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b6000602082840312156100c857600080fd5b813567ffffffffffffffff808211156100e057600080fd5b818401915084601f8301126100f457600080fd5b813581811115610106576101066100a0565b604051601f8201601f19908116603f0116810190838211818310171561012e5761012e6100a0565b8160405282815287602084870101111561014757600080fd5b82602086016020830137600092810160200192909252509594505050505056fea26469706673582212201b2ec5ac3f64bc0b73fe2515f6c12d958b63dbd7387cae5d88affc9c69b01e5664736f6c63430008110033"
+var RegistryBin = "0x608060405234801561001057600080fd5b5061019d806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063e2693e3f14610030575b600080fd5b61004361003e3660046100b6565b61005f565b6040516001600160a01b03909116815260200160405180910390f35b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b6000602082840312156100c857600080fd5b813567ffffffffffffffff808211156100e057600080fd5b818401915084601f8301126100f457600080fd5b813581811115610106576101066100a0565b604051601f8201601f19908116603f0116810190838211818310171561012e5761012e6100a0565b8160405282815287602084870101111561014757600080fd5b82602086016020830137600092810160200192909252509594505050505056fea26469706673582212202baebcbf67ab9b5cbd8fc6dcc00c381bef5833202c81d669604bbe8d34bc7bb764736f6c63430008110033"
 
 // DeployRegistry deploys a new Klaytn contract, binding an instance of Registry to it.
 func DeployRegistry(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Registry, error) {
@@ -375,47 +375,47 @@ func (_Registry *RegistryTransactorRaw) Transact(opts *bind.TransactOpts, method
 	return _Registry.Contract.contract.Transact(opts, method, params...)
 }
 
-// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getActiveContract(string name) view returns(address)
-func (_Registry *RegistryCaller) GetActiveContract(opts *bind.CallOpts, name string) (common.Address, error) {
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_Registry *RegistryCaller) GetActiveAddr(opts *bind.CallOpts, name string) (common.Address, error) {
 	var (
 		ret0 = new(common.Address)
 	)
 	out := ret0
-	err := _Registry.contract.Call(opts, out, "getActiveContract", name)
+	err := _Registry.contract.Call(opts, out, "getActiveAddr", name)
 	return *ret0, err
 }
 
-// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getActiveContract(string name) view returns(address)
-func (_Registry *RegistrySession) GetActiveContract(name string) (common.Address, error) {
-	return _Registry.Contract.GetActiveContract(&_Registry.CallOpts, name)
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_Registry *RegistrySession) GetActiveAddr(name string) (common.Address, error) {
+	return _Registry.Contract.GetActiveAddr(&_Registry.CallOpts, name)
 }
 
-// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getActiveContract(string name) view returns(address)
-func (_Registry *RegistryCallerSession) GetActiveContract(name string) (common.Address, error) {
-	return _Registry.Contract.GetActiveContract(&_Registry.CallOpts, name)
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_Registry *RegistryCallerSession) GetActiveAddr(name string) (common.Address, error) {
+	return _Registry.Contract.GetActiveAddr(&_Registry.CallOpts, name)
 }
 
 // RegistryMockABI is the input ABI used to generate the binding from.
-const RegistryMockABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+const RegistryMockABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
 
 // RegistryMockBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
-const RegistryMockBinRuntime = `608060405234801561001057600080fd5b50600436106100415760003560e01c8063080d5721146100465780631e59c52914610075578063541e771d1461008a575b600080fd5b6100596100543660046101d5565b6100be565b6040516001600160a01b03909116815260200160405180910390f35b610088610083366004610212565b6100ee565b005b6100596100983660046101d5565b80516020818301810180516000825292820191909301209152546001600160a01b031681565b600080826040516100cf9190610270565b908152604051908190036020019020546001600160a01b031692915050565b806000836040516100ff9190610270565b90815260405190819003602001902080546001600160a01b03929092166001600160a01b03199092169190911790555050565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261015957600080fd5b813567ffffffffffffffff8082111561017457610174610132565b604051601f8301601f19908116603f0116810190828211818310171561019c5761019c610132565b816040528381528660208588010111156101b557600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000602082840312156101e757600080fd5b813567ffffffffffffffff8111156101fe57600080fd5b61020a84828501610148565b949350505050565b6000806040838503121561022557600080fd5b823567ffffffffffffffff81111561023c57600080fd5b61024885828601610148565b92505060208301356001600160a01b038116811461026557600080fd5b809150509250929050565b6000825160005b818110156102915760208186018101518583015201610277565b50600092019182525091905056fea26469706673582212200be7666a50b9065e81c071c025510f3e57b6e8294690ac5940a1c711cf00340b64736f6c63430008110033`
+const RegistryMockBinRuntime = `608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d14610046578063d393c8711461007d578063e2693e3f14610092575b600080fd5b6100596100543660046102b6565b6100bd565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102fb565b610112565b005b6100a56100a0366004610361565b610181565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100e857600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600083604051610122919061039e565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b600080600083604051610194919061039e565b90815260405190819003602001902054905060008190036101b85750600092915050565b6000836040516101c8919061039e565b9081526040519081900360200190206101e26001836103cd565b815481106101f2576101f26103f4565b60009182526020909120600290910201546001600160a01b03169392505050565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023a57600080fd5b813567ffffffffffffffff8082111561025557610255610213565b604051601f8301601f19908116603f0116810190828211818310171561027d5761027d610213565b8160405283815286602085880101111561029657600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c957600080fd5b823567ffffffffffffffff8111156102e057600080fd5b6102ec85828601610229565b95602094909401359450505050565b60008060006060848603121561031057600080fd5b833567ffffffffffffffff81111561032757600080fd5b61033386828701610229565b93505060208401356001600160a01b038116811461035057600080fd5b929592945050506040919091013590565b60006020828403121561037357600080fd5b813567ffffffffffffffff81111561038a57600080fd5b61039684828501610229565b949350505050565b6000825160005b818110156103bf57602081860181015185830152016103a5565b506000920191825250919050565b818103818111156103ee57634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea26469706673582212205fe32fa81ee789c8e1f6cf6e001eeea21e25ad22870152e09ff2b670f942aa8c64736f6c63430008110033`
 
 // RegistryMockFuncSigs maps the 4-byte function signature to its string representation.
 var RegistryMockFuncSigs = map[string]string{
-	"080d5721": "getActiveContract(string)",
-	"541e771d": "records(string)",
-	"1e59c529": "register(string,address)",
+	"e2693e3f": "getActiveAddr(string)",
+	"3b51650d": "records(string,uint256)",
+	"d393c871": "register(string,address,uint256)",
 }
 
 // RegistryMockBin is the compiled bytecode used for deploying new contracts.
-var RegistryMockBin = "0x608060405234801561001057600080fd5b506102d5806100206000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c8063080d5721146100465780631e59c52914610075578063541e771d1461008a575b600080fd5b6100596100543660046101d5565b6100be565b6040516001600160a01b03909116815260200160405180910390f35b610088610083366004610212565b6100ee565b005b6100596100983660046101d5565b80516020818301810180516000825292820191909301209152546001600160a01b031681565b600080826040516100cf9190610270565b908152604051908190036020019020546001600160a01b031692915050565b806000836040516100ff9190610270565b90815260405190819003602001902080546001600160a01b03929092166001600160a01b03199092169190911790555050565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261015957600080fd5b813567ffffffffffffffff8082111561017457610174610132565b604051601f8301601f19908116603f0116810190828211818310171561019c5761019c610132565b816040528381528660208588010111156101b557600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000602082840312156101e757600080fd5b813567ffffffffffffffff8111156101fe57600080fd5b61020a84828501610148565b949350505050565b6000806040838503121561022557600080fd5b823567ffffffffffffffff81111561023c57600080fd5b61024885828601610148565b92505060208301356001600160a01b038116811461026557600080fd5b809150509250929050565b6000825160005b818110156102915760208186018101518583015201610277565b50600092019182525091905056fea26469706673582212200be7666a50b9065e81c071c025510f3e57b6e8294690ac5940a1c711cf00340b64736f6c63430008110033"
+var RegistryMockBin = "0x608060405234801561001057600080fd5b50610440806100206000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d14610046578063d393c8711461007d578063e2693e3f14610092575b600080fd5b6100596100543660046102b6565b6100bd565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102fb565b610112565b005b6100a56100a0366004610361565b610181565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100e857600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600083604051610122919061039e565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b600080600083604051610194919061039e565b90815260405190819003602001902054905060008190036101b85750600092915050565b6000836040516101c8919061039e565b9081526040519081900360200190206101e26001836103cd565b815481106101f2576101f26103f4565b60009182526020909120600290910201546001600160a01b03169392505050565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023a57600080fd5b813567ffffffffffffffff8082111561025557610255610213565b604051601f8301601f19908116603f0116810190828211818310171561027d5761027d610213565b8160405283815286602085880101111561029657600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c957600080fd5b823567ffffffffffffffff8111156102e057600080fd5b6102ec85828601610229565b95602094909401359450505050565b60008060006060848603121561031057600080fd5b833567ffffffffffffffff81111561032757600080fd5b61033386828701610229565b93505060208401356001600160a01b038116811461035057600080fd5b929592945050506040919091013590565b60006020828403121561037357600080fd5b813567ffffffffffffffff81111561038a57600080fd5b61039684828501610229565b949350505050565b6000825160005b818110156103bf57602081860181015185830152016103a5565b506000920191825250919050565b818103818111156103ee57634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea26469706673582212205fe32fa81ee789c8e1f6cf6e001eeea21e25ad22870152e09ff2b670f942aa8c64736f6c63430008110033"
 
 // DeployRegistryMock deploys a new Klaytn contract, binding an instance of RegistryMock to it.
 func DeployRegistryMock(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *RegistryMock, error) {
@@ -573,75 +573,85 @@ func (_RegistryMock *RegistryMockTransactorRaw) Transact(opts *bind.TransactOpts
 	return _RegistryMock.Contract.contract.Transact(opts, method, params...)
 }
 
-// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getActiveContract(string name) view returns(address)
-func (_RegistryMock *RegistryMockCaller) GetActiveContract(opts *bind.CallOpts, name string) (common.Address, error) {
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_RegistryMock *RegistryMockCaller) GetActiveAddr(opts *bind.CallOpts, name string) (common.Address, error) {
 	var (
 		ret0 = new(common.Address)
 	)
 	out := ret0
-	err := _RegistryMock.contract.Call(opts, out, "getActiveContract", name)
+	err := _RegistryMock.contract.Call(opts, out, "getActiveAddr", name)
 	return *ret0, err
 }
 
-// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getActiveContract(string name) view returns(address)
-func (_RegistryMock *RegistryMockSession) GetActiveContract(name string) (common.Address, error) {
-	return _RegistryMock.Contract.GetActiveContract(&_RegistryMock.CallOpts, name)
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_RegistryMock *RegistryMockSession) GetActiveAddr(name string) (common.Address, error) {
+	return _RegistryMock.Contract.GetActiveAddr(&_RegistryMock.CallOpts, name)
 }
 
-// GetActiveContract is a free data retrieval call binding the contract method 0x080d5721.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getActiveContract(string name) view returns(address)
-func (_RegistryMock *RegistryMockCallerSession) GetActiveContract(name string) (common.Address, error) {
-	return _RegistryMock.Contract.GetActiveContract(&_RegistryMock.CallOpts, name)
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_RegistryMock *RegistryMockCallerSession) GetActiveAddr(name string) (common.Address, error) {
+	return _RegistryMock.Contract.GetActiveAddr(&_RegistryMock.CallOpts, name)
 }
 
-// Records is a free data retrieval call binding the contract method 0x541e771d.
+// Records is a free data retrieval call binding the contract method 0x3b51650d.
 //
-// Solidity: function records(string ) view returns(address)
-func (_RegistryMock *RegistryMockCaller) Records(opts *bind.CallOpts, arg0 string) (common.Address, error) {
-	var (
-		ret0 = new(common.Address)
-	)
-	out := ret0
-	err := _RegistryMock.contract.Call(opts, out, "records", arg0)
-	return *ret0, err
+// Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
+func (_RegistryMock *RegistryMockCaller) Records(opts *bind.CallOpts, arg0 string, arg1 *big.Int) (struct {
+	Addr       common.Address
+	Activation *big.Int
+}, error) {
+	ret := new(struct {
+		Addr       common.Address
+		Activation *big.Int
+	})
+	out := ret
+	err := _RegistryMock.contract.Call(opts, out, "records", arg0, arg1)
+	return *ret, err
 }
 
-// Records is a free data retrieval call binding the contract method 0x541e771d.
+// Records is a free data retrieval call binding the contract method 0x3b51650d.
 //
-// Solidity: function records(string ) view returns(address)
-func (_RegistryMock *RegistryMockSession) Records(arg0 string) (common.Address, error) {
-	return _RegistryMock.Contract.Records(&_RegistryMock.CallOpts, arg0)
+// Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
+func (_RegistryMock *RegistryMockSession) Records(arg0 string, arg1 *big.Int) (struct {
+	Addr       common.Address
+	Activation *big.Int
+}, error) {
+	return _RegistryMock.Contract.Records(&_RegistryMock.CallOpts, arg0, arg1)
 }
 
-// Records is a free data retrieval call binding the contract method 0x541e771d.
+// Records is a free data retrieval call binding the contract method 0x3b51650d.
 //
-// Solidity: function records(string ) view returns(address)
-func (_RegistryMock *RegistryMockCallerSession) Records(arg0 string) (common.Address, error) {
-	return _RegistryMock.Contract.Records(&_RegistryMock.CallOpts, arg0)
+// Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
+func (_RegistryMock *RegistryMockCallerSession) Records(arg0 string, arg1 *big.Int) (struct {
+	Addr       common.Address
+	Activation *big.Int
+}, error) {
+	return _RegistryMock.Contract.Records(&_RegistryMock.CallOpts, arg0, arg1)
 }
 
-// Register is a paid mutator transaction binding the contract method 0x1e59c529.
+// Register is a paid mutator transaction binding the contract method 0xd393c871.
 //
-// Solidity: function register(string name, address addr) returns()
-func (_RegistryMock *RegistryMockTransactor) Register(opts *bind.TransactOpts, name string, addr common.Address) (*types.Transaction, error) {
-	return _RegistryMock.contract.Transact(opts, "register", name, addr)
+// Solidity: function register(string name, address addr, uint256 activation) returns()
+func (_RegistryMock *RegistryMockTransactor) Register(opts *bind.TransactOpts, name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
+	return _RegistryMock.contract.Transact(opts, "register", name, addr, activation)
 }
 
-// Register is a paid mutator transaction binding the contract method 0x1e59c529.
+// Register is a paid mutator transaction binding the contract method 0xd393c871.
 //
-// Solidity: function register(string name, address addr) returns()
-func (_RegistryMock *RegistryMockSession) Register(name string, addr common.Address) (*types.Transaction, error) {
-	return _RegistryMock.Contract.Register(&_RegistryMock.TransactOpts, name, addr)
+// Solidity: function register(string name, address addr, uint256 activation) returns()
+func (_RegistryMock *RegistryMockSession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
+	return _RegistryMock.Contract.Register(&_RegistryMock.TransactOpts, name, addr, activation)
 }
 
-// Register is a paid mutator transaction binding the contract method 0x1e59c529.
+// Register is a paid mutator transaction binding the contract method 0xd393c871.
 //
-// Solidity: function register(string name, address addr) returns()
-func (_RegistryMock *RegistryMockTransactorSession) Register(name string, addr common.Address) (*types.Transaction, error) {
-	return _RegistryMock.Contract.Register(&_RegistryMock.TransactOpts, name, addr)
+// Solidity: function register(string name, address addr, uint256 activation) returns()
+func (_RegistryMock *RegistryMockTransactorSession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
+	return _RegistryMock.Contract.Register(&_RegistryMock.TransactOpts, name, addr, activation)
 }

--- a/contracts/system_contracts/all.sol
+++ b/contracts/system_contracts/all.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+// This file import all contracts so that single `abigen` can generate all bindings at once,
+// Because otherwise, separate `abigen` per contract may cause symbol conflict
+// when one .sol file is imported from multiple .sol files.
+
+import "./registry/Registry.sol";
+import "./registry/RegistryMock.sol";

--- a/contracts/system_contracts/registry/IRegistry.sol
+++ b/contracts/system_contracts/registry/IRegistry.sol
@@ -18,5 +18,10 @@
 pragma solidity ^0.8.0;
 
 interface IRegistry {
-    function getActiveContract(string memory name) external view returns (address);
+    struct Record {
+        address addr;
+        uint256 activation;
+    }
+
+    function getActiveAddr(string memory name) external virtual view returns (address);
 }

--- a/contracts/system_contracts/registry/IRegistry.sol
+++ b/contracts/system_contracts/registry/IRegistry.sol
@@ -17,11 +17,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.0;
 
-interface IRegistry {
+abstract contract IRegistry {
     struct Record {
         address addr;
         uint256 activation;
     }
+
+    // Crucial variables are baked in the interface
+    // because their storage layout matters in protocol consensus.
+    mapping(string => Record[]) public records;
+    string[] public names;
+    address internal _owner;
 
     function getActiveAddr(string memory name) external virtual view returns (address);
 }

--- a/contracts/system_contracts/registry/IRegistry.sol
+++ b/contracts/system_contracts/registry/IRegistry.sol
@@ -1,0 +1,22 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+interface IRegistry {
+    function getActiveContract(string memory name) external view returns (address);
+}

--- a/contracts/system_contracts/registry/Registry.sol
+++ b/contracts/system_contracts/registry/Registry.sol
@@ -1,0 +1,26 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "./IRegistry.sol";
+
+contract Registry is IRegistry {
+    function getActiveContract(string memory name) external view returns (address) {
+        revert("not implemented");
+    }
+}

--- a/contracts/system_contracts/registry/Registry.sol
+++ b/contracts/system_contracts/registry/Registry.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.0;
 import "./IRegistry.sol";
 
 contract Registry is IRegistry {
-    function getActiveContract(string memory name) external view returns (address) {
+    function getActiveAddr(string memory name) external override view returns (address) {
         revert("not implemented");
     }
 }

--- a/contracts/system_contracts/registry/RegistryMock.sol
+++ b/contracts/system_contracts/registry/RegistryMock.sol
@@ -1,0 +1,32 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "./IRegistry.sol";
+
+contract RegistryMock is IRegistry {
+    mapping(string => address) public records;
+
+    function register(string memory name, address addr) external {
+        records[name] = addr;
+    }
+
+    function getActiveContract(string memory name) external view returns (address) {
+        return records[name];
+    }
+}

--- a/contracts/system_contracts/registry/RegistryMock.sol
+++ b/contracts/system_contracts/registry/RegistryMock.sol
@@ -20,13 +20,18 @@ pragma solidity ^0.8.0;
 import "./IRegistry.sol";
 
 contract RegistryMock is IRegistry {
-    mapping(string => address) public records;
+    mapping(string => Record[]) public records;
 
-    function register(string memory name, address addr) external {
-        records[name] = addr;
+    function register(string memory name, address addr, uint256 activation) external {
+        records[name].push(Record(addr, activation));
     }
 
-    function getActiveContract(string memory name) external view returns (address) {
-        return records[name];
+    function getActiveAddr(string memory name) external override view returns (address) {
+        uint256 len = records[name].length;
+        if (len == 0) {
+            return address(0);
+        } else {
+            return records[name][len-1].addr;
+        }
     }
 }

--- a/contracts/system_contracts/registry/RegistryMock.sol
+++ b/contracts/system_contracts/registry/RegistryMock.sol
@@ -20,9 +20,14 @@ pragma solidity ^0.8.0;
 import "./IRegistry.sol";
 
 contract RegistryMock is IRegistry {
-    mapping(string => Record[]) public records;
+    function transferOwnership(address newOwner) external {
+        _owner = newOwner;
+    }
 
-    function register(string memory name, address addr, uint256 activation) external {
+    function register(string memory name, address addr, uint256 activation) public {
+        if (records[name].length == 0) {
+            names.push(name);
+        }
         records[name].push(Record(addr, activation));
     }
 


### PR DESCRIPTION
## Proposed changes

- Add simple Registry contract mockup
- Actual Registry.sol will be added later.
- Add accessors to the Registry system contract.
  - `AllocRegistry` creates an initial storage state from the given contents (i.e. records). Intended to be used to generate genesis allocation and the InstallRegistry function.
  - `InstallRegistry` installs the code and initial storage to the given StateDB. Intended to be used at hardforks.
  - `ReadRegistryAddr` calls the `getActiveAddr` function.

### Use cases

- Install at genesis
  ```go
  genesisAlloc[RegistryAddr] = {
      Code: RegistryCode
      Storage: AllocRegistry(...)
  }
  ```
- Install at nonzero hardfork block number
  ```go
  // post-transaction state modifications
  func Finalize() {
      if num + 1 == config.CancunForkNumber { // If next block is fork block
          InstallRegistry(state, ...)
      }
  }
  ```
- Read registry
  ```go
  if config.IsCancunForkEnabled(num) {
      addr = ReadRegistryActiveAddr(chain, AddressBookName, num)
  } else {
      addr = addressBookAddress
  }
  ```

### Future works

- Call `AllocRegistry()` in `homi setup` if CancunForkNumber == 0
- Call `InstallRegistry()` in `Finalize()` if CancunForkNumber > 0
- Add end-to-end test in `tests` directory

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

**Why calculate solidity slots in `AllocRegistry`?**
I chose between the two approaches, (1) calculate slot index (as implemented in this PR) (2) execute a Mock contract and extract resulting storage (as in `registry_test.go:80:TestAllocRegistry`)
Option (1) was viable because slot calculation is well-documented. Option (2) was concerning because in the process of executing a Mock contract, a new BlockChain instance is created and that might interfere with global variables or logging systems.

**Why fill storage states at all?**
At hardfork, we have two options: (a) state.SetCode and state.SetStorage (b) state.SetCode and run `register()` transactions on the state. But at genesis (e.g. test chain), we only have option (a). The storage states have to be statically determined when injecting the bytecode. 
