### PR TITLE
Split evm context into block and tx context

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -126,12 +126,14 @@ func (b *BlockchainContractBackend) callContract(call klaytn.CallMsg, block *typ
 	msg := types.NewMessage(call.From, call.To, 0, call.Value, call.Gas, call.GasPrice, call.Data,
 		false, intrinsicGas)
 
-	evmContext := blockchain.NewEVMContext(msg, block.Header(), b.bc, nil)
+	txContext := blockchain.NewEVMTxContext(msg, block.Header())
+	blockContext := blockchain.NewEVMBlockContext(block.Header(), b.bc, nil)
+
 	// EVM demands the sender to have enough KLAY balance (gasPrice * gasLimit) in buyGas()
 	// After KIP-71, gasPrice is nonzero baseFee, regardless of the msg.gasPrice (usually 0)
 	// But our sender (usually 0x0) won't have enough balance. Instead we override gasPrice = 0 here
-	evmContext.GasPrice = big.NewInt(0)
-	evm := vm.NewEVM(evmContext, state, b.bc.Config(), &vm.Config{})
+	txContext.GasPrice = big.NewInt(0)
+	evm := vm.NewEVM(blockContext, txContext, state, b.bc.Config(), &vm.Config{})
 
 	return blockchain.ApplyMessage(evm, msg)
 }

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -463,10 +463,11 @@ func (b *SimulatedBackend) callContract(_ context.Context, call klaytn.CallMsg, 
 	intrinsicGas, _ := types.IntrinsicGas(call.Data, nil, call.To == nil, b.config.Rules(block.Number()))
 	msg := types.NewMessage(call.From, call.To, nonce, call.Value, call.Gas, call.GasPrice, call.Data, true, intrinsicGas)
 
-	evmContext := blockchain.NewEVMContext(msg, block.Header(), b.blockchain, nil)
+	txContext := blockchain.NewEVMTxContext(msg, block.Header())
+	blockContext := blockchain.NewEVMBlockContext(block.Header(), b.blockchain, nil)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
-	vmenv := vm.NewEVM(evmContext, stateDB, b.config, &vm.Config{})
+	vmenv := vm.NewEVM(blockContext, txContext, stateDB, b.config, &vm.Config{})
 
 	return blockchain.NewStateTransition(vmenv, msg).TransitionDb()
 }

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -2493,8 +2493,9 @@ func testEstimateGas(t *testing.T, mockBackend *mock_api.MockBackend, fnEstimate
 	getEVM := func(_ context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmConfig vm.Config) (*vm.EVM, func() error, error) {
 		// Taken from node/cn/api_backend.go
 		vmError := func() error { return nil }
-		context := blockchain.NewEVMContext(msg, header, chain, nil)
-		return vm.NewEVM(context, state, chainConfig, &vmConfig), vmError, nil
+		txContext := blockchain.NewEVMTxContext(msg, header)
+		blockContext := blockchain.NewEVMBlockContext(header, chain, nil)
+		return vm.NewEVM(blockContext, txContext, state, chainConfig, &vmConfig), vmError, nil
 	}
 	mockBackend.EXPECT().ChainConfig().Return(chainConfig).AnyTimes()
 	mockBackend.EXPECT().RPCGasCap().Return(common.Big0).AnyTimes()

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2706,10 +2706,11 @@ func (bc *BlockChain) ApplyTransaction(chainConfig *params.ChainConfig, author *
 		return nil, nil, err
 	}
 	// Create a new context to be used in the EVM environment
-	context := NewEVMContext(msg, header, bc, author)
+	blockContext := NewEVMBlockContext(header, bc, author)
+	txContext := NewEVMTxContext(msg, header)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
-	vmenv := vm.NewEVM(context, statedb, chainConfig, vmConfig)
+	vmenv := vm.NewEVM(blockContext, txContext, statedb, chainConfig, vmConfig)
 	// Apply the transaction to the current state (included in the env)
 	result, err := ApplyMessage(vmenv, msg)
 	if err != nil {
@@ -2729,7 +2730,7 @@ func (bc *BlockChain) ApplyTransaction(chainConfig *params.ChainConfig, author *
 
 	receipt := types.NewReceipt(result.VmExecutionStatus, tx.Hash(), result.UsedGas)
 	// if the transaction created a contract, store the creation address in the receipt.
-	msg.FillContractAddress(vmenv.Context.Origin, receipt)
+	msg.FillContractAddress(vmenv.Origin, receipt)
 	// Set the receipt logs and create a bloom for filtering
 	receipt.Logs = statedb.GetLogs(tx.Hash())
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})

--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -45,14 +45,13 @@ type ChainContext interface {
 	GetHeader(common.Hash, uint64) *types.Header
 }
 
-// NewEVMContext creates a new context for use in the EVM.
-func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author *common.Address) vm.Context {
+// NewEVMBlockContext creates a new context for use in the EVM.
+func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common.Address) vm.BlockContext {
 	// If we don't have an explicit author (i.e. not mining), extract from the header
 	var (
-		beneficiary       common.Address
-		rewardBase        common.Address
-		baseFee           *big.Int
-		effectiveGasPrice *big.Int
+		beneficiary common.Address
+		rewardBase  common.Address
+		baseFee     *big.Int
 	)
 
 	if author == nil {
@@ -65,25 +64,34 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author
 
 	if header.BaseFee != nil {
 		baseFee = header.BaseFee
-		effectiveGasPrice = header.BaseFee
 	} else {
 		// before magma hardfork, base fee is 0, effectiveGasPrice is unitPrice
 		baseFee = new(big.Int).SetUint64(params.ZeroBaseFee)
-		effectiveGasPrice = msg.GasPrice()
 	}
 
-	return vm.Context{
+	return vm.BlockContext{
 		CanTransfer: CanTransfer,
 		Transfer:    Transfer,
 		GetHash:     GetHashFn(header, chain),
-		Origin:      msg.ValidatedSender(),
 		Coinbase:    beneficiary,
 		Rewardbase:  rewardBase,
 		BlockNumber: new(big.Int).Set(header.Number),
 		Time:        new(big.Int).Set(header.Time),
 		BlockScore:  new(big.Int).Set(header.BlockScore),
-		GasPrice:    new(big.Int).Set(effectiveGasPrice),
 		BaseFee:     baseFee,
+	}
+}
+
+// NewEVMTxContext creates a new transaction context for a single transaction.
+func NewEVMTxContext(msg Message, header *types.Header) vm.TxContext {
+	effectiveGasPrice := msg.GasPrice()
+	if header.BaseFee != nil {
+		effectiveGasPrice = header.BaseFee
+	}
+
+	return vm.TxContext{
+		Origin:   msg.ValidatedSender(),
+		GasPrice: new(big.Int).Set(effectiveGasPrice),
 	}
 }
 

--- a/blockchain/state_prefetcher.go
+++ b/blockchain/state_prefetcher.go
@@ -100,8 +100,9 @@ func precacheTransaction(config *params.ChainConfig, bc ChainContext, author *co
 		return err
 	}
 	// Create the EVM and execute the transaction
-	context := NewEVMContext(msg, header, bc, author)
-	vm := vm.NewEVM(context, statedb, config, &cfg)
+	blockContext := NewEVMBlockContext(header, bc, author)
+	txContext := NewEVMTxContext(msg, header)
+	vm := vm.NewEVM(blockContext, txContext, statedb, config, &cfg)
 
 	_, err = ApplyMessage(vm, msg)
 	return err

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -187,7 +187,7 @@ func getReceiptStatusFromErrTxFailed(errTxFailed error) (status uint) {
 func NewStateTransition(evm *vm.EVM, msg Message) *StateTransition {
 	// before magma hardfork, effectiveGasPrice is GasPrice of tx
 	// after magma hardfork, effectiveGasPrice is BaseFee
-	effectiveGasPrice := evm.Context.GasPrice
+	effectiveGasPrice := evm.GasPrice
 
 	return &StateTransition{
 		evm:       evm,
@@ -342,7 +342,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
 	if rules.IsKore {
-		st.state.PrepareAccessList(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Coinbase, msg.To(), vm.ActivePrecompiles(rules))
+		st.state.PrepareAccessList(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Context.Coinbase, msg.To(), vm.ActivePrecompiles(rules))
 	}
 
 	// Check whether the init code size has been exceeded.
@@ -354,7 +354,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		ret   []byte
 		vmerr error
 	)
-	ret, st.gas, vmerr = msg.Execute(st.evm, st.state, st.evm.BlockNumber.Uint64(), st.gas, st.value)
+	ret, st.gas, vmerr = msg.Execute(st.evm, st.state, st.evm.Context.BlockNumber.Uint64(), st.gas, st.value)
 
 	// time-limit error is not a vm error. This error is returned when the EVM is still running while the
 	// block proposer's total execution time of txs for a candidate block reached the predefined limit.
@@ -375,10 +375,10 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		if rules.IsMagma {
 			effectiveGasPrice := st.gasPrice
 			txFee := getBurnAmountMagma(new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), effectiveGasPrice))
-			st.state.AddBalance(st.evm.Rewardbase, txFee)
+			st.state.AddBalance(st.evm.Context.Rewardbase, txFee)
 		} else {
 			effectiveGasPrice := msg.EffectiveGasPrice(nil)
-			st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), effectiveGasPrice))
+			st.state.AddBalance(st.evm.Context.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), effectiveGasPrice))
 		}
 	}
 

--- a/blockchain/vm/contracts.go
+++ b/blockchain/vm/contracts.go
@@ -675,7 +675,7 @@ func (c *validateSender) GetRequiredGasAndComputationCost(input []byte) (uint64,
 }
 
 func (c *validateSender) Run(input []byte, contract *Contract, evm *EVM) ([]byte, error) {
-	if err := c.validateSender(input, evm.StateDB, evm.BlockNumber.Uint64()); err != nil {
+	if err := c.validateSender(input, evm.StateDB, evm.Context.BlockNumber.Uint64()); err != nil {
 		// If return error makes contract execution failed, do not return the error.
 		// Instead, print log.
 		logger.Trace("validateSender failed", "err", err)

--- a/blockchain/vm/contracts_test.go
+++ b/blockchain/vm/contracts_test.go
@@ -110,7 +110,7 @@ func prepare(reqGas uint64) (*Contract, *EVM, error) {
 	stateDb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	txhash := common.HexToHash("0xc6a37e155d3fa480faea012a68ad35fd53c8cc3cd8263a434c697755985a6577")
 	stateDb.Prepare(txhash, common.Hash{}, 0)
-	evm := NewEVM(Context{BlockNumber: big.NewInt(0)}, stateDb, &params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)}, &Config{})
+	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(0)}, TxContext{}, stateDb, &params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)}, &Config{})
 
 	// Only stdout logging is tested to avoid file handling. It is used at vmLog test.
 	params.VMLogTarget = params.VMLogToStdout
@@ -388,7 +388,7 @@ func TestEVM_CVE_2021_39137(t *testing.T) {
 
 	gasLimit := uint64(99999999)
 	tracer := NewStructLogger(nil)
-	vmctx := Context{
+	blockCtx := BlockContext{
 		CanTransfer: func(StateDB, common.Address, *big.Int) bool { return true },
 		Transfer:    func(StateDB, common.Address, common.Address, *big.Int) {},
 	}
@@ -397,7 +397,7 @@ func TestEVM_CVE_2021_39137(t *testing.T) {
 	for _, tc := range testCases {
 		stateDb.SetCode(contractAddr, tc.testCode)
 
-		evm := NewEVM(vmctx, stateDb, params.TestChainConfig, &Config{Debug: true, Tracer: tracer})
+		evm := NewEVM(blockCtx, TxContext{}, stateDb, params.TestChainConfig, &Config{Debug: true, Tracer: tracer})
 		ret, _, err := evm.Call(AccountRef(fromAddr), contractAddr, nil, gasLimit, new(big.Int))
 		if err != nil {
 			t.Fatal(err)

--- a/blockchain/vm/evm_test.go
+++ b/blockchain/vm/evm_test.go
@@ -40,12 +40,12 @@ func runPrecompiledContractTestWithHFCondition(t *testing.T, config *params.Chai
 		statedb.CreateSmartContractAccount(callerAddr, params.CodeFormatEVM, params.Rules{IsIstanbul: tc.isDeployedAfterIstanbulHF})
 
 		// Make EVM environment
-		vmctx := Context{
+		blockCtx := BlockContext{
 			CanTransfer: func(StateDB, common.Address, *big.Int) bool { return true },
 			Transfer:    func(StateDB, common.Address, common.Address, *big.Int) {},
 			BlockNumber: tc.block,
 		}
-		vmenv := NewEVM(vmctx, statedb, config, &Config{})
+		vmenv := NewEVM(blockCtx, TxContext{}, statedb, config, &Config{})
 
 		// run
 		ret, gas, err := vmenv.Call(AccountRef(callerAddr), common.HexToAddress(tc.addr), tc.input, math.MaxUint64, new(big.Int))

--- a/blockchain/vm/gas_table_test.go
+++ b/blockchain/vm/gas_table_test.go
@@ -115,15 +115,15 @@ func TestEIP2200(t *testing.T) {
 		statedb.SetState(address, common.Hash{}, common.BytesToHash([]byte{tt.original}))
 		statedb.Finalise(true, false) // Push the state into the "original" slot
 
-		vmctx := Context{
+		vmctx := BlockContext{
 			CanTransfer: func(StateDB, common.Address, *big.Int) bool { return true },
 			Transfer:    func(StateDB, common.Address, common.Address, *big.Int) {},
 		}
 		var vmenv *EVM
 		if i <= 18 {
-			vmenv = NewEVM(vmctx, statedb, params.AllGxhashProtocolChanges, &Config{})
+			vmenv = NewEVM(vmctx, TxContext{}, statedb, params.AllGxhashProtocolChanges, &Config{})
 		} else {
-			vmenv = NewEVM(vmctx, statedb, params.AllGxhashProtocolChanges, &Config{ExtraEips: []int{2200}})
+			vmenv = NewEVM(vmctx, TxContext{}, statedb, params.AllGxhashProtocolChanges, &Config{ExtraEips: []int{2200}})
 		}
 
 		_, gas, err := vmenv.Call(AccountRef(common.Address{}), address, nil, tt.gaspool, new(big.Int))
@@ -171,7 +171,7 @@ func TestCreateGas(t *testing.T) {
 			statedb.SetCode(address, hexutil.MustDecode(tt.code))
 			statedb.Finalise(true, false)
 
-			vmctx := Context{
+			vmctx := BlockContext{
 				CanTransfer: func(StateDB, common.Address, *big.Int) bool { return true },
 				Transfer:    func(StateDB, common.Address, common.Address, *big.Int) {},
 			}
@@ -180,7 +180,7 @@ func TestCreateGas(t *testing.T) {
 				config.ExtraEips = []int{3860}
 			}
 
-			vmenv := NewEVM(vmctx, statedb, params.AllGxhashProtocolChanges, &config)
+			vmenv := NewEVM(vmctx, TxContext{}, statedb, params.AllGxhashProtocolChanges, &config)
 			startGas := uint64(testGas)
 			ret, gas, err := vmenv.Call(AccountRef(common.Address{}), address, nil, startGas, new(big.Int))
 			if err != nil {

--- a/blockchain/vm/instructions.go
+++ b/blockchain/vm/instructions.go
@@ -561,9 +561,9 @@ func opGasprice(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack 
 func opBlockhash(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	num := stack.pop()
 
-	n := evm.interpreter.intPool.get().Sub(evm.BlockNumber, common.Big257)
-	if num.Cmp(n) > 0 && num.Cmp(evm.BlockNumber) < 0 {
-		stack.push(evm.GetHash(num.Uint64()).Big())
+	n := evm.interpreter.intPool.get().Sub(evm.Context.BlockNumber, common.Big257)
+	if num.Cmp(n) > 0 && num.Cmp(evm.Context.BlockNumber) < 0 {
+		stack.push(evm.Context.GetHash(num.Uint64()).Big())
 	} else {
 		stack.push(evm.interpreter.intPool.getZero())
 	}
@@ -572,34 +572,34 @@ func opBlockhash(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack
 }
 
 func opCoinbase(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.interpreter.intPool.get().SetBytes(evm.Coinbase.Bytes()))
+	stack.push(evm.interpreter.intPool.get().SetBytes(evm.Context.Coinbase.Bytes()))
 	return nil, nil
 }
 
 func opTimestamp(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(math.U256(evm.interpreter.intPool.get().Set(evm.Time)))
+	stack.push(math.U256(evm.interpreter.intPool.get().Set(evm.Context.Time)))
 	return nil, nil
 }
 
 func opNumber(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(math.U256(evm.interpreter.intPool.get().Set(evm.BlockNumber)))
+	stack.push(math.U256(evm.interpreter.intPool.get().Set(evm.Context.BlockNumber)))
 	return nil, nil
 }
 
 func opDifficulty(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(math.U256(evm.interpreter.intPool.get().Set(evm.BlockScore)))
+	stack.push(math.U256(evm.interpreter.intPool.get().Set(evm.Context.BlockScore)))
 	return nil, nil
 }
 
 func opRandom(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	// evm.BlockNumber.Uint64() is always greater than or equal to 1
 	// since evm will not run on the genesis block
-	stack.push(evm.GetHash(evm.BlockNumber.Uint64() - 1).Big())
+	stack.push(evm.Context.GetHash(evm.Context.BlockNumber.Uint64() - 1).Big())
 	return nil, nil
 }
 
 func opGasLimit(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(math.U256(evm.interpreter.intPool.get().SetUint64(evm.GasLimit)))
+	stack.push(math.U256(evm.interpreter.intPool.get().SetUint64(evm.Context.GasLimit)))
 	return nil, nil
 }
 
@@ -925,7 +925,7 @@ func makeLog(size int) executionFunc {
 			Data:    d,
 			// This is a non-consensus field, but assigned here because
 			// blockchain/state doesn't know the current block number.
-			BlockNumber: evm.BlockNumber.Uint64(),
+			BlockNumber: evm.Context.BlockNumber.Uint64(),
 		})
 
 		evm.interpreter.intPool.put(mStart, mSize)

--- a/blockchain/vm/instructions_test.go
+++ b/blockchain/vm/instructions_test.go
@@ -99,7 +99,7 @@ func init() {
 
 func testTwoOperandOp(t *testing.T, tests []TwoOperandTestcase, opFn executionFunc, name string) {
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, &Config{})
+		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, &Config{})
 		stack          = newstack()
 		pc             = uint64(0)
 		evmInterpreter = env.interpreter
@@ -218,7 +218,7 @@ func TestSAR(t *testing.T) {
 // getResult is a convenience function to generate the expected values
 func getResult(args []*twoOperandParams, opFn executionFunc) []TwoOperandTestcase {
 	var (
-		env         = NewEVM(Context{}, nil, params.TestChainConfig, &Config{})
+		env         = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, &Config{})
 		stack       = newstack()
 		pc          = uint64(0)
 		interpreter = env.interpreter
@@ -307,11 +307,10 @@ func opBenchmark(bench *testing.B, op func(pc *uint64, evm *EVM, contract *Contr
 			return db.GetBalance(address).Cmp(amount) >= 0
 		}
 
-		ctx = Context{
+		blockCtx = BlockContext{
 			BlockNumber: big1024,
 			BlockScore:  big.NewInt(0),
 			Coinbase:    common.HexToAddress("0xf4b0cb429b7d341bf467f2d51c09b64cd9add37c"),
-			GasPrice:    big.NewInt(1),
 			BaseFee:     big.NewInt(1000000000000000000),
 			GasLimit:    uint64(1000000000000000),
 			Time:        big.NewInt(1488928920),
@@ -321,11 +320,14 @@ func opBenchmark(bench *testing.B, op func(pc *uint64, evm *EVM, contract *Contr
 			CanTransfer: canTransfer,
 			Transfer:    func(db StateDB, sender, recipient common.Address, amount *big.Int) {},
 		}
+		txCtx = TxContext{
+			GasPrice: big.NewInt(1),
+		}
 
 		memDBManager = database.NewMemoryDBManager()
 		statedb      = initStateDB(memDBManager)
 
-		env            = NewEVM(ctx, statedb, params.TestChainConfig, &Config{})
+		env            = NewEVM(blockCtx, txCtx, statedb, params.TestChainConfig, &Config{})
 		stack          = newstack()
 		mem            = NewMemory()
 		evmInterpreter = NewEVMInterpreter(env, env.VMConfig)
@@ -585,7 +587,7 @@ func BenchmarkOpIsZero(b *testing.B) {
 
 func TestOpMstore(t *testing.T) {
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, &Config{})
+		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, &Config{})
 		stack          = newstack()
 		mem            = NewMemory()
 		evmInterpreter = NewEVMInterpreter(env, env.VMConfig)
@@ -611,7 +613,7 @@ func TestOpMstore(t *testing.T) {
 
 func BenchmarkOpMstore(bench *testing.B) {
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, &Config{})
+		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, &Config{})
 		stack          = newstack()
 		mem            = NewMemory()
 		evmInterpreter = NewEVMInterpreter(env, env.VMConfig)
@@ -634,7 +636,7 @@ func BenchmarkOpMstore(bench *testing.B) {
 
 func BenchmarkOpSHA3(bench *testing.B) {
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, &Config{})
+		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, &Config{})
 		stack          = newstack()
 		mem            = NewMemory()
 		evmInterpreter = NewEVMInterpreter(env, env.VMConfig)
@@ -873,7 +875,7 @@ func BenchmarkOpSstore(bench *testing.B) {
 		memDBManager = database.NewMemoryDBManager()
 		statedb      = initStateDB(memDBManager)
 
-		env            = NewEVM(Context{}, statedb, params.TestChainConfig, &Config{})
+		env            = NewEVM(BlockContext{}, TxContext{}, statedb, params.TestChainConfig, &Config{})
 		stack          = newstack()
 		evmInterpreter = NewEVMInterpreter(env, env.VMConfig)
 	)

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -203,7 +203,7 @@ func (this *InternalTxTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, 
 	if this.err == nil {
 		// Initialize the context if it wasn't done yet
 		if !this.initialized {
-			this.ctx["block"] = env.BlockNumber.Uint64()
+			this.ctx["block"] = env.Context.BlockNumber.Uint64()
 			this.initialized = true
 		}
 		// If tracing was interrupted, set the error and stop

--- a/blockchain/vm/logger_test.go
+++ b/blockchain/vm/logger_test.go
@@ -55,7 +55,7 @@ func (*dummyStatedb) GetRefund() uint64 { return 1337 }
 
 func TestStoreCapture(t *testing.T) {
 	var (
-		env      = NewEVM(Context{}, &dummyStatedb{}, params.TestChainConfig, &Config{})
+		env      = NewEVM(BlockContext{}, TxContext{}, &dummyStatedb{}, params.TestChainConfig, &Config{})
 		logger   = NewStructLogger(nil)
 		mem      = NewMemory()
 		stack    = newstack()

--- a/blockchain/vm/runtime/env.go
+++ b/blockchain/vm/runtime/env.go
@@ -27,8 +27,8 @@ import (
 
 func NewEnv(cfg *Config) *vm.EVM {
 	txContext := vm.TxContext{
-		Origin:      cfg.Origin,
-		GasPrice:    cfg.GasPrice,
+		Origin:   cfg.Origin,
+		GasPrice: cfg.GasPrice,
 	}
 	blockContext := vm.BlockContext{
 		CanTransfer: blockchain.CanTransfer,

--- a/blockchain/vm/runtime/env.go
+++ b/blockchain/vm/runtime/env.go
@@ -26,21 +26,22 @@ import (
 )
 
 func NewEnv(cfg *Config) *vm.EVM {
-	context := vm.Context{
+	txContext := vm.TxContext{
+		Origin:      cfg.Origin,
+		GasPrice:    cfg.GasPrice,
+	}
+	blockContext := vm.BlockContext{
 		CanTransfer: blockchain.CanTransfer,
 		Transfer:    blockchain.Transfer,
 		GetHash:     cfg.GetHashFn,
 
-		Origin:      cfg.Origin,
 		Coinbase:    cfg.Coinbase,
 		Rewardbase:  cfg.Rewardbase,
 		BlockNumber: cfg.BlockNumber,
 		Time:        cfg.Time,
 		BlockScore:  cfg.BlockScore,
 		GasLimit:    cfg.GasLimit,
-		GasPrice:    cfg.GasPrice,
 		BaseFee:     cfg.BaseFee,
 	}
-
-	return vm.NewEVM(context, cfg.State, cfg.ChainConfig, &cfg.EVMConfig)
+	return vm.NewEVM(blockContext, txContext, cfg.State, cfg.ChainConfig, &cfg.EVMConfig)
 }

--- a/blockchain/vm/runtime/runtime.go
+++ b/blockchain/vm/runtime/runtime.go
@@ -115,7 +115,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 		address = common.BytesToAddress([]byte("contract"))
 		vmenv   = NewEnv(cfg)
 		sender  = vm.AccountRef(cfg.Origin)
-		rules   = cfg.ChainConfig.Rules(vmenv.BlockNumber)
+		rules   = cfg.ChainConfig.Rules(vmenv.Context.BlockNumber)
 	)
 	if rules.IsKore {
 		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules))
@@ -149,7 +149,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 	var (
 		vmenv  = NewEnv(cfg)
 		sender = vm.AccountRef(cfg.Origin)
-		rules  = cfg.ChainConfig.Rules(vmenv.BlockNumber)
+		rules  = cfg.ChainConfig.Rules(vmenv.Context.BlockNumber)
 	)
 	if rules.IsKore {
 		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, nil, vm.ActivePrecompiles(rules))
@@ -177,7 +177,7 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 		vmenv         = NewEnv(cfg)
 		senderAccount = cfg.State.GetOrNewStateObject(cfg.Origin)
 		sender        = types.NewAccountRefWithFeePayer(senderAccount.Address(), senderAccount.Address())
-		rules         = cfg.ChainConfig.Rules(vmenv.BlockNumber)
+		rules         = cfg.ChainConfig.Rules(vmenv.Context.BlockNumber)
 	)
 	if rules.IsKore {
 		cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules))

--- a/consensus/istanbul/backend/kip103.go
+++ b/consensus/istanbul/backend/kip103.go
@@ -45,9 +45,10 @@ func (caller *Kip103ContractCaller) CallContract(ctx context.Context, call klayt
 	msg := types.NewMessage(call.From, call.To, caller.state.GetNonce(call.From),
 		call.Value, gasLimit, gasPrice, call.Data, false, intrinsicGas)
 
-	context := blockchain.NewEVMContext(msg, caller.header, caller.chain, nil)
-	context.GasPrice = gasPrice                                                  // set gasPrice again if baseFee is assigned
-	evm := vm.NewEVM(context, caller.state, caller.chain.Config(), &vm.Config{}) // no additional vm config required
+	blockContext := blockchain.NewEVMBlockContext(caller.header, caller.chain, nil)
+	txContext := blockchain.NewEVMTxContext(msg, caller.header)
+	txContext.GasPrice = gasPrice                                                  // set gasPrice again if baseFee is assigned
+	evm := vm.NewEVM(blockContext, txContext, caller.state, caller.chain.Config(), &vm.Config{}) // no additional vm config required
 
 	result, err := blockchain.ApplyMessage(evm, msg)
 	return result.Return(), err

--- a/consensus/istanbul/backend/kip103.go
+++ b/consensus/istanbul/backend/kip103.go
@@ -47,7 +47,7 @@ func (caller *Kip103ContractCaller) CallContract(ctx context.Context, call klayt
 
 	blockContext := blockchain.NewEVMBlockContext(caller.header, caller.chain, nil)
 	txContext := blockchain.NewEVMTxContext(msg, caller.header)
-	txContext.GasPrice = gasPrice                                                  // set gasPrice again if baseFee is assigned
+	txContext.GasPrice = gasPrice                                                                // set gasPrice again if baseFee is assigned
 	evm := vm.NewEVM(blockContext, txContext, caller.state, caller.chain.Config(), &vm.Config{}) // no additional vm config required
 
 	result, err := blockchain.ApplyMessage(evm, msg)

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -431,7 +431,7 @@ func (api *PrivateDebugAPI) StorageRangeAt(ctx context.Context, blockHash common
 	if block == nil {
 		return StorageRangeResult{}, fmt.Errorf("block %#x not found", blockHash)
 	}
-	_, _, statedb, err := api.cn.stateAtTransaction(block, txIndex, 0)
+	_, _, _, statedb, err := api.cn.stateAtTransaction(block, txIndex, 0)
 	if err != nil {
 		return StorageRangeResult{}, err
 	}

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -220,8 +220,10 @@ func (b *CNAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 func (b *CNAPIBackend) GetEVM(ctx context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error) {
 	vmError := func() error { return nil }
 
-	context := blockchain.NewEVMContext(msg, header, b.cn.BlockChain(), nil)
-	return vm.NewEVM(context, state, b.cn.chainConfig, &vmCfg), vmError, nil
+	txContext := blockchain.NewEVMTxContext(msg, header)
+	blockContext := blockchain.NewEVMBlockContext(header, b.cn.BlockChain(), nil)
+
+	return vm.NewEVM(blockContext, txContext, state, b.cn.chainConfig, &vmCfg), vmError, nil
 }
 
 func (b *CNAPIBackend) SubscribeRemovedLogsEvent(ch chan<- blockchain.RemovedLogsEvent) event.Subscription {
@@ -371,7 +373,7 @@ func (b *CNAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, ree
 	return b.cn.stateAtBlock(block, reexec, base, checkLive, preferDisk)
 }
 
-func (b *CNAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (blockchain.Message, vm.Context, *state.StateDB, error) {
+func (b *CNAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (blockchain.Message, vm.BlockContext, vm.TxContext, *state.StateDB, error) {
 	return b.cn.stateAtTransaction(block, txIndex, reexec)
 }
 

--- a/node/cn/state_accessor.go
+++ b/node/cn/state_accessor.go
@@ -155,24 +155,24 @@ func (cn *CN) stateAtBlock(block *types.Block, reexec uint64, base *state.StateD
 }
 
 // stateAtTransaction returns the execution environment of a certain transaction.
-func (cn *CN) stateAtTransaction(block *types.Block, txIndex int, reexec uint64) (blockchain.Message, vm.Context, *state.StateDB, error) {
+func (cn *CN) stateAtTransaction(block *types.Block, txIndex int, reexec uint64) (blockchain.Message, vm.BlockContext, vm.TxContext, *state.StateDB, error) {
 	// Short circuit if it's genesis block.
 	if block.NumberU64() == 0 {
-		return nil, vm.Context{}, nil, errors.New("no transaction in genesis")
+		return nil, vm.BlockContext{}, vm.TxContext{}, nil, errors.New("no transaction in genesis")
 	}
 	// Create the parent state database
 	parent := cn.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
 	if parent == nil {
-		return nil, vm.Context{}, nil, fmt.Errorf("parent %#x not found", block.ParentHash())
+		return nil, vm.BlockContext{}, vm.TxContext{}, nil, fmt.Errorf("parent %#x not found", block.ParentHash())
 	}
 	// Lookup the statedb of parent block from the live database,
 	// otherwise regenerate it on the flight.
 	statedb, err := cn.stateAtBlock(parent, reexec, nil, true, false)
 	if err != nil {
-		return nil, vm.Context{}, nil, err
+		return nil, vm.BlockContext{}, vm.TxContext{}, nil, err
 	}
 	if txIndex == 0 && len(block.Transactions()) == 0 {
-		return nil, vm.Context{}, statedb, nil
+		return nil, vm.BlockContext{}, vm.TxContext{}, statedb, nil
 	}
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(cn.blockchain.Config(), block.Number())
@@ -181,21 +181,22 @@ func (cn *CN) stateAtTransaction(block *types.Block, txIndex int, reexec uint64)
 		msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, block.NumberU64())
 		if err != nil {
 			logger.Warn("stateAtTransition failed", "hash", tx.Hash(), "block", block.NumberU64(), "err", err)
-			return nil, vm.Context{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
+			return nil, vm.BlockContext{}, vm.TxContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 
-		context := blockchain.NewEVMContext(msg, block.Header(), cn.blockchain, nil)
+		txContext := blockchain.NewEVMTxContext(msg, block.Header())
+		blockContext := blockchain.NewEVMBlockContext(block.Header(), cn.blockchain, nil)
 		if idx == txIndex {
-			return msg, context, statedb, nil
+			return msg, blockContext, txContext, statedb, nil
 		}
 		// Not yet the searched for transaction, execute on top of the current state
-		vmenv := vm.NewEVM(context, statedb, cn.blockchain.Config(), &vm.Config{UseOpcodeComputationCost: true})
+		vmenv := vm.NewEVM(blockContext, txContext, statedb, cn.blockchain.Config(), &vm.Config{UseOpcodeComputationCost: true})
 		if _, err := blockchain.ApplyMessage(vmenv, msg); err != nil {
-			return nil, vm.Context{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
+			return nil, vm.BlockContext{}, vm.TxContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 		// Ensure any modifications are committed to the state
 		// Since klaytn is forked after EIP158/161 (a.k.a Spurious Dragon), deleting empty object is always effective
 		statedb.Finalise(true, true)
 	}
-	return nil, vm.Context{}, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
+	return nil, vm.BlockContext{}, vm.TxContext{}, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
 }

--- a/node/cn/tracers/tracer.go
+++ b/node/cn/tracers/tracer.go
@@ -575,7 +575,7 @@ func (jst *Tracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost 
 	if jst.err == nil {
 		// Initialize the context if it wasn't done yet
 		if !jst.inited {
-			jst.ctx["block"] = env.BlockNumber.Uint64()
+			jst.ctx["block"] = env.Context.BlockNumber.Uint64()
 			jst.inited = true
 		}
 		// If tracing was interrupted, set the error and stop

--- a/node/cn/tracers/tracer_test.go
+++ b/node/cn/tracers/tracer_test.go
@@ -57,7 +57,7 @@ type dummyStatedb struct {
 func (*dummyStatedb) GetRefund() uint64 { return 1337 }
 
 func runTrace(tracer *Tracer) (json.RawMessage, error) {
-	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, &vm.Config{Debug: true, Tracer: tracer})
+	env := vm.NewEVM(vm.BlockContext{BlockNumber: big.NewInt(1)}, vm.TxContext{}, &dummyStatedb{}, params.TestChainConfig, &vm.Config{Debug: true, Tracer: tracer})
 
 	contract := vm.NewContract(account{}, account{}, big.NewInt(0), 10000)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
@@ -193,7 +193,7 @@ func TestHaltBetweenSteps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, &vm.Config{Debug: true, Tracer: tracer})
+	env := vm.NewEVM(vm.BlockContext{BlockNumber: big.NewInt(1)}, vm.TxContext{}, &dummyStatedb{}, params.TestChainConfig, &vm.Config{Debug: true, Tracer: tracer})
 	contract := vm.NewContract(&account{}, &account{}, big.NewInt(0), 0)
 
 	tracer.CaptureState(env, 0, 0, 0, 0, nil, nil, contract, 0, nil)

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -108,8 +108,8 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	*/
 	origin, _ := signer.Sender(tx)
 	txContext := vm.TxContext{
-		Origin:      origin,
-		GasPrice:    big.NewInt(1),
+		Origin:   origin,
+		GasPrice: big.NewInt(1),
 	}
 	blockContext := vm.BlockContext{
 		CanTransfer: blockchain.CanTransfer,
@@ -290,8 +290,8 @@ func TestCallTracer(t *testing.T) {
 			origin, _ := signer.Sender(tx)
 
 			txContext := vm.TxContext{
-				Origin:      origin,
-				GasPrice:    tx.GasPrice(),
+				Origin:   origin,
+				GasPrice: tx.GasPrice(),
 			}
 			blockContext := vm.BlockContext{
 				CanTransfer: blockchain.CanTransfer,
@@ -403,8 +403,8 @@ func TestInternalCallTracer(t *testing.T) {
 			origin, _ := signer.Sender(tx)
 
 			txContext := vm.TxContext{
-				Origin:      origin,
-				GasPrice:    tx.GasPrice(),
+				Origin:   origin,
+				GasPrice: tx.GasPrice(),
 			}
 			blockContext := vm.BlockContext{
 				CanTransfer: blockchain.CanTransfer,

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -107,16 +107,18 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	    result: 0x60f3f640a8508fC6a86d45DF051962668E1e8AC7
 	*/
 	origin, _ := signer.Sender(tx)
-	context := vm.Context{
+	txContext := vm.TxContext{
+		Origin:      origin,
+		GasPrice:    big.NewInt(1),
+	}
+	blockContext := vm.BlockContext{
 		CanTransfer: blockchain.CanTransfer,
 		Transfer:    blockchain.Transfer,
-		Origin:      origin,
 		Coinbase:    common.Address{},
 		BlockNumber: new(big.Int).SetUint64(8000000),
 		Time:        new(big.Int).SetUint64(5),
 		BlockScore:  big.NewInt(0x30000),
 		GasLimit:    uint64(6000000),
-		GasPrice:    big.NewInt(1),
 	}
 	alloc := blockchain.GenesisAlloc{}
 	// The code pushes 'deadbeef' into memory, then the other params, and calls CREATE2, then returns
@@ -137,10 +139,10 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create call tracer: %v", err)
 	}
-	evm := vm.NewEVM(context, statedb, params.CypressChainConfig, &vm.Config{Debug: true, Tracer: tracer})
+	evm := vm.NewEVM(blockContext, txContext, statedb, params.CypressChainConfig, &vm.Config{Debug: true, Tracer: tracer})
 
 	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
-	msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
+	msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, blockContext.BlockNumber.Uint64())
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
@@ -287,15 +289,17 @@ func TestCallTracer(t *testing.T) {
 
 			origin, _ := signer.Sender(tx)
 
-			context := vm.Context{
+			txContext := vm.TxContext{
+				Origin:      origin,
+				GasPrice:    tx.GasPrice(),
+			}
+			blockContext := vm.BlockContext{
 				CanTransfer: blockchain.CanTransfer,
 				Transfer:    blockchain.Transfer,
-				Origin:      origin,
 				BlockNumber: new(big.Int).SetUint64(uint64(test.Context.Number)),
 				Time:        new(big.Int).SetUint64(uint64(test.Context.Time)),
 				BlockScore:  (*big.Int)(test.Context.BlockScore),
 				GasLimit:    uint64(test.Context.GasLimit),
-				GasPrice:    tx.GasPrice(),
 			}
 			statedb := tests.MakePreState(database.NewMemoryDBManager(), test.Genesis.Alloc)
 
@@ -304,10 +308,10 @@ func TestCallTracer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}
-			evm := vm.NewEVM(context, statedb, test.Genesis.Config, &vm.Config{Debug: true, Tracer: tracer})
+			evm := vm.NewEVM(blockContext, txContext, statedb, test.Genesis.Config, &vm.Config{Debug: true, Tracer: tracer})
 
 			fork.SetHardForkBlockNumberConfig(test.Genesis.Config)
-			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
+			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, blockContext.BlockNumber.Uint64())
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
@@ -398,24 +402,26 @@ func TestInternalCallTracer(t *testing.T) {
 
 			origin, _ := signer.Sender(tx)
 
-			context := vm.Context{
+			txContext := vm.TxContext{
+				Origin:      origin,
+				GasPrice:    tx.GasPrice(),
+			}
+			blockContext := vm.BlockContext{
 				CanTransfer: blockchain.CanTransfer,
 				Transfer:    blockchain.Transfer,
-				Origin:      origin,
 				BlockNumber: new(big.Int).SetUint64(uint64(test.Context.Number)),
 				Time:        new(big.Int).SetUint64(uint64(test.Context.Time)),
 				BlockScore:  (*big.Int)(test.Context.BlockScore),
 				GasLimit:    uint64(test.Context.GasLimit),
-				GasPrice:    tx.GasPrice(),
 			}
 			statedb := tests.MakePreState(database.NewMemoryDBManager(), test.Genesis.Alloc)
 
 			// Create the tracer, the EVM environment and run it
 			tracer := vm.NewInternalTxTracer()
-			evm := vm.NewEVM(context, statedb, test.Genesis.Config, &vm.Config{Debug: true, Tracer: tracer})
+			evm := vm.NewEVM(blockContext, txContext, statedb, test.Genesis.Config, &vm.Config{Debug: true, Tracer: tracer})
 
 			fork.SetHardForkBlockNumberConfig(test.Genesis.Config)
-			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, context.BlockNumber.Uint64())
+			msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, blockContext.BlockNumber.Uint64())
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}

--- a/tests/benchmarks/benchmarks_test_utils.go
+++ b/tests/benchmarks/benchmarks_test_utils.go
@@ -72,20 +72,21 @@ func makeBenchConfig() *BenchConfig {
 func prepareInterpreterAndContract(code []byte) (*vm.Interpreter, *vm.Contract) {
 	// runtime.go:Execute()
 	cfg := makeBenchConfig()
-	context := vm.Context{
+	txContext := vm.TxContext{
+		Origin:      cfg.Origin,
+		GasPrice:    cfg.GasPrice,
+	}
+	blockContext := vm.BlockContext{
 		CanTransfer: blockchain.CanTransfer,
 		Transfer:    blockchain.Transfer,
 		GetHash:     func(uint64) common.Hash { return common.Hash{} },
 
-		Origin:      cfg.Origin,
 		BlockNumber: cfg.BlockNumber,
 		Time:        cfg.Time,
 		BlockScore:  cfg.BlockScore,
 		GasLimit:    cfg.GasLimit,
-		GasPrice:    cfg.GasPrice,
 	}
-
-	evm := vm.NewEVM(context, cfg.State, cfg.ChainConfig, &cfg.EVMConfig)
+	evm := vm.NewEVM(blockContext, txContext, cfg.State, cfg.ChainConfig, &cfg.EVMConfig)
 
 	address := common.BytesToAddress([]byte("contract"))
 	sender := vm.AccountRef(cfg.Origin)

--- a/tests/benchmarks/benchmarks_test_utils.go
+++ b/tests/benchmarks/benchmarks_test_utils.go
@@ -73,8 +73,8 @@ func prepareInterpreterAndContract(code []byte) (*vm.Interpreter, *vm.Contract) 
 	// runtime.go:Execute()
 	cfg := makeBenchConfig()
 	txContext := vm.TxContext{
-		Origin:      cfg.Origin,
-		GasPrice:    cfg.GasPrice,
+		Origin:   cfg.Origin,
+		GasPrice: cfg.GasPrice,
 	}
 	blockContext := vm.BlockContext{
 		CanTransfer: blockchain.CanTransfer,

--- a/tests/smartcontract_execution_test.go
+++ b/tests/smartcontract_execution_test.go
@@ -107,8 +107,9 @@ func callContract(bcdata *BCData, tx *types.Transaction) ([]byte, error) {
 		return nil, err
 	}
 
-	evmContext := blockchain.NewEVMContext(msg, header, bcdata.bc, nil)
-	vmenv := vm.NewEVM(evmContext, statedb, bcdata.bc.Config(), &vm.Config{})
+	txContext := blockchain.NewEVMTxContext(msg, header)
+	blockContext := blockchain.NewEVMBlockContext(header, bcdata.bc, nil)
+	vmenv := vm.NewEVM(blockContext, txContext, statedb, bcdata.bc.Config(), &vm.Config{})
 
 	ret, err := blockchain.NewStateTransition(vmenv, msg).TransitionDb()
 	if err != nil {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -164,9 +164,10 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 	if err != nil {
 		return nil, err
 	}
-	context := blockchain.NewEVMContext(msg, block.Header(), nil, &t.json.Env.Coinbase)
-	context.GetHash = vmTestBlockHash
-	evm := vm.NewEVM(context, statedb, config, &vmconfig)
+	txContext := blockchain.NewEVMTxContext(msg, block.Header())
+	blockContext := blockchain.NewEVMBlockContext(block.Header(), nil, &t.json.Env.Coinbase)
+	blockContext.GetHash = vmTestBlockHash
+	evm := vm.NewEVM(blockContext, txContext, statedb, config, &vmconfig)
 
 	snapshot := statedb.Snapshot()
 	if _, err = blockchain.ApplyMessage(evm, msg); err != nil {

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -143,20 +143,22 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 		return blockchain.CanTransfer(db, address, amount)
 	}
 	transfer := func(db vm.StateDB, sender, recipient common.Address, amount *big.Int) {}
-	context := vm.Context{
+	txContext := vm.TxContext{
+		Origin:      t.json.Exec.Origin,
+		GasPrice:    t.json.Exec.GasPrice,
+	}
+	blockContext := vm.BlockContext{
 		CanTransfer: canTransfer,
 		Transfer:    transfer,
 		GetHash:     vmTestBlockHash,
-		Origin:      t.json.Exec.Origin,
 		Coinbase:    t.json.Env.Coinbase,
 		BlockNumber: new(big.Int).SetUint64(t.json.Env.Number),
 		Time:        new(big.Int).SetUint64(t.json.Env.Timestamp),
 		GasLimit:    t.json.Env.GasLimit,
 		BlockScore:  t.json.Env.BlockScore,
-		GasPrice:    t.json.Exec.GasPrice,
 	}
 	vmconfig.NoRecursion = true
-	return vm.NewEVM(context, statedb, params.CypressChainConfig, &vmconfig)
+	return vm.NewEVM(blockContext, txContext, statedb, params.CypressChainConfig, &vmconfig)
 }
 
 func vmTestBlockHash(n uint64) common.Hash {

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -144,8 +144,8 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 	}
 	transfer := func(db vm.StateDB, sender, recipient common.Address, amount *big.Int) {}
 	txContext := vm.TxContext{
-		Origin:      t.json.Exec.Origin,
-		GasPrice:    t.json.Exec.GasPrice,
+		Origin:   t.json.Exec.Origin,
+		GasPrice: t.json.Exec.GasPrice,
 	}
 	blockContext := vm.BlockContext{
 		CanTransfer: canTransfer,


### PR DESCRIPTION
## Proposed changes

In this PR, #1972 PR is too large, so only the context split was extracted from that PR.
- split vm.Context into BlockContext and TxContext ([21672](https://github.com/ethereum/go-ethereum/pull/21672))

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
