### PR TITLE
KIP-113 BLS PublicKey Registry accessors

### DIFF
--- a/blockchain/system/constant.go
+++ b/blockchain/system/constant.go
@@ -32,11 +32,13 @@ var (
 	AddressBookName = "AddressBook"
 	GovParamName    = "GovParam"
 	Kip103Name      = "TreasuryRebalance"
+	Kip113Name      = "KIP113"
 
 	AllContractNames = []string{
 		AddressBookName,
 		GovParamName,
 		Kip103Name,
+		Kip113Name,
 	}
 
 	// Some system contracts are allocated at special addresses.
@@ -46,7 +48,10 @@ var (
 	// System contract binaries to be injected at hardfork or used in testing.
 	RegistryCode     = hexutil.MustDecode("0x" + contracts.RegistryBinRuntime)
 	RegistryMockCode = hexutil.MustDecode("0x" + contracts.RegistryMockBinRuntime)
+	Kip113MockCode   = hexutil.MustDecode("0x" + contracts.KIP113MockBinRuntime)
 
 	// Errors
 	ErrRegistryNotInstalled = errors.New("Registry contract not installed")
+	ErrKip113BadResult      = errors.New("KIP113 call returned bad data")
+	ErrKip113BadPop         = errors.New("KIP113 PoP verification failed")
 )

--- a/blockchain/system/kip113.go
+++ b/blockchain/system/kip113.go
@@ -1,0 +1,83 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"math/big"
+
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/common"
+	contracts "github.com/klaytn/klaytn/contracts/system_contracts"
+	"github.com/klaytn/klaytn/crypto/bls"
+)
+
+type BlsPublicKeyInfo struct {
+	PublicKey []byte
+	Pop       []byte
+}
+
+type BlsPublicKeyInfos map[common.Address]BlsPublicKeyInfo
+
+func (info BlsPublicKeyInfo) Verify() error {
+	pk, err := bls.PublicKeyFromBytes(info.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	sig, err := bls.SignatureFromBytes(info.Pop)
+	if err != nil {
+		return err
+	}
+
+	if !bls.PopVerify(pk, sig) {
+		return ErrKip113BadPop
+	}
+
+	return nil
+}
+
+func ReadKip113All(backend bind.ContractCaller, contractAddr common.Address, num *big.Int) (BlsPublicKeyInfos, error) {
+	caller, err := contracts.NewIKIP113Caller(contractAddr, backend)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &bind.CallOpts{BlockNumber: num}
+	ret, err := caller.GetAllInfo(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ret.AddrList) != len(ret.PubkeyList) {
+		return nil, ErrKip113BadResult
+	}
+
+	infos := make(BlsPublicKeyInfos)
+	for i := 0; i < len(ret.AddrList); i++ {
+		addr := ret.AddrList[i]
+		info := BlsPublicKeyInfo{
+			PublicKey: ret.PubkeyList[i].PublicKey,
+			Pop:       ret.PubkeyList[i].Pop,
+		}
+
+		if err := info.Verify(); err == nil {
+			infos[addr] = info
+		}
+	}
+
+	return infos, err
+}

--- a/blockchain/system/kip113.go
+++ b/blockchain/system/kip113.go
@@ -38,7 +38,7 @@ type AllocKIP113Init struct {
 
 type BlsPublicKeyInfos map[common.Address]BlsPublicKeyInfo
 
-func AllocKIP113(init *AllocKIP113Init) map[common.Hash]common.Hash {
+func AllocKip113(init *AllocKIP113Init) map[common.Hash]common.Hash {
 	if init == nil {
 		return nil
 	}
@@ -119,18 +119,18 @@ func ReadKip113All(backend bind.ContractCaller, contractAddr common.Address, num
 	}
 
 	opts := &bind.CallOpts{BlockNumber: num}
-	ret, err := caller.GetAllInfo(opts)
+	ret, err := caller.GetAllBlsInfo(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(ret.AddrList) != len(ret.PubkeyList) {
+	if len(ret.NodeIdList) != len(ret.PubkeyList) {
 		return nil, ErrKip113BadResult
 	}
 
 	infos := make(BlsPublicKeyInfos)
-	for i := 0; i < len(ret.AddrList); i++ {
-		addr := ret.AddrList[i]
+	for i := 0; i < len(ret.NodeIdList); i++ {
+		addr := ret.NodeIdList[i]
 		info := BlsPublicKeyInfo{
 			PublicKey: ret.PubkeyList[i].PublicKey,
 			Pop:       ret.PubkeyList[i].Pop,

--- a/blockchain/system/kip113_test.go
+++ b/blockchain/system/kip113_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
 	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/common"
 	contracts "github.com/klaytn/klaytn/contracts/system_contracts"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/crypto/bls"
@@ -54,10 +55,85 @@ func TestReadKip113(t *testing.T) {
 	contract.RegisterPublicKey(sender, pub2, pop1) // pub vs. pop mismatch
 	backend.Commit()
 
-	// Returns zero record because the only record is invalid.
+	// Returns zero record because invalid records have been filtered out.
 	infos, err = ReadKip113All(backend, contractAddr, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(infos))
+}
+
+func TestAllocKIP113(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+
+	var (
+		senderKey, _ = crypto.GenerateKey()
+		sender       = bind.NewKeyedTransactor(senderKey)
+		senderAddr   = sender.From
+
+		senderKey2, _ = crypto.GenerateKey()
+		sender2       = bind.NewKeyedTransactor(senderKey2)
+		senderAddr2   = sender2.From
+
+		KIP113MockAddr = common.HexToAddress("0x0000000000000000000000000000000000000402")
+
+		_, pub1, pop1 = makeBlsKey()
+		_, pub2, pop2 = makeBlsKey()
+	)
+
+	// 1. Create storage with AllocKIP113
+	allocStorage := AllocKIP113(&AllocKIP113Init{
+		Infos: map[common.Address]BlsPublicKeyInfo{
+			senderAddr: {
+				PublicKey: pub1,
+				Pop:       pop1,
+			},
+			senderAddr2: {
+				PublicKey: pub2,
+				Pop:       pop2,
+			},
+		},
+		Addrs: []common.Address{
+			senderAddr,
+			senderAddr2,
+		},
+	})
+
+	// 2. Create storage by calling registerPublicKey()
+	var (
+		alloc = blockchain.GenesisAlloc{
+			sender.From: {
+				Balance: big.NewInt(params.KLAY),
+			},
+			sender2.From: {
+				Balance: big.NewInt(params.KLAY),
+			},
+			KIP113MockAddr: {
+				Code:    Kip113MockCode,
+				Balance: common.Big0,
+			},
+		}
+		backend     = backends.NewSimulatedBackend(alloc)
+		contract, _ = contracts.NewKIP113MockTransactor(KIP113MockAddr, backend)
+	)
+
+	contract.RegisterPublicKey(sender, pub1, pop1)
+	contract.RegisterPublicKey(sender2, pub2, pop2)
+	backend.Commit()
+
+	execStorage := make(map[common.Hash]common.Hash)
+	stateDB, _ := backend.BlockChain().State()
+	stateDB.ForEachStorage(KIP113MockAddr, func(key common.Hash, value common.Hash) bool {
+		execStorage[key] = value
+		return true
+	})
+
+	// 3. Compare the two states
+	for k, v := range allocStorage {
+		assert.Equal(t, v.Hex(), execStorage[k].Hex(), k.Hex())
+		t.Logf("%x %x\n", k, v)
+	}
+	for k, v := range execStorage {
+		assert.Equal(t, v.Hex(), allocStorage[k].Hex(), k.Hex())
+	}
 }
 
 func makeBlsKey() (priv, pub, pop []byte) {

--- a/blockchain/system/kip113_test.go
+++ b/blockchain/system/kip113_test.go
@@ -77,21 +77,9 @@ func TestAllocKip113(t *testing.T) {
 	)
 
 	// 1. Create storage with AllocKIP113
-	allocStorage := AllocKip113(&AllocKIP113Init{
-		Infos: map[common.Address]BlsPublicKeyInfo{
-			nodeId1: {
-				PublicKey: pub1,
-				Pop:       pop1,
-			},
-			nodeId2: {
-				PublicKey: pub2,
-				Pop:       pop2,
-			},
-		},
-		Addrs: []common.Address{
-			nodeId1,
-			nodeId2,
-		},
+	allocStorage := AllocKip113(AllocKip113Init{
+		nodeId1: {PublicKey: pub1, Pop: pop1},
+		nodeId2: {PublicKey: pub2, Pop: pop2},
 	})
 
 	// 2. Create storage by calling register()

--- a/blockchain/system/kip113_test.go
+++ b/blockchain/system/kip113_test.go
@@ -1,0 +1,78 @@
+package system
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
+	"github.com/klaytn/klaytn/blockchain"
+	contracts "github.com/klaytn/klaytn/contracts/system_contracts"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/crypto/bls"
+	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadKip113(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	var (
+		senderKey, _ = crypto.GenerateKey()
+		sender       = bind.NewKeyedTransactor(senderKey)
+		senderAddr   = sender.From
+
+		alloc = blockchain.GenesisAlloc{
+			sender.From: {
+				Balance: big.NewInt(params.KLAY),
+			},
+		}
+		backend = backends.NewSimulatedBackend(alloc)
+
+		_, pub1, pop1 = makeBlsKey()
+		_, pub2, _    = makeBlsKey()
+	)
+
+	contractAddr, _, contract, err := contracts.DeployKIP113Mock(sender, backend)
+	backend.Commit()
+	assert.Nil(t, err)
+	t.Logf("KIP113Mock at %x", contractAddr)
+
+	// With a valid record
+	contract.RegisterPublicKey(sender, pub1, pop1)
+	backend.Commit()
+
+	infos, err := ReadKip113All(backend, contractAddr, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(infos))
+	assert.Equal(t, pub1, infos[senderAddr].PublicKey)
+	assert.Equal(t, pop1, infos[senderAddr].Pop)
+
+	// With an invalid record
+	// Another registerPublicKey() call from the same sender overwrites the existing info.
+	contract.RegisterPublicKey(sender, pub2, pop1) // pub vs. pop mismatch
+	backend.Commit()
+
+	// Returns zero record because the only record is invalid.
+	infos, err = ReadKip113All(backend, contractAddr, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(infos))
+}
+
+func makeBlsKey() (priv, pub, pop []byte) {
+	ikm := make([]byte, 32)
+	rand.Read(ikm)
+
+	sk, _ := bls.GenerateKey(ikm)
+	pk := sk.PublicKey()
+	sig := bls.PopProve(sk)
+
+	priv = sk.Marshal()
+	pub = pk.Marshal()
+	pop = sig.Marshal()
+	if len(priv) != 32 || len(pub) != 48 || len(pop) != 96 {
+		panic("bad bls key")
+	}
+	return
+}

--- a/blockchain/system/registry.go
+++ b/blockchain/system/registry.go
@@ -46,7 +46,7 @@ func AllocRegistry(init *params.RegistryConfig) map[common.Hash]common.Hash {
 	// - records[x][i].addr @ Hash(Hash(x, 0)) + (2*i)
 	// - records[x][i].activation @ Hash(Hash(x, 0)) + (2*i + 1)
 	for name, addr := range init.Records {
-		arraySlot := calcMappingSlot(0, name)
+		arraySlot := calcMappingSlot(0, name, 0)
 		storage[arraySlot] = lpad32(1) // records[name].length = 1
 
 		addrSlot := calcArraySlot(arraySlot, 2, 0, 0)
@@ -65,10 +65,12 @@ func AllocRegistry(init *params.RegistryConfig) map[common.Hash]common.Hash {
 	// slot[1]: string[] names;
 	// - names.length @ 1
 	// - names[i] @ Hash(1) + i
-	storage[lpad32(1)] = lpad32(len(names)) // names.length
+	storage[lpad32(1)] = lpad32(len(names))
 	for i, name := range names {
-		nameSlot := calcArraySlot(1, 1, i, 0)
-		storage[nameSlot] = encodeShortString(name) // names[i]
+		nameSlot := calcArraySlot(1, 1, i, 0) // Hash(1) + 1*i + 0
+		for k, v := range allocDynamicData(nameSlot, []byte(name)) {
+			storage[k] = v
+		}
 	}
 
 	// slot[2]: address _owner;

--- a/blockchain/system/storage.go
+++ b/blockchain/system/storage.go
@@ -85,6 +85,19 @@ func calcArraySlot(baseSlot interface{}, elemSize, index, offset int) common.Has
 	return common.BytesToHash(slot.Bytes())
 }
 
+// Calculate the contract storage slot for a struct element.
+// Returns keccak256(base) + index
+func calcStructSlot(baseSlot interface{}, index int) common.Hash {
+	baseBytes := lpad32(baseSlot).Bytes()
+	baseHash := crypto.Keccak256Hash(baseBytes)
+
+	slot := new(big.Int).SetBytes(baseHash.Bytes())
+
+	slot.Add(slot, big.NewInt(int64(index))) // slot += index
+
+	return common.BytesToHash(slot.Bytes())
+}
+
 // Pad Solidity "value types" to 32 bytes.
 // Only a few value types are implemented here.
 // See https://docs.soliditylang.org/en/v0.8.20/types.html
@@ -122,4 +135,13 @@ func encodeShortString(s string) common.Hash {
 	copy(b, []byte(s))
 	b[31] = byte(len(s)) * 2
 	return common.BytesToHash(b)
+}
+
+// Add a int to a hash.
+func addIntToHash(h common.Hash, i int) common.Hash {
+	slot := new(big.Int).SetBytes(h.Bytes())
+
+	slot.Add(slot, big.NewInt(int64(i))) // slot += index
+
+	return common.BytesToHash(slot.Bytes())
 }

--- a/blockchain/system/storage_test.go
+++ b/blockchain/system/storage_test.go
@@ -20,14 +20,66 @@ import (
 	"testing"
 
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStorageCalc(t *testing.T) {
-	assert.Equal(t,
-		common.HexToHash("0000000000000000000000000000000000000000000000000000000000001234"),
-		lpad32(0x1234))
-	assert.Equal(t,
-		common.HexToHash("41636d65436f6e74726163740000000000000000000000000000000000000018"),
-		encodeShortString("AcmeContract"))
+	assert.Equal(t, "0x839613f731613c3a2f728362760f939c8004b5d9066154aab51d6dadf74733f3",
+		calcMappingSlot(0, common.HexToAddress("0xaaaa"), 0).Hex())
+	assert.Equal(t, "0x839613f731613c3a2f728362760f939c8004b5d9066154aab51d6dadf74733f4",
+		calcMappingSlot(0, common.HexToAddress("0xaaaa"), 1).Hex())
+
+	assert.Equal(t, "0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6",
+		calcArraySlot(1, 1, 0, 0).Hex())
+	assert.Equal(t, "0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf7",
+		calcArraySlot(1, 1, 1, 0).Hex())
+
+	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000001234",
+		lpad32(0x1234).Hex())
+}
+
+func TestStorageDynamicData(t *testing.T) {
+	testcases := []struct {
+		baseSlot interface{}
+		data     []byte
+		expected map[string]string
+	}{
+		{ // short data
+			baseSlot: 1,
+			data:     []byte("AcmeContract"),
+			expected: map[string]string{
+				"0x0000000000000000000000000000000000000000000000000000000000000001": "0x41636d65436f6e74726163740000000000000000000000000000000000000018",
+			},
+		},
+		{ // long 48-byte data (e.g. BLS public key)
+			baseSlot: common.HexToHash("0x839613f731613c3a2f728362760f939c8004b5d9066154aab51d6dadf74733f3"),
+			data:     hexutil.MustDecode("0x91edb62902264ada822e48f0beedf582fa8c5d1518c0b536b1347983f2fe9c80f283c1e5dfc7a37c3437ceaaa9a1f867"),
+			expected: map[string]string{
+				"0x839613f731613c3a2f728362760f939c8004b5d9066154aab51d6dadf74733f3": "0x0000000000000000000000000000000000000000000000000000000000000061",
+				"0x89005672ae92e5773a2b83cb802d9bc9be4cf262b7ddcca0635550f0ea96e12d": "0x91edb62902264ada822e48f0beedf582fa8c5d1518c0b536b1347983f2fe9c80",
+				"0x89005672ae92e5773a2b83cb802d9bc9be4cf262b7ddcca0635550f0ea96e12e": "0xf283c1e5dfc7a37c3437ceaaa9a1f86700000000000000000000000000000000",
+			},
+		},
+		{ // long 95-byte data (e.g. BLS PoP)
+			baseSlot: common.HexToHash("0x839613f731613c3a2f728362760f939c8004b5d9066154aab51d6dadf74733f4"),
+			data:     hexutil.MustDecode("0xb72d443815683d633b5933366ac8aa6e2891aaff8ab95e69a7531aa2afe10f0740368128992a2a54cb24f0c93dad5c220692915ddb5013fb475726baf711590f7ea1eafaf396264cc2940c744ee6914f3734a4d404dffa91d15e3d138ee81464"),
+			expected: map[string]string{
+				"0x839613f731613c3a2f728362760f939c8004b5d9066154aab51d6dadf74733f4": "0x00000000000000000000000000000000000000000000000000000000000000c1",
+				"0xccf7c844150261de21551c00e90c49fd101dcf60b58bfeb3f7c1ce662560a383": "0xb72d443815683d633b5933366ac8aa6e2891aaff8ab95e69a7531aa2afe10f07",
+				"0xccf7c844150261de21551c00e90c49fd101dcf60b58bfeb3f7c1ce662560a384": "0x40368128992a2a54cb24f0c93dad5c220692915ddb5013fb475726baf711590f",
+				"0xccf7c844150261de21551c00e90c49fd101dcf60b58bfeb3f7c1ce662560a385": "0x7ea1eafaf396264cc2940c744ee6914f3734a4d404dffa91d15e3d138ee81464",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		alloc := allocDynamicData(tc.baseSlot, tc.data)
+
+		strAlloc := make(map[string]string)
+		for k, v := range alloc {
+			strAlloc[k.Hex()] = v.Hex()
+		}
+		assert.Equal(t, tc.expected, strAlloc)
+	}
 }

--- a/contracts/system_contracts/all.go
+++ b/contracts/system_contracts/all.go
@@ -4,11 +4,11 @@
 package system_contracts
 
 import (
-	"errors"
 	"math/big"
 	"strings"
 
 	"github.com/klaytn/klaytn"
+	"github.com/klaytn/klaytn/accounts/abi"
 	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -17,7 +17,6 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var (
-	_ = errors.New
 	_ = big.NewInt
 	_ = strings.NewReader
 	_ = klaytn.NotFound
@@ -27,37 +26,213 @@ var (
 	_ = event.NewSubscription
 )
 
-// IRegistryRecord is an auto generated low-level Go binding around an user-defined struct.
-type IRegistryRecord struct {
-	Addr       common.Address
-	Activation *big.Int
+// IKIP113BlsPublicKeyInfo is an auto generated low-level Go binding around an user-defined struct.
+type IKIP113BlsPublicKeyInfo struct {
+	PublicKey []byte
+	Pop       []byte
 }
 
-// IRegistryMetaData contains all meta data concerning the IRegistry contract.
-var IRegistryMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"Registered\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAllNames\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getAllRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"internalType\":\"structIRegistry.Record[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
-	Sigs: map[string]string{
-		"e2693e3f": "getActiveAddr(string)",
-		"fb825e5f": "getAllNames()",
-		"78d573a2": "getAllRecords(string)",
-		"4622ab03": "names(uint256)",
-		"8da5cb5b": "owner()",
-		"3b51650d": "records(string,uint256)",
-		"d393c871": "register(string,address,uint256)",
-		"f2fde38b": "transferOwnership(address)",
-	},
+// IKIP113ABI is the input ABI used to generate the binding from.
+const IKIP113ABI = "[{\"inputs\":[],\"name\":\"getAllBlsInfo\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"nodeIdList\",\"type\":\"address[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"publicKey\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"pop\",\"type\":\"bytes\"}],\"internalType\":\"structIKIP113.BlsPublicKeyInfo[]\",\"name\":\"pubkeyList\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
+
+// IKIP113BinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const IKIP113BinRuntime = ``
+
+// IKIP113FuncSigs maps the 4-byte function signature to its string representation.
+var IKIP113FuncSigs = map[string]string{
+	"6968b53f": "getAllBlsInfo()",
+}
+
+// IKIP113 is an auto generated Go binding around a Klaytn contract.
+type IKIP113 struct {
+	IKIP113Caller     // Read-only binding to the contract
+	IKIP113Transactor // Write-only binding to the contract
+	IKIP113Filterer   // Log filterer for contract events
+}
+
+// IKIP113Caller is an auto generated read-only Go binding around a Klaytn contract.
+type IKIP113Caller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IKIP113Transactor is an auto generated write-only Go binding around a Klaytn contract.
+type IKIP113Transactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IKIP113Filterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type IKIP113Filterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IKIP113Session is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type IKIP113Session struct {
+	Contract     *IKIP113          // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IKIP113CallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type IKIP113CallerSession struct {
+	Contract *IKIP113Caller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts  // Call options to use throughout this session
+}
+
+// IKIP113TransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type IKIP113TransactorSession struct {
+	Contract     *IKIP113Transactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// IKIP113Raw is an auto generated low-level Go binding around a Klaytn contract.
+type IKIP113Raw struct {
+	Contract *IKIP113 // Generic contract binding to access the raw methods on
+}
+
+// IKIP113CallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type IKIP113CallerRaw struct {
+	Contract *IKIP113Caller // Generic read-only contract binding to access the raw methods on
+}
+
+// IKIP113TransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type IKIP113TransactorRaw struct {
+	Contract *IKIP113Transactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIKIP113 creates a new instance of IKIP113, bound to a specific deployed contract.
+func NewIKIP113(address common.Address, backend bind.ContractBackend) (*IKIP113, error) {
+	contract, err := bindIKIP113(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IKIP113{IKIP113Caller: IKIP113Caller{contract: contract}, IKIP113Transactor: IKIP113Transactor{contract: contract}, IKIP113Filterer: IKIP113Filterer{contract: contract}}, nil
+}
+
+// NewIKIP113Caller creates a new read-only instance of IKIP113, bound to a specific deployed contract.
+func NewIKIP113Caller(address common.Address, caller bind.ContractCaller) (*IKIP113Caller, error) {
+	contract, err := bindIKIP113(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IKIP113Caller{contract: contract}, nil
+}
+
+// NewIKIP113Transactor creates a new write-only instance of IKIP113, bound to a specific deployed contract.
+func NewIKIP113Transactor(address common.Address, transactor bind.ContractTransactor) (*IKIP113Transactor, error) {
+	contract, err := bindIKIP113(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IKIP113Transactor{contract: contract}, nil
+}
+
+// NewIKIP113Filterer creates a new log filterer instance of IKIP113, bound to a specific deployed contract.
+func NewIKIP113Filterer(address common.Address, filterer bind.ContractFilterer) (*IKIP113Filterer, error) {
+	contract, err := bindIKIP113(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IKIP113Filterer{contract: contract}, nil
+}
+
+// bindIKIP113 binds a generic wrapper to an already deployed contract.
+func bindIKIP113(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(IKIP113ABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IKIP113 *IKIP113Raw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _IKIP113.Contract.IKIP113Caller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IKIP113 *IKIP113Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IKIP113.Contract.IKIP113Transactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IKIP113 *IKIP113Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IKIP113.Contract.IKIP113Transactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IKIP113 *IKIP113CallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _IKIP113.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IKIP113 *IKIP113TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IKIP113.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IKIP113 *IKIP113TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IKIP113.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetAllBlsInfo is a free data retrieval call binding the contract method 0x6968b53f.
+//
+// Solidity: function getAllBlsInfo() view returns(address[] nodeIdList, (bytes,bytes)[] pubkeyList)
+func (_IKIP113 *IKIP113Caller) GetAllBlsInfo(opts *bind.CallOpts) (struct {
+	NodeIdList []common.Address
+	PubkeyList []IKIP113BlsPublicKeyInfo
+}, error) {
+	ret := new(struct {
+		NodeIdList []common.Address
+		PubkeyList []IKIP113BlsPublicKeyInfo
+	})
+	out := ret
+	err := _IKIP113.contract.Call(opts, out, "getAllBlsInfo")
+	return *ret, err
+}
+
+// GetAllBlsInfo is a free data retrieval call binding the contract method 0x6968b53f.
+//
+// Solidity: function getAllBlsInfo() view returns(address[] nodeIdList, (bytes,bytes)[] pubkeyList)
+func (_IKIP113 *IKIP113Session) GetAllBlsInfo() (struct {
+	NodeIdList []common.Address
+	PubkeyList []IKIP113BlsPublicKeyInfo
+}, error) {
+	return _IKIP113.Contract.GetAllBlsInfo(&_IKIP113.CallOpts)
+}
+
+// GetAllBlsInfo is a free data retrieval call binding the contract method 0x6968b53f.
+//
+// Solidity: function getAllBlsInfo() view returns(address[] nodeIdList, (bytes,bytes)[] pubkeyList)
+func (_IKIP113 *IKIP113CallerSession) GetAllBlsInfo() (struct {
+	NodeIdList []common.Address
+	PubkeyList []IKIP113BlsPublicKeyInfo
+}, error) {
+	return _IKIP113.Contract.GetAllBlsInfo(&_IKIP113.CallOpts)
 }
 
 // IRegistryABI is the input ABI used to generate the binding from.
-// Deprecated: Use IRegistryMetaData.ABI instead.
-var IRegistryABI = IRegistryMetaData.ABI
+const IRegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
 
 // IRegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
 const IRegistryBinRuntime = ``
 
 // IRegistryFuncSigs maps the 4-byte function signature to its string representation.
-// Deprecated: Use IRegistryMetaData.Sigs instead.
-var IRegistryFuncSigs = IRegistryMetaData.Sigs
+var IRegistryFuncSigs = map[string]string{
+	"e2693e3f": "getActiveAddr(string)",
+	"4622ab03": "names(uint256)",
+	"3b51650d": "records(string,uint256)",
+}
 
 // IRegistry is an auto generated Go binding around a Klaytn contract.
 type IRegistry struct {
@@ -156,11 +331,11 @@ func NewIRegistryFilterer(address common.Address, filterer bind.ContractFilterer
 
 // bindIRegistry binds a generic wrapper to an already deployed contract.
 func bindIRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := IRegistryMetaData.GetAbi()
+	parsed, err := abi.JSON(strings.NewReader(IRegistryABI))
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and
@@ -201,59 +376,39 @@ func (_IRegistry *IRegistryTransactorRaw) Transact(opts *bind.TransactOpts, meth
 	return _IRegistry.Contract.contract.Transact(opts, method, params...)
 }
 
-// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getAllNames() view returns(string[])
-func (_IRegistry *IRegistryCaller) GetAllNames(opts *bind.CallOpts) ([]string, error) {
-	ret0 := new([]string)
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_IRegistry *IRegistryCaller) GetActiveAddr(opts *bind.CallOpts, name string) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
 	out := ret0
-	err := _IRegistry.contract.Call(opts, out, "getAllNames")
+	err := _IRegistry.contract.Call(opts, out, "getActiveAddr", name)
 	return *ret0, err
 }
 
-// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getAllNames() view returns(string[])
-func (_IRegistry *IRegistrySession) GetAllNames() ([]string, error) {
-	return _IRegistry.Contract.GetAllNames(&_IRegistry.CallOpts)
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_IRegistry *IRegistrySession) GetActiveAddr(name string) (common.Address, error) {
+	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.CallOpts, name)
 }
 
-// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
+// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
 //
-// Solidity: function getAllNames() view returns(string[])
-func (_IRegistry *IRegistryCallerSession) GetAllNames() ([]string, error) {
-	return _IRegistry.Contract.GetAllNames(&_IRegistry.CallOpts)
-}
-
-// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
-//
-// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
-func (_IRegistry *IRegistryCaller) GetAllRecords(opts *bind.CallOpts, name string) ([]IRegistryRecord, error) {
-	ret0 := new([]IRegistryRecord)
-	out := ret0
-	err := _IRegistry.contract.Call(opts, out, "getAllRecords", name)
-	return *ret0, err
-}
-
-// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
-//
-// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
-func (_IRegistry *IRegistrySession) GetAllRecords(name string) ([]IRegistryRecord, error) {
-	return _IRegistry.Contract.GetAllRecords(&_IRegistry.CallOpts, name)
-}
-
-// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
-//
-// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
-func (_IRegistry *IRegistryCallerSession) GetAllRecords(name string) ([]IRegistryRecord, error) {
-	return _IRegistry.Contract.GetAllRecords(&_IRegistry.CallOpts, name)
+// Solidity: function getActiveAddr(string name) view returns(address)
+func (_IRegistry *IRegistryCallerSession) GetActiveAddr(name string) (common.Address, error) {
+	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.CallOpts, name)
 }
 
 // Names is a free data retrieval call binding the contract method 0x4622ab03.
 //
 // Solidity: function names(uint256 ) view returns(string)
 func (_IRegistry *IRegistryCaller) Names(opts *bind.CallOpts, arg0 *big.Int) (string, error) {
-	ret0 := new(string)
+	var (
+		ret0 = new(string)
+	)
 	out := ret0
 	err := _IRegistry.contract.Call(opts, out, "names", arg0)
 	return *ret0, err
@@ -273,38 +428,13 @@ func (_IRegistry *IRegistryCallerSession) Names(arg0 *big.Int) (string, error) {
 	return _IRegistry.Contract.Names(&_IRegistry.CallOpts, arg0)
 }
 
-// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
-//
-// Solidity: function owner() view returns(address)
-func (_IRegistry *IRegistryCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
-	ret0 := new(common.Address)
-	out := ret0
-	err := _IRegistry.contract.Call(opts, out, "owner")
-	return *ret0, err
-}
-
-// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
-//
-// Solidity: function owner() view returns(address)
-func (_IRegistry *IRegistrySession) Owner() (common.Address, error) {
-	return _IRegistry.Contract.Owner(&_IRegistry.CallOpts)
-}
-
-// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
-//
-// Solidity: function owner() view returns(address)
-func (_IRegistry *IRegistryCallerSession) Owner() (common.Address, error) {
-	return _IRegistry.Contract.Owner(&_IRegistry.CallOpts)
-}
-
 // Records is a free data retrieval call binding the contract method 0x3b51650d.
 //
 // Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
 func (_IRegistry *IRegistryCaller) Records(opts *bind.CallOpts, arg0 string, arg1 *big.Int) (struct {
 	Addr       common.Address
 	Activation *big.Int
-}, error,
-) {
+}, error) {
 	ret := new(struct {
 		Addr       common.Address
 		Activation *big.Int
@@ -320,8 +450,7 @@ func (_IRegistry *IRegistryCaller) Records(opts *bind.CallOpts, arg0 string, arg
 func (_IRegistry *IRegistrySession) Records(arg0 string, arg1 *big.Int) (struct {
 	Addr       common.Address
 	Activation *big.Int
-}, error,
-) {
+}, error) {
 	return _IRegistry.Contract.Records(&_IRegistry.CallOpts, arg0, arg1)
 }
 
@@ -331,417 +460,326 @@ func (_IRegistry *IRegistrySession) Records(arg0 string, arg1 *big.Int) (struct 
 func (_IRegistry *IRegistryCallerSession) Records(arg0 string, arg1 *big.Int) (struct {
 	Addr       common.Address
 	Activation *big.Int
-}, error,
-) {
+}, error) {
 	return _IRegistry.Contract.Records(&_IRegistry.CallOpts, arg0, arg1)
 }
 
-// GetActiveAddr is a paid mutator transaction binding the contract method 0xe2693e3f.
-//
-// Solidity: function getActiveAddr(string name) returns(address)
-func (_IRegistry *IRegistryTransactor) GetActiveAddr(opts *bind.TransactOpts, name string) (*types.Transaction, error) {
-	return _IRegistry.contract.Transact(opts, "getActiveAddr", name)
+// KIP113MockABI is the input ABI used to generate the binding from.
+const KIP113MockABI = "[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"allNodeIds\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAllBlsInfo\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"nodeIdList\",\"type\":\"address[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"publicKey\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"pop\",\"type\":\"bytes\"}],\"internalType\":\"structIKIP113.BlsPublicKeyInfo[]\",\"name\":\"pubkeyList\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"record\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"publicKey\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"pop\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"publicKey\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"pop\",\"type\":\"bytes\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+
+// KIP113MockBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const KIP113MockBinRuntime = `608060405234801561001057600080fd5b506004361061004c5760003560e01c80633465d6d5146100515780636968b53f1461007b578063786cd4d714610091578063a5834971146100a6575b600080fd5b61006461005f366004610631565b6100d1565b604051610072929190610699565b60405180910390f35b6100836101fd565b6040516100729291906106c7565b6100a461009f3660046107d5565b6104b7565b005b6100b96100b4366004610856565b6105eb565b6040516001600160a01b039091168152602001610072565b6000602081905290815260409020805481906100ec9061086f565b80601f01602080910402602001604051908101604052809291908181526020018280546101189061086f565b80156101655780601f1061013a57610100808354040283529160200191610165565b820191906000526020600020905b81548152906001019060200180831161014857829003601f168201915b50505050509080600101805461017a9061086f565b80601f01602080910402602001604051908101604052809291908181526020018280546101a69061086f565b80156101f35780601f106101c8576101008083540402835291602001916101f3565b820191906000526020600020905b8154815290600101906020018083116101d657829003601f168201915b5050505050905082565b60015460609081908067ffffffffffffffff81111561021e5761021e6108a9565b604051908082528060200260200182016040528015610247578160200160208202803683370190505b5092508067ffffffffffffffff811115610263576102636108a9565b6040519080825280602002602001820160405280156102a857816020015b60408051808201909152606080825260208201528152602001906001900390816102815790505b50915060005b818110156104b157600181815481106102c9576102c96108bf565b9060005260206000200160009054906101000a90046001600160a01b03168482815181106102f9576102f96108bf565b60200260200101906001600160a01b031690816001600160a01b0316815250506000806001838154811061032f5761032f6108bf565b60009182526020808320909101546001600160a01b031683528201929092526040908101909120815180830190925280548290829061036d9061086f565b80601f01602080910402602001604051908101604052809291908181526020018280546103999061086f565b80156103e65780601f106103bb576101008083540402835291602001916103e6565b820191906000526020600020905b8154815290600101906020018083116103c957829003601f168201915b505050505081526020016001820180546103ff9061086f565b80601f016020809104026020016040519081016040528092919081815260200182805461042b9061086f565b80156104785780601f1061044d57610100808354040283529160200191610478565b820191906000526020600020905b81548152906001019060200180831161045b57829003601f168201915b505050505081525050838281518110610493576104936108bf565b602002602001018190525080806104a9906108d5565b9150506102ae565b50509091565b6001600160a01b038516600090815260208190526040902080546104da9061086f565b905060000361052e576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60180546001600160a01b0319166001600160a01b0387161790555b6040805160606020601f87018190040282018101835291810185815290918291908790879081908501838280828437600092019190915250505090825250604080516020601f86018190048102820181019092528481529181019190859085908190840183828082843760009201829052509390945250506001600160a01b0388168152602081905260409020825190915081906105cc908261094b565b50602082015160018201906105e1908261094b565b5050505050505050565b600181815481106105fb57600080fd5b6000918252602090912001546001600160a01b0316905081565b80356001600160a01b038116811461062c57600080fd5b919050565b60006020828403121561064357600080fd5b61064c82610615565b9392505050565b6000815180845260005b818110156106795760208185018101518683018201520161065d565b506000602082860101526020601f19601f83011685010191505092915050565b6040815260006106ac6040830185610653565b82810360208401526106be8185610653565b95945050505050565b60408082528351828201819052600091906020906060850190828801855b8281101561070a5781516001600160a01b0316845292840192908401906001016106e5565b50505084810382860152855180825282820190600581901b8301840188850160005b8381101561077c57858303601f19018552815180518985526107508a860182610653565b91890151858303868b01529190506107688183610653565b96890196945050509086019060010161072c565b50909a9950505050505050505050565b60008083601f84011261079e57600080fd5b50813567ffffffffffffffff8111156107b657600080fd5b6020830191508360208285010111156107ce57600080fd5b9250929050565b6000806000806000606086880312156107ed57600080fd5b6107f686610615565b9450602086013567ffffffffffffffff8082111561081357600080fd5b61081f89838a0161078c565b9096509450604088013591508082111561083857600080fd5b506108458882890161078c565b969995985093965092949392505050565b60006020828403121561086857600080fd5b5035919050565b600181811c9082168061088357607f821691505b6020821081036108a357634e487b7160e01b600052602260045260246000fd5b50919050565b634e487b7160e01b600052604160045260246000fd5b634e487b7160e01b600052603260045260246000fd5b6000600182016108f557634e487b7160e01b600052601160045260246000fd5b5060010190565b601f82111561094657600081815260208120601f850160051c810160208610156109235750805b601f850160051c820191505b818110156109425782815560010161092f565b5050505b505050565b815167ffffffffffffffff811115610965576109656108a9565b61097981610973845461086f565b846108fc565b602080601f8311600181146109ae57600084156109965750858301515b600019600386901b1c1916600185901b178555610942565b600085815260208120601f198616915b828110156109dd578886015182559484019460019091019084016109be565b50858210156109fb5787850151600019600388901b60f8161c191681555b5050505050600190811b0190555056fea26469706673582212204113607f3e91773b3f06c6cb723f751b7dfbc7877c631e26f3df94555695da0d64736f6c63430008110033`
+
+// KIP113MockFuncSigs maps the 4-byte function signature to its string representation.
+var KIP113MockFuncSigs = map[string]string{
+	"a5834971": "allNodeIds(uint256)",
+	"6968b53f": "getAllBlsInfo()",
+	"3465d6d5": "record(address)",
+	"786cd4d7": "register(address,bytes,bytes)",
 }
 
-// GetActiveAddr is a paid mutator transaction binding the contract method 0xe2693e3f.
-//
-// Solidity: function getActiveAddr(string name) returns(address)
-func (_IRegistry *IRegistrySession) GetActiveAddr(name string) (*types.Transaction, error) {
-	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.TransactOpts, name)
-}
+// KIP113MockBin is the compiled bytecode used for deploying new contracts.
+var KIP113MockBin = "0x608060405234801561001057600080fd5b50610a41806100206000396000f3fe608060405234801561001057600080fd5b506004361061004c5760003560e01c80633465d6d5146100515780636968b53f1461007b578063786cd4d714610091578063a5834971146100a6575b600080fd5b61006461005f366004610631565b6100d1565b604051610072929190610699565b60405180910390f35b6100836101fd565b6040516100729291906106c7565b6100a461009f3660046107d5565b6104b7565b005b6100b96100b4366004610856565b6105eb565b6040516001600160a01b039091168152602001610072565b6000602081905290815260409020805481906100ec9061086f565b80601f01602080910402602001604051908101604052809291908181526020018280546101189061086f565b80156101655780601f1061013a57610100808354040283529160200191610165565b820191906000526020600020905b81548152906001019060200180831161014857829003601f168201915b50505050509080600101805461017a9061086f565b80601f01602080910402602001604051908101604052809291908181526020018280546101a69061086f565b80156101f35780601f106101c8576101008083540402835291602001916101f3565b820191906000526020600020905b8154815290600101906020018083116101d657829003601f168201915b5050505050905082565b60015460609081908067ffffffffffffffff81111561021e5761021e6108a9565b604051908082528060200260200182016040528015610247578160200160208202803683370190505b5092508067ffffffffffffffff811115610263576102636108a9565b6040519080825280602002602001820160405280156102a857816020015b60408051808201909152606080825260208201528152602001906001900390816102815790505b50915060005b818110156104b157600181815481106102c9576102c96108bf565b9060005260206000200160009054906101000a90046001600160a01b03168482815181106102f9576102f96108bf565b60200260200101906001600160a01b031690816001600160a01b0316815250506000806001838154811061032f5761032f6108bf565b60009182526020808320909101546001600160a01b031683528201929092526040908101909120815180830190925280548290829061036d9061086f565b80601f01602080910402602001604051908101604052809291908181526020018280546103999061086f565b80156103e65780601f106103bb576101008083540402835291602001916103e6565b820191906000526020600020905b8154815290600101906020018083116103c957829003601f168201915b505050505081526020016001820180546103ff9061086f565b80601f016020809104026020016040519081016040528092919081815260200182805461042b9061086f565b80156104785780601f1061044d57610100808354040283529160200191610478565b820191906000526020600020905b81548152906001019060200180831161045b57829003601f168201915b505050505081525050838281518110610493576104936108bf565b602002602001018190525080806104a9906108d5565b9150506102ae565b50509091565b6001600160a01b038516600090815260208190526040902080546104da9061086f565b905060000361052e576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60180546001600160a01b0319166001600160a01b0387161790555b6040805160606020601f87018190040282018101835291810185815290918291908790879081908501838280828437600092019190915250505090825250604080516020601f86018190048102820181019092528481529181019190859085908190840183828082843760009201829052509390945250506001600160a01b0388168152602081905260409020825190915081906105cc908261094b565b50602082015160018201906105e1908261094b565b5050505050505050565b600181815481106105fb57600080fd5b6000918252602090912001546001600160a01b0316905081565b80356001600160a01b038116811461062c57600080fd5b919050565b60006020828403121561064357600080fd5b61064c82610615565b9392505050565b6000815180845260005b818110156106795760208185018101518683018201520161065d565b506000602082860101526020601f19601f83011685010191505092915050565b6040815260006106ac6040830185610653565b82810360208401526106be8185610653565b95945050505050565b60408082528351828201819052600091906020906060850190828801855b8281101561070a5781516001600160a01b0316845292840192908401906001016106e5565b50505084810382860152855180825282820190600581901b8301840188850160005b8381101561077c57858303601f19018552815180518985526107508a860182610653565b91890151858303868b01529190506107688183610653565b96890196945050509086019060010161072c565b50909a9950505050505050505050565b60008083601f84011261079e57600080fd5b50813567ffffffffffffffff8111156107b657600080fd5b6020830191508360208285010111156107ce57600080fd5b9250929050565b6000806000806000606086880312156107ed57600080fd5b6107f686610615565b9450602086013567ffffffffffffffff8082111561081357600080fd5b61081f89838a0161078c565b9096509450604088013591508082111561083857600080fd5b506108458882890161078c565b969995985093965092949392505050565b60006020828403121561086857600080fd5b5035919050565b600181811c9082168061088357607f821691505b6020821081036108a357634e487b7160e01b600052602260045260246000fd5b50919050565b634e487b7160e01b600052604160045260246000fd5b634e487b7160e01b600052603260045260246000fd5b6000600182016108f557634e487b7160e01b600052601160045260246000fd5b5060010190565b601f82111561094657600081815260208120601f850160051c810160208610156109235750805b601f850160051c820191505b818110156109425782815560010161092f565b5050505b505050565b815167ffffffffffffffff811115610965576109656108a9565b61097981610973845461086f565b846108fc565b602080601f8311600181146109ae57600084156109965750858301515b600019600386901b1c1916600185901b178555610942565b600085815260208120601f198616915b828110156109dd578886015182559484019460019091019084016109be565b50858210156109fb5787850151600019600388901b60f8161c191681555b5050505050600190811b0190555056fea26469706673582212204113607f3e91773b3f06c6cb723f751b7dfbc7877c631e26f3df94555695da0d64736f6c63430008110033"
 
-// GetActiveAddr is a paid mutator transaction binding the contract method 0xe2693e3f.
-//
-// Solidity: function getActiveAddr(string name) returns(address)
-func (_IRegistry *IRegistryTransactorSession) GetActiveAddr(name string) (*types.Transaction, error) {
-	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.TransactOpts, name)
-}
-
-// Register is a paid mutator transaction binding the contract method 0xd393c871.
-//
-// Solidity: function register(string name, address addr, uint256 activation) returns()
-func (_IRegistry *IRegistryTransactor) Register(opts *bind.TransactOpts, name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
-	return _IRegistry.contract.Transact(opts, "register", name, addr, activation)
-}
-
-// Register is a paid mutator transaction binding the contract method 0xd393c871.
-//
-// Solidity: function register(string name, address addr, uint256 activation) returns()
-func (_IRegistry *IRegistrySession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
-	return _IRegistry.Contract.Register(&_IRegistry.TransactOpts, name, addr, activation)
-}
-
-// Register is a paid mutator transaction binding the contract method 0xd393c871.
-//
-// Solidity: function register(string name, address addr, uint256 activation) returns()
-func (_IRegistry *IRegistryTransactorSession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
-	return _IRegistry.Contract.Register(&_IRegistry.TransactOpts, name, addr, activation)
-}
-
-// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
-//
-// Solidity: function transferOwnership(address newOwner) returns()
-func (_IRegistry *IRegistryTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
-	return _IRegistry.contract.Transact(opts, "transferOwnership", newOwner)
-}
-
-// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
-//
-// Solidity: function transferOwnership(address newOwner) returns()
-func (_IRegistry *IRegistrySession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _IRegistry.Contract.TransferOwnership(&_IRegistry.TransactOpts, newOwner)
-}
-
-// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
-//
-// Solidity: function transferOwnership(address newOwner) returns()
-func (_IRegistry *IRegistryTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _IRegistry.Contract.TransferOwnership(&_IRegistry.TransactOpts, newOwner)
-}
-
-// IRegistryOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the IRegistry contract.
-type IRegistryOwnershipTransferredIterator struct {
-	Event *IRegistryOwnershipTransferred // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log      // Log channel receiving the found contract events
-	sub  klaytn.Subscription // Subscription for errors, completion and termination
-	done bool                // Whether the subscription completed delivering logs
-	fail error               // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *IRegistryOwnershipTransferredIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(IRegistryOwnershipTransferred)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(IRegistryOwnershipTransferred)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *IRegistryOwnershipTransferredIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *IRegistryOwnershipTransferredIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// IRegistryOwnershipTransferred represents a OwnershipTransferred event raised by the IRegistry contract.
-type IRegistryOwnershipTransferred struct {
-	PreviousOwner common.Address
-	NewOwner      common.Address
-	Raw           types.Log // Blockchain specific contextual infos
-}
-
-// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
-//
-// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_IRegistry *IRegistryFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*IRegistryOwnershipTransferredIterator, error) {
-	var previousOwnerRule []interface{}
-	for _, previousOwnerItem := range previousOwner {
-		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
-	}
-	var newOwnerRule []interface{}
-	for _, newOwnerItem := range newOwner {
-		newOwnerRule = append(newOwnerRule, newOwnerItem)
-	}
-
-	logs, sub, err := _IRegistry.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
-	if err != nil {
-		return nil, err
-	}
-	return &IRegistryOwnershipTransferredIterator{contract: _IRegistry.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
-}
-
-// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
-//
-// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_IRegistry *IRegistryFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *IRegistryOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
-	var previousOwnerRule []interface{}
-	for _, previousOwnerItem := range previousOwner {
-		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
-	}
-	var newOwnerRule []interface{}
-	for _, newOwnerItem := range newOwner {
-		newOwnerRule = append(newOwnerRule, newOwnerItem)
-	}
-
-	logs, sub, err := _IRegistry.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(IRegistryOwnershipTransferred)
-				if err := _IRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
-//
-// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_IRegistry *IRegistryFilterer) ParseOwnershipTransferred(log types.Log) (*IRegistryOwnershipTransferred, error) {
-	event := new(IRegistryOwnershipTransferred)
-	if err := _IRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
-		return nil, err
-	}
-	return event, nil
-}
-
-// IRegistryRegisteredIterator is returned from FilterRegistered and is used to iterate over the raw logs and unpacked data for Registered events raised by the IRegistry contract.
-type IRegistryRegisteredIterator struct {
-	Event *IRegistryRegistered // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log      // Log channel receiving the found contract events
-	sub  klaytn.Subscription // Subscription for errors, completion and termination
-	done bool                // Whether the subscription completed delivering logs
-	fail error               // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *IRegistryRegisteredIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(IRegistryRegistered)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(IRegistryRegistered)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *IRegistryRegisteredIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *IRegistryRegisteredIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// IRegistryRegistered represents a Registered event raised by the IRegistry contract.
-type IRegistryRegistered struct {
-	Name       string
-	Addr       common.Address
-	Activation *big.Int
-	Raw        types.Log // Blockchain specific contextual infos
-}
-
-// FilterRegistered is a free log retrieval operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
-//
-// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
-func (_IRegistry *IRegistryFilterer) FilterRegistered(opts *bind.FilterOpts, addr []common.Address, activation []*big.Int) (*IRegistryRegisteredIterator, error) {
-	var addrRule []interface{}
-	for _, addrItem := range addr {
-		addrRule = append(addrRule, addrItem)
-	}
-	var activationRule []interface{}
-	for _, activationItem := range activation {
-		activationRule = append(activationRule, activationItem)
-	}
-
-	logs, sub, err := _IRegistry.contract.FilterLogs(opts, "Registered", addrRule, activationRule)
-	if err != nil {
-		return nil, err
-	}
-	return &IRegistryRegisteredIterator{contract: _IRegistry.contract, event: "Registered", logs: logs, sub: sub}, nil
-}
-
-// WatchRegistered is a free log subscription operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
-//
-// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
-func (_IRegistry *IRegistryFilterer) WatchRegistered(opts *bind.WatchOpts, sink chan<- *IRegistryRegistered, addr []common.Address, activation []*big.Int) (event.Subscription, error) {
-	var addrRule []interface{}
-	for _, addrItem := range addr {
-		addrRule = append(addrRule, addrItem)
-	}
-	var activationRule []interface{}
-	for _, activationItem := range activation {
-		activationRule = append(activationRule, activationItem)
-	}
-
-	logs, sub, err := _IRegistry.contract.WatchLogs(opts, "Registered", addrRule, activationRule)
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(IRegistryRegistered)
-				if err := _IRegistry.contract.UnpackLog(event, "Registered", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseRegistered is a log parse operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
-//
-// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
-func (_IRegistry *IRegistryFilterer) ParseRegistered(log types.Log) (*IRegistryRegistered, error) {
-	event := new(IRegistryRegistered)
-	if err := _IRegistry.contract.UnpackLog(event, "Registered", log); err != nil {
-		return nil, err
-	}
-	return event, nil
-}
-
-// RegistryMetaData contains all meta data concerning the Registry contract.
-var RegistryMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"Registered\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAllNames\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getAllRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"internalType\":\"structIRegistry.Record[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
-	Sigs: map[string]string{
-		"e2693e3f": "getActiveAddr(string)",
-		"fb825e5f": "getAllNames()",
-		"78d573a2": "getAllRecords(string)",
-		"4622ab03": "names(uint256)",
-		"8da5cb5b": "owner()",
-		"3b51650d": "records(string,uint256)",
-		"d393c871": "register(string,address,uint256)",
-		"f2fde38b": "transferOwnership(address)",
-	},
-	Bin: "0x608060405234801561001057600080fd5b50610db9806100206000396000f3fe608060405234801561001057600080fd5b50600436106100885760003560e01c8063d393c8711161005b578063d393c87114610129578063e2693e3f1461013e578063f2fde38b14610151578063fb825e5f1461016457600080fd5b80633b51650d1461008d5780634622ab03146100c457806378d573a2146100e45780638da5cb5b14610104575b600080fd5b6100a061009b366004610975565b610179565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100d76100d23660046109ba565b6101ce565b6040516100bb9190610a23565b6100f76100f2366004610a3d565b61027a565b6040516100bb9190610a7a565b6002546001600160a01b03165b6040516001600160a01b0390911681526020016100bb565b61013c610137366004610aee565b61030d565b005b61011161014c366004610a3d565b61062b565b61013c61015f366004610b45565b610722565b61016c6107f9565b6040516100bb9190610b60565b815160208184018101805160008252928201918501919091209190528054829081106101a457600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600181815481106101de57600080fd5b9060005260206000200160009150905080546101f990610bc2565b80601f016020809104026020016040519081016040528092919081815260200182805461022590610bc2565b80156102725780601f1061024757610100808354040283529160200191610272565b820191906000526020600020905b81548152906001019060200180831161025557829003601f168201915b505050505081565b606060008260405161028c9190610bfc565b9081526020016040518091039020805480602002602001604051908101604052809291908181526020016000905b82821015610302576000848152602090819020604080518082019091526002850290910180546001600160a01b031682526001908101548284015290835290920191016102ba565b505050509050919050565b6002546001600160a01b031633146103585760405162461bcd60e51b81526020600482015260096024820152682737ba1037bbb732b960b91b60448201526064015b60405180910390fd5b8260008160405160200161036c9190610bfc565b604051602081830303815290604052905080516000036103bd5760405162461bcd60e51b815260206004820152600c60248201526b456d70747920737472696e6760a01b604482015260640161034f565b4383116104165760405162461bcd60e51b815260206004820152602160248201527f43616e277420726567697374657220636f6e74726163742066726f6d207061736044820152601d60fa1b606482015260840161034f565b600080866040516104279190610bfc565b90815260405190819003602001902054905060008190036104f3576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60161047d8782610c67565b5060008660405161048e9190610bfc565b90815260408051602092819003830181208183019092526001600160a01b0388811682528382018881528354600180820186556000958652959094209251600290940290920180546001600160a01b03191693909116929092178255519101556105e1565b600080876040516105049190610bfc565b90815260405190819003602001902061051e600184610d3d565b8154811061052e5761052e610d56565b90600052602060002090600202019050438160010154116105be576000876040516105599190610bfc565b90815260408051602092819003830181208183019092526001600160a01b0389811682528382018981528354600180820186556000958652959094209251600290940290920180546001600160a01b03191693909116929092178255519101556105df565b80546001600160a01b0319166001600160a01b038716178155600181018590555b505b83856001600160a01b03167f142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f308860405161061b9190610a23565b60405180910390a3505050505050565b60008060008360405161063e9190610bfc565b908152604051908190036020019020549050805b801561071857436000856040516106699190610bfc565b908152604051908190036020019020610683600184610d3d565b8154811061069357610693610d56565b90600052602060002090600202016001015411610706576000846040516106ba9190610bfc565b9081526040519081900360200190206106d4600183610d3d565b815481106106e4576106e4610d56565b60009182526020909120600290910201546001600160a01b0316949350505050565b8061071081610d6c565b915050610652565b5060009392505050565b6002546001600160a01b031633146107685760405162461bcd60e51b81526020600482015260096024820152682737ba1037bbb732b960b91b604482015260640161034f565b6001600160a01b0381166107ad5760405162461bcd60e51b815260206004820152600c60248201526b5a65726f206164647265737360a01b604482015260640161034f565b600280546001600160a01b0319166001600160a01b03831690811790915560405133907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a350565b60606001805480602002602001604051908101604052809291908181526020016000905b828210156108c957838290600052602060002001805461083c90610bc2565b80601f016020809104026020016040519081016040528092919081815260200182805461086890610bc2565b80156108b55780601f1061088a576101008083540402835291602001916108b5565b820191906000526020600020905b81548152906001019060200180831161089857829003601f168201915b50505050508152602001906001019061081d565b50505050905090565b634e487b7160e01b600052604160045260246000fd5b600082601f8301126108f957600080fd5b813567ffffffffffffffff80821115610914576109146108d2565b604051601f8301601f19908116603f0116810190828211818310171561093c5761093c6108d2565b8160405283815286602085880101111561095557600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561098857600080fd5b823567ffffffffffffffff81111561099f57600080fd5b6109ab858286016108e8565b95602094909401359450505050565b6000602082840312156109cc57600080fd5b5035919050565b60005b838110156109ee5781810151838201526020016109d6565b50506000910152565b60008151808452610a0f8160208601602086016109d3565b601f01601f19169290920160200192915050565b602081526000610a3660208301846109f7565b9392505050565b600060208284031215610a4f57600080fd5b813567ffffffffffffffff811115610a6657600080fd5b610a72848285016108e8565b949350505050565b602080825282518282018190526000919060409081850190868401855b82811015610ac557815180516001600160a01b03168552860151868501529284019290850190600101610a97565b5091979650505050505050565b80356001600160a01b0381168114610ae957600080fd5b919050565b600080600060608486031215610b0357600080fd5b833567ffffffffffffffff811115610b1a57600080fd5b610b26868287016108e8565b935050610b3560208501610ad2565b9150604084013590509250925092565b600060208284031215610b5757600080fd5b610a3682610ad2565b6000602080830181845280855180835260408601915060408160051b870101925083870160005b82811015610bb557603f19888603018452610ba38583516109f7565b94509285019290850190600101610b87565b5092979650505050505050565b600181811c90821680610bd657607f821691505b602082108103610bf657634e487b7160e01b600052602260045260246000fd5b50919050565b60008251610c0e8184602087016109d3565b9190910192915050565b601f821115610c6257600081815260208120601f850160051c81016020861015610c3f5750805b601f850160051c820191505b81811015610c5e57828155600101610c4b565b5050505b505050565b815167ffffffffffffffff811115610c8157610c816108d2565b610c9581610c8f8454610bc2565b84610c18565b602080601f831160018114610cca5760008415610cb25750858301515b600019600386901b1c1916600185901b178555610c5e565b600085815260208120601f198616915b82811015610cf957888601518255948401946001909101908401610cda565b5085821015610d175787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b634e487b7160e01b600052601160045260246000fd5b81810381811115610d5057610d50610d27565b92915050565b634e487b7160e01b600052603260045260246000fd5b600081610d7b57610d7b610d27565b50600019019056fea264697066735822122068eb5c8d79fe7f203ec0bb15418269092388e1e7ea724560c1d280a8c5c6c45e64736f6c63430008130033",
-}
-
-// RegistryABI is the input ABI used to generate the binding from.
-// Deprecated: Use RegistryMetaData.ABI instead.
-var RegistryABI = RegistryMetaData.ABI
-
-// RegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
-const RegistryBinRuntime = `608060405234801561001057600080fd5b50600436106100885760003560e01c8063d393c8711161005b578063d393c87114610129578063e2693e3f1461013e578063f2fde38b14610151578063fb825e5f1461016457600080fd5b80633b51650d1461008d5780634622ab03146100c457806378d573a2146100e45780638da5cb5b14610104575b600080fd5b6100a061009b366004610975565b610179565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100d76100d23660046109ba565b6101ce565b6040516100bb9190610a23565b6100f76100f2366004610a3d565b61027a565b6040516100bb9190610a7a565b6002546001600160a01b03165b6040516001600160a01b0390911681526020016100bb565b61013c610137366004610aee565b61030d565b005b61011161014c366004610a3d565b61062b565b61013c61015f366004610b45565b610722565b61016c6107f9565b6040516100bb9190610b60565b815160208184018101805160008252928201918501919091209190528054829081106101a457600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600181815481106101de57600080fd5b9060005260206000200160009150905080546101f990610bc2565b80601f016020809104026020016040519081016040528092919081815260200182805461022590610bc2565b80156102725780601f1061024757610100808354040283529160200191610272565b820191906000526020600020905b81548152906001019060200180831161025557829003601f168201915b505050505081565b606060008260405161028c9190610bfc565b9081526020016040518091039020805480602002602001604051908101604052809291908181526020016000905b82821015610302576000848152602090819020604080518082019091526002850290910180546001600160a01b031682526001908101548284015290835290920191016102ba565b505050509050919050565b6002546001600160a01b031633146103585760405162461bcd60e51b81526020600482015260096024820152682737ba1037bbb732b960b91b60448201526064015b60405180910390fd5b8260008160405160200161036c9190610bfc565b604051602081830303815290604052905080516000036103bd5760405162461bcd60e51b815260206004820152600c60248201526b456d70747920737472696e6760a01b604482015260640161034f565b4383116104165760405162461bcd60e51b815260206004820152602160248201527f43616e277420726567697374657220636f6e74726163742066726f6d207061736044820152601d60fa1b606482015260840161034f565b600080866040516104279190610bfc565b90815260405190819003602001902054905060008190036104f3576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60161047d8782610c67565b5060008660405161048e9190610bfc565b90815260408051602092819003830181208183019092526001600160a01b0388811682528382018881528354600180820186556000958652959094209251600290940290920180546001600160a01b03191693909116929092178255519101556105e1565b600080876040516105049190610bfc565b90815260405190819003602001902061051e600184610d3d565b8154811061052e5761052e610d56565b90600052602060002090600202019050438160010154116105be576000876040516105599190610bfc565b90815260408051602092819003830181208183019092526001600160a01b0389811682528382018981528354600180820186556000958652959094209251600290940290920180546001600160a01b03191693909116929092178255519101556105df565b80546001600160a01b0319166001600160a01b038716178155600181018590555b505b83856001600160a01b03167f142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f308860405161061b9190610a23565b60405180910390a3505050505050565b60008060008360405161063e9190610bfc565b908152604051908190036020019020549050805b801561071857436000856040516106699190610bfc565b908152604051908190036020019020610683600184610d3d565b8154811061069357610693610d56565b90600052602060002090600202016001015411610706576000846040516106ba9190610bfc565b9081526040519081900360200190206106d4600183610d3d565b815481106106e4576106e4610d56565b60009182526020909120600290910201546001600160a01b0316949350505050565b8061071081610d6c565b915050610652565b5060009392505050565b6002546001600160a01b031633146107685760405162461bcd60e51b81526020600482015260096024820152682737ba1037bbb732b960b91b604482015260640161034f565b6001600160a01b0381166107ad5760405162461bcd60e51b815260206004820152600c60248201526b5a65726f206164647265737360a01b604482015260640161034f565b600280546001600160a01b0319166001600160a01b03831690811790915560405133907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a350565b60606001805480602002602001604051908101604052809291908181526020016000905b828210156108c957838290600052602060002001805461083c90610bc2565b80601f016020809104026020016040519081016040528092919081815260200182805461086890610bc2565b80156108b55780601f1061088a576101008083540402835291602001916108b5565b820191906000526020600020905b81548152906001019060200180831161089857829003601f168201915b50505050508152602001906001019061081d565b50505050905090565b634e487b7160e01b600052604160045260246000fd5b600082601f8301126108f957600080fd5b813567ffffffffffffffff80821115610914576109146108d2565b604051601f8301601f19908116603f0116810190828211818310171561093c5761093c6108d2565b8160405283815286602085880101111561095557600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561098857600080fd5b823567ffffffffffffffff81111561099f57600080fd5b6109ab858286016108e8565b95602094909401359450505050565b6000602082840312156109cc57600080fd5b5035919050565b60005b838110156109ee5781810151838201526020016109d6565b50506000910152565b60008151808452610a0f8160208601602086016109d3565b601f01601f19169290920160200192915050565b602081526000610a3660208301846109f7565b9392505050565b600060208284031215610a4f57600080fd5b813567ffffffffffffffff811115610a6657600080fd5b610a72848285016108e8565b949350505050565b602080825282518282018190526000919060409081850190868401855b82811015610ac557815180516001600160a01b03168552860151868501529284019290850190600101610a97565b5091979650505050505050565b80356001600160a01b0381168114610ae957600080fd5b919050565b600080600060608486031215610b0357600080fd5b833567ffffffffffffffff811115610b1a57600080fd5b610b26868287016108e8565b935050610b3560208501610ad2565b9150604084013590509250925092565b600060208284031215610b5757600080fd5b610a3682610ad2565b6000602080830181845280855180835260408601915060408160051b870101925083870160005b82811015610bb557603f19888603018452610ba38583516109f7565b94509285019290850190600101610b87565b5092979650505050505050565b600181811c90821680610bd657607f821691505b602082108103610bf657634e487b7160e01b600052602260045260246000fd5b50919050565b60008251610c0e8184602087016109d3565b9190910192915050565b601f821115610c6257600081815260208120601f850160051c81016020861015610c3f5750805b601f850160051c820191505b81811015610c5e57828155600101610c4b565b5050505b505050565b815167ffffffffffffffff811115610c8157610c816108d2565b610c9581610c8f8454610bc2565b84610c18565b602080601f831160018114610cca5760008415610cb25750858301515b600019600386901b1c1916600185901b178555610c5e565b600085815260208120601f198616915b82811015610cf957888601518255948401946001909101908401610cda565b5085821015610d175787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b634e487b7160e01b600052601160045260246000fd5b81810381811115610d5057610d50610d27565b92915050565b634e487b7160e01b600052603260045260246000fd5b600081610d7b57610d7b610d27565b50600019019056fea264697066735822122068eb5c8d79fe7f203ec0bb15418269092388e1e7ea724560c1d280a8c5c6c45e64736f6c63430008130033`
-
-// RegistryFuncSigs maps the 4-byte function signature to its string representation.
-// Deprecated: Use RegistryMetaData.Sigs instead.
-var RegistryFuncSigs = RegistryMetaData.Sigs
-
-// RegistryBin is the compiled bytecode used for deploying new contracts.
-// Deprecated: Use RegistryMetaData.Bin instead.
-var RegistryBin = RegistryMetaData.Bin
-
-// DeployRegistry deploys a new Klaytn contract, binding an instance of Registry to it.
-func DeployRegistry(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Registry, error) {
-	parsed, err := RegistryMetaData.GetAbi()
+// DeployKIP113Mock deploys a new Klaytn contract, binding an instance of KIP113Mock to it.
+func DeployKIP113Mock(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *KIP113Mock, error) {
+	parsed, err := abi.JSON(strings.NewReader(KIP113MockABI))
 	if err != nil {
 		return common.Address{}, nil, nil, err
 	}
-	if parsed == nil {
-		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(KIP113MockBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &KIP113Mock{KIP113MockCaller: KIP113MockCaller{contract: contract}, KIP113MockTransactor: KIP113MockTransactor{contract: contract}, KIP113MockFilterer: KIP113MockFilterer{contract: contract}}, nil
+}
+
+// KIP113Mock is an auto generated Go binding around a Klaytn contract.
+type KIP113Mock struct {
+	KIP113MockCaller     // Read-only binding to the contract
+	KIP113MockTransactor // Write-only binding to the contract
+	KIP113MockFilterer   // Log filterer for contract events
+}
+
+// KIP113MockCaller is an auto generated read-only Go binding around a Klaytn contract.
+type KIP113MockCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// KIP113MockTransactor is an auto generated write-only Go binding around a Klaytn contract.
+type KIP113MockTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// KIP113MockFilterer is an auto generated log filtering Go binding around a Klaytn contract events.
+type KIP113MockFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// KIP113MockSession is an auto generated Go binding around a Klaytn contract,
+// with pre-set call and transact options.
+type KIP113MockSession struct {
+	Contract     *KIP113Mock       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// KIP113MockCallerSession is an auto generated read-only Go binding around a Klaytn contract,
+// with pre-set call options.
+type KIP113MockCallerSession struct {
+	Contract *KIP113MockCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// KIP113MockTransactorSession is an auto generated write-only Go binding around a Klaytn contract,
+// with pre-set transact options.
+type KIP113MockTransactorSession struct {
+	Contract     *KIP113MockTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// KIP113MockRaw is an auto generated low-level Go binding around a Klaytn contract.
+type KIP113MockRaw struct {
+	Contract *KIP113Mock // Generic contract binding to access the raw methods on
+}
+
+// KIP113MockCallerRaw is an auto generated low-level read-only Go binding around a Klaytn contract.
+type KIP113MockCallerRaw struct {
+	Contract *KIP113MockCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// KIP113MockTransactorRaw is an auto generated low-level write-only Go binding around a Klaytn contract.
+type KIP113MockTransactorRaw struct {
+	Contract *KIP113MockTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewKIP113Mock creates a new instance of KIP113Mock, bound to a specific deployed contract.
+func NewKIP113Mock(address common.Address, backend bind.ContractBackend) (*KIP113Mock, error) {
+	contract, err := bindKIP113Mock(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &KIP113Mock{KIP113MockCaller: KIP113MockCaller{contract: contract}, KIP113MockTransactor: KIP113MockTransactor{contract: contract}, KIP113MockFilterer: KIP113MockFilterer{contract: contract}}, nil
+}
+
+// NewKIP113MockCaller creates a new read-only instance of KIP113Mock, bound to a specific deployed contract.
+func NewKIP113MockCaller(address common.Address, caller bind.ContractCaller) (*KIP113MockCaller, error) {
+	contract, err := bindKIP113Mock(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &KIP113MockCaller{contract: contract}, nil
+}
+
+// NewKIP113MockTransactor creates a new write-only instance of KIP113Mock, bound to a specific deployed contract.
+func NewKIP113MockTransactor(address common.Address, transactor bind.ContractTransactor) (*KIP113MockTransactor, error) {
+	contract, err := bindKIP113Mock(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &KIP113MockTransactor{contract: contract}, nil
+}
+
+// NewKIP113MockFilterer creates a new log filterer instance of KIP113Mock, bound to a specific deployed contract.
+func NewKIP113MockFilterer(address common.Address, filterer bind.ContractFilterer) (*KIP113MockFilterer, error) {
+	contract, err := bindKIP113Mock(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &KIP113MockFilterer{contract: contract}, nil
+}
+
+// bindKIP113Mock binds a generic wrapper to an already deployed contract.
+func bindKIP113Mock(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(KIP113MockABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_KIP113Mock *KIP113MockRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _KIP113Mock.Contract.KIP113MockCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_KIP113Mock *KIP113MockRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _KIP113Mock.Contract.KIP113MockTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_KIP113Mock *KIP113MockRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _KIP113Mock.Contract.KIP113MockTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_KIP113Mock *KIP113MockCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _KIP113Mock.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_KIP113Mock *KIP113MockTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _KIP113Mock.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_KIP113Mock *KIP113MockTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _KIP113Mock.Contract.contract.Transact(opts, method, params...)
+}
+
+// AllNodeIds is a free data retrieval call binding the contract method 0xa5834971.
+//
+// Solidity: function allNodeIds(uint256 ) view returns(address)
+func (_KIP113Mock *KIP113MockCaller) AllNodeIds(opts *bind.CallOpts, arg0 *big.Int) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _KIP113Mock.contract.Call(opts, out, "allNodeIds", arg0)
+	return *ret0, err
+}
+
+// AllNodeIds is a free data retrieval call binding the contract method 0xa5834971.
+//
+// Solidity: function allNodeIds(uint256 ) view returns(address)
+func (_KIP113Mock *KIP113MockSession) AllNodeIds(arg0 *big.Int) (common.Address, error) {
+	return _KIP113Mock.Contract.AllNodeIds(&_KIP113Mock.CallOpts, arg0)
+}
+
+// AllNodeIds is a free data retrieval call binding the contract method 0xa5834971.
+//
+// Solidity: function allNodeIds(uint256 ) view returns(address)
+func (_KIP113Mock *KIP113MockCallerSession) AllNodeIds(arg0 *big.Int) (common.Address, error) {
+	return _KIP113Mock.Contract.AllNodeIds(&_KIP113Mock.CallOpts, arg0)
+}
+
+// GetAllBlsInfo is a free data retrieval call binding the contract method 0x6968b53f.
+//
+// Solidity: function getAllBlsInfo() view returns(address[] nodeIdList, (bytes,bytes)[] pubkeyList)
+func (_KIP113Mock *KIP113MockCaller) GetAllBlsInfo(opts *bind.CallOpts) (struct {
+	NodeIdList []common.Address
+	PubkeyList []IKIP113BlsPublicKeyInfo
+}, error) {
+	ret := new(struct {
+		NodeIdList []common.Address
+		PubkeyList []IKIP113BlsPublicKeyInfo
+	})
+	out := ret
+	err := _KIP113Mock.contract.Call(opts, out, "getAllBlsInfo")
+	return *ret, err
+}
+
+// GetAllBlsInfo is a free data retrieval call binding the contract method 0x6968b53f.
+//
+// Solidity: function getAllBlsInfo() view returns(address[] nodeIdList, (bytes,bytes)[] pubkeyList)
+func (_KIP113Mock *KIP113MockSession) GetAllBlsInfo() (struct {
+	NodeIdList []common.Address
+	PubkeyList []IKIP113BlsPublicKeyInfo
+}, error) {
+	return _KIP113Mock.Contract.GetAllBlsInfo(&_KIP113Mock.CallOpts)
+}
+
+// GetAllBlsInfo is a free data retrieval call binding the contract method 0x6968b53f.
+//
+// Solidity: function getAllBlsInfo() view returns(address[] nodeIdList, (bytes,bytes)[] pubkeyList)
+func (_KIP113Mock *KIP113MockCallerSession) GetAllBlsInfo() (struct {
+	NodeIdList []common.Address
+	PubkeyList []IKIP113BlsPublicKeyInfo
+}, error) {
+	return _KIP113Mock.Contract.GetAllBlsInfo(&_KIP113Mock.CallOpts)
+}
+
+// Record is a free data retrieval call binding the contract method 0x3465d6d5.
+//
+// Solidity: function record(address ) view returns(bytes publicKey, bytes pop)
+func (_KIP113Mock *KIP113MockCaller) Record(opts *bind.CallOpts, arg0 common.Address) (struct {
+	PublicKey []byte
+	Pop       []byte
+}, error) {
+	ret := new(struct {
+		PublicKey []byte
+		Pop       []byte
+	})
+	out := ret
+	err := _KIP113Mock.contract.Call(opts, out, "record", arg0)
+	return *ret, err
+}
+
+// Record is a free data retrieval call binding the contract method 0x3465d6d5.
+//
+// Solidity: function record(address ) view returns(bytes publicKey, bytes pop)
+func (_KIP113Mock *KIP113MockSession) Record(arg0 common.Address) (struct {
+	PublicKey []byte
+	Pop       []byte
+}, error) {
+	return _KIP113Mock.Contract.Record(&_KIP113Mock.CallOpts, arg0)
+}
+
+// Record is a free data retrieval call binding the contract method 0x3465d6d5.
+//
+// Solidity: function record(address ) view returns(bytes publicKey, bytes pop)
+func (_KIP113Mock *KIP113MockCallerSession) Record(arg0 common.Address) (struct {
+	PublicKey []byte
+	Pop       []byte
+}, error) {
+	return _KIP113Mock.Contract.Record(&_KIP113Mock.CallOpts, arg0)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x786cd4d7.
+//
+// Solidity: function register(address addr, bytes publicKey, bytes pop) returns()
+func (_KIP113Mock *KIP113MockTransactor) Register(opts *bind.TransactOpts, addr common.Address, publicKey []byte, pop []byte) (*types.Transaction, error) {
+	return _KIP113Mock.contract.Transact(opts, "register", addr, publicKey, pop)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x786cd4d7.
+//
+// Solidity: function register(address addr, bytes publicKey, bytes pop) returns()
+func (_KIP113Mock *KIP113MockSession) Register(addr common.Address, publicKey []byte, pop []byte) (*types.Transaction, error) {
+	return _KIP113Mock.Contract.Register(&_KIP113Mock.TransactOpts, addr, publicKey, pop)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x786cd4d7.
+//
+// Solidity: function register(address addr, bytes publicKey, bytes pop) returns()
+func (_KIP113Mock *KIP113MockTransactorSession) Register(addr common.Address, publicKey []byte, pop []byte) (*types.Transaction, error) {
+	return _KIP113Mock.Contract.Register(&_KIP113Mock.TransactOpts, addr, publicKey, pop)
+}
+
+// RegistryABI is the input ABI used to generate the binding from.
+const RegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
+
+// RegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
+const RegistryBinRuntime = `608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d146100465780634622ab031461007d578063e2693e3f1461009d575b600080fd5b6100596100543660046102ad565b6100c8565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102f2565b61011d565b604051610074919061030b565b6100b06100ab366004610359565b6101c9565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100f357600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061012d57600080fd5b90600052602060002001600091509050805461014890610396565b80601f016020809104026020016040519081016040528092919081815260200182805461017490610396565b80156101c15780601f10610196576101008083540402835291602001916101c1565b820191906000526020600020905b8154815290600101906020018083116101a457829003601f168201915b505050505081565b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023157600080fd5b813567ffffffffffffffff8082111561024c5761024c61020a565b604051601f8301601f19908116603f011681019082821181831017156102745761027461020a565b8160405283815286602085880101111561028d57600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c057600080fd5b823567ffffffffffffffff8111156102d757600080fd5b6102e385828601610220565b95602094909401359450505050565b60006020828403121561030457600080fd5b5035919050565b600060208083528351808285015260005b818110156103385785810183015185820160400152820161031c565b506000604082860101526040601f19601f8301168501019250505092915050565b60006020828403121561036b57600080fd5b813567ffffffffffffffff81111561038257600080fd5b61038e84828501610220565b949350505050565b600181811c908216806103aa57607f821691505b6020821081036103ca57634e487b7160e01b600052602260045260246000fd5b5091905056fea264697066735822122081d8382cad173f430e0005a96faaba1ff204fe72b466874499e03026c424a33964736f6c63430008110033`
+
+// RegistryFuncSigs maps the 4-byte function signature to its string representation.
+var RegistryFuncSigs = map[string]string{
+	"e2693e3f": "getActiveAddr(string)",
+	"4622ab03": "names(uint256)",
+	"3b51650d": "records(string,uint256)",
+}
+
+// RegistryBin is the compiled bytecode used for deploying new contracts.
+var RegistryBin = "0x608060405234801561001057600080fd5b50610406806100206000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d146100465780634622ab031461007d578063e2693e3f1461009d575b600080fd5b6100596100543660046102ad565b6100c8565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102f2565b61011d565b604051610074919061030b565b6100b06100ab366004610359565b6101c9565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100f357600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061012d57600080fd5b90600052602060002001600091509050805461014890610396565b80601f016020809104026020016040519081016040528092919081815260200182805461017490610396565b80156101c15780601f10610196576101008083540402835291602001916101c1565b820191906000526020600020905b8154815290600101906020018083116101a457829003601f168201915b505050505081565b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023157600080fd5b813567ffffffffffffffff8082111561024c5761024c61020a565b604051601f8301601f19908116603f011681019082821181831017156102745761027461020a565b8160405283815286602085880101111561028d57600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c057600080fd5b823567ffffffffffffffff8111156102d757600080fd5b6102e385828601610220565b95602094909401359450505050565b60006020828403121561030457600080fd5b5035919050565b600060208083528351808285015260005b818110156103385785810183015185820160400152820161031c565b506000604082860101526040601f19601f8301168501019250505092915050565b60006020828403121561036b57600080fd5b813567ffffffffffffffff81111561038257600080fd5b61038e84828501610220565b949350505050565b600181811c908216806103aa57607f821691505b6020821081036103ca57634e487b7160e01b600052602260045260246000fd5b5091905056fea264697066735822122081d8382cad173f430e0005a96faaba1ff204fe72b466874499e03026c424a33964736f6c63430008110033"
+
+// DeployRegistry deploys a new Klaytn contract, binding an instance of Registry to it.
+func DeployRegistry(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Registry, error) {
+	parsed, err := abi.JSON(strings.NewReader(RegistryABI))
+	if err != nil {
+		return common.Address{}, nil, nil, err
 	}
 
-	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(RegistryBin), backend)
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(RegistryBin), backend)
 	if err != nil {
 		return common.Address{}, nil, nil, err
 	}
@@ -845,11 +883,11 @@ func NewRegistryFilterer(address common.Address, filterer bind.ContractFilterer)
 
 // bindRegistry binds a generic wrapper to an already deployed contract.
 func bindRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := RegistryMetaData.GetAbi()
+	parsed, err := abi.JSON(strings.NewReader(RegistryABI))
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and
@@ -894,7 +932,9 @@ func (_Registry *RegistryTransactorRaw) Transact(opts *bind.TransactOpts, method
 //
 // Solidity: function getActiveAddr(string name) view returns(address)
 func (_Registry *RegistryCaller) GetActiveAddr(opts *bind.CallOpts, name string) (common.Address, error) {
-	ret0 := new(common.Address)
+	var (
+		ret0 = new(common.Address)
+	)
 	out := ret0
 	err := _Registry.contract.Call(opts, out, "getActiveAddr", name)
 	return *ret0, err
@@ -914,59 +954,13 @@ func (_Registry *RegistryCallerSession) GetActiveAddr(name string) (common.Addre
 	return _Registry.Contract.GetActiveAddr(&_Registry.CallOpts, name)
 }
 
-// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
-//
-// Solidity: function getAllNames() view returns(string[])
-func (_Registry *RegistryCaller) GetAllNames(opts *bind.CallOpts) ([]string, error) {
-	ret0 := new([]string)
-	out := ret0
-	err := _Registry.contract.Call(opts, out, "getAllNames")
-	return *ret0, err
-}
-
-// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
-//
-// Solidity: function getAllNames() view returns(string[])
-func (_Registry *RegistrySession) GetAllNames() ([]string, error) {
-	return _Registry.Contract.GetAllNames(&_Registry.CallOpts)
-}
-
-// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
-//
-// Solidity: function getAllNames() view returns(string[])
-func (_Registry *RegistryCallerSession) GetAllNames() ([]string, error) {
-	return _Registry.Contract.GetAllNames(&_Registry.CallOpts)
-}
-
-// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
-//
-// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
-func (_Registry *RegistryCaller) GetAllRecords(opts *bind.CallOpts, name string) ([]IRegistryRecord, error) {
-	ret0 := new([]IRegistryRecord)
-	out := ret0
-	err := _Registry.contract.Call(opts, out, "getAllRecords", name)
-	return *ret0, err
-}
-
-// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
-//
-// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
-func (_Registry *RegistrySession) GetAllRecords(name string) ([]IRegistryRecord, error) {
-	return _Registry.Contract.GetAllRecords(&_Registry.CallOpts, name)
-}
-
-// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
-//
-// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
-func (_Registry *RegistryCallerSession) GetAllRecords(name string) ([]IRegistryRecord, error) {
-	return _Registry.Contract.GetAllRecords(&_Registry.CallOpts, name)
-}
-
 // Names is a free data retrieval call binding the contract method 0x4622ab03.
 //
 // Solidity: function names(uint256 ) view returns(string)
 func (_Registry *RegistryCaller) Names(opts *bind.CallOpts, arg0 *big.Int) (string, error) {
-	ret0 := new(string)
+	var (
+		ret0 = new(string)
+	)
 	out := ret0
 	err := _Registry.contract.Call(opts, out, "names", arg0)
 	return *ret0, err
@@ -986,38 +980,13 @@ func (_Registry *RegistryCallerSession) Names(arg0 *big.Int) (string, error) {
 	return _Registry.Contract.Names(&_Registry.CallOpts, arg0)
 }
 
-// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
-//
-// Solidity: function owner() view returns(address)
-func (_Registry *RegistryCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
-	ret0 := new(common.Address)
-	out := ret0
-	err := _Registry.contract.Call(opts, out, "owner")
-	return *ret0, err
-}
-
-// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
-//
-// Solidity: function owner() view returns(address)
-func (_Registry *RegistrySession) Owner() (common.Address, error) {
-	return _Registry.Contract.Owner(&_Registry.CallOpts)
-}
-
-// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
-//
-// Solidity: function owner() view returns(address)
-func (_Registry *RegistryCallerSession) Owner() (common.Address, error) {
-	return _Registry.Contract.Owner(&_Registry.CallOpts)
-}
-
 // Records is a free data retrieval call binding the contract method 0x3b51650d.
 //
 // Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
 func (_Registry *RegistryCaller) Records(opts *bind.CallOpts, arg0 string, arg1 *big.Int) (struct {
 	Addr       common.Address
 	Activation *big.Int
-}, error,
-) {
+}, error) {
 	ret := new(struct {
 		Addr       common.Address
 		Activation *big.Int
@@ -1033,8 +1002,7 @@ func (_Registry *RegistryCaller) Records(opts *bind.CallOpts, arg0 string, arg1 
 func (_Registry *RegistrySession) Records(arg0 string, arg1 *big.Int) (struct {
 	Addr       common.Address
 	Activation *big.Int
-}, error,
-) {
+}, error) {
 	return _Registry.Contract.Records(&_Registry.CallOpts, arg0, arg1)
 }
 
@@ -1044,396 +1012,36 @@ func (_Registry *RegistrySession) Records(arg0 string, arg1 *big.Int) (struct {
 func (_Registry *RegistryCallerSession) Records(arg0 string, arg1 *big.Int) (struct {
 	Addr       common.Address
 	Activation *big.Int
-}, error,
-) {
+}, error) {
 	return _Registry.Contract.Records(&_Registry.CallOpts, arg0, arg1)
 }
 
-// Register is a paid mutator transaction binding the contract method 0xd393c871.
-//
-// Solidity: function register(string name, address addr, uint256 activation) returns()
-func (_Registry *RegistryTransactor) Register(opts *bind.TransactOpts, name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
-	return _Registry.contract.Transact(opts, "register", name, addr, activation)
-}
-
-// Register is a paid mutator transaction binding the contract method 0xd393c871.
-//
-// Solidity: function register(string name, address addr, uint256 activation) returns()
-func (_Registry *RegistrySession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
-	return _Registry.Contract.Register(&_Registry.TransactOpts, name, addr, activation)
-}
-
-// Register is a paid mutator transaction binding the contract method 0xd393c871.
-//
-// Solidity: function register(string name, address addr, uint256 activation) returns()
-func (_Registry *RegistryTransactorSession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
-	return _Registry.Contract.Register(&_Registry.TransactOpts, name, addr, activation)
-}
-
-// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
-//
-// Solidity: function transferOwnership(address newOwner) returns()
-func (_Registry *RegistryTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
-	return _Registry.contract.Transact(opts, "transferOwnership", newOwner)
-}
-
-// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
-//
-// Solidity: function transferOwnership(address newOwner) returns()
-func (_Registry *RegistrySession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _Registry.Contract.TransferOwnership(&_Registry.TransactOpts, newOwner)
-}
-
-// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
-//
-// Solidity: function transferOwnership(address newOwner) returns()
-func (_Registry *RegistryTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _Registry.Contract.TransferOwnership(&_Registry.TransactOpts, newOwner)
-}
-
-// RegistryOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Registry contract.
-type RegistryOwnershipTransferredIterator struct {
-	Event *RegistryOwnershipTransferred // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log      // Log channel receiving the found contract events
-	sub  klaytn.Subscription // Subscription for errors, completion and termination
-	done bool                // Whether the subscription completed delivering logs
-	fail error               // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *RegistryOwnershipTransferredIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(RegistryOwnershipTransferred)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(RegistryOwnershipTransferred)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *RegistryOwnershipTransferredIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *RegistryOwnershipTransferredIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// RegistryOwnershipTransferred represents a OwnershipTransferred event raised by the Registry contract.
-type RegistryOwnershipTransferred struct {
-	PreviousOwner common.Address
-	NewOwner      common.Address
-	Raw           types.Log // Blockchain specific contextual infos
-}
-
-// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
-//
-// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_Registry *RegistryFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*RegistryOwnershipTransferredIterator, error) {
-	var previousOwnerRule []interface{}
-	for _, previousOwnerItem := range previousOwner {
-		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
-	}
-	var newOwnerRule []interface{}
-	for _, newOwnerItem := range newOwner {
-		newOwnerRule = append(newOwnerRule, newOwnerItem)
-	}
-
-	logs, sub, err := _Registry.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
-	if err != nil {
-		return nil, err
-	}
-	return &RegistryOwnershipTransferredIterator{contract: _Registry.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
-}
-
-// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
-//
-// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_Registry *RegistryFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RegistryOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
-	var previousOwnerRule []interface{}
-	for _, previousOwnerItem := range previousOwner {
-		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
-	}
-	var newOwnerRule []interface{}
-	for _, newOwnerItem := range newOwner {
-		newOwnerRule = append(newOwnerRule, newOwnerItem)
-	}
-
-	logs, sub, err := _Registry.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(RegistryOwnershipTransferred)
-				if err := _Registry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
-//
-// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_Registry *RegistryFilterer) ParseOwnershipTransferred(log types.Log) (*RegistryOwnershipTransferred, error) {
-	event := new(RegistryOwnershipTransferred)
-	if err := _Registry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
-		return nil, err
-	}
-	return event, nil
-}
-
-// RegistryRegisteredIterator is returned from FilterRegistered and is used to iterate over the raw logs and unpacked data for Registered events raised by the Registry contract.
-type RegistryRegisteredIterator struct {
-	Event *RegistryRegistered // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log      // Log channel receiving the found contract events
-	sub  klaytn.Subscription // Subscription for errors, completion and termination
-	done bool                // Whether the subscription completed delivering logs
-	fail error               // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *RegistryRegisteredIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(RegistryRegistered)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(RegistryRegistered)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *RegistryRegisteredIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *RegistryRegisteredIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// RegistryRegistered represents a Registered event raised by the Registry contract.
-type RegistryRegistered struct {
-	Name       string
-	Addr       common.Address
-	Activation *big.Int
-	Raw        types.Log // Blockchain specific contextual infos
-}
-
-// FilterRegistered is a free log retrieval operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
-//
-// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
-func (_Registry *RegistryFilterer) FilterRegistered(opts *bind.FilterOpts, addr []common.Address, activation []*big.Int) (*RegistryRegisteredIterator, error) {
-	var addrRule []interface{}
-	for _, addrItem := range addr {
-		addrRule = append(addrRule, addrItem)
-	}
-	var activationRule []interface{}
-	for _, activationItem := range activation {
-		activationRule = append(activationRule, activationItem)
-	}
-
-	logs, sub, err := _Registry.contract.FilterLogs(opts, "Registered", addrRule, activationRule)
-	if err != nil {
-		return nil, err
-	}
-	return &RegistryRegisteredIterator{contract: _Registry.contract, event: "Registered", logs: logs, sub: sub}, nil
-}
-
-// WatchRegistered is a free log subscription operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
-//
-// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
-func (_Registry *RegistryFilterer) WatchRegistered(opts *bind.WatchOpts, sink chan<- *RegistryRegistered, addr []common.Address, activation []*big.Int) (event.Subscription, error) {
-	var addrRule []interface{}
-	for _, addrItem := range addr {
-		addrRule = append(addrRule, addrItem)
-	}
-	var activationRule []interface{}
-	for _, activationItem := range activation {
-		activationRule = append(activationRule, activationItem)
-	}
-
-	logs, sub, err := _Registry.contract.WatchLogs(opts, "Registered", addrRule, activationRule)
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(RegistryRegistered)
-				if err := _Registry.contract.UnpackLog(event, "Registered", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseRegistered is a log parse operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
-//
-// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
-func (_Registry *RegistryFilterer) ParseRegistered(log types.Log) (*RegistryRegistered, error) {
-	event := new(RegistryRegistered)
-	if err := _Registry.contract.UnpackLog(event, "Registered", log); err != nil {
-		return nil, err
-	}
-	return event, nil
-}
-
-// RegistryMockMetaData contains all meta data concerning the RegistryMock contract.
-var RegistryMockMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"Registered\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAllNames\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getAllRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"internalType\":\"structIRegistry.Record[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
-	Sigs: map[string]string{
-		"e2693e3f": "getActiveAddr(string)",
-		"fb825e5f": "getAllNames()",
-		"78d573a2": "getAllRecords(string)",
-		"4622ab03": "names(uint256)",
-		"8da5cb5b": "owner()",
-		"3b51650d": "records(string,uint256)",
-		"d393c871": "register(string,address,uint256)",
-		"f2fde38b": "transferOwnership(address)",
-	},
-	Bin: "0x608060405234801561001057600080fd5b50610a30806100206000396000f3fe608060405234801561001057600080fd5b50600436106100885760003560e01c8063d393c8711161005b578063d393c87114610129578063e2693e3f1461013e578063f2fde38b14610151578063fb825e5f1461018157600080fd5b80633b51650d1461008d5780634622ab03146100c457806378d573a2146100e45780638da5cb5b14610104575b600080fd5b6100a061009b366004610611565b610196565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100d76100d2366004610656565b6101eb565b6040516100bb91906106bf565b6100f76100f23660046106d9565b610297565b6040516100bb9190610716565b6002546001600160a01b03165b6040516001600160a01b0390911681526020016100bb565b61013c61013736600461078a565b61032a565b005b61011161014c3660046106d9565b6103fd565b61013c61015f3660046107e1565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b610189610495565b6040516100bb91906107fc565b815160208184018101805160008252928201918501919091209190528054829081106101c157600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600181815481106101fb57600080fd5b9060005260206000200160009150905080546102169061085e565b80601f01602080910402602001604051908101604052809291908181526020018280546102429061085e565b801561028f5780601f106102645761010080835404028352916020019161028f565b820191906000526020600020905b81548152906001019060200180831161027257829003601f168201915b505050505081565b60606000826040516102a99190610892565b9081526020016040518091039020805480602002602001604051908101604052809291908181526020016000905b8282101561031f576000848152602090819020604080518082019091526002850290910180546001600160a01b031682526001908101548284015290835290920191016102d7565b505050509050919050565b60008360405161033a9190610892565b9081526040519081900360200190205460000361038e576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60161038c84826108fd565b505b60008360405161039e9190610892565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b6000806000836040516104109190610892565b90815260405190819003602001902054905060008190036104345750600092915050565b6000836040516104449190610892565b90815260405190819003602001902061045e6001836109bd565b8154811061046e5761046e6109e4565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b60606001805480602002602001604051908101604052809291908181526020016000905b828210156105655783829060005260206000200180546104d89061085e565b80601f01602080910402602001604051908101604052809291908181526020018280546105049061085e565b80156105515780601f1061052657610100808354040283529160200191610551565b820191906000526020600020905b81548152906001019060200180831161053457829003601f168201915b5050505050815260200190600101906104b9565b50505050905090565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261059557600080fd5b813567ffffffffffffffff808211156105b0576105b061056e565b604051601f8301601f19908116603f011681019082821181831017156105d8576105d861056e565b816040528381528660208588010111156105f157600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561062457600080fd5b823567ffffffffffffffff81111561063b57600080fd5b61064785828601610584565b95602094909401359450505050565b60006020828403121561066857600080fd5b5035919050565b60005b8381101561068a578181015183820152602001610672565b50506000910152565b600081518084526106ab81602086016020860161066f565b601f01601f19169290920160200192915050565b6020815260006106d26020830184610693565b9392505050565b6000602082840312156106eb57600080fd5b813567ffffffffffffffff81111561070257600080fd5b61070e84828501610584565b949350505050565b602080825282518282018190526000919060409081850190868401855b8281101561076157815180516001600160a01b03168552860151868501529284019290850190600101610733565b5091979650505050505050565b80356001600160a01b038116811461078557600080fd5b919050565b60008060006060848603121561079f57600080fd5b833567ffffffffffffffff8111156107b657600080fd5b6107c286828701610584565b9350506107d16020850161076e565b9150604084013590509250925092565b6000602082840312156107f357600080fd5b6106d28261076e565b6000602080830181845280855180835260408601915060408160051b870101925083870160005b8281101561085157603f1988860301845261083f858351610693565b94509285019290850190600101610823565b5092979650505050505050565b600181811c9082168061087257607f821691505b60208210810361048f57634e487b7160e01b600052602260045260246000fd5b600082516108a481846020870161066f565b9190910192915050565b601f8211156108f857600081815260208120601f850160051c810160208610156108d55750805b601f850160051c820191505b818110156108f4578281556001016108e1565b5050505b505050565b815167ffffffffffffffff8111156109175761091761056e565b61092b81610925845461085e565b846108ae565b602080601f83116001811461096057600084156109485750858301515b600019600386901b1c1916600185901b1785556108f4565b600085815260208120601f198616915b8281101561098f57888601518255948401946001909101908401610970565b50858210156109ad5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b818103818111156109de57634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea2646970667358221220ed8f09a11ce51fc18cd7ad3cdc792cb949f6e2d1d09fa3ad637c4559c3e862a064736f6c63430008130033",
-}
-
 // RegistryMockABI is the input ABI used to generate the binding from.
-// Deprecated: Use RegistryMockMetaData.ABI instead.
-var RegistryMockABI = RegistryMockMetaData.ABI
+const RegistryMockABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
 
 // RegistryMockBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
-const RegistryMockBinRuntime = `608060405234801561001057600080fd5b50600436106100885760003560e01c8063d393c8711161005b578063d393c87114610129578063e2693e3f1461013e578063f2fde38b14610151578063fb825e5f1461018157600080fd5b80633b51650d1461008d5780634622ab03146100c457806378d573a2146100e45780638da5cb5b14610104575b600080fd5b6100a061009b366004610611565b610196565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100d76100d2366004610656565b6101eb565b6040516100bb91906106bf565b6100f76100f23660046106d9565b610297565b6040516100bb9190610716565b6002546001600160a01b03165b6040516001600160a01b0390911681526020016100bb565b61013c61013736600461078a565b61032a565b005b61011161014c3660046106d9565b6103fd565b61013c61015f3660046107e1565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b610189610495565b6040516100bb91906107fc565b815160208184018101805160008252928201918501919091209190528054829081106101c157600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600181815481106101fb57600080fd5b9060005260206000200160009150905080546102169061085e565b80601f01602080910402602001604051908101604052809291908181526020018280546102429061085e565b801561028f5780601f106102645761010080835404028352916020019161028f565b820191906000526020600020905b81548152906001019060200180831161027257829003601f168201915b505050505081565b60606000826040516102a99190610892565b9081526020016040518091039020805480602002602001604051908101604052809291908181526020016000905b8282101561031f576000848152602090819020604080518082019091526002850290910180546001600160a01b031682526001908101548284015290835290920191016102d7565b505050509050919050565b60008360405161033a9190610892565b9081526040519081900360200190205460000361038e576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60161038c84826108fd565b505b60008360405161039e9190610892565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b6000806000836040516104109190610892565b90815260405190819003602001902054905060008190036104345750600092915050565b6000836040516104449190610892565b90815260405190819003602001902061045e6001836109bd565b8154811061046e5761046e6109e4565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b60606001805480602002602001604051908101604052809291908181526020016000905b828210156105655783829060005260206000200180546104d89061085e565b80601f01602080910402602001604051908101604052809291908181526020018280546105049061085e565b80156105515780601f1061052657610100808354040283529160200191610551565b820191906000526020600020905b81548152906001019060200180831161053457829003601f168201915b5050505050815260200190600101906104b9565b50505050905090565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261059557600080fd5b813567ffffffffffffffff808211156105b0576105b061056e565b604051601f8301601f19908116603f011681019082821181831017156105d8576105d861056e565b816040528381528660208588010111156105f157600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561062457600080fd5b823567ffffffffffffffff81111561063b57600080fd5b61064785828601610584565b95602094909401359450505050565b60006020828403121561066857600080fd5b5035919050565b60005b8381101561068a578181015183820152602001610672565b50506000910152565b600081518084526106ab81602086016020860161066f565b601f01601f19169290920160200192915050565b6020815260006106d26020830184610693565b9392505050565b6000602082840312156106eb57600080fd5b813567ffffffffffffffff81111561070257600080fd5b61070e84828501610584565b949350505050565b602080825282518282018190526000919060409081850190868401855b8281101561076157815180516001600160a01b03168552860151868501529284019290850190600101610733565b5091979650505050505050565b80356001600160a01b038116811461078557600080fd5b919050565b60008060006060848603121561079f57600080fd5b833567ffffffffffffffff8111156107b657600080fd5b6107c286828701610584565b9350506107d16020850161076e565b9150604084013590509250925092565b6000602082840312156107f357600080fd5b6106d28261076e565b6000602080830181845280855180835260408601915060408160051b870101925083870160005b8281101561085157603f1988860301845261083f858351610693565b94509285019290850190600101610823565b5092979650505050505050565b600181811c9082168061087257607f821691505b60208210810361048f57634e487b7160e01b600052602260045260246000fd5b600082516108a481846020870161066f565b9190910192915050565b601f8211156108f857600081815260208120601f850160051c810160208610156108d55750805b601f850160051c820191505b818110156108f4578281556001016108e1565b5050505b505050565b815167ffffffffffffffff8111156109175761091761056e565b61092b81610925845461085e565b846108ae565b602080601f83116001811461096057600084156109485750858301515b600019600386901b1c1916600185901b1785556108f4565b600085815260208120601f198616915b8281101561098f57888601518255948401946001909101908401610970565b50858210156109ad5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b818103818111156109de57634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea2646970667358221220ed8f09a11ce51fc18cd7ad3cdc792cb949f6e2d1d09fa3ad637c4559c3e862a064736f6c63430008130033`
+const RegistryMockBinRuntime = `608060405234801561001057600080fd5b50600436106100575760003560e01c80633b51650d1461005c5780634622ab0314610093578063d393c871146100b3578063e2693e3f146100c8578063f2fde38b146100f3575b600080fd5b61006f61006a366004610432565b610123565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100a66100a1366004610477565b610178565b60405161008a91906104b4565b6100c66100c1366004610503565b610224565b005b6100db6100d636600461055a565b6102f7565b6040516001600160a01b03909116815260200161008a565b6100c6610101366004610597565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b8151602081840181018051600082529282019185019190912091905280548290811061014e57600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061018857600080fd5b9060005260206000200160009150905080546101a3906105b9565b80601f01602080910402602001604051908101604052809291908181526020018280546101cf906105b9565b801561021c5780601f106101f15761010080835404028352916020019161021c565b820191906000526020600020905b8154815290600101906020018083116101ff57829003601f168201915b505050505081565b60008360405161023491906105ed565b90815260405190819003602001902054600003610288576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6016102868482610658565b505b60008360405161029891906105ed565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b60008060008360405161030a91906105ed565b908152604051908190036020019020549050600081900361032e5750600092915050565b60008360405161033e91906105ed565b908152604051908190036020019020610358600183610718565b815481106103685761036861073f565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b634e487b7160e01b600052604160045260246000fd5b600082601f8301126103b657600080fd5b813567ffffffffffffffff808211156103d1576103d161038f565b604051601f8301601f19908116603f011681019082821181831017156103f9576103f961038f565b8160405283815286602085880101111561041257600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561044557600080fd5b823567ffffffffffffffff81111561045c57600080fd5b610468858286016103a5565b95602094909401359450505050565b60006020828403121561048957600080fd5b5035919050565b60005b838110156104ab578181015183820152602001610493565b50506000910152565b60208152600082518060208401526104d3816040850160208701610490565b601f01601f19169190910160400192915050565b80356001600160a01b03811681146104fe57600080fd5b919050565b60008060006060848603121561051857600080fd5b833567ffffffffffffffff81111561052f57600080fd5b61053b868287016103a5565b93505061054a602085016104e7565b9150604084013590509250925092565b60006020828403121561056c57600080fd5b813567ffffffffffffffff81111561058357600080fd5b61058f848285016103a5565b949350505050565b6000602082840312156105a957600080fd5b6105b2826104e7565b9392505050565b600181811c908216806105cd57607f821691505b60208210810361038957634e487b7160e01b600052602260045260246000fd5b600082516105ff818460208701610490565b9190910192915050565b601f82111561065357600081815260208120601f850160051c810160208610156106305750805b601f850160051c820191505b8181101561064f5782815560010161063c565b5050505b505050565b815167ffffffffffffffff8111156106725761067261038f565b6106868161068084546105b9565b84610609565b602080601f8311600181146106bb57600084156106a35750858301515b600019600386901b1c1916600185901b17855561064f565b600085815260208120601f198616915b828110156106ea578886015182559484019460019091019084016106cb565b50858210156107085787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b8181038181111561073957634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea2646970667358221220614d57a0d78769a7f0862854ec412095f7372467ccb4c829a29ffd97a72e5b1464736f6c63430008110033`
 
 // RegistryMockFuncSigs maps the 4-byte function signature to its string representation.
-// Deprecated: Use RegistryMockMetaData.Sigs instead.
-var RegistryMockFuncSigs = RegistryMockMetaData.Sigs
+var RegistryMockFuncSigs = map[string]string{
+	"e2693e3f": "getActiveAddr(string)",
+	"4622ab03": "names(uint256)",
+	"3b51650d": "records(string,uint256)",
+	"d393c871": "register(string,address,uint256)",
+	"f2fde38b": "transferOwnership(address)",
+}
 
 // RegistryMockBin is the compiled bytecode used for deploying new contracts.
-// Deprecated: Use RegistryMockMetaData.Bin instead.
-var RegistryMockBin = RegistryMockMetaData.Bin
+var RegistryMockBin = "0x608060405234801561001057600080fd5b5061078b806100206000396000f3fe608060405234801561001057600080fd5b50600436106100575760003560e01c80633b51650d1461005c5780634622ab0314610093578063d393c871146100b3578063e2693e3f146100c8578063f2fde38b146100f3575b600080fd5b61006f61006a366004610432565b610123565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100a66100a1366004610477565b610178565b60405161008a91906104b4565b6100c66100c1366004610503565b610224565b005b6100db6100d636600461055a565b6102f7565b6040516001600160a01b03909116815260200161008a565b6100c6610101366004610597565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b8151602081840181018051600082529282019185019190912091905280548290811061014e57600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061018857600080fd5b9060005260206000200160009150905080546101a3906105b9565b80601f01602080910402602001604051908101604052809291908181526020018280546101cf906105b9565b801561021c5780601f106101f15761010080835404028352916020019161021c565b820191906000526020600020905b8154815290600101906020018083116101ff57829003601f168201915b505050505081565b60008360405161023491906105ed565b90815260405190819003602001902054600003610288576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6016102868482610658565b505b60008360405161029891906105ed565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b60008060008360405161030a91906105ed565b908152604051908190036020019020549050600081900361032e5750600092915050565b60008360405161033e91906105ed565b908152604051908190036020019020610358600183610718565b815481106103685761036861073f565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b634e487b7160e01b600052604160045260246000fd5b600082601f8301126103b657600080fd5b813567ffffffffffffffff808211156103d1576103d161038f565b604051601f8301601f19908116603f011681019082821181831017156103f9576103f961038f565b8160405283815286602085880101111561041257600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561044557600080fd5b823567ffffffffffffffff81111561045c57600080fd5b610468858286016103a5565b95602094909401359450505050565b60006020828403121561048957600080fd5b5035919050565b60005b838110156104ab578181015183820152602001610493565b50506000910152565b60208152600082518060208401526104d3816040850160208701610490565b601f01601f19169190910160400192915050565b80356001600160a01b03811681146104fe57600080fd5b919050565b60008060006060848603121561051857600080fd5b833567ffffffffffffffff81111561052f57600080fd5b61053b868287016103a5565b93505061054a602085016104e7565b9150604084013590509250925092565b60006020828403121561056c57600080fd5b813567ffffffffffffffff81111561058357600080fd5b61058f848285016103a5565b949350505050565b6000602082840312156105a957600080fd5b6105b2826104e7565b9392505050565b600181811c908216806105cd57607f821691505b60208210810361038957634e487b7160e01b600052602260045260246000fd5b600082516105ff818460208701610490565b9190910192915050565b601f82111561065357600081815260208120601f850160051c810160208610156106305750805b601f850160051c820191505b8181101561064f5782815560010161063c565b5050505b505050565b815167ffffffffffffffff8111156106725761067261038f565b6106868161068084546105b9565b84610609565b602080601f8311600181146106bb57600084156106a35750858301515b600019600386901b1c1916600185901b17855561064f565b600085815260208120601f198616915b828110156106ea578886015182559484019460019091019084016106cb565b50858210156107085787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b8181038181111561073957634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea2646970667358221220614d57a0d78769a7f0862854ec412095f7372467ccb4c829a29ffd97a72e5b1464736f6c63430008110033"
 
 // DeployRegistryMock deploys a new Klaytn contract, binding an instance of RegistryMock to it.
 func DeployRegistryMock(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *RegistryMock, error) {
-	parsed, err := RegistryMockMetaData.GetAbi()
+	parsed, err := abi.JSON(strings.NewReader(RegistryMockABI))
 	if err != nil {
 		return common.Address{}, nil, nil, err
 	}
-	if parsed == nil {
-		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
-	}
 
-	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(RegistryMockBin), backend)
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(RegistryMockBin), backend)
 	if err != nil {
 		return common.Address{}, nil, nil, err
 	}
@@ -1537,11 +1145,11 @@ func NewRegistryMockFilterer(address common.Address, filterer bind.ContractFilte
 
 // bindRegistryMock binds a generic wrapper to an already deployed contract.
 func bindRegistryMock(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := RegistryMockMetaData.GetAbi()
+	parsed, err := abi.JSON(strings.NewReader(RegistryMockABI))
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and
@@ -1586,7 +1194,9 @@ func (_RegistryMock *RegistryMockTransactorRaw) Transact(opts *bind.TransactOpts
 //
 // Solidity: function getActiveAddr(string name) view returns(address)
 func (_RegistryMock *RegistryMockCaller) GetActiveAddr(opts *bind.CallOpts, name string) (common.Address, error) {
-	ret0 := new(common.Address)
+	var (
+		ret0 = new(common.Address)
+	)
 	out := ret0
 	err := _RegistryMock.contract.Call(opts, out, "getActiveAddr", name)
 	return *ret0, err
@@ -1606,59 +1216,13 @@ func (_RegistryMock *RegistryMockCallerSession) GetActiveAddr(name string) (comm
 	return _RegistryMock.Contract.GetActiveAddr(&_RegistryMock.CallOpts, name)
 }
 
-// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
-//
-// Solidity: function getAllNames() view returns(string[])
-func (_RegistryMock *RegistryMockCaller) GetAllNames(opts *bind.CallOpts) ([]string, error) {
-	ret0 := new([]string)
-	out := ret0
-	err := _RegistryMock.contract.Call(opts, out, "getAllNames")
-	return *ret0, err
-}
-
-// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
-//
-// Solidity: function getAllNames() view returns(string[])
-func (_RegistryMock *RegistryMockSession) GetAllNames() ([]string, error) {
-	return _RegistryMock.Contract.GetAllNames(&_RegistryMock.CallOpts)
-}
-
-// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
-//
-// Solidity: function getAllNames() view returns(string[])
-func (_RegistryMock *RegistryMockCallerSession) GetAllNames() ([]string, error) {
-	return _RegistryMock.Contract.GetAllNames(&_RegistryMock.CallOpts)
-}
-
-// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
-//
-// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
-func (_RegistryMock *RegistryMockCaller) GetAllRecords(opts *bind.CallOpts, name string) ([]IRegistryRecord, error) {
-	ret0 := new([]IRegistryRecord)
-	out := ret0
-	err := _RegistryMock.contract.Call(opts, out, "getAllRecords", name)
-	return *ret0, err
-}
-
-// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
-//
-// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
-func (_RegistryMock *RegistryMockSession) GetAllRecords(name string) ([]IRegistryRecord, error) {
-	return _RegistryMock.Contract.GetAllRecords(&_RegistryMock.CallOpts, name)
-}
-
-// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
-//
-// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
-func (_RegistryMock *RegistryMockCallerSession) GetAllRecords(name string) ([]IRegistryRecord, error) {
-	return _RegistryMock.Contract.GetAllRecords(&_RegistryMock.CallOpts, name)
-}
-
 // Names is a free data retrieval call binding the contract method 0x4622ab03.
 //
 // Solidity: function names(uint256 ) view returns(string)
 func (_RegistryMock *RegistryMockCaller) Names(opts *bind.CallOpts, arg0 *big.Int) (string, error) {
-	ret0 := new(string)
+	var (
+		ret0 = new(string)
+	)
 	out := ret0
 	err := _RegistryMock.contract.Call(opts, out, "names", arg0)
 	return *ret0, err
@@ -1678,38 +1242,13 @@ func (_RegistryMock *RegistryMockCallerSession) Names(arg0 *big.Int) (string, er
 	return _RegistryMock.Contract.Names(&_RegistryMock.CallOpts, arg0)
 }
 
-// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
-//
-// Solidity: function owner() view returns(address)
-func (_RegistryMock *RegistryMockCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
-	ret0 := new(common.Address)
-	out := ret0
-	err := _RegistryMock.contract.Call(opts, out, "owner")
-	return *ret0, err
-}
-
-// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
-//
-// Solidity: function owner() view returns(address)
-func (_RegistryMock *RegistryMockSession) Owner() (common.Address, error) {
-	return _RegistryMock.Contract.Owner(&_RegistryMock.CallOpts)
-}
-
-// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
-//
-// Solidity: function owner() view returns(address)
-func (_RegistryMock *RegistryMockCallerSession) Owner() (common.Address, error) {
-	return _RegistryMock.Contract.Owner(&_RegistryMock.CallOpts)
-}
-
 // Records is a free data retrieval call binding the contract method 0x3b51650d.
 //
 // Solidity: function records(string , uint256 ) view returns(address addr, uint256 activation)
 func (_RegistryMock *RegistryMockCaller) Records(opts *bind.CallOpts, arg0 string, arg1 *big.Int) (struct {
 	Addr       common.Address
 	Activation *big.Int
-}, error,
-) {
+}, error) {
 	ret := new(struct {
 		Addr       common.Address
 		Activation *big.Int
@@ -1725,8 +1264,7 @@ func (_RegistryMock *RegistryMockCaller) Records(opts *bind.CallOpts, arg0 strin
 func (_RegistryMock *RegistryMockSession) Records(arg0 string, arg1 *big.Int) (struct {
 	Addr       common.Address
 	Activation *big.Int
-}, error,
-) {
+}, error) {
 	return _RegistryMock.Contract.Records(&_RegistryMock.CallOpts, arg0, arg1)
 }
 
@@ -1736,8 +1274,7 @@ func (_RegistryMock *RegistryMockSession) Records(arg0 string, arg1 *big.Int) (s
 func (_RegistryMock *RegistryMockCallerSession) Records(arg0 string, arg1 *big.Int) (struct {
 	Addr       common.Address
 	Activation *big.Int
-}, error,
-) {
+}, error) {
 	return _RegistryMock.Contract.Records(&_RegistryMock.CallOpts, arg0, arg1)
 }
 
@@ -1781,305 +1318,4 @@ func (_RegistryMock *RegistryMockSession) TransferOwnership(newOwner common.Addr
 // Solidity: function transferOwnership(address newOwner) returns()
 func (_RegistryMock *RegistryMockTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
 	return _RegistryMock.Contract.TransferOwnership(&_RegistryMock.TransactOpts, newOwner)
-}
-
-// RegistryMockOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the RegistryMock contract.
-type RegistryMockOwnershipTransferredIterator struct {
-	Event *RegistryMockOwnershipTransferred // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log      // Log channel receiving the found contract events
-	sub  klaytn.Subscription // Subscription for errors, completion and termination
-	done bool                // Whether the subscription completed delivering logs
-	fail error               // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *RegistryMockOwnershipTransferredIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(RegistryMockOwnershipTransferred)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(RegistryMockOwnershipTransferred)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *RegistryMockOwnershipTransferredIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *RegistryMockOwnershipTransferredIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// RegistryMockOwnershipTransferred represents a OwnershipTransferred event raised by the RegistryMock contract.
-type RegistryMockOwnershipTransferred struct {
-	PreviousOwner common.Address
-	NewOwner      common.Address
-	Raw           types.Log // Blockchain specific contextual infos
-}
-
-// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
-//
-// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_RegistryMock *RegistryMockFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*RegistryMockOwnershipTransferredIterator, error) {
-	var previousOwnerRule []interface{}
-	for _, previousOwnerItem := range previousOwner {
-		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
-	}
-	var newOwnerRule []interface{}
-	for _, newOwnerItem := range newOwner {
-		newOwnerRule = append(newOwnerRule, newOwnerItem)
-	}
-
-	logs, sub, err := _RegistryMock.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
-	if err != nil {
-		return nil, err
-	}
-	return &RegistryMockOwnershipTransferredIterator{contract: _RegistryMock.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
-}
-
-// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
-//
-// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_RegistryMock *RegistryMockFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RegistryMockOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
-	var previousOwnerRule []interface{}
-	for _, previousOwnerItem := range previousOwner {
-		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
-	}
-	var newOwnerRule []interface{}
-	for _, newOwnerItem := range newOwner {
-		newOwnerRule = append(newOwnerRule, newOwnerItem)
-	}
-
-	logs, sub, err := _RegistryMock.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(RegistryMockOwnershipTransferred)
-				if err := _RegistryMock.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
-//
-// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_RegistryMock *RegistryMockFilterer) ParseOwnershipTransferred(log types.Log) (*RegistryMockOwnershipTransferred, error) {
-	event := new(RegistryMockOwnershipTransferred)
-	if err := _RegistryMock.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
-		return nil, err
-	}
-	return event, nil
-}
-
-// RegistryMockRegisteredIterator is returned from FilterRegistered and is used to iterate over the raw logs and unpacked data for Registered events raised by the RegistryMock contract.
-type RegistryMockRegisteredIterator struct {
-	Event *RegistryMockRegistered // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log      // Log channel receiving the found contract events
-	sub  klaytn.Subscription // Subscription for errors, completion and termination
-	done bool                // Whether the subscription completed delivering logs
-	fail error               // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *RegistryMockRegisteredIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(RegistryMockRegistered)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(RegistryMockRegistered)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *RegistryMockRegisteredIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *RegistryMockRegisteredIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// RegistryMockRegistered represents a Registered event raised by the RegistryMock contract.
-type RegistryMockRegistered struct {
-	Name       string
-	Addr       common.Address
-	Activation *big.Int
-	Raw        types.Log // Blockchain specific contextual infos
-}
-
-// FilterRegistered is a free log retrieval operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
-//
-// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
-func (_RegistryMock *RegistryMockFilterer) FilterRegistered(opts *bind.FilterOpts, addr []common.Address, activation []*big.Int) (*RegistryMockRegisteredIterator, error) {
-	var addrRule []interface{}
-	for _, addrItem := range addr {
-		addrRule = append(addrRule, addrItem)
-	}
-	var activationRule []interface{}
-	for _, activationItem := range activation {
-		activationRule = append(activationRule, activationItem)
-	}
-
-	logs, sub, err := _RegistryMock.contract.FilterLogs(opts, "Registered", addrRule, activationRule)
-	if err != nil {
-		return nil, err
-	}
-	return &RegistryMockRegisteredIterator{contract: _RegistryMock.contract, event: "Registered", logs: logs, sub: sub}, nil
-}
-
-// WatchRegistered is a free log subscription operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
-//
-// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
-func (_RegistryMock *RegistryMockFilterer) WatchRegistered(opts *bind.WatchOpts, sink chan<- *RegistryMockRegistered, addr []common.Address, activation []*big.Int) (event.Subscription, error) {
-	var addrRule []interface{}
-	for _, addrItem := range addr {
-		addrRule = append(addrRule, addrItem)
-	}
-	var activationRule []interface{}
-	for _, activationItem := range activation {
-		activationRule = append(activationRule, activationItem)
-	}
-
-	logs, sub, err := _RegistryMock.contract.WatchLogs(opts, "Registered", addrRule, activationRule)
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(RegistryMockRegistered)
-				if err := _RegistryMock.contract.UnpackLog(event, "Registered", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseRegistered is a log parse operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
-//
-// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
-func (_RegistryMock *RegistryMockFilterer) ParseRegistered(log types.Log) (*RegistryMockRegistered, error) {
-	event := new(RegistryMockRegistered)
-	if err := _RegistryMock.contract.UnpackLog(event, "Registered", log); err != nil {
-		return nil, err
-	}
-	return event, nil
 }

--- a/contracts/system_contracts/all.go
+++ b/contracts/system_contracts/all.go
@@ -32,6 +32,12 @@ type IKIP113BlsPublicKeyInfo struct {
 	Pop       []byte
 }
 
+// IRegistryRecord is an auto generated low-level Go binding around an user-defined struct.
+type IRegistryRecord struct {
+	Addr       common.Address
+	Activation *big.Int
+}
+
 // IKIP113ABI is the input ABI used to generate the binding from.
 const IKIP113ABI = "[{\"inputs\":[],\"name\":\"getAllBlsInfo\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"nodeIdList\",\"type\":\"address[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"publicKey\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"pop\",\"type\":\"bytes\"}],\"internalType\":\"structIKIP113.BlsPublicKeyInfo[]\",\"name\":\"pubkeyList\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
 
@@ -222,7 +228,7 @@ func (_IKIP113 *IKIP113CallerSession) GetAllBlsInfo() (struct {
 }
 
 // IRegistryABI is the input ABI used to generate the binding from.
-const IRegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
+const IRegistryABI = "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"Registered\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAllNames\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getAllRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"internalType\":\"structIRegistry.Record[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
 
 // IRegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
 const IRegistryBinRuntime = ``
@@ -230,8 +236,13 @@ const IRegistryBinRuntime = ``
 // IRegistryFuncSigs maps the 4-byte function signature to its string representation.
 var IRegistryFuncSigs = map[string]string{
 	"e2693e3f": "getActiveAddr(string)",
+	"fb825e5f": "getAllNames()",
+	"78d573a2": "getAllRecords(string)",
 	"4622ab03": "names(uint256)",
+	"8da5cb5b": "owner()",
 	"3b51650d": "records(string,uint256)",
+	"d393c871": "register(string,address,uint256)",
+	"f2fde38b": "transferOwnership(address)",
 }
 
 // IRegistry is an auto generated Go binding around a Klaytn contract.
@@ -376,30 +387,56 @@ func (_IRegistry *IRegistryTransactorRaw) Transact(opts *bind.TransactOpts, meth
 	return _IRegistry.Contract.contract.Transact(opts, method, params...)
 }
 
-// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
+// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
 //
-// Solidity: function getActiveAddr(string name) view returns(address)
-func (_IRegistry *IRegistryCaller) GetActiveAddr(opts *bind.CallOpts, name string) (common.Address, error) {
+// Solidity: function getAllNames() view returns(string[])
+func (_IRegistry *IRegistryCaller) GetAllNames(opts *bind.CallOpts) ([]string, error) {
 	var (
-		ret0 = new(common.Address)
+		ret0 = new([]string)
 	)
 	out := ret0
-	err := _IRegistry.contract.Call(opts, out, "getActiveAddr", name)
+	err := _IRegistry.contract.Call(opts, out, "getAllNames")
 	return *ret0, err
 }
 
-// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
+// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
 //
-// Solidity: function getActiveAddr(string name) view returns(address)
-func (_IRegistry *IRegistrySession) GetActiveAddr(name string) (common.Address, error) {
-	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.CallOpts, name)
+// Solidity: function getAllNames() view returns(string[])
+func (_IRegistry *IRegistrySession) GetAllNames() ([]string, error) {
+	return _IRegistry.Contract.GetAllNames(&_IRegistry.CallOpts)
 }
 
-// GetActiveAddr is a free data retrieval call binding the contract method 0xe2693e3f.
+// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
 //
-// Solidity: function getActiveAddr(string name) view returns(address)
-func (_IRegistry *IRegistryCallerSession) GetActiveAddr(name string) (common.Address, error) {
-	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.CallOpts, name)
+// Solidity: function getAllNames() view returns(string[])
+func (_IRegistry *IRegistryCallerSession) GetAllNames() ([]string, error) {
+	return _IRegistry.Contract.GetAllNames(&_IRegistry.CallOpts)
+}
+
+// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
+//
+// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
+func (_IRegistry *IRegistryCaller) GetAllRecords(opts *bind.CallOpts, name string) ([]IRegistryRecord, error) {
+	var (
+		ret0 = new([]IRegistryRecord)
+	)
+	out := ret0
+	err := _IRegistry.contract.Call(opts, out, "getAllRecords", name)
+	return *ret0, err
+}
+
+// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
+//
+// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
+func (_IRegistry *IRegistrySession) GetAllRecords(name string) ([]IRegistryRecord, error) {
+	return _IRegistry.Contract.GetAllRecords(&_IRegistry.CallOpts, name)
+}
+
+// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
+//
+// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
+func (_IRegistry *IRegistryCallerSession) GetAllRecords(name string) ([]IRegistryRecord, error) {
+	return _IRegistry.Contract.GetAllRecords(&_IRegistry.CallOpts, name)
 }
 
 // Names is a free data retrieval call binding the contract method 0x4622ab03.
@@ -426,6 +463,32 @@ func (_IRegistry *IRegistrySession) Names(arg0 *big.Int) (string, error) {
 // Solidity: function names(uint256 ) view returns(string)
 func (_IRegistry *IRegistryCallerSession) Names(arg0 *big.Int) (string, error) {
 	return _IRegistry.Contract.Names(&_IRegistry.CallOpts, arg0)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_IRegistry *IRegistryCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _IRegistry.contract.Call(opts, out, "owner")
+	return *ret0, err
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_IRegistry *IRegistrySession) Owner() (common.Address, error) {
+	return _IRegistry.Contract.Owner(&_IRegistry.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_IRegistry *IRegistryCallerSession) Owner() (common.Address, error) {
+	return _IRegistry.Contract.Owner(&_IRegistry.CallOpts)
 }
 
 // Records is a free data retrieval call binding the contract method 0x3b51650d.
@@ -462,6 +525,374 @@ func (_IRegistry *IRegistryCallerSession) Records(arg0 string, arg1 *big.Int) (s
 	Activation *big.Int
 }, error) {
 	return _IRegistry.Contract.Records(&_IRegistry.CallOpts, arg0, arg1)
+}
+
+// GetActiveAddr is a paid mutator transaction binding the contract method 0xe2693e3f.
+//
+// Solidity: function getActiveAddr(string name) returns(address)
+func (_IRegistry *IRegistryTransactor) GetActiveAddr(opts *bind.TransactOpts, name string) (*types.Transaction, error) {
+	return _IRegistry.contract.Transact(opts, "getActiveAddr", name)
+}
+
+// GetActiveAddr is a paid mutator transaction binding the contract method 0xe2693e3f.
+//
+// Solidity: function getActiveAddr(string name) returns(address)
+func (_IRegistry *IRegistrySession) GetActiveAddr(name string) (*types.Transaction, error) {
+	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.TransactOpts, name)
+}
+
+// GetActiveAddr is a paid mutator transaction binding the contract method 0xe2693e3f.
+//
+// Solidity: function getActiveAddr(string name) returns(address)
+func (_IRegistry *IRegistryTransactorSession) GetActiveAddr(name string) (*types.Transaction, error) {
+	return _IRegistry.Contract.GetActiveAddr(&_IRegistry.TransactOpts, name)
+}
+
+// Register is a paid mutator transaction binding the contract method 0xd393c871.
+//
+// Solidity: function register(string name, address addr, uint256 activation) returns()
+func (_IRegistry *IRegistryTransactor) Register(opts *bind.TransactOpts, name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
+	return _IRegistry.contract.Transact(opts, "register", name, addr, activation)
+}
+
+// Register is a paid mutator transaction binding the contract method 0xd393c871.
+//
+// Solidity: function register(string name, address addr, uint256 activation) returns()
+func (_IRegistry *IRegistrySession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
+	return _IRegistry.Contract.Register(&_IRegistry.TransactOpts, name, addr, activation)
+}
+
+// Register is a paid mutator transaction binding the contract method 0xd393c871.
+//
+// Solidity: function register(string name, address addr, uint256 activation) returns()
+func (_IRegistry *IRegistryTransactorSession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
+	return _IRegistry.Contract.Register(&_IRegistry.TransactOpts, name, addr, activation)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_IRegistry *IRegistryTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _IRegistry.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_IRegistry *IRegistrySession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _IRegistry.Contract.TransferOwnership(&_IRegistry.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_IRegistry *IRegistryTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _IRegistry.Contract.TransferOwnership(&_IRegistry.TransactOpts, newOwner)
+}
+
+// IRegistryOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the IRegistry contract.
+type IRegistryOwnershipTransferredIterator struct {
+	Event *IRegistryOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IRegistryOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IRegistryOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IRegistryOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IRegistryOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IRegistryOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IRegistryOwnershipTransferred represents a OwnershipTransferred event raised by the IRegistry contract.
+type IRegistryOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_IRegistry *IRegistryFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*IRegistryOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _IRegistry.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IRegistryOwnershipTransferredIterator{contract: _IRegistry.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_IRegistry *IRegistryFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *IRegistryOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _IRegistry.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IRegistryOwnershipTransferred)
+				if err := _IRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_IRegistry *IRegistryFilterer) ParseOwnershipTransferred(log types.Log) (*IRegistryOwnershipTransferred, error) {
+	event := new(IRegistryOwnershipTransferred)
+	if err := _IRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// IRegistryRegisteredIterator is returned from FilterRegistered and is used to iterate over the raw logs and unpacked data for Registered events raised by the IRegistry contract.
+type IRegistryRegisteredIterator struct {
+	Event *IRegistryRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IRegistryRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IRegistryRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IRegistryRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IRegistryRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IRegistryRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IRegistryRegistered represents a Registered event raised by the IRegistry contract.
+type IRegistryRegistered struct {
+	Name       string
+	Addr       common.Address
+	Activation *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterRegistered is a free log retrieval operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
+//
+// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
+func (_IRegistry *IRegistryFilterer) FilterRegistered(opts *bind.FilterOpts, addr []common.Address, activation []*big.Int) (*IRegistryRegisteredIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+	var activationRule []interface{}
+	for _, activationItem := range activation {
+		activationRule = append(activationRule, activationItem)
+	}
+
+	logs, sub, err := _IRegistry.contract.FilterLogs(opts, "Registered", addrRule, activationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IRegistryRegisteredIterator{contract: _IRegistry.contract, event: "Registered", logs: logs, sub: sub}, nil
+}
+
+// WatchRegistered is a free log subscription operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
+//
+// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
+func (_IRegistry *IRegistryFilterer) WatchRegistered(opts *bind.WatchOpts, sink chan<- *IRegistryRegistered, addr []common.Address, activation []*big.Int) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+	var activationRule []interface{}
+	for _, activationItem := range activation {
+		activationRule = append(activationRule, activationItem)
+	}
+
+	logs, sub, err := _IRegistry.contract.WatchLogs(opts, "Registered", addrRule, activationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IRegistryRegistered)
+				if err := _IRegistry.contract.UnpackLog(event, "Registered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRegistered is a log parse operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
+//
+// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
+func (_IRegistry *IRegistryFilterer) ParseRegistered(log types.Log) (*IRegistryRegistered, error) {
+	event := new(IRegistryRegistered)
+	if err := _IRegistry.contract.UnpackLog(event, "Registered", log); err != nil {
+		return nil, err
+	}
+	return event, nil
 }
 
 // KIP113MockABI is the input ABI used to generate the binding from.
@@ -757,20 +1188,25 @@ func (_KIP113Mock *KIP113MockTransactorSession) Register(addr common.Address, pu
 }
 
 // RegistryABI is the input ABI used to generate the binding from.
-const RegistryABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]"
+const RegistryABI = "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"Registered\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAllNames\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getAllRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"internalType\":\"structIRegistry.Record[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
 
 // RegistryBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
-const RegistryBinRuntime = `608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d146100465780634622ab031461007d578063e2693e3f1461009d575b600080fd5b6100596100543660046102ad565b6100c8565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102f2565b61011d565b604051610074919061030b565b6100b06100ab366004610359565b6101c9565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100f357600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061012d57600080fd5b90600052602060002001600091509050805461014890610396565b80601f016020809104026020016040519081016040528092919081815260200182805461017490610396565b80156101c15780601f10610196576101008083540402835291602001916101c1565b820191906000526020600020905b8154815290600101906020018083116101a457829003601f168201915b505050505081565b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023157600080fd5b813567ffffffffffffffff8082111561024c5761024c61020a565b604051601f8301601f19908116603f011681019082821181831017156102745761027461020a565b8160405283815286602085880101111561028d57600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c057600080fd5b823567ffffffffffffffff8111156102d757600080fd5b6102e385828601610220565b95602094909401359450505050565b60006020828403121561030457600080fd5b5035919050565b600060208083528351808285015260005b818110156103385785810183015185820160400152820161031c565b506000604082860101526040601f19601f8301168501019250505092915050565b60006020828403121561036b57600080fd5b813567ffffffffffffffff81111561038257600080fd5b61038e84828501610220565b949350505050565b600181811c908216806103aa57607f821691505b6020821081036103ca57634e487b7160e01b600052602260045260246000fd5b5091905056fea264697066735822122081d8382cad173f430e0005a96faaba1ff204fe72b466874499e03026c424a33964736f6c63430008110033`
+const RegistryBinRuntime = `608060405234801561001057600080fd5b50600436106100885760003560e01c8063d393c8711161005b578063d393c87114610129578063e2693e3f1461013e578063f2fde38b14610151578063fb825e5f1461016457600080fd5b80633b51650d1461008d5780634622ab03146100c457806378d573a2146100e45780638da5cb5b14610104575b600080fd5b6100a061009b366004610975565b610179565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100d76100d23660046109ba565b6101ce565b6040516100bb9190610a23565b6100f76100f2366004610a3d565b61027a565b6040516100bb9190610a7a565b6002546001600160a01b03165b6040516001600160a01b0390911681526020016100bb565b61013c610137366004610aee565b61030d565b005b61011161014c366004610a3d565b61062b565b61013c61015f366004610b45565b610722565b61016c6107f9565b6040516100bb9190610b60565b815160208184018101805160008252928201918501919091209190528054829081106101a457600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600181815481106101de57600080fd5b9060005260206000200160009150905080546101f990610bc2565b80601f016020809104026020016040519081016040528092919081815260200182805461022590610bc2565b80156102725780601f1061024757610100808354040283529160200191610272565b820191906000526020600020905b81548152906001019060200180831161025557829003601f168201915b505050505081565b606060008260405161028c9190610bfc565b9081526020016040518091039020805480602002602001604051908101604052809291908181526020016000905b82821015610302576000848152602090819020604080518082019091526002850290910180546001600160a01b031682526001908101548284015290835290920191016102ba565b505050509050919050565b6002546001600160a01b031633146103585760405162461bcd60e51b81526020600482015260096024820152682737ba1037bbb732b960b91b60448201526064015b60405180910390fd5b8260008160405160200161036c9190610bfc565b604051602081830303815290604052905080516000036103bd5760405162461bcd60e51b815260206004820152600c60248201526b456d70747920737472696e6760a01b604482015260640161034f565b4383116104165760405162461bcd60e51b815260206004820152602160248201527f43616e277420726567697374657220636f6e74726163742066726f6d207061736044820152601d60fa1b606482015260840161034f565b600080866040516104279190610bfc565b90815260405190819003602001902054905060008190036104f3576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60161047d8782610c67565b5060008660405161048e9190610bfc565b90815260408051602092819003830181208183019092526001600160a01b0388811682528382018881528354600180820186556000958652959094209251600290940290920180546001600160a01b03191693909116929092178255519101556105e1565b600080876040516105049190610bfc565b90815260405190819003602001902061051e600184610d3d565b8154811061052e5761052e610d56565b90600052602060002090600202019050438160010154116105be576000876040516105599190610bfc565b90815260408051602092819003830181208183019092526001600160a01b0389811682528382018981528354600180820186556000958652959094209251600290940290920180546001600160a01b03191693909116929092178255519101556105df565b80546001600160a01b0319166001600160a01b038716178155600181018590555b505b83856001600160a01b03167f142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f308860405161061b9190610a23565b60405180910390a3505050505050565b60008060008360405161063e9190610bfc565b908152604051908190036020019020549050805b801561071857436000856040516106699190610bfc565b908152604051908190036020019020610683600184610d3d565b8154811061069357610693610d56565b90600052602060002090600202016001015411610706576000846040516106ba9190610bfc565b9081526040519081900360200190206106d4600183610d3d565b815481106106e4576106e4610d56565b60009182526020909120600290910201546001600160a01b0316949350505050565b8061071081610d6c565b915050610652565b5060009392505050565b6002546001600160a01b031633146107685760405162461bcd60e51b81526020600482015260096024820152682737ba1037bbb732b960b91b604482015260640161034f565b6001600160a01b0381166107ad5760405162461bcd60e51b815260206004820152600c60248201526b5a65726f206164647265737360a01b604482015260640161034f565b600280546001600160a01b0319166001600160a01b03831690811790915560405133907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a350565b60606001805480602002602001604051908101604052809291908181526020016000905b828210156108c957838290600052602060002001805461083c90610bc2565b80601f016020809104026020016040519081016040528092919081815260200182805461086890610bc2565b80156108b55780601f1061088a576101008083540402835291602001916108b5565b820191906000526020600020905b81548152906001019060200180831161089857829003601f168201915b50505050508152602001906001019061081d565b50505050905090565b634e487b7160e01b600052604160045260246000fd5b600082601f8301126108f957600080fd5b813567ffffffffffffffff80821115610914576109146108d2565b604051601f8301601f19908116603f0116810190828211818310171561093c5761093c6108d2565b8160405283815286602085880101111561095557600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561098857600080fd5b823567ffffffffffffffff81111561099f57600080fd5b6109ab858286016108e8565b95602094909401359450505050565b6000602082840312156109cc57600080fd5b5035919050565b60005b838110156109ee5781810151838201526020016109d6565b50506000910152565b60008151808452610a0f8160208601602086016109d3565b601f01601f19169290920160200192915050565b602081526000610a3660208301846109f7565b9392505050565b600060208284031215610a4f57600080fd5b813567ffffffffffffffff811115610a6657600080fd5b610a72848285016108e8565b949350505050565b602080825282518282018190526000919060409081850190868401855b82811015610ac557815180516001600160a01b03168552860151868501529284019290850190600101610a97565b5091979650505050505050565b80356001600160a01b0381168114610ae957600080fd5b919050565b600080600060608486031215610b0357600080fd5b833567ffffffffffffffff811115610b1a57600080fd5b610b26868287016108e8565b935050610b3560208501610ad2565b9150604084013590509250925092565b600060208284031215610b5757600080fd5b610a3682610ad2565b6000602080830181845280855180835260408601915060408160051b870101925083870160005b82811015610bb557603f19888603018452610ba38583516109f7565b94509285019290850190600101610b87565b5092979650505050505050565b600181811c90821680610bd657607f821691505b602082108103610bf657634e487b7160e01b600052602260045260246000fd5b50919050565b60008251610c0e8184602087016109d3565b9190910192915050565b601f821115610c6257600081815260208120601f850160051c81016020861015610c3f5750805b601f850160051c820191505b81811015610c5e57828155600101610c4b565b5050505b505050565b815167ffffffffffffffff811115610c8157610c816108d2565b610c9581610c8f8454610bc2565b84610c18565b602080601f831160018114610cca5760008415610cb25750858301515b600019600386901b1c1916600185901b178555610c5e565b600085815260208120601f198616915b82811015610cf957888601518255948401946001909101908401610cda565b5085821015610d175787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b634e487b7160e01b600052601160045260246000fd5b81810381811115610d5057610d50610d27565b92915050565b634e487b7160e01b600052603260045260246000fd5b600081610d7b57610d7b610d27565b50600019019056fea2646970667358221220dec0ab0bd90558df37ff0a87cf78fb70b20ae65ac7a4292a8b2a7682ec1fd45d64736f6c63430008110033`
 
 // RegistryFuncSigs maps the 4-byte function signature to its string representation.
 var RegistryFuncSigs = map[string]string{
 	"e2693e3f": "getActiveAddr(string)",
+	"fb825e5f": "getAllNames()",
+	"78d573a2": "getAllRecords(string)",
 	"4622ab03": "names(uint256)",
+	"8da5cb5b": "owner()",
 	"3b51650d": "records(string,uint256)",
+	"d393c871": "register(string,address,uint256)",
+	"f2fde38b": "transferOwnership(address)",
 }
 
 // RegistryBin is the compiled bytecode used for deploying new contracts.
-var RegistryBin = "0x608060405234801561001057600080fd5b50610406806100206000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c80633b51650d146100465780634622ab031461007d578063e2693e3f1461009d575b600080fd5b6100596100543660046102ad565b6100c8565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b61009061008b3660046102f2565b61011d565b604051610074919061030b565b6100b06100ab366004610359565b6101c9565b6040516001600160a01b039091168152602001610074565b815160208184018101805160008252928201918501919091209190528054829081106100f357600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061012d57600080fd5b90600052602060002001600091509050805461014890610396565b80601f016020809104026020016040519081016040528092919081815260200182805461017490610396565b80156101c15780601f10610196576101008083540402835291602001916101c1565b820191906000526020600020905b8154815290600101906020018083116101a457829003601f168201915b505050505081565b60405162461bcd60e51b815260206004820152600f60248201526e1b9bdd081a5b5c1b195b595b9d1959608a1b604482015260009060640160405180910390fd5b634e487b7160e01b600052604160045260246000fd5b600082601f83011261023157600080fd5b813567ffffffffffffffff8082111561024c5761024c61020a565b604051601f8301601f19908116603f011681019082821181831017156102745761027461020a565b8160405283815286602085880101111561028d57600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156102c057600080fd5b823567ffffffffffffffff8111156102d757600080fd5b6102e385828601610220565b95602094909401359450505050565b60006020828403121561030457600080fd5b5035919050565b600060208083528351808285015260005b818110156103385785810183015185820160400152820161031c565b506000604082860101526040601f19601f8301168501019250505092915050565b60006020828403121561036b57600080fd5b813567ffffffffffffffff81111561038257600080fd5b61038e84828501610220565b949350505050565b600181811c908216806103aa57607f821691505b6020821081036103ca57634e487b7160e01b600052602260045260246000fd5b5091905056fea264697066735822122081d8382cad173f430e0005a96faaba1ff204fe72b466874499e03026c424a33964736f6c63430008110033"
+var RegistryBin = "0x608060405234801561001057600080fd5b50610db9806100206000396000f3fe608060405234801561001057600080fd5b50600436106100885760003560e01c8063d393c8711161005b578063d393c87114610129578063e2693e3f1461013e578063f2fde38b14610151578063fb825e5f1461016457600080fd5b80633b51650d1461008d5780634622ab03146100c457806378d573a2146100e45780638da5cb5b14610104575b600080fd5b6100a061009b366004610975565b610179565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100d76100d23660046109ba565b6101ce565b6040516100bb9190610a23565b6100f76100f2366004610a3d565b61027a565b6040516100bb9190610a7a565b6002546001600160a01b03165b6040516001600160a01b0390911681526020016100bb565b61013c610137366004610aee565b61030d565b005b61011161014c366004610a3d565b61062b565b61013c61015f366004610b45565b610722565b61016c6107f9565b6040516100bb9190610b60565b815160208184018101805160008252928201918501919091209190528054829081106101a457600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600181815481106101de57600080fd5b9060005260206000200160009150905080546101f990610bc2565b80601f016020809104026020016040519081016040528092919081815260200182805461022590610bc2565b80156102725780601f1061024757610100808354040283529160200191610272565b820191906000526020600020905b81548152906001019060200180831161025557829003601f168201915b505050505081565b606060008260405161028c9190610bfc565b9081526020016040518091039020805480602002602001604051908101604052809291908181526020016000905b82821015610302576000848152602090819020604080518082019091526002850290910180546001600160a01b031682526001908101548284015290835290920191016102ba565b505050509050919050565b6002546001600160a01b031633146103585760405162461bcd60e51b81526020600482015260096024820152682737ba1037bbb732b960b91b60448201526064015b60405180910390fd5b8260008160405160200161036c9190610bfc565b604051602081830303815290604052905080516000036103bd5760405162461bcd60e51b815260206004820152600c60248201526b456d70747920737472696e6760a01b604482015260640161034f565b4383116104165760405162461bcd60e51b815260206004820152602160248201527f43616e277420726567697374657220636f6e74726163742066726f6d207061736044820152601d60fa1b606482015260840161034f565b600080866040516104279190610bfc565b90815260405190819003602001902054905060008190036104f3576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60161047d8782610c67565b5060008660405161048e9190610bfc565b90815260408051602092819003830181208183019092526001600160a01b0388811682528382018881528354600180820186556000958652959094209251600290940290920180546001600160a01b03191693909116929092178255519101556105e1565b600080876040516105049190610bfc565b90815260405190819003602001902061051e600184610d3d565b8154811061052e5761052e610d56565b90600052602060002090600202019050438160010154116105be576000876040516105599190610bfc565b90815260408051602092819003830181208183019092526001600160a01b0389811682528382018981528354600180820186556000958652959094209251600290940290920180546001600160a01b03191693909116929092178255519101556105df565b80546001600160a01b0319166001600160a01b038716178155600181018590555b505b83856001600160a01b03167f142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f308860405161061b9190610a23565b60405180910390a3505050505050565b60008060008360405161063e9190610bfc565b908152604051908190036020019020549050805b801561071857436000856040516106699190610bfc565b908152604051908190036020019020610683600184610d3d565b8154811061069357610693610d56565b90600052602060002090600202016001015411610706576000846040516106ba9190610bfc565b9081526040519081900360200190206106d4600183610d3d565b815481106106e4576106e4610d56565b60009182526020909120600290910201546001600160a01b0316949350505050565b8061071081610d6c565b915050610652565b5060009392505050565b6002546001600160a01b031633146107685760405162461bcd60e51b81526020600482015260096024820152682737ba1037bbb732b960b91b604482015260640161034f565b6001600160a01b0381166107ad5760405162461bcd60e51b815260206004820152600c60248201526b5a65726f206164647265737360a01b604482015260640161034f565b600280546001600160a01b0319166001600160a01b03831690811790915560405133907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a350565b60606001805480602002602001604051908101604052809291908181526020016000905b828210156108c957838290600052602060002001805461083c90610bc2565b80601f016020809104026020016040519081016040528092919081815260200182805461086890610bc2565b80156108b55780601f1061088a576101008083540402835291602001916108b5565b820191906000526020600020905b81548152906001019060200180831161089857829003601f168201915b50505050508152602001906001019061081d565b50505050905090565b634e487b7160e01b600052604160045260246000fd5b600082601f8301126108f957600080fd5b813567ffffffffffffffff80821115610914576109146108d2565b604051601f8301601f19908116603f0116810190828211818310171561093c5761093c6108d2565b8160405283815286602085880101111561095557600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561098857600080fd5b823567ffffffffffffffff81111561099f57600080fd5b6109ab858286016108e8565b95602094909401359450505050565b6000602082840312156109cc57600080fd5b5035919050565b60005b838110156109ee5781810151838201526020016109d6565b50506000910152565b60008151808452610a0f8160208601602086016109d3565b601f01601f19169290920160200192915050565b602081526000610a3660208301846109f7565b9392505050565b600060208284031215610a4f57600080fd5b813567ffffffffffffffff811115610a6657600080fd5b610a72848285016108e8565b949350505050565b602080825282518282018190526000919060409081850190868401855b82811015610ac557815180516001600160a01b03168552860151868501529284019290850190600101610a97565b5091979650505050505050565b80356001600160a01b0381168114610ae957600080fd5b919050565b600080600060608486031215610b0357600080fd5b833567ffffffffffffffff811115610b1a57600080fd5b610b26868287016108e8565b935050610b3560208501610ad2565b9150604084013590509250925092565b600060208284031215610b5757600080fd5b610a3682610ad2565b6000602080830181845280855180835260408601915060408160051b870101925083870160005b82811015610bb557603f19888603018452610ba38583516109f7565b94509285019290850190600101610b87565b5092979650505050505050565b600181811c90821680610bd657607f821691505b602082108103610bf657634e487b7160e01b600052602260045260246000fd5b50919050565b60008251610c0e8184602087016109d3565b9190910192915050565b601f821115610c6257600081815260208120601f850160051c81016020861015610c3f5750805b601f850160051c820191505b81811015610c5e57828155600101610c4b565b5050505b505050565b815167ffffffffffffffff811115610c8157610c816108d2565b610c9581610c8f8454610bc2565b84610c18565b602080601f831160018114610cca5760008415610cb25750858301515b600019600386901b1c1916600185901b178555610c5e565b600085815260208120601f198616915b82811015610cf957888601518255948401946001909101908401610cda565b5085821015610d175787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b634e487b7160e01b600052601160045260246000fd5b81810381811115610d5057610d50610d27565b92915050565b634e487b7160e01b600052603260045260246000fd5b600081610d7b57610d7b610d27565b50600019019056fea2646970667358221220dec0ab0bd90558df37ff0a87cf78fb70b20ae65ac7a4292a8b2a7682ec1fd45d64736f6c63430008110033"
 
 // DeployRegistry deploys a new Klaytn contract, binding an instance of Registry to it.
 func DeployRegistry(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Registry, error) {
@@ -954,6 +1390,58 @@ func (_Registry *RegistryCallerSession) GetActiveAddr(name string) (common.Addre
 	return _Registry.Contract.GetActiveAddr(&_Registry.CallOpts, name)
 }
 
+// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
+//
+// Solidity: function getAllNames() view returns(string[])
+func (_Registry *RegistryCaller) GetAllNames(opts *bind.CallOpts) ([]string, error) {
+	var (
+		ret0 = new([]string)
+	)
+	out := ret0
+	err := _Registry.contract.Call(opts, out, "getAllNames")
+	return *ret0, err
+}
+
+// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
+//
+// Solidity: function getAllNames() view returns(string[])
+func (_Registry *RegistrySession) GetAllNames() ([]string, error) {
+	return _Registry.Contract.GetAllNames(&_Registry.CallOpts)
+}
+
+// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
+//
+// Solidity: function getAllNames() view returns(string[])
+func (_Registry *RegistryCallerSession) GetAllNames() ([]string, error) {
+	return _Registry.Contract.GetAllNames(&_Registry.CallOpts)
+}
+
+// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
+//
+// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
+func (_Registry *RegistryCaller) GetAllRecords(opts *bind.CallOpts, name string) ([]IRegistryRecord, error) {
+	var (
+		ret0 = new([]IRegistryRecord)
+	)
+	out := ret0
+	err := _Registry.contract.Call(opts, out, "getAllRecords", name)
+	return *ret0, err
+}
+
+// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
+//
+// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
+func (_Registry *RegistrySession) GetAllRecords(name string) ([]IRegistryRecord, error) {
+	return _Registry.Contract.GetAllRecords(&_Registry.CallOpts, name)
+}
+
+// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
+//
+// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
+func (_Registry *RegistryCallerSession) GetAllRecords(name string) ([]IRegistryRecord, error) {
+	return _Registry.Contract.GetAllRecords(&_Registry.CallOpts, name)
+}
+
 // Names is a free data retrieval call binding the contract method 0x4622ab03.
 //
 // Solidity: function names(uint256 ) view returns(string)
@@ -978,6 +1466,32 @@ func (_Registry *RegistrySession) Names(arg0 *big.Int) (string, error) {
 // Solidity: function names(uint256 ) view returns(string)
 func (_Registry *RegistryCallerSession) Names(arg0 *big.Int) (string, error) {
 	return _Registry.Contract.Names(&_Registry.CallOpts, arg0)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Registry *RegistryCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _Registry.contract.Call(opts, out, "owner")
+	return *ret0, err
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Registry *RegistrySession) Owner() (common.Address, error) {
+	return _Registry.Contract.Owner(&_Registry.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Registry *RegistryCallerSession) Owner() (common.Address, error) {
+	return _Registry.Contract.Owner(&_Registry.CallOpts)
 }
 
 // Records is a free data retrieval call binding the contract method 0x3b51650d.
@@ -1016,23 +1530,373 @@ func (_Registry *RegistryCallerSession) Records(arg0 string, arg1 *big.Int) (str
 	return _Registry.Contract.Records(&_Registry.CallOpts, arg0, arg1)
 }
 
+// Register is a paid mutator transaction binding the contract method 0xd393c871.
+//
+// Solidity: function register(string name, address addr, uint256 activation) returns()
+func (_Registry *RegistryTransactor) Register(opts *bind.TransactOpts, name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
+	return _Registry.contract.Transact(opts, "register", name, addr, activation)
+}
+
+// Register is a paid mutator transaction binding the contract method 0xd393c871.
+//
+// Solidity: function register(string name, address addr, uint256 activation) returns()
+func (_Registry *RegistrySession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
+	return _Registry.Contract.Register(&_Registry.TransactOpts, name, addr, activation)
+}
+
+// Register is a paid mutator transaction binding the contract method 0xd393c871.
+//
+// Solidity: function register(string name, address addr, uint256 activation) returns()
+func (_Registry *RegistryTransactorSession) Register(name string, addr common.Address, activation *big.Int) (*types.Transaction, error) {
+	return _Registry.Contract.Register(&_Registry.TransactOpts, name, addr, activation)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Registry *RegistryTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _Registry.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Registry *RegistrySession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Registry.Contract.TransferOwnership(&_Registry.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Registry *RegistryTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Registry.Contract.TransferOwnership(&_Registry.TransactOpts, newOwner)
+}
+
+// RegistryOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Registry contract.
+type RegistryOwnershipTransferredIterator struct {
+	Event *RegistryOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RegistryOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RegistryOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RegistryOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RegistryOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RegistryOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RegistryOwnershipTransferred represents a OwnershipTransferred event raised by the Registry contract.
+type RegistryOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Registry *RegistryFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*RegistryOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Registry.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryOwnershipTransferredIterator{contract: _Registry.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Registry *RegistryFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RegistryOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Registry.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RegistryOwnershipTransferred)
+				if err := _Registry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Registry *RegistryFilterer) ParseOwnershipTransferred(log types.Log) (*RegistryOwnershipTransferred, error) {
+	event := new(RegistryOwnershipTransferred)
+	if err := _Registry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// RegistryRegisteredIterator is returned from FilterRegistered and is used to iterate over the raw logs and unpacked data for Registered events raised by the Registry contract.
+type RegistryRegisteredIterator struct {
+	Event *RegistryRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RegistryRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RegistryRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RegistryRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RegistryRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RegistryRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RegistryRegistered represents a Registered event raised by the Registry contract.
+type RegistryRegistered struct {
+	Name       string
+	Addr       common.Address
+	Activation *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterRegistered is a free log retrieval operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
+//
+// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
+func (_Registry *RegistryFilterer) FilterRegistered(opts *bind.FilterOpts, addr []common.Address, activation []*big.Int) (*RegistryRegisteredIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+	var activationRule []interface{}
+	for _, activationItem := range activation {
+		activationRule = append(activationRule, activationItem)
+	}
+
+	logs, sub, err := _Registry.contract.FilterLogs(opts, "Registered", addrRule, activationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryRegisteredIterator{contract: _Registry.contract, event: "Registered", logs: logs, sub: sub}, nil
+}
+
+// WatchRegistered is a free log subscription operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
+//
+// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
+func (_Registry *RegistryFilterer) WatchRegistered(opts *bind.WatchOpts, sink chan<- *RegistryRegistered, addr []common.Address, activation []*big.Int) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+	var activationRule []interface{}
+	for _, activationItem := range activation {
+		activationRule = append(activationRule, activationItem)
+	}
+
+	logs, sub, err := _Registry.contract.WatchLogs(opts, "Registered", addrRule, activationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RegistryRegistered)
+				if err := _Registry.contract.UnpackLog(event, "Registered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRegistered is a log parse operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
+//
+// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
+func (_Registry *RegistryFilterer) ParseRegistered(log types.Log) (*RegistryRegistered, error) {
+	event := new(RegistryRegistered)
+	if err := _Registry.contract.UnpackLog(event, "Registered", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
 // RegistryMockABI is the input ABI used to generate the binding from.
-const RegistryMockABI = "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+const RegistryMockABI = "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"Registered\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getActiveAddr\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAllNames\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"}],\"name\":\"getAllRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"internalType\":\"structIRegistry.Record[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"names\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"records\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"activation\",\"type\":\"uint256\"}],\"name\":\"register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
 
 // RegistryMockBinRuntime is the compiled bytecode used for adding genesis block without deploying code.
-const RegistryMockBinRuntime = `608060405234801561001057600080fd5b50600436106100575760003560e01c80633b51650d1461005c5780634622ab0314610093578063d393c871146100b3578063e2693e3f146100c8578063f2fde38b146100f3575b600080fd5b61006f61006a366004610432565b610123565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100a66100a1366004610477565b610178565b60405161008a91906104b4565b6100c66100c1366004610503565b610224565b005b6100db6100d636600461055a565b6102f7565b6040516001600160a01b03909116815260200161008a565b6100c6610101366004610597565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b8151602081840181018051600082529282019185019190912091905280548290811061014e57600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061018857600080fd5b9060005260206000200160009150905080546101a3906105b9565b80601f01602080910402602001604051908101604052809291908181526020018280546101cf906105b9565b801561021c5780601f106101f15761010080835404028352916020019161021c565b820191906000526020600020905b8154815290600101906020018083116101ff57829003601f168201915b505050505081565b60008360405161023491906105ed565b90815260405190819003602001902054600003610288576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6016102868482610658565b505b60008360405161029891906105ed565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b60008060008360405161030a91906105ed565b908152604051908190036020019020549050600081900361032e5750600092915050565b60008360405161033e91906105ed565b908152604051908190036020019020610358600183610718565b815481106103685761036861073f565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b634e487b7160e01b600052604160045260246000fd5b600082601f8301126103b657600080fd5b813567ffffffffffffffff808211156103d1576103d161038f565b604051601f8301601f19908116603f011681019082821181831017156103f9576103f961038f565b8160405283815286602085880101111561041257600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561044557600080fd5b823567ffffffffffffffff81111561045c57600080fd5b610468858286016103a5565b95602094909401359450505050565b60006020828403121561048957600080fd5b5035919050565b60005b838110156104ab578181015183820152602001610493565b50506000910152565b60208152600082518060208401526104d3816040850160208701610490565b601f01601f19169190910160400192915050565b80356001600160a01b03811681146104fe57600080fd5b919050565b60008060006060848603121561051857600080fd5b833567ffffffffffffffff81111561052f57600080fd5b61053b868287016103a5565b93505061054a602085016104e7565b9150604084013590509250925092565b60006020828403121561056c57600080fd5b813567ffffffffffffffff81111561058357600080fd5b61058f848285016103a5565b949350505050565b6000602082840312156105a957600080fd5b6105b2826104e7565b9392505050565b600181811c908216806105cd57607f821691505b60208210810361038957634e487b7160e01b600052602260045260246000fd5b600082516105ff818460208701610490565b9190910192915050565b601f82111561065357600081815260208120601f850160051c810160208610156106305750805b601f850160051c820191505b8181101561064f5782815560010161063c565b5050505b505050565b815167ffffffffffffffff8111156106725761067261038f565b6106868161068084546105b9565b84610609565b602080601f8311600181146106bb57600084156106a35750858301515b600019600386901b1c1916600185901b17855561064f565b600085815260208120601f198616915b828110156106ea578886015182559484019460019091019084016106cb565b50858210156107085787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b8181038181111561073957634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea2646970667358221220614d57a0d78769a7f0862854ec412095f7372467ccb4c829a29ffd97a72e5b1464736f6c63430008110033`
+const RegistryMockBinRuntime = `608060405234801561001057600080fd5b50600436106100885760003560e01c8063d393c8711161005b578063d393c87114610129578063e2693e3f1461013e578063f2fde38b14610151578063fb825e5f1461018157600080fd5b80633b51650d1461008d5780634622ab03146100c457806378d573a2146100e45780638da5cb5b14610104575b600080fd5b6100a061009b366004610611565b610196565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100d76100d2366004610656565b6101eb565b6040516100bb91906106bf565b6100f76100f23660046106d9565b610297565b6040516100bb9190610716565b6002546001600160a01b03165b6040516001600160a01b0390911681526020016100bb565b61013c61013736600461078a565b61032a565b005b61011161014c3660046106d9565b6103fd565b61013c61015f3660046107e1565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b610189610495565b6040516100bb91906107fc565b815160208184018101805160008252928201918501919091209190528054829081106101c157600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600181815481106101fb57600080fd5b9060005260206000200160009150905080546102169061085e565b80601f01602080910402602001604051908101604052809291908181526020018280546102429061085e565b801561028f5780601f106102645761010080835404028352916020019161028f565b820191906000526020600020905b81548152906001019060200180831161027257829003601f168201915b505050505081565b60606000826040516102a99190610892565b9081526020016040518091039020805480602002602001604051908101604052809291908181526020016000905b8282101561031f576000848152602090819020604080518082019091526002850290910180546001600160a01b031682526001908101548284015290835290920191016102d7565b505050509050919050565b60008360405161033a9190610892565b9081526040519081900360200190205460000361038e576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60161038c84826108fd565b505b60008360405161039e9190610892565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b6000806000836040516104109190610892565b90815260405190819003602001902054905060008190036104345750600092915050565b6000836040516104449190610892565b90815260405190819003602001902061045e6001836109bd565b8154811061046e5761046e6109e4565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b60606001805480602002602001604051908101604052809291908181526020016000905b828210156105655783829060005260206000200180546104d89061085e565b80601f01602080910402602001604051908101604052809291908181526020018280546105049061085e565b80156105515780601f1061052657610100808354040283529160200191610551565b820191906000526020600020905b81548152906001019060200180831161053457829003601f168201915b5050505050815260200190600101906104b9565b50505050905090565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261059557600080fd5b813567ffffffffffffffff808211156105b0576105b061056e565b604051601f8301601f19908116603f011681019082821181831017156105d8576105d861056e565b816040528381528660208588010111156105f157600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561062457600080fd5b823567ffffffffffffffff81111561063b57600080fd5b61064785828601610584565b95602094909401359450505050565b60006020828403121561066857600080fd5b5035919050565b60005b8381101561068a578181015183820152602001610672565b50506000910152565b600081518084526106ab81602086016020860161066f565b601f01601f19169290920160200192915050565b6020815260006106d26020830184610693565b9392505050565b6000602082840312156106eb57600080fd5b813567ffffffffffffffff81111561070257600080fd5b61070e84828501610584565b949350505050565b602080825282518282018190526000919060409081850190868401855b8281101561076157815180516001600160a01b03168552860151868501529284019290850190600101610733565b5091979650505050505050565b80356001600160a01b038116811461078557600080fd5b919050565b60008060006060848603121561079f57600080fd5b833567ffffffffffffffff8111156107b657600080fd5b6107c286828701610584565b9350506107d16020850161076e565b9150604084013590509250925092565b6000602082840312156107f357600080fd5b6106d28261076e565b6000602080830181845280855180835260408601915060408160051b870101925083870160005b8281101561085157603f1988860301845261083f858351610693565b94509285019290850190600101610823565b5092979650505050505050565b600181811c9082168061087257607f821691505b60208210810361048f57634e487b7160e01b600052602260045260246000fd5b600082516108a481846020870161066f565b9190910192915050565b601f8211156108f857600081815260208120601f850160051c810160208610156108d55750805b601f850160051c820191505b818110156108f4578281556001016108e1565b5050505b505050565b815167ffffffffffffffff8111156109175761091761056e565b61092b81610925845461085e565b846108ae565b602080601f83116001811461096057600084156109485750858301515b600019600386901b1c1916600185901b1785556108f4565b600085815260208120601f198616915b8281101561098f57888601518255948401946001909101908401610970565b50858210156109ad5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b818103818111156109de57634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea2646970667358221220da61e5fee94fcad7c7fffa1ab47fba5f2e0df57cb3294b1ec8f4ad0467db40d564736f6c63430008110033`
 
 // RegistryMockFuncSigs maps the 4-byte function signature to its string representation.
 var RegistryMockFuncSigs = map[string]string{
 	"e2693e3f": "getActiveAddr(string)",
+	"fb825e5f": "getAllNames()",
+	"78d573a2": "getAllRecords(string)",
 	"4622ab03": "names(uint256)",
+	"8da5cb5b": "owner()",
 	"3b51650d": "records(string,uint256)",
 	"d393c871": "register(string,address,uint256)",
 	"f2fde38b": "transferOwnership(address)",
 }
 
 // RegistryMockBin is the compiled bytecode used for deploying new contracts.
-var RegistryMockBin = "0x608060405234801561001057600080fd5b5061078b806100206000396000f3fe608060405234801561001057600080fd5b50600436106100575760003560e01c80633b51650d1461005c5780634622ab0314610093578063d393c871146100b3578063e2693e3f146100c8578063f2fde38b146100f3575b600080fd5b61006f61006a366004610432565b610123565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100a66100a1366004610477565b610178565b60405161008a91906104b4565b6100c66100c1366004610503565b610224565b005b6100db6100d636600461055a565b6102f7565b6040516001600160a01b03909116815260200161008a565b6100c6610101366004610597565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b8151602081840181018051600082529282019185019190912091905280548290811061014e57600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b6001818154811061018857600080fd5b9060005260206000200160009150905080546101a3906105b9565b80601f01602080910402602001604051908101604052809291908181526020018280546101cf906105b9565b801561021c5780601f106101f15761010080835404028352916020019161021c565b820191906000526020600020905b8154815290600101906020018083116101ff57829003601f168201915b505050505081565b60008360405161023491906105ed565b90815260405190819003602001902054600003610288576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6016102868482610658565b505b60008360405161029891906105ed565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b60008060008360405161030a91906105ed565b908152604051908190036020019020549050600081900361032e5750600092915050565b60008360405161033e91906105ed565b908152604051908190036020019020610358600183610718565b815481106103685761036861073f565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b634e487b7160e01b600052604160045260246000fd5b600082601f8301126103b657600080fd5b813567ffffffffffffffff808211156103d1576103d161038f565b604051601f8301601f19908116603f011681019082821181831017156103f9576103f961038f565b8160405283815286602085880101111561041257600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561044557600080fd5b823567ffffffffffffffff81111561045c57600080fd5b610468858286016103a5565b95602094909401359450505050565b60006020828403121561048957600080fd5b5035919050565b60005b838110156104ab578181015183820152602001610493565b50506000910152565b60208152600082518060208401526104d3816040850160208701610490565b601f01601f19169190910160400192915050565b80356001600160a01b03811681146104fe57600080fd5b919050565b60008060006060848603121561051857600080fd5b833567ffffffffffffffff81111561052f57600080fd5b61053b868287016103a5565b93505061054a602085016104e7565b9150604084013590509250925092565b60006020828403121561056c57600080fd5b813567ffffffffffffffff81111561058357600080fd5b61058f848285016103a5565b949350505050565b6000602082840312156105a957600080fd5b6105b2826104e7565b9392505050565b600181811c908216806105cd57607f821691505b60208210810361038957634e487b7160e01b600052602260045260246000fd5b600082516105ff818460208701610490565b9190910192915050565b601f82111561065357600081815260208120601f850160051c810160208610156106305750805b601f850160051c820191505b8181101561064f5782815560010161063c565b5050505b505050565b815167ffffffffffffffff8111156106725761067261038f565b6106868161068084546105b9565b84610609565b602080601f8311600181146106bb57600084156106a35750858301515b600019600386901b1c1916600185901b17855561064f565b600085815260208120601f198616915b828110156106ea578886015182559484019460019091019084016106cb565b50858210156107085787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b8181038181111561073957634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea2646970667358221220614d57a0d78769a7f0862854ec412095f7372467ccb4c829a29ffd97a72e5b1464736f6c63430008110033"
+var RegistryMockBin = "0x608060405234801561001057600080fd5b50610a30806100206000396000f3fe608060405234801561001057600080fd5b50600436106100885760003560e01c8063d393c8711161005b578063d393c87114610129578063e2693e3f1461013e578063f2fde38b14610151578063fb825e5f1461018157600080fd5b80633b51650d1461008d5780634622ab03146100c457806378d573a2146100e45780638da5cb5b14610104575b600080fd5b6100a061009b366004610611565b610196565b604080516001600160a01b0390931683526020830191909152015b60405180910390f35b6100d76100d2366004610656565b6101eb565b6040516100bb91906106bf565b6100f76100f23660046106d9565b610297565b6040516100bb9190610716565b6002546001600160a01b03165b6040516001600160a01b0390911681526020016100bb565b61013c61013736600461078a565b61032a565b005b61011161014c3660046106d9565b6103fd565b61013c61015f3660046107e1565b600280546001600160a01b0319166001600160a01b0392909216919091179055565b610189610495565b6040516100bb91906107fc565b815160208184018101805160008252928201918501919091209190528054829081106101c157600080fd5b6000918252602090912060029091020180546001909101546001600160a01b039091169250905082565b600181815481106101fb57600080fd5b9060005260206000200160009150905080546102169061085e565b80601f01602080910402602001604051908101604052809291908181526020018280546102429061085e565b801561028f5780601f106102645761010080835404028352916020019161028f565b820191906000526020600020905b81548152906001019060200180831161027257829003601f168201915b505050505081565b60606000826040516102a99190610892565b9081526020016040518091039020805480602002602001604051908101604052809291908181526020016000905b8282101561031f576000848152602090819020604080518082019091526002850290910180546001600160a01b031682526001908101548284015290835290920191016102d7565b505050509050919050565b60008360405161033a9190610892565b9081526040519081900360200190205460000361038e576001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf60161038c84826108fd565b505b60008360405161039e9190610892565b90815260408051602092819003830181208183019092526001600160a01b039485168152828101938452815460018082018455600093845293909220905160029092020180546001600160a01b03191691909416178355905191015550565b6000806000836040516104109190610892565b90815260405190819003602001902054905060008190036104345750600092915050565b6000836040516104449190610892565b90815260405190819003602001902061045e6001836109bd565b8154811061046e5761046e6109e4565b60009182526020909120600290910201546001600160a01b03169392505050565b50919050565b60606001805480602002602001604051908101604052809291908181526020016000905b828210156105655783829060005260206000200180546104d89061085e565b80601f01602080910402602001604051908101604052809291908181526020018280546105049061085e565b80156105515780601f1061052657610100808354040283529160200191610551565b820191906000526020600020905b81548152906001019060200180831161053457829003601f168201915b5050505050815260200190600101906104b9565b50505050905090565b634e487b7160e01b600052604160045260246000fd5b600082601f83011261059557600080fd5b813567ffffffffffffffff808211156105b0576105b061056e565b604051601f8301601f19908116603f011681019082821181831017156105d8576105d861056e565b816040528381528660208588010111156105f157600080fd5b836020870160208301376000602085830101528094505050505092915050565b6000806040838503121561062457600080fd5b823567ffffffffffffffff81111561063b57600080fd5b61064785828601610584565b95602094909401359450505050565b60006020828403121561066857600080fd5b5035919050565b60005b8381101561068a578181015183820152602001610672565b50506000910152565b600081518084526106ab81602086016020860161066f565b601f01601f19169290920160200192915050565b6020815260006106d26020830184610693565b9392505050565b6000602082840312156106eb57600080fd5b813567ffffffffffffffff81111561070257600080fd5b61070e84828501610584565b949350505050565b602080825282518282018190526000919060409081850190868401855b8281101561076157815180516001600160a01b03168552860151868501529284019290850190600101610733565b5091979650505050505050565b80356001600160a01b038116811461078557600080fd5b919050565b60008060006060848603121561079f57600080fd5b833567ffffffffffffffff8111156107b657600080fd5b6107c286828701610584565b9350506107d16020850161076e565b9150604084013590509250925092565b6000602082840312156107f357600080fd5b6106d28261076e565b6000602080830181845280855180835260408601915060408160051b870101925083870160005b8281101561085157603f1988860301845261083f858351610693565b94509285019290850190600101610823565b5092979650505050505050565b600181811c9082168061087257607f821691505b60208210810361048f57634e487b7160e01b600052602260045260246000fd5b600082516108a481846020870161066f565b9190910192915050565b601f8211156108f857600081815260208120601f850160051c810160208610156108d55750805b601f850160051c820191505b818110156108f4578281556001016108e1565b5050505b505050565b815167ffffffffffffffff8111156109175761091761056e565b61092b81610925845461085e565b846108ae565b602080601f83116001811461096057600084156109485750858301515b600019600386901b1c1916600185901b1785556108f4565b600085815260208120601f198616915b8281101561098f57888601518255948401946001909101908401610970565b50858210156109ad5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b818103818111156109de57634e487b7160e01b600052601160045260246000fd5b92915050565b634e487b7160e01b600052603260045260246000fdfea2646970667358221220da61e5fee94fcad7c7fffa1ab47fba5f2e0df57cb3294b1ec8f4ad0467db40d564736f6c63430008110033"
 
 // DeployRegistryMock deploys a new Klaytn contract, binding an instance of RegistryMock to it.
 func DeployRegistryMock(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *RegistryMock, error) {
@@ -1216,6 +2080,58 @@ func (_RegistryMock *RegistryMockCallerSession) GetActiveAddr(name string) (comm
 	return _RegistryMock.Contract.GetActiveAddr(&_RegistryMock.CallOpts, name)
 }
 
+// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
+//
+// Solidity: function getAllNames() view returns(string[])
+func (_RegistryMock *RegistryMockCaller) GetAllNames(opts *bind.CallOpts) ([]string, error) {
+	var (
+		ret0 = new([]string)
+	)
+	out := ret0
+	err := _RegistryMock.contract.Call(opts, out, "getAllNames")
+	return *ret0, err
+}
+
+// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
+//
+// Solidity: function getAllNames() view returns(string[])
+func (_RegistryMock *RegistryMockSession) GetAllNames() ([]string, error) {
+	return _RegistryMock.Contract.GetAllNames(&_RegistryMock.CallOpts)
+}
+
+// GetAllNames is a free data retrieval call binding the contract method 0xfb825e5f.
+//
+// Solidity: function getAllNames() view returns(string[])
+func (_RegistryMock *RegistryMockCallerSession) GetAllNames() ([]string, error) {
+	return _RegistryMock.Contract.GetAllNames(&_RegistryMock.CallOpts)
+}
+
+// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
+//
+// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
+func (_RegistryMock *RegistryMockCaller) GetAllRecords(opts *bind.CallOpts, name string) ([]IRegistryRecord, error) {
+	var (
+		ret0 = new([]IRegistryRecord)
+	)
+	out := ret0
+	err := _RegistryMock.contract.Call(opts, out, "getAllRecords", name)
+	return *ret0, err
+}
+
+// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
+//
+// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
+func (_RegistryMock *RegistryMockSession) GetAllRecords(name string) ([]IRegistryRecord, error) {
+	return _RegistryMock.Contract.GetAllRecords(&_RegistryMock.CallOpts, name)
+}
+
+// GetAllRecords is a free data retrieval call binding the contract method 0x78d573a2.
+//
+// Solidity: function getAllRecords(string name) view returns((address,uint256)[])
+func (_RegistryMock *RegistryMockCallerSession) GetAllRecords(name string) ([]IRegistryRecord, error) {
+	return _RegistryMock.Contract.GetAllRecords(&_RegistryMock.CallOpts, name)
+}
+
 // Names is a free data retrieval call binding the contract method 0x4622ab03.
 //
 // Solidity: function names(uint256 ) view returns(string)
@@ -1240,6 +2156,32 @@ func (_RegistryMock *RegistryMockSession) Names(arg0 *big.Int) (string, error) {
 // Solidity: function names(uint256 ) view returns(string)
 func (_RegistryMock *RegistryMockCallerSession) Names(arg0 *big.Int) (string, error) {
 	return _RegistryMock.Contract.Names(&_RegistryMock.CallOpts, arg0)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_RegistryMock *RegistryMockCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _RegistryMock.contract.Call(opts, out, "owner")
+	return *ret0, err
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_RegistryMock *RegistryMockSession) Owner() (common.Address, error) {
+	return _RegistryMock.Contract.Owner(&_RegistryMock.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_RegistryMock *RegistryMockCallerSession) Owner() (common.Address, error) {
+	return _RegistryMock.Contract.Owner(&_RegistryMock.CallOpts)
 }
 
 // Records is a free data retrieval call binding the contract method 0x3b51650d.
@@ -1318,4 +2260,309 @@ func (_RegistryMock *RegistryMockSession) TransferOwnership(newOwner common.Addr
 // Solidity: function transferOwnership(address newOwner) returns()
 func (_RegistryMock *RegistryMockTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
 	return _RegistryMock.Contract.TransferOwnership(&_RegistryMock.TransactOpts, newOwner)
+}
+
+// RegistryMockOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the RegistryMock contract.
+type RegistryMockOwnershipTransferredIterator struct {
+	Event *RegistryMockOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RegistryMockOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RegistryMockOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RegistryMockOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RegistryMockOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RegistryMockOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RegistryMockOwnershipTransferred represents a OwnershipTransferred event raised by the RegistryMock contract.
+type RegistryMockOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_RegistryMock *RegistryMockFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*RegistryMockOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _RegistryMock.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryMockOwnershipTransferredIterator{contract: _RegistryMock.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_RegistryMock *RegistryMockFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RegistryMockOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _RegistryMock.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RegistryMockOwnershipTransferred)
+				if err := _RegistryMock.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_RegistryMock *RegistryMockFilterer) ParseOwnershipTransferred(log types.Log) (*RegistryMockOwnershipTransferred, error) {
+	event := new(RegistryMockOwnershipTransferred)
+	if err := _RegistryMock.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// RegistryMockRegisteredIterator is returned from FilterRegistered and is used to iterate over the raw logs and unpacked data for Registered events raised by the RegistryMock contract.
+type RegistryMockRegisteredIterator struct {
+	Event *RegistryMockRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log      // Log channel receiving the found contract events
+	sub  klaytn.Subscription // Subscription for errors, completion and termination
+	done bool                // Whether the subscription completed delivering logs
+	fail error               // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RegistryMockRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RegistryMockRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RegistryMockRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RegistryMockRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RegistryMockRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RegistryMockRegistered represents a Registered event raised by the RegistryMock contract.
+type RegistryMockRegistered struct {
+	Name       string
+	Addr       common.Address
+	Activation *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterRegistered is a free log retrieval operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
+//
+// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
+func (_RegistryMock *RegistryMockFilterer) FilterRegistered(opts *bind.FilterOpts, addr []common.Address, activation []*big.Int) (*RegistryMockRegisteredIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+	var activationRule []interface{}
+	for _, activationItem := range activation {
+		activationRule = append(activationRule, activationItem)
+	}
+
+	logs, sub, err := _RegistryMock.contract.FilterLogs(opts, "Registered", addrRule, activationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryMockRegisteredIterator{contract: _RegistryMock.contract, event: "Registered", logs: logs, sub: sub}, nil
+}
+
+// WatchRegistered is a free log subscription operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
+//
+// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
+func (_RegistryMock *RegistryMockFilterer) WatchRegistered(opts *bind.WatchOpts, sink chan<- *RegistryMockRegistered, addr []common.Address, activation []*big.Int) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+	var activationRule []interface{}
+	for _, activationItem := range activation {
+		activationRule = append(activationRule, activationItem)
+	}
+
+	logs, sub, err := _RegistryMock.contract.WatchLogs(opts, "Registered", addrRule, activationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RegistryMockRegistered)
+				if err := _RegistryMock.contract.UnpackLog(event, "Registered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRegistered is a log parse operation binding the contract event 0x142e1fdac7ecccbc62af925f0b4039db26847b625602e56b1421dfbc8a0e4f30.
+//
+// Solidity: event Registered(string name, address indexed addr, uint256 indexed activation)
+func (_RegistryMock *RegistryMockFilterer) ParseRegistered(log types.Log) (*RegistryMockRegistered, error) {
+	event := new(RegistryMockRegistered)
+	if err := _RegistryMock.contract.UnpackLog(event, "Registered", log); err != nil {
+		return nil, err
+	}
+	return event, nil
 }

--- a/contracts/system_contracts/all.sol
+++ b/contracts/system_contracts/all.sol
@@ -7,3 +7,4 @@ pragma solidity ^0.8.0;
 
 import "./registry/Registry.sol";
 import "./registry/RegistryMock.sol";
+import "./kip113/KIP113Mock.sol";

--- a/contracts/system_contracts/kip113/IKIP113.sol
+++ b/contracts/system_contracts/kip113/IKIP113.sol
@@ -19,8 +19,7 @@ pragma solidity ^0.8.0;
 
 /// @title KIP-113 BLS public key registry
 /// @dev See https://github.com/klaytn/kips/issues/113
-abstract contract IKIP113 {
-
+interface IKIP113 {
     struct BlsPublicKeyInfo {
         /// @dev compressed BLS12-381 public key (48 bytes)
         bytes publicKey;
@@ -31,34 +30,7 @@ abstract contract IKIP113 {
         bytes pop;
     }
 
-    mapping(address => BlsPublicKeyInfo) infos;
-    address[] addrs;
-
-    event PubkeyRegistered(address addr, bytes publicKey, bytes pop);
-    event PubkeyUnregistered(address addr, bytes publicKey, bytes pop);
-
-    /// @dev Registers the given public key associated with the `msg.sender` address.
-    ///  The function validates the following requirements:
-    ///  - The function MUST revert if `publicKey.length != 48` or `pop.length != 96`.
-    ///  - The function MUST revert if `publicKey` or `pop` is equal to zero.
-    ///  - The function SHOULD authenticate and authorize `msg.sender`.
-    ///  The function emits a `PubkeyRegistered` event.
-    ///  _Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](https://kips.klaytn.foundation/KIPs/kip-113#validation) for off-chain validation.
-    function registerPublicKey(bytes calldata publicKey, bytes calldata pop) external virtual;
-
-    /// @dev Unregisters the public key associated with the given `addr` address.
-    ///  The function validates the following requirements:
-    ///  - The function MUST revert if `addr` has not been registered.
-    ///  - The function SHOULD authenticate and authorize `msg.sender`.
-    ///  The function emits a `PubkeyUnregistered` event.
-    function unregisterPublicKey(address addr) external virtual;
-
-    /// @dev Returns the public key and proof-of-possession given a `addr`.
-    ///  The function MUST revert if given `addr` is not registered.
-    ///  _Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](https://kips.klaytn.foundation/KIPs/kip-113#validation) for off-chain validation.
-    function getInfo(address addr) external virtual view returns (BlsPublicKeyInfo memory pubkey);
-
     /// @dev Returns all the stored addresses, public keys, and proof-of-possessions at once.
     ///  _Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](https://kips.klaytn.foundation/KIPs/kip-113#validation) for off-chain validation.
-    function getAllInfo() external virtual view returns (address[] memory addrList, BlsPublicKeyInfo[] memory pubkeyList);
+    function getAllBlsInfo() external view returns (address[] memory nodeIdList, BlsPublicKeyInfo[] memory pubkeyList);
 }

--- a/contracts/system_contracts/kip113/IKIP113.sol
+++ b/contracts/system_contracts/kip113/IKIP113.sol
@@ -1,0 +1,64 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+/// @title KIP-113 BLS public key registry
+/// @dev See https://github.com/klaytn/kips/issues/113
+abstract contract IKIP113 {
+
+    struct BlsPublicKeyInfo {
+        /// @dev compressed BLS12-381 public key (48 bytes)
+        bytes publicKey;
+        /// @dev proof-of-possession (96 bytes)
+        ///  must be a result of PopProve algorithm as per
+        ///  draft-irtf-cfrg-bls-signature-05 section 3.3.3.
+        ///  with ciphersuite "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_"
+        bytes pop;
+    }
+
+    mapping(address => BlsPublicKeyInfo) infos;
+    address[] addrs;
+
+    event PubkeyRegistered(address addr, bytes publicKey, bytes pop);
+    event PubkeyUnregistered(address addr, bytes publicKey, bytes pop);
+
+    /// @dev Registers the given public key associated with the `msg.sender` address.
+    ///  The function validates the following requirements:
+    ///  - The function MUST revert if `publicKey.length != 48` or `pop.length != 96`.
+    ///  - The function MUST revert if `publicKey` or `pop` is equal to zero.
+    ///  - The function SHOULD authenticate and authorize `msg.sender`.
+    ///  The function emits a `PubkeyRegistered` event.
+    ///  _Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](https://kips.klaytn.foundation/KIPs/kip-113#validation) for off-chain validation.
+    function registerPublicKey(bytes calldata publicKey, bytes calldata pop) external virtual;
+
+    /// @dev Unregisters the public key associated with the given `addr` address.
+    ///  The function validates the following requirements:
+    ///  - The function MUST revert if `addr` has not been registered.
+    ///  - The function SHOULD authenticate and authorize `msg.sender`.
+    ///  The function emits a `PubkeyUnregistered` event.
+    function unregisterPublicKey(address addr) external virtual;
+
+    /// @dev Returns the public key and proof-of-possession given a `addr`.
+    ///  The function MUST revert if given `addr` is not registered.
+    ///  _Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](https://kips.klaytn.foundation/KIPs/kip-113#validation) for off-chain validation.
+    function getInfo(address addr) external virtual view returns (BlsPublicKeyInfo memory pubkey);
+
+    /// @dev Returns all the stored addresses, public keys, and proof-of-possessions at once.
+    ///  _Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](https://kips.klaytn.foundation/KIPs/kip-113#validation) for off-chain validation.
+    function getAllInfo() external virtual view returns (address[] memory addrList, BlsPublicKeyInfo[] memory pubkeyList);
+}

--- a/contracts/system_contracts/kip113/KIP113Mock.sol
+++ b/contracts/system_contracts/kip113/KIP113Mock.sol
@@ -20,35 +20,31 @@ pragma solidity ^0.8.0;
 import "./IKIP113.sol";
 
 contract KIP113Mock is IKIP113 {
-    function registerPublicKey(bytes calldata publicKey, bytes calldata pop) external virtual override {
-        address addr = msg.sender;
+    mapping(address => BlsPublicKeyInfo) public record;
+    address[] public allNodeIds;
 
-        if (infos[addr].publicKey.length == 0) {
-            addrs.push(addr);
+    function register(
+        address addr,
+        bytes calldata publicKey,
+        bytes calldata pop
+    ) external {
+        if (record[addr].publicKey.length == 0) {
+            allNodeIds.push(addr);
         }
-
-        infos[addr] = BlsPublicKeyInfo(publicKey, pop);
+        record[addr] = BlsPublicKeyInfo(publicKey, pop);
     }
 
-    function unregisterPublicKey(address addr) external virtual override {
-        delete infos[addr];
-    }
+    function getAllBlsInfo() external virtual override view
+    returns (address[] memory nodeIdList, BlsPublicKeyInfo[] memory pubkeyList) {
+        uint count = allNodeIds.length;
 
-    function getInfo(address addr) external virtual override view returns (BlsPublicKeyInfo memory pubkey) {
-        return infos[addr];
-    }
-
-    function getAllInfo() external virtual override view returns (address[] memory addrList, BlsPublicKeyInfo[] memory pubkeyList) {
-        uint count = addrs.length;
-
-        addrList = new address[](count);
+        nodeIdList = new address[](count);
         pubkeyList = new BlsPublicKeyInfo[](count);
 
         for (uint i = 0; i < count; i++) {
-            addrList[i] = addrs[i];
-            pubkeyList[i] = infos[addrs[i]];
+            nodeIdList[i] = allNodeIds[i];
+            pubkeyList[i] = record[allNodeIds[i]];
         }
-        return (addrList, pubkeyList);
+        return (nodeIdList, pubkeyList);
     }
 }
-

--- a/contracts/system_contracts/kip113/KIP113Mock.sol
+++ b/contracts/system_contracts/kip113/KIP113Mock.sol
@@ -1,0 +1,54 @@
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "./IKIP113.sol";
+
+contract KIP113Mock is IKIP113 {
+    function registerPublicKey(bytes calldata publicKey, bytes calldata pop) external virtual override {
+        address addr = msg.sender;
+
+        if (infos[addr].publicKey.length == 0) {
+            addrs.push(addr);
+        }
+
+        infos[addr] = BlsPublicKeyInfo(publicKey, pop);
+    }
+
+    function unregisterPublicKey(address addr) external virtual override {
+        delete infos[addr];
+    }
+
+    function getInfo(address addr) external virtual override view returns (BlsPublicKeyInfo memory pubkey) {
+        return infos[addr];
+    }
+
+    function getAllInfo() external virtual override view returns (address[] memory addrList, BlsPublicKeyInfo[] memory pubkeyList) {
+        uint count = addrs.length;
+
+        addrList = new address[](count);
+        pubkeyList = new BlsPublicKeyInfo[](count);
+
+        for (uint i = 0; i < count; i++) {
+            addrList[i] = addrs[i];
+            pubkeyList[i] = infos[addrs[i]];
+        }
+        return (addrList, pubkeyList);
+    }
+}
+

--- a/tests/kip113_test.go
+++ b/tests/kip113_test.go
@@ -1,0 +1,136 @@
+// Copyright 2018 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+
+package tests
+
+import (
+	"math/big"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/klaytn/klaytn/accounts/abi/bind"
+	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
+	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/system"
+	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/consensus/istanbul"
+	contracts "github.com/klaytn/klaytn/contracts/system_contracts"
+	"github.com/klaytn/klaytn/crypto/bls"
+	"github.com/klaytn/klaytn/log"
+	"github.com/klaytn/klaytn/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKIP113(t *testing.T) {
+	log.EnableLogForTest(log.LvlError, log.LvlInfo)
+
+	// prepare chain configuration
+	config := params.CypressChainConfig.Copy()
+	config.LondonCompatibleBlock = big.NewInt(0)
+	config.IstanbulCompatibleBlock = big.NewInt(0)
+	config.EthTxTypeCompatibleBlock = big.NewInt(0)
+	config.MagmaCompatibleBlock = big.NewInt(0)
+	config.KoreCompatibleBlock = big.NewInt(0)
+	config.ShanghaiCompatibleBlock = big.NewInt(0)
+	config.Istanbul.SubGroupSize = 1
+	config.Istanbul.ProposerPolicy = uint64(istanbul.RoundRobin)
+	config.Governance.Reward.MintingAmount = new(big.Int).Mul(big.NewInt(9000000000000000000), big.NewInt(params.KLAY))
+
+	// make a blockchain node
+	fullNode, node, validator, _, workspace := newBlockchain(t, config)
+	defer func() {
+		fullNode.Stop()
+		os.RemoveAll(workspace)
+	}()
+
+	var (
+		senderKey  = validator.Keys[0]
+		sender     = bind.NewKeyedTransactor(senderKey)
+		senderAddr = sender.From
+
+		transactor = backends.NewBlockchainContractBackend(node.BlockChain(), node.TxPool().(*blockchain.TxPool), nil)
+
+		_, pub1, pop1 = makeBlsKey()
+		_, pub2, _    = makeBlsKey()
+	)
+	contractAddr, tx, contract, err := contracts.DeployKIP113Mock(sender, transactor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkReceipt(t, node.BlockChain().(*blockchain.BlockChain), tx.Hash())
+
+	// Register BLS key for sender
+	if tx, err = contract.RegisterPublicKey(sender, pub1, pop1); err != nil {
+		t.Fatal(err)
+	}
+	checkReceipt(t, node.BlockChain().(*blockchain.BlockChain), tx.Hash())
+
+	infos, err := system.ReadKip113All(transactor, contractAddr, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(infos))
+	assert.Equal(t, pub1, infos[senderAddr].PublicKey)
+	assert.Equal(t, pop1, infos[senderAddr].Pop)
+
+	// Unregister BLS key for sender
+	if tx, err = contract.UnregisterPublicKey(sender, senderAddr); err != nil {
+		t.Fatal(err)
+	}
+	checkReceipt(t, node.BlockChain().(*blockchain.BlockChain), tx.Hash())
+
+	infos, err = system.ReadKip113All(transactor, contractAddr, nil)
+	assert.Nil(t, err)
+	assert.Nil(t, infos[senderAddr].PublicKey)
+	assert.Nil(t, infos[senderAddr].Pop)
+	assert.Equal(t, 0, len(infos))
+
+	// Register invalid BLS key for sender
+	if tx, err = contract.RegisterPublicKey(sender, pub2, pop1); err != nil {
+		t.Fatal(err)
+	}
+	checkReceipt(t, node.BlockChain().(*blockchain.BlockChain), tx.Hash())
+
+	// Invalid BLS key will be filtered out in REadKip113All function
+	infos, err = system.ReadKip113All(transactor, contractAddr, nil)
+	assert.Nil(t, err)
+	assert.Nil(t, infos[senderAddr].PublicKey)
+	assert.Nil(t, infos[senderAddr].Pop)
+	assert.Equal(t, 0, len(infos))
+}
+
+func makeBlsKey() (priv, pub, pop []byte) {
+	ikm := make([]byte, 32)
+	rand.Read(ikm)
+
+	sk, _ := bls.GenerateKey(ikm)
+	pk := sk.PublicKey()
+	sig := bls.PopProve(sk)
+
+	priv = sk.Marshal()
+	pub = pk.Marshal()
+	pop = sig.Marshal()
+	if len(priv) != 32 || len(pub) != 48 || len(pop) != 96 {
+		panic("bad bls key")
+	}
+	return
+}
+
+func checkReceipt(t *testing.T, chain *blockchain.BlockChain, txHash common.Hash) {
+	receipt := waitReceipt(chain, txHash)
+	if receipt == nil {
+		t.Fatal("timeout")
+	}
+}


### PR DESCRIPTION
## Proposed changes

- Add KIP113 contract mockup (see [KIP-113](https://github.com/klaytn/kips/blob/main/KIPs/kip-113.md))
- Actual KIP113.sol won't be added because the concrete implementation is out of the Klaytn node's scope.
- Add accessors to the KIP113 system contract.
  - `ReadKip113All()` calls the `getAllInfo()` function, and filters out records with invalid public key or pop values.
  - `AllocKip113()` calculates the storage layout of KIP113Mock contract, for testing.

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

Since #1987 conflicts with `contracts/system_contracts/all.go`, This PR will be merged after that.