### PR TITLE
Faster trie node encoding updated

### DIFF
--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -185,11 +185,7 @@ func (n *cachedNode) rlp() []byte {
 	if node, ok := n.node.(rawNode); ok {
 		return node
 	}
-	blob, err := rlp.EncodeToBytes(n.node)
-	if err != nil {
-		panic(err)
-	}
-	return blob
+	return nodeToBytes(n.node)
 }
 
 // obj returns the decoded and expanded trie node, either directly from the cache,

--- a/storage/statedb/node.go
+++ b/storage/statedb/node.go
@@ -35,6 +35,7 @@ type node interface {
 	fstring(string) string
 	cache() (hashNode, bool)
 	lenEncoded() uint16
+	encode(w rlp.EncoderBuffer)
 }
 
 type (
@@ -57,16 +58,9 @@ var nilValueNode = valueNode(nil)
 
 // EncodeRLP encodes a full node into the consensus RLP format.
 func (n *fullNode) EncodeRLP(w io.Writer) error {
-	var nodes [17]node
-
-	for i, child := range &n.Children {
-		if child != nil {
-			nodes[i] = child
-		} else {
-			nodes[i] = nilValueNode
-		}
-	}
-	return rlp.Encode(w, nodes)
+	eb := rlp.NewEncoderBuffer(w)
+	n.encode(eb)
+	return eb.Flush()
 }
 
 func (n *fullNode) copy() *fullNode   { copy := *n; return &copy }

--- a/storage/statedb/node_enc.go
+++ b/storage/statedb/node_enc.go
@@ -1,0 +1,91 @@
+// Modifications Copyright 2023 The klaytn Authors
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from trie/node_enc.go (2023/09/19).
+// Modified and improved for the klaytn development.
+
+package statedb
+
+import (
+	"github.com/klaytn/klaytn/rlp"
+)
+
+func nodeToBytes(n node) []byte {
+	w := rlp.NewEncoderBuffer(nil)
+	n.encode(w)
+	result := w.ToBytes()
+	w.Flush()
+	return result
+}
+
+func (n *fullNode) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	for _, c := range n.Children {
+		if c != nil {
+			c.encode(w)
+		} else {
+			w.Write(rlp.EmptyString)
+		}
+	}
+	w.ListEnd(offset)
+}
+
+func (n *shortNode) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	w.WriteBytes(n.Key)
+	if n.Val != nil {
+		n.Val.encode(w)
+	} else {
+		w.Write(rlp.EmptyString)
+	}
+	w.ListEnd(offset)
+}
+
+func (n hashNode) encode(w rlp.EncoderBuffer) {
+	w.WriteBytes(n)
+}
+
+func (n valueNode) encode(w rlp.EncoderBuffer) {
+	w.WriteBytes(n)
+}
+
+func (n rawFullNode) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	for _, c := range n {
+		if c != nil {
+			c.encode(w)
+		} else {
+			w.Write(rlp.EmptyString)
+		}
+	}
+	w.ListEnd(offset)
+}
+
+func (n *rawShortNode) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	w.WriteBytes(n.Key)
+	if n.Val != nil {
+		n.Val.encode(w)
+	} else {
+		w.Write(rlp.EmptyString)
+	}
+	w.ListEnd(offset)
+}
+
+func (n rawNode) encode(w rlp.EncoderBuffer) {
+	w.Write(n)
+}

--- a/storage/statedb/proof.go
+++ b/storage/statedb/proof.go
@@ -93,7 +93,7 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDB ProofDBWriter) error {
 				// hash is for the merkle proof. hash = Keccak(rlp.Encode(nodeForHashing(n)))
 				enc, _ := rlp.EncodeToBytes(hasher.nodeForHashing(n))
 				if !ok {
-					hash = hasher.makeHashNode(enc, false)
+					hash = hasher.hashData(enc, false)
 				}
 				dbKey := database.TrieNodeKey(common.BytesToExtHash(hash))
 				proofDB.WriteMerkleProof(dbKey, enc)


### PR DESCRIPTION
## Proposed changes

Continuation of #1679.

- Replace `rlp.EncodeToBytes()` with concrete `node.encode()` to avoid type reflection. 

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

Running time 16% and memalloc 2% decreased.

```
cd storage/statedb
git checkout dev
go test -v -run=^$ -bench=BenchmarkHashFixedSize -count=7 | tee before.txt
git checkout faster-trie-node-encode
go test -v -run=^$ -bench=BenchmarkHashFixedSize -count=7 | tee after.txt
benchstat before.txt after.txt

goos: darwin
goarch: arm64
pkg: github.com/klaytn/klaytn/storage/statedb
                      │ before.txt  │             after.txt              │
                      │   sec/op    │   sec/op     vs base               │
HashFixedSize/10-10     74.53µ ± 1%   65.24µ ± 3%  -12.47% (p=0.001 n=7)
HashFixedSize/100-10    199.3µ ± 1%   156.8µ ± 3%  -21.33% (p=0.001 n=7)
HashFixedSize/1K-10     1.393m ± 2%   1.206m ± 4%  -13.38% (p=0.001 n=7)
HashFixedSize/10K-10    8.803m ± 1%   7.296m ± 3%  -17.12% (p=0.001 n=7)
HashFixedSize/100K-10   76.55m ± 3%   62.78m ± 5%  -17.99% (p=0.001 n=7)
geomean                 1.694m        1.414m       -16.52%

                      │  before.txt  │              after.txt              │
                      │     B/op     │     B/op      vs base               │
HashFixedSize/10-10     34.83Ki ± 0%   30.86Ki ± 0%  -11.38% (p=0.001 n=7)
HashFixedSize/100-10    168.1Ki ± 0%   149.5Ki ± 0%  -11.08% (p=0.001 n=7)
HashFixedSize/1K-10     1.644Mi ± 0%   1.456Mi ± 0%  -11.44% (p=0.001 n=7)
HashFixedSize/10K-10    17.11Mi ± 0%   15.03Mi ± 0%  -12.12% (p=0.001 n=7)
HashFixedSize/100K-10   169.8Mi ± 0%   149.3Mi ± 0%  -12.07% (p=0.001 n=7)
geomean                 1.928Mi        1.704Mi       -11.62%

                      │ before.txt  │             after.txt             │
                      │  allocs/op  │  allocs/op   vs base              │
HashFixedSize/10-10      630.0 ± 0%    616.0 ± 0%  -2.22% (p=0.001 n=7)
HashFixedSize/100-10    3.079k ± 0%   3.012k ± 0%  -2.18% (p=0.001 n=7)
HashFixedSize/1K-10     30.60k ± 0%   29.91k ± 0%  -2.26% (p=0.001 n=7)
HashFixedSize/10K-10    310.7k ± 0%   303.1k ± 0%  -2.44% (p=0.001 n=7)
HashFixedSize/100K-10   3.102M ± 0%   3.027M ± 0%  -2.41% (p=0.001 n=7)
geomean                 35.60k        34.78k       -2.30%
```