### PR TITLE
[Validator] Disconnect released validator in time

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -293,6 +293,13 @@ func (sb *backend) disconnectReleasedVal(header *types.Header, curVals istanbul.
 	if header == nil {
 		return errors.New("header is nil")
 	}
+	// Istanbul BFT chain does not have nil for `sb.broadcaster`,
+	// This addition is for existing testbase that did not correctly intiialize
+	// braodcaster. Theferoe, it can be interpreted that the network setup
+	// is not correctly configured, which is not the case of production
+	if sb.broadcaster == nil {
+		return nil
+	}
 
 	var ppNumber uint64
 	switch header.Number.Uint64() {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -286,7 +286,7 @@ func (sb *backend) VerifyHeaders(chain consensus.ChainReader, headers []*types.H
 	return abort, results
 }
 
-func (sb *backend) removeReleasedVal(header *types.Header, curVals istanbul.ValidatorSet) error {
+func (sb *backend) disconnectReleasedVal(header *types.Header, curVals istanbul.ValidatorSet) error {
 	if curVals == nil {
 		return errors.New("validator set is nil")
 	}
@@ -343,7 +343,7 @@ func (sb *backend) verifySigner(chain consensus.ChainReader, header *types.Heade
 	if err != nil {
 		return err
 	}
-	err = sb.removeReleasedVal(header, snap.ValSet)
+	err = sb.disconnectReleasedVal(header, snap.ValSet)
 	if err != nil {
 		return err
 	}

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -72,6 +72,9 @@ type Peer interface {
 	// Send sends the message to this peer
 	Send(msgcode uint64, data interface{}) error
 
+	// DisconnectP2PPeer disconnects the p2p peer with the given reason.
+	DisconnectP2PPeer(discReason p2p.DiscReason)
+
 	// RegisterConsensusMsgCode registers the channel of consensus msg.
 	RegisterConsensusMsgCode(msgCode uint64) error
 }


### PR DESCRIPTION
## Proposed changes


Validators are fully interconnected (`1:N-1`). When governance releases a validator, it no longer takes part in block consensus, but the connection remains active. This live connection can potentially disrupt other current validators. To address this issue, this PR proposes disconnecting such a node promptly. This change does not involve hardfork.

I used the disconnection reason `DiscInvalidIdentity`, but it seems not fully explainable itself, considering this context. If you give a suggestion, I'll add a new dedicated constant for this.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
