### PR TITLE
eip-1153: add tload, tstore opcode

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -2176,7 +2176,7 @@ func TestTransientStorageReset(t *testing.T) {
 		signer := types.LatestSigner(gen.config)
 		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(address), common.Address{}, nil, 100000, fee, initCode), signer, key)
 		gen.AddTx(tx)
-		tx, _ = types.SignTx(types.NewTransaction(gen.TxNonce(address), destAddress, nil, 100000, fee, initCode), signer, key)
+		tx, _ = types.SignTx(types.NewTransaction(gen.TxNonce(address), destAddress, nil, 100000, fee, nil), signer, key)
 		gen.AddTx(tx)
 	})
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -2151,7 +2151,7 @@ func TestTransientStorageReset(t *testing.T) {
 	}...)
 
 	gspec := &Genesis{
-		Config: params.TestChainConfig,
+		Config: params.TestChainConfig.Copy(),
 		Alloc: GenesisAlloc{
 			address: {Balance: funds},
 		},

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -91,7 +91,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 // added. If contract code relies on the BLOCKHASH instruction,
 // the block in chain will be returned.
 func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
-	b.statedb.Prepare(tx.Hash(), common.Hash{}, len(b.txs))
+	b.statedb.SetTxContext(tx.Hash(), common.Hash{}, len(b.txs))
 	receipt, _, err := bc.ApplyTransaction(b.config, &params.AuthorAddressForTesting, b.statedb, b.header, tx, &b.header.GasUsed, &vm.Config{})
 	if err != nil {
 		panic(err)

--- a/blockchain/state/journal.go
+++ b/blockchain/state/journal.go
@@ -140,9 +140,14 @@ type (
 	accessListAddAccountChange struct {
 		address *common.Address
 	}
+
 	accessListAddSlotChange struct {
 		address *common.Address
 		slot    *common.Hash
+	}
+	transientStorageChange struct {
+		account       *common.Address
+		key, prevalue common.Hash
 	}
 )
 
@@ -217,6 +222,14 @@ func (ch storageChange) revert(s *StateDB) {
 
 func (ch storageChange) dirtied() *common.Address {
 	return ch.account
+}
+
+func (ch transientStorageChange) revert(s *StateDB) {
+	s.setTransientState(*ch.account, ch.key, ch.prevalue)
+}
+
+func (ch transientStorageChange) dirtied() *common.Address {
+	return nil
 }
 
 func (ch refundChange) revert(s *StateDB) {

--- a/blockchain/state/statedb_test.go
+++ b/blockchain/state/statedb_test.go
@@ -391,6 +391,16 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 			},
 			args: make([]int64, 1),
 		},
+		{
+			name: "SetTransientState",
+			fn: func(a testAction, s *StateDB) {
+				var key, val common.Hash
+				binary.BigEndian.PutUint16(key[:], uint16(a.args[0]))
+				binary.BigEndian.PutUint16(val[:], uint16(a.args[1]))
+				s.SetTransientState(addr, key, val)
+			},
+			args: make([]int64, 2),
+		},
 	}
 	action := actions[r.Intn(len(actions))]
 	var nameargs []string
@@ -786,5 +796,39 @@ func TestStateDBAccessList(t *testing.T) {
 	}
 	if got, exp := len(state.accessList.slots), 1; got != exp {
 		t.Fatalf("expected empty, got %d", got)
+	}
+}
+
+func TestStateDBTransientStorage(t *testing.T) {
+	memDb := database.NewMemoryDBManager()
+	db := NewDatabase(memDb)
+	state, _ := New(common.Hash{}, db, nil, nil)
+
+	key := common.Hash{0x01}
+	value := common.Hash{0x02}
+	addr := common.Address{}
+
+	state.SetTransientState(addr, key, value)
+	if exp, got := 1, state.journal.length(); exp != got {
+		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
+	}
+	// the retrieved value should equal what was set
+	if got := state.GetTransientState(addr, key); got != value {
+		t.Fatalf("transient storage mismatch: have %x, want %x", got, value)
+	}
+
+	// revert the transient state being set and then check that the
+	// value is now the empty hash
+	state.journal.revert(state, 0)
+	if got, exp := state.GetTransientState(addr, key), (common.Hash{}); exp != got {
+		t.Fatalf("transient storage mismatch: have %x, want %x", got, exp)
+	}
+
+	// set transient state and then copy the statedb and ensure that
+	// the transient state is copied
+	state.SetTransientState(addr, key, value)
+	cpy := state.Copy()
+	if got := cpy.GetTransientState(addr, key); got != value {
+		t.Fatalf("transient storage mismatch: have %x, want %x", got, value)
 	}
 }

--- a/blockchain/state/transient_storage.go
+++ b/blockchain/state/transient_storage.go
@@ -1,0 +1,59 @@
+// Modifications Copyright 2018 The klaytn Authors
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from core/state/transient_storage.go (2023/10/06).
+// Modified and improved for the klaytn development.
+
+package state
+
+import (
+	"github.com/klaytn/klaytn/common"
+)
+
+// transientStorage is a representation of EIP-1153 "Transient Storage".
+type transientStorage map[common.Address]Storage
+
+// newTransientStorage creates a new instance of a transientStorage.
+func newTransientStorage() transientStorage {
+	return make(transientStorage)
+}
+
+// Set sets the transient-storage `value` for `key` at the given `addr`.
+func (t transientStorage) Set(addr common.Address, key, value common.Hash) {
+	if _, ok := t[addr]; !ok {
+		t[addr] = make(Storage)
+	}
+	t[addr][key] = value
+}
+
+// Get gets the transient storage for `key` at the given `addr`.
+func (t transientStorage) Get(addr common.Address, key common.Hash) common.Hash {
+	val, ok := t[addr]
+	if !ok {
+		return common.Hash{}
+	}
+	return val[key]
+}
+
+// Copy does a deep copy of the transientStorage
+func (t transientStorage) Copy() transientStorage {
+	storage := make(transientStorage)
+	for key, value := range t {
+		storage[key] = value.Copy()
+	}
+	return storage
+}

--- a/blockchain/state_prefetcher.go
+++ b/blockchain/state_prefetcher.go
@@ -61,7 +61,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, stateDB *state.StateDB, c
 			return
 		}
 		// Block precaching permitted to continue, execute the transaction
-		stateDB.Prepare(tx.Hash(), block.Hash(), i)
+		stateDB.SetTxContext(tx.Hash(), block.Hash(), i)
 		if err := precacheTransaction(p.config, p.bc, nil, stateDB, header, tx, cfg); err != nil {
 			return // Ugh, something went horribly wrong, bail out
 		}
@@ -84,7 +84,7 @@ func (p *statePrefetcher) PrefetchTx(block *types.Block, ti int, stateDB *state.
 	}
 
 	// Block precaching permitted to continue, execute the transaction
-	stateDB.Prepare(tx.Hash(), block.Hash(), ti)
+	stateDB.SetTxContext(tx.Hash(), block.Hash(), ti)
 	if err := precacheTransaction(p.config, p.bc, nil, stateDB, header, tx, cfg); err != nil {
 		return // Ugh, something went horribly wrong, bail out
 	}

--- a/blockchain/state_processor.go
+++ b/blockchain/state_processor.go
@@ -81,7 +81,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	processStats.BeforeApplyTxs = time.Now()
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		statedb.Prepare(tx.Hash(), block.Hash(), i)
+		statedb.SetTxContext(tx.Hash(), block.Hash(), i)
 		receipt, internalTxTrace, err := p.bc.ApplyTransaction(p.config, &author, statedb, header, tx, usedGas, &cfg)
 		if err != nil {
 			return nil, nil, 0, nil, processStats, err

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -343,7 +343,11 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
-	st.state.PrepareAccessList(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Context.Coinbase, msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
+
+	// Execute the preparatory steps for state transition which includes:
+	// - prepare accessList(post-berlin)
+	// - reset transient storage(eip 1153)
+	st.state.Prepare(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Context.Coinbase, msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
 
 	// Check whether the init code size has been exceeded.
 	if rules.IsShanghai && msg.To() == nil && len(st.data) > params.MaxInitCodeSize {

--- a/blockchain/vm/contracts_test.go
+++ b/blockchain/vm/contracts_test.go
@@ -109,7 +109,7 @@ func prepare(reqGas uint64) (*Contract, *EVM, error) {
 	// Generate EVM
 	stateDb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	txhash := common.HexToHash("0xc6a37e155d3fa480faea012a68ad35fd53c8cc3cd8263a434c697755985a6577")
-	stateDb.Prepare(txhash, common.Hash{}, 0)
+	stateDb.SetTxContext(txhash, common.Hash{}, 0)
 	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(0)}, TxContext{}, stateDb, &params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)}, &Config{})
 
 	// Only stdout logging is tested to avoid file handling. It is used at vmLog test.

--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -153,9 +153,13 @@ func opTload(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 
 // opTstore implements TSTORE opcode
 func opTstore(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	if evm.interpreter.readOnly {
+		return nil, ErrWriteProtection
+	}
 	loc := scope.Stack.pop()
 	val := scope.Stack.pop()
 	evm.StateDB.SetTransientState(scope.Contract.Address(), common.BigToHash(loc), common.BigToHash(val))
+	evm.interpreter.intPool.put(loc, val)
 	return nil, nil
 }
 

--- a/blockchain/vm/instructions_test.go
+++ b/blockchain/vm/instructions_test.go
@@ -86,6 +86,7 @@ func TestOpTstore(t *testing.T) {
 	statedb.CreateAccount(to)
 
 	env.interpreter = evmInterpreter
+	env.interpreter.intPool = poolOfIntPools.get()
 	pc := uint64(0)
 	// push the value to the stack
 	stack.push(new(big.Int).SetBytes(value))
@@ -1466,8 +1467,9 @@ func BenchmarkOpTload(b *testing.B) {
 }
 
 func BenchmarkOpTstore(b *testing.B) {
-	x := "FBCDEF090807060504030201ffffffffFBCDEF090807060504030201ffffffff"
-	opBenchmark(b, opTstore, x, "0x20")
+	x := "ffffffff"
+	y := "ffffffff"
+	opBenchmark(b, opTstore, x, y)
 }
 
 func TestOpMCopy(t *testing.T) {

--- a/blockchain/vm/interface.go
+++ b/blockchain/vm/interface.go
@@ -58,6 +58,9 @@ type StateDB interface {
 	GetState(common.Address, common.Hash) common.Hash
 	SetState(common.Address, common.Hash, common.Hash)
 
+	GetTransientState(addr common.Address, key common.Hash) common.Hash
+	SetTransientState(addr common.Address, key, value common.Hash)
+
 	SelfDestruct(common.Address)
 	HasSelfDestructed(common.Address) bool
 
@@ -73,7 +76,6 @@ type StateDB interface {
 	// is defined according to EIP161 (balance = nonce = code = 0).
 	Empty(common.Address) bool
 
-	PrepareAccessList(rules params.Rules, sender, feePayer, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
 	AddressInAccessList(addr common.Address) bool
 	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
 	// AddAddressToAccessList adds the given address to the access list. This operation is safe to perform
@@ -82,6 +84,7 @@ type StateDB interface {
 	// AddSlotToAccessList adds the given (address,slot) to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
 	AddSlotToAccessList(addr common.Address, slot common.Hash)
+	Prepare(rules params.Rules, sender, feePayer, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
 
 	RevertToSnapshot(int)
 	Snapshot() int

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -72,6 +72,7 @@ func newCancunInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
 	enable5656(&instructionSet) // EIP-5656 (MCOPY opcode)
 	enable6780(&instructionSet) // EIP-6780 SELFDESTRUCT only in same transaction
+	enable1153(&instructionSet) // EIP-1153 (Tload, Tstore opcode)
 	return instructionSet
 }
 

--- a/blockchain/vm/opcodes.go
+++ b/blockchain/vm/opcodes.go
@@ -123,8 +123,10 @@ const (
 	MSIZE
 	GAS
 	JUMPDEST
-	MCOPY OpCode = 0x5e
-	PUSH0 OpCode = 0x5f
+	TLOAD  OpCode = 0x5c
+	TSTORE OpCode = 0x5d
+	MCOPY  OpCode = 0x5e
+	PUSH0  OpCode = 0x5f
 )
 
 // 0x60 range.
@@ -550,6 +552,8 @@ var stringToOp = map[string]OpCode{
 	"CALLCODE":       CALLCODE,
 	"REVERT":         REVERT,
 	"SELFDESTRUCT":   SELFDESTRUCT,
+	"TLOAD":          TLOAD,
+	"TSTORE":         TSTORE,
 }
 
 // StringToOp finds the opcode whose name is stored in `str`.

--- a/blockchain/vm/runtime/runtime.go
+++ b/blockchain/vm/runtime/runtime.go
@@ -118,7 +118,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 		rules   = cfg.ChainConfig.Rules(vmenv.Context.BlockNumber)
 	)
 
-	cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
+	cfg.State.Prepare(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
 	cfg.State.CreateSmartContractAccount(address, params.CodeFormatEVM, cfg.ChainConfig.Rules(cfg.BlockNumber))
 	// set the receiver's (the executing contract) code for execution.
 	cfg.State.SetCode(address, code)
@@ -151,7 +151,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 		rules  = cfg.ChainConfig.Rules(vmenv.Context.BlockNumber)
 	)
 
-	cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, nil, vm.ActivePrecompiles(rules), nil)
+	cfg.State.Prepare(rules, cfg.Origin, common.Address{}, cfg.Coinbase, nil, vm.ActivePrecompiles(rules), nil)
 	// Call the code with the given configuration.
 	code, address, leftOverGas, err := vmenv.Create(
 		sender,
@@ -178,7 +178,7 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 		rules         = cfg.ChainConfig.Rules(vmenv.Context.BlockNumber)
 	)
 
-	cfg.State.PrepareAccessList(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
+	cfg.State.Prepare(rules, cfg.Origin, common.Address{}, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
 	// Call the code with the given configuration.
 	ret, leftOverGas, err := vmenv.Call(
 		sender,

--- a/params/computation_cost_params.go
+++ b/params/computation_cost_params.go
@@ -177,6 +177,6 @@ const (
 
 	// computation cost added at CancunCompatible
 	McopyComputationCost  = 250
-	TloadComputationCost  = 300
-	TstoreComputationCost = 540
+	TloadComputationCost  = 220
+	TstoreComputationCost = 280
 )

--- a/params/computation_cost_params.go
+++ b/params/computation_cost_params.go
@@ -69,7 +69,6 @@ const (
 	DifficultyComputationCost     = 180
 	GasLimitComputationCost       = 166
 	PopComputationCost            = 140
-	McopyComputationCost          = 250
 	MloadComputationCost          = 376
 	MstoreComputationCost         = 288
 	Mstore8ComputationCost        = 5142
@@ -81,7 +80,6 @@ const (
 	MsizeComputationCost          = 137
 	GasComputationCost            = 230
 	JumpDestComputationCost       = 10
-	Push0ComputationCost          = 80
 	PushComputationCost           = 120
 	Dup1ComputationCost           = 190
 	Dup2ComputationCost           = 190
@@ -171,6 +169,14 @@ const (
 	XorComputationCost            = 657
 	XorComputationCostIstanbul    = 454
 
-	// computation costs for opcode added at koreCompatible Protocol Upgrade
+	// computation cost added at KoreCompatible
 	RandomComputationCost = 1498
+
+	// computation cost added at ShanghaiCompatible
+	Push0ComputationCost = 80
+
+	// computation cost added at CancunCompatible
+	McopyComputationCost  = 250
+	TloadComputationCost  = 300
+	TstoreComputationCost = 540
 )

--- a/work/worker.go
+++ b/work/worker.go
@@ -746,7 +746,7 @@ CommitTransactionLoop:
 		//	continue
 		//}
 		// Start executing the transaction
-		env.state.Prepare(tx.Hash(), common.Hash{}, env.tcount)
+		env.state.SetTxContext(tx.Hash(), common.Hash{}, env.tcount)
 
 		err, logs := env.commitTransaction(tx, bc, rewardbase, vmConfig)
 		switch err {


### PR DESCRIPTION
## Proposed changes

- This PR brings [eip-1153](https://eips.ethereum.org/EIPS/eip-1153).
- Tload(`0x5c`), Tstore(`0x5d`) opcodes has been added.
- Will be open after https://github.com/klaytn/klaytn/pull/1986 is merged.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
