### PR TITLE
Silence Error log when AddressBook code is not installed

### DIFF
--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -17,6 +17,7 @@
 package reward
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -225,6 +226,16 @@ func getStakingInfoFromAddressBook(blockNum uint64) (*StakingInfo, error) {
 	}
 
 	caller := backends.NewBlockchainContractBackend(stakingManager.blockchain, nil, nil)
+	code, err := caller.CodeAt(context.Background(), addressBookContractAddress, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve code of AddressBook contract. root err: %s", err)
+	}
+	if code == nil {
+		// This is an expected behavior when the addressBook contract is not installed.
+		logger.Info("The addressBook is not installed. Use empty stakingInfo")
+		return newEmptyStakingInfo(blockNum), nil
+	}
+
 	contract, err := contract.NewAddressBookCaller(addressBookContractAddress, caller)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call AddressBook contract. root err: %s", err)


### PR DESCRIPTION
## Proposed changes

In the chains without AddressBook installed at genesis,
- Until v1.10.2, only an INFO log is printed:
  ```
  INFO[09/25,05:53:52 Z] [44] The addressBook is not installed. Use empty stakingInfo
  ```
- Starting from v1.11.0, ERROR logs are printed, clogging the log even at a high log level.
  ```
  ERROR[09/25,05:56:38 Z] [44] failed to update stakingInfo              staking block number=0 err="failed to call AddressBook contract. root err: no contract code at given address"
  ERROR[09/25,05:56:38 Z] [44] unable to fetch staking info              blockNum=3
  ```

This PR reverts to v1.10.2 behavior.
- This PR does not affect Cypress and Baobab because AddressBook is installed there.
- This PR does not affect service chains with RoundRobin or Sticky proposer policy
- This PR affects service chains with WeightedRandom proposer policy in the log message perspective, but the proposer selection procedure should not change.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
