### PR TITLE
API RecoverFromTransaction handles eth txtypes

### DIFF
--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -556,6 +556,14 @@ func resend(s *PublicTransactionPoolAPI, ctx context.Context, sendArgs NewTxArgs
 // RecoverFromTransaction recovers the sender address from a signed raw transaction.
 // The signature is validated against the sender account's key configuration at the given block number.
 func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, encodedTx hexutil.Bytes, blockNumber rpc.BlockNumber) (common.Address, error) {
+	if len(encodedTx) == 0 {
+		return common.Address{}, fmt.Errorf("Empty input")
+	}
+	if 0 < encodedTx[0] && encodedTx[0] < 0x8 { // TODO: Add helper to distinguish eth vs klay txtypes
+		ethEnvelope := []byte{byte(types.EthereumTxTypeEnvelope)}
+		encodedTx = append(ethEnvelope, encodedTx...)
+	}
+
 	tx := new(types.Transaction)
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return common.Address{}, err


### PR DESCRIPTION
## Proposed changes

Currently `klay_recoverFromTransaction` fails when the input transaction has the txtype 0x02 (AccessList).
This PR automatically prepends the [EthereumTxTypeEnvelope](https://medium.com/klaytn/toward-ethereum-equivalence-4-ethereum-transaction-types-a5aefb18e5bf) if the encoded tx is of ethereum type. 

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
