### PR TITLE
[Governance] Vote reflecting condition adjusted

### DIFF
--- a/governance/handler.go
+++ b/governance/handler.go
@@ -492,7 +492,6 @@ func (gov *Governance) addNewVote(valset istanbul.ValidatorSet, votes []Governan
 			(governanceMode == params.GovernanceMode_Ballot && currentVotes > valset.TotalVotingPower()/2) {
 			switch GovernanceKeyMap[gVote.Key] {
 			case params.AddValidator:
-				// reward.GetStakingInfo()
 				if addr, ok := gVote.Value.(common.Address); ok {
 					valset.AddValidator(addr)
 				} else {

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -514,7 +514,7 @@ func (gov *Governance) addNewVote(valset istanbul.ValidatorSet, votes []Governan
 				atomic.StoreUint64(&istanbul.DefaultConfig.Timeout, timeout)
 				fallthrough
 			default:
-				if writable && blockNum > atomic.LoadUint64(&gov.lastGovernanceStateBlock) {
+				if writable && blockNum >= atomic.LoadUint64(&gov.lastGovernanceStateBlock) {
 					logger.Info("Reflecting parameter vote", "num", blockNum, "key", gVote.Key, "value", gVote.Value)
 					gov.ReflectVotes(*gVote)
 				}


### PR DESCRIPTION
## Proposed changes

Considering the following voting scenario:

0. preparation: chain's epoch = 10
1. Vote at block 33
2. Terminate a node at block 36
3. Restart the node and wait to sync latest block number
4. Failed to verify block 40 that contains non-empty governnace data

The root cause of this failure was the condition that compares if a current block number is greater than `gov.lastGovernanceStateBlock`.  The above scenario has a block that contains non-empty vote data at block number 33. On rebooting the node, the node rewinds the istanbul snapshot through `snap.apply()` function with 33 blocks (1 ~ 33). However, the previously stored `gov.lastGovernanceStateBlock` was 33 and the block number that executes `snap.apply()` is also 33. Then, the condition `blockNum > atomic.LoadUint64(&gov.lastGovernanceStateBlock)` evaluates to false and leading to not calling `gov.ReflectVotes()` which updates the changeset.

This PR fixes the condition `>` to `>=` and resolves the problem. 


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
