### PR TITLE
replace uses of ioutil with io and os

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -24,7 +24,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math/big"
 
 	"github.com/klaytn/klaytn/accounts"
@@ -37,7 +36,7 @@ import (
 // NewTransactor is a utility method to easily create a transaction signer from
 // an encrypted json key stream and the associated passphrase.
 func NewTransactor(keyin io.Reader, passphrase string) (*TransactOpts, error) {
-	json, err := ioutil.ReadAll(keyin)
+	json, err := io.ReadAll(keyin)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -22,7 +22,6 @@ package bind
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1709,7 +1708,7 @@ func TestGolangBindings(t *testing.T) {
 		t.Skip("go sdk not found for testing")
 	}
 	// Create a temporary workspace for the test suite
-	ws, err := ioutil.TempDir("", "binding-test")
+	ws, err := os.MkdirTemp("", "binding-test")
 	if err != nil {
 		t.Fatalf("failed to create temporary workspace: %v", err)
 	}
@@ -1733,7 +1732,7 @@ func TestGolangBindings(t *testing.T) {
 			if err != nil {
 				t.Fatalf("test %d: failed to generate binding: %v", i, err)
 			}
-			if err = ioutil.WriteFile(filepath.Join(pkg, strings.ToLower(tt.name)+".go"), []byte(bind), 0o600); err != nil {
+			if err = os.WriteFile(filepath.Join(pkg, strings.ToLower(tt.name)+".go"), []byte(bind), 0o600); err != nil {
 				t.Fatalf("test %d: failed to write binding: %v", i, err)
 			}
 			// Generate the test file with the injected test code
@@ -1749,7 +1748,7 @@ func TestGolangBindings(t *testing.T) {
 					%s
 				}
 			`, tt.imports, tt.name, tt.tester)
-			if err := ioutil.WriteFile(filepath.Join(pkg, strings.ToLower(tt.name)+"_test.go"), []byte(code), 0o600); err != nil {
+			if err := os.WriteFile(filepath.Join(pkg, strings.ToLower(tt.name)+"_test.go"), []byte(code), 0o600); err != nil {
 				t.Fatalf("test %d: failed to write tests: %v", i, err)
 			}
 		})

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -22,7 +22,6 @@ package keystore
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -390,11 +389,11 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
-	// needed so that modTime of `file` is different to its current value after ioutil.WriteFile
+	// needed so that modTime of `file` is different to its current value after os.WriteFile
 	time.Sleep(1000 * time.Millisecond)
 
 	// Now replace file contents with crap
-	if err := ioutil.WriteFile(file, []byte("foo"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("foo"), 0644); err != nil {
 		t.Fatal(err)
 		return
 	}
@@ -408,9 +407,9 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 
 // forceCopyFile is like cp.CopyFile, but doesn't complain if the destination exists.
 func forceCopyFile(dst, src string) error {
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dst, data, 0o644)
+	return os.WriteFile(dst, data, 0o644)
 }

--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -246,7 +245,7 @@ func writeTemporaryKeyFile(file string, content []byte) (string, error) {
 	}
 	// Atomic write: create a temporary hidden file first
 	// then move it into place. TempFile assigns mode 0600.
-	f, err := ioutil.TempFile(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
+	f, err := os.CreateTemp(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
 	if err != nil {
 		return "", err
 	}

--- a/accounts/keystore/keystore_passphrase.go
+++ b/accounts/keystore/keystore_passphrase.go
@@ -30,7 +30,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -77,7 +76,7 @@ type keyStorePassphrase struct {
 
 func (ks keyStorePassphrase) GetKey(addr common.Address, filename, auth string) (Key, error) {
 	// Load the key from the keystore and decrypt its contents
-	keyjson, err := ioutil.ReadFile(filename)
+	keyjson, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/keystore/keystore_passphrase_test.go
+++ b/accounts/keystore/keystore_passphrase_test.go
@@ -22,7 +22,7 @@ package keystore
 
 import (
 	"crypto/ecdsa"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/klaytn/klaytn/crypto"
@@ -39,7 +39,7 @@ const (
 
 // Tests that a json key file can be decrypted and encrypted in multiple rounds.
 func TestKeyEncryptDecrypt(t *testing.T) {
-	keyjson, err := ioutil.ReadFile("testdata/very-light-scrypt.json")
+	keyjson, err := os.ReadFile("testdata/very-light-scrypt.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/accounts/keystore/keystore_plain_test.go
+++ b/accounts/keystore/keystore_plain_test.go
@@ -24,7 +24,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -36,7 +35,7 @@ import (
 )
 
 func tmpKeyStoreIface(t *testing.T, encrypted bool) (dir string, ks keyStore) {
-	d, err := ioutil.TempDir("", "klay-keystore-test")
+	d, err := os.MkdirTemp("", "klay-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -22,7 +22,6 @@ package keystore
 
 import (
 	"crypto/ecdsa"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -388,7 +387,7 @@ func checkEvents(t *testing.T, want []walletEvent, have []walletEvent) {
 }
 
 func tmpKeyStore(t *testing.T, encrypted bool) (string, *KeyStore) {
-	d, err := ioutil.TempDir("", "klay-keystore-test")
+	d, err := os.MkdirTemp("", "klay-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/api_private_account_test.go
+++ b/api/api_private_account_test.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -35,7 +34,7 @@ func TestPrivateAccountAPI_ImportRawKey(t *testing.T) {
 
 	// To get JSON files use below.
 	// keydir := filepath.Join(".", "keystore")
-	keydir, err := ioutil.TempDir("", "klay-test")
+	keydir, err := os.MkdirTemp("", "klay-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(keydir)
 

--- a/api/api_public_transaction_pool_test.go
+++ b/api/api_public_transaction_pool_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"reflect"
@@ -72,7 +71,7 @@ func TestTxTypeSupport(t *testing.T) {
 	chainConf := params.ChainConfig{ChainID: big.NewInt(1)}
 
 	// generate a keystore and active accounts
-	dir, err := ioutil.TempDir("", "klay-keystore-test")
+	dir, err := os.MkdirTemp("", "klay-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -22,7 +22,6 @@ package blockchain
 
 import (
 	"crypto/ecdsa"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -360,7 +359,7 @@ func benchReadChain(b *testing.B, full bool, databaseType database.DBType, count
 
 // genTempDirForDB returns temp dir for database
 func genTempDirForDB(b *testing.B) string {
-	dir, err := ioutil.TempDir("", "klay-blockchain-bench")
+	dir, err := os.MkdirTemp("", "klay-blockchain-bench")
 	if err != nil {
 		b.Fatalf("cannot create temporary directory: %v", err)
 	}

--- a/blockchain/blockchain_kes_test.go
+++ b/blockchain/blockchain_kes_test.go
@@ -17,7 +17,7 @@
 package blockchain
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -34,7 +34,7 @@ import (
 
 func getTestBlock(t *testing.T) types.Block {
 	var block types.Block
-	blockDump, err := ioutil.ReadFile("../tests/b1.rlp")
+	blockDump, err := os.ReadFile("../tests/b1.rlp")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/blockchain/state_migration_test.go
+++ b/blockchain/state_migration_test.go
@@ -18,7 +18,6 @@ package blockchain
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -32,7 +31,7 @@ import (
 )
 
 func createLocalTestDB(t *testing.T) (string, database.DBManager) {
-	dir, err := ioutil.TempDir("", "klaytn-test-migration")
+	dir, err := os.MkdirTemp("", "klaytn-test-migration")
 	if err != nil {
 		t.Fatalf("failed to create a database: %v", err)
 	}

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -24,7 +24,6 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -1921,15 +1920,13 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	t.Parallel()
 
 	// Create a temporary file for the journal
-	file, err := ioutil.TempFile("", "")
+	journal, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary journal: %v", err)
 	}
-	journal := file.Name()
 	defer os.Remove(journal)
 
 	// Clean up the temporary file, we only need the path for now
-	file.Close()
 	os.Remove(journal)
 
 	// Create the original pool to inject transaction into the journal
@@ -2638,15 +2635,13 @@ func TestTransactionJournalingSortedByTime(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary file for the journal
-	file, err := ioutil.TempFile("", "")
+	journal, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary journal: %v", err)
 	}
-	journal := file.Name()
 	defer os.Remove(journal)
 
 	// Clean up the temporary file, we only need the path for now
-	file.Close()
 	os.Remove(journal)
 
 	// Create the pool to test the status retrievals with

--- a/blockchain/types/block_test.go
+++ b/blockchain/types/block_test.go
@@ -22,8 +22,8 @@ package types
 
 import (
 	"bytes"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"reflect"
 	"testing"
 
@@ -467,7 +467,7 @@ func TestHeaderSizeCalc(t *testing.T) {
 }
 
 func BenchmarkBlockEncodingHashWithInterface(b *testing.B) {
-	data, err := ioutil.ReadFile("../../tests/b1.rlp")
+	data, err := os.ReadFile("../../tests/b1.rlp")
 	if err != nil {
 		b.Fatal("Failed to read a block file: ", err)
 	}
@@ -485,7 +485,7 @@ func BenchmarkBlockEncodingHashWithInterface(b *testing.B) {
 }
 
 func BenchmarkBlockEncodingRlpHash(b *testing.B) {
-	data, err := ioutil.ReadFile("../../tests/b1.rlp")
+	data, err := os.ReadFile("../../tests/b1.rlp")
 	if err != nil {
 		b.Fatal("Failed to read a block file: ", err)
 	}
@@ -503,7 +503,7 @@ func BenchmarkBlockEncodingRlpHash(b *testing.B) {
 }
 
 func BenchmarkBlockEncodingCopiedBlockHeader(b *testing.B) {
-	data, err := ioutil.ReadFile("../../tests/b1.rlp")
+	data, err := os.ReadFile("../../tests/b1.rlp")
 	if err != nil {
 		b.Fatal("Failed to read a block file: ", err)
 	}

--- a/blockchain/vm/contracts_test.go
+++ b/blockchain/vm/contracts_test.go
@@ -24,8 +24,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/klaytn/klaytn/blockchain/state"
@@ -277,7 +277,7 @@ func TestPrecompiledModExpOOG(t *testing.T) {
 }
 
 func loadJson(name string) ([]precompiledTest, error) {
-	data, err := ioutil.ReadFile(fmt.Sprintf("testdata/precompiles/%v.json", name))
+	data, err := os.ReadFile(fmt.Sprintf("testdata/precompiles/%v.json", name))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func loadJson(name string) ([]precompiledTest, error) {
 }
 
 func loadJsonFail(name string) ([]precompiledFailureTest, error) {
-	data, err := ioutil.ReadFile(fmt.Sprintf("testdata/precompiles/fail-%v.json", name))
+	data, err := os.ReadFile(fmt.Sprintf("testdata/precompiles/fail-%v.json", name))
 	if err != nil {
 		return nil, err
 	}

--- a/build/ci.go
+++ b/build/ci.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -175,7 +174,7 @@ func doInstall(cmdline []string) {
 	goinstall.Args = append(goinstall.Args, packages...)
 	build.MustRun(goinstall)
 
-	if cmds, err := ioutil.ReadDir("cmd"); err == nil {
+	if cmds, err := os.ReadDir("cmd"); err == nil {
 		for _, cmd := range cmds {
 			pkgs, err := parser.ParseDir(token.NewFileSet(), filepath.Join(".", "cmd", cmd.Name()), nil, parser.PackageClauseOnly)
 			if err != nil {
@@ -567,7 +566,7 @@ func makeWorkdir(wdflag string) string {
 	if wdflag != "" {
 		err = os.MkdirAll(wdflag, 0o744)
 	} else {
-		wdflag, err = ioutil.TempDir("", "klay-build-")
+		wdflag, err = os.MkdirTemp("", "klay-build-")
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/build/update-license.go
+++ b/build/update-license.go
@@ -44,7 +44,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -910,7 +909,7 @@ func gitAuthors(files []string) []string {
 
 // gitAuthors returns git authors from AUTHORS file
 func readAuthors() []string {
-	content, err := ioutil.ReadFile("AUTHORS")
+	content, err := os.ReadFile("AUTHORS")
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatalln("error reading AUTHORS:", err)
 	}
@@ -969,7 +968,7 @@ func writeAuthors(files []string) {
 		content.WriteString("\n")
 	}
 	fmt.Println("writing AUTHORS")
-	if err := ioutil.WriteFile("AUTHORS", content.Bytes(), 0o644); err != nil {
+	if err := os.WriteFile("AUTHORS", content.Bytes(), 0o644); err != nil {
 		log.Fatalln(err)
 	}
 }
@@ -1055,7 +1054,7 @@ func writeLicense(info *info) {
 	if err != nil {
 		log.Fatalf("error stat'ing %s: %v\n", info.file, err)
 	}
-	content, err := ioutil.ReadFile(info.file)
+	content, err := os.ReadFile(info.file)
 	if err != nil {
 		log.Fatalf("error reading %s: %v\n", info.file, err)
 	}
@@ -1095,7 +1094,7 @@ func writeLicense(info *info) {
 		fmt.Println("skipping (no changes)", info.file)
 		return
 	}
-	if err := ioutil.WriteFile(info.file, buf.Bytes(), fi.Mode()); err != nil {
+	if err := os.WriteFile(info.file, buf.Bytes(), fi.Mode()); err != nil {
 		log.Fatalf("error writing %s: %v", info.file, err)
 	}
 }

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -23,7 +23,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -163,9 +163,9 @@ func abigen(c *cli.Context) error {
 		)
 		input := c.String(abiFlag.Name)
 		if input == "-" {
-			abi, err = ioutil.ReadAll(os.Stdin)
+			abi, err = io.ReadAll(os.Stdin)
 		} else {
-			abi, err = ioutil.ReadFile(input)
+			abi, err = os.ReadFile(input)
 		}
 		if err != nil {
 			log.Fatalf("Failed to read input ABI: %v", err)
@@ -174,7 +174,7 @@ func abigen(c *cli.Context) error {
 
 		var bin []byte
 		if binFile := c.String(binFlag.Name); binFile != "" {
-			if bin, err = ioutil.ReadFile(binFile); err != nil {
+			if bin, err = os.ReadFile(binFile); err != nil {
 				log.Fatalf("Failed to read input bytecode: %v", err)
 			}
 			if strings.Contains(string(bin), "//") {
@@ -184,7 +184,7 @@ func abigen(c *cli.Context) error {
 		bins = append(bins, string(bin))
 		var binruntime []byte
 		if binruntimeFile := c.String(binruntimeFlag.Name); binruntimeFile != "" {
-			if binruntime, err = ioutil.ReadFile(binruntimeFile); err != nil {
+			if binruntime, err = os.ReadFile(binruntimeFile); err != nil {
 				log.Fatalf("Failed to read input runtime-bytecode: %v", err)
 			}
 			if strings.Contains(string(binruntime), "//") {
@@ -214,7 +214,7 @@ func abigen(c *cli.Context) error {
 				log.Fatalf("Failed to build Solidity contract: %v", err)
 			}
 		case c.IsSet(jsonFlag.Name):
-			jsonOutput, err := ioutil.ReadFile(c.String(jsonFlag.Name))
+			jsonOutput, err := os.ReadFile(c.String(jsonFlag.Name))
 			if err != nil {
 				log.Fatalf("Failed to read combined-json from compiler: %v", err)
 			}
@@ -265,7 +265,7 @@ func abigen(c *cli.Context) error {
 		fmt.Printf("%s\n", code)
 		return nil
 	}
-	if err := ioutil.WriteFile(c.String(outFlag.Name), []byte(code), 0o600); err != nil {
+	if err := os.WriteFile(c.String(outFlag.Name), []byte(code), 0o600); err != nil {
 		log.Fatalf("Failed to write ABI binding: %v", err)
 	}
 	return nil

--- a/cmd/homi/common/utils.go
+++ b/cmd/homi/common/utils.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -138,12 +137,12 @@ func RandomBytes(len int) ([]byte, error) {
 }
 
 func copyFile(src string, dst string) {
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		logger.Error("Failed to read file", "file", src, "err", err)
 		return
 	}
-	err = ioutil.WriteFile(dst, data, 0o644)
+	err = os.WriteFile(dst, data, 0o644)
 	if err != nil {
 		logger.Error("Failed to write file", "file", dst, "err", err)
 		return

--- a/cmd/homi/genesis/genesis.go
+++ b/cmd/homi/genesis/genesis.go
@@ -19,8 +19,8 @@ package genesis
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -94,5 +94,5 @@ func Save(dataDir string, genesis *blockchain.Genesis) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filePath, raw, 0o600)
+	return os.WriteFile(filePath, raw, 0o600)
 }

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -21,7 +21,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"math/rand"
 	"net"
@@ -337,7 +337,7 @@ func genRewardKeystore(account accounts.Account, i int) {
 	}
 	defer file.Close()
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		log.Fatalf("Failed to read file: %s", err)
 	}
@@ -758,9 +758,9 @@ func Gen(ctx *cli.Context) error {
 				TxGenDuration:   ctx.String(txGenDurFlag.Name),
 			})
 		os.MkdirAll(outputPath, os.ModePerm)
-		ioutil.WriteFile(path.Join(outputPath, "docker-compose.yml"), []byte(compose.String()), os.ModePerm)
+		os.WriteFile(path.Join(outputPath, "docker-compose.yml"), []byte(compose.String()), os.ModePerm)
 		fmt.Println("Created : ", path.Join(outputPath, "docker-compose.yml"))
-		ioutil.WriteFile(path.Join(outputPath, "prometheus.yml"), []byte(compose.PrometheusService.Config.String()), os.ModePerm)
+		os.WriteFile(path.Join(outputPath, "prometheus.yml"), []byte(compose.PrometheusService.Config.String()), os.ModePerm)
 		fmt.Println("Created : ", path.Join(outputPath, "prometheus.yml"))
 		downLoadGrafanaJson()
 	case TypeLocal:
@@ -792,12 +792,12 @@ func downLoadGrafanaJson() {
 		} else if resp.StatusCode != 200 {
 			fmt.Printf("Failed to download the imgs dashboard file(%s) [%s] - %v\n", file.url, resp.Status, err)
 		} else {
-			bytes, e := ioutil.ReadAll(resp.Body)
+			bytes, e := io.ReadAll(resp.Body)
 			if e != nil {
 				fmt.Println("Failed to read http response", e)
 			} else {
 				fileName := file.name
-				ioutil.WriteFile(path.Join(outputPath, fileName), bytes, os.ModePerm)
+				os.WriteFile(path.Join(outputPath, fileName), bytes, os.ModePerm)
 				fmt.Println("Created : ", path.Join(outputPath, fileName))
 			}
 			resp.Body.Close()
@@ -1116,12 +1116,12 @@ func writeValidatorsAndNodesToFile(validators []*ValidatorInfo, parentDir string
 
 	for i, v := range validators {
 		nodeKeyFilePath := path.Join(parentPath, "nodekey"+strconv.Itoa(i+1))
-		ioutil.WriteFile(nodeKeyFilePath, []byte(nodekeys[i]), os.ModePerm)
+		os.WriteFile(nodeKeyFilePath, []byte(nodekeys[i]), os.ModePerm)
 		fmt.Println("Created : ", nodeKeyFilePath)
 
 		str, _ := json.MarshalIndent(v, "", "\t")
 		validatorInfoFilePath := path.Join(parentPath, "validator"+strconv.Itoa(i+1))
-		ioutil.WriteFile(validatorInfoFilePath, []byte(str), os.ModePerm)
+		os.WriteFile(validatorInfoFilePath, []byte(str), os.ModePerm)
 		fmt.Println("Created : ", validatorInfoFilePath)
 	}
 }
@@ -1132,7 +1132,7 @@ func writeTestKeys(parentDir string, privKeys []*ecdsa.PrivateKey, keys []string
 
 	for i, key := range keys {
 		testKeyFilePath := path.Join(parentPath, "testkey"+strconv.Itoa(i+1))
-		ioutil.WriteFile(testKeyFilePath, []byte(key), os.ModePerm)
+		os.WriteFile(testKeyFilePath, []byte(key), os.ModePerm)
 		fmt.Println("Created : ", testKeyFilePath)
 
 		pk := privKeys[i]
@@ -1147,7 +1147,7 @@ func writeTestKeys(parentDir string, privKeys []*ecdsa.PrivateKey, keys []string
 func WriteFile(content []byte, parentFolder string, fileName string) {
 	filePath := path.Join(outputPath, parentFolder, fileName)
 	os.MkdirAll(path.Dir(filePath), os.ModePerm)
-	ioutil.WriteFile(filePath, content, os.ModePerm)
+	os.WriteFile(filePath, content, os.ModePerm)
 	fmt.Println("Created : ", filePath)
 }
 

--- a/cmd/kgen/main.go
+++ b/cmd/kgen/main.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -100,7 +99,7 @@ func writeNodeKeyInfoToFile(validator *validatorInfo, parentDir string, nodekey 
 	}
 
 	nodeKeyFilePath := path.Join(parentPath, "nodekey")
-	if err = ioutil.WriteFile(nodeKeyFilePath, []byte(nodekey), os.ModePerm); err != nil {
+	if err = os.WriteFile(nodeKeyFilePath, []byte(nodekey), os.ModePerm); err != nil {
 		return err
 	}
 	fmt.Println("Created : ", nodeKeyFilePath)
@@ -110,7 +109,7 @@ func writeNodeKeyInfoToFile(validator *validatorInfo, parentDir string, nodekey 
 		return err
 	}
 	validatorInfoFilePath := path.Join(parentPath, "node_info.json")
-	if err = ioutil.WriteFile(validatorInfoFilePath, []byte(str), os.ModePerm); err != nil {
+	if err = os.WriteFile(validatorInfoFilePath, []byte(str), os.ModePerm); err != nil {
 		return err
 	}
 

--- a/cmd/utils/files.go
+++ b/cmd/utils/files.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 )
@@ -30,7 +29,7 @@ func WriteFile(content, filePath, fileName string) {
 		os.Exit(-1)
 	}
 
-	err = ioutil.WriteFile(path.Join(filePath, fileName), []byte(content), 0o644)
+	err = os.WriteFile(path.Join(filePath, fileName), []byte(content), 0o644)
 	if err != nil {
 		fmt.Printf("Failed to write %v file: %v\n", fileName, err)
 		os.Exit(-1)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -22,7 +22,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1993,7 +1992,7 @@ func MakePasswordList(ctx *cli.Context) []string {
 	if path == "" {
 		return nil
 	}
-	text, err := ioutil.ReadFile(path)
+	text, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("Failed to read password file: %v", err)
 	}

--- a/cmd/utils/nodecmd/flags_test.go
+++ b/cmd/utils/nodecmd/flags_test.go
@@ -21,7 +21,6 @@
 package nodecmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -777,7 +776,7 @@ func testFlags(t *testing.T, flag string, value string, idx int) {
 	defer os.RemoveAll(datadir)
 
 	json := filepath.Join(datadir, "genesis.json")
-	if err := ioutil.WriteFile(json, []byte(genesis), 0o600); err != nil {
+	if err := os.WriteFile(json, []byte(genesis), 0o600); err != nil {
 		t.Fatalf("test %d: failed to write genesis file: %v", idx, err)
 	}
 
@@ -792,7 +791,7 @@ func testWrongFlags(t *testing.T, flag string, value string, idx int, expectedEr
 	defer os.RemoveAll(datadir)
 
 	json := filepath.Join(datadir, "genesis.json")
-	if err := ioutil.WriteFile(json, []byte(genesis), 0o600); err != nil {
+	if err := os.WriteFile(json, []byte(genesis), 0o600); err != nil {
 		t.Fatalf("test %d: failed to write genesis file: %v", idx, err)
 	}
 

--- a/cmd/utils/nodecmd/genesis_test.go
+++ b/cmd/utils/nodecmd/genesis_test.go
@@ -21,7 +21,6 @@
 package nodecmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -170,7 +169,7 @@ func TestCustomGenesis(t *testing.T) {
 
 		// Initialize the data directory with the custom genesis block
 		json := filepath.Join(datadir, "genesis.json")
-		if err := ioutil.WriteFile(json, []byte(tt.genesis), 0o600); err != nil {
+		if err := os.WriteFile(json, []byte(tt.genesis), 0o600); err != nil {
 			t.Fatalf("test %d: failed to write genesis file: %v", i, err)
 		}
 		runKlay(t, "klay-test", "--datadir", datadir, "--verbosity", "0", "init", json).WaitExit()

--- a/cmd/utils/nodecmd/run_test.go
+++ b/cmd/utils/nodecmd/run_test.go
@@ -22,7 +22,6 @@ package nodecmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"sort"
@@ -38,7 +37,7 @@ import (
 )
 
 func tmpdir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "klay-test")
+	dir, err := os.MkdirTemp("", "klay-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/utils/nodecmd/util.go
+++ b/cmd/utils/nodecmd/util.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/klaytn/klaytn/accounts/keystore"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -132,7 +132,7 @@ func prettyPrint(m map[string]interface{}) {
 }
 
 func extractKeypair(keystorePath, passwd string) (map[string]interface{}, error) {
-	keyjson, err := ioutil.ReadFile(keystorePath)
+	keyjson, err := os.ReadFile(keystorePath)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func decodeGov(bytes []byte) (map[string]interface{}, error) {
 
 func parseHeaderFile(headerFile string) (*types.Header, common.Hash, error) {
 	header := new(types.Header)
-	bytes, err := ioutil.ReadFile(headerFile)
+	bytes, err := os.ReadFile(headerFile)
 	if err != nil {
 		return nil, common.Hash{}, err
 	}

--- a/cmd/utils/testcmd.go
+++ b/cmd/utils/testcmd.go
@@ -25,7 +25,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -81,7 +80,7 @@ func (tt *TestCmd) Run(name string, args ...string) {
 // InputLine writes the given text to the childs stdin.
 // This method can also be called from an expect template, e.g.:
 //
-//     klay.expect(`Passphrase: {{.InputLine "password"}}`)
+//	klay.expect(`Passphrase: {{.InputLine "password"}}`)
 func (tt *TestCmd) InputLine(s string) string {
 	io.WriteString(tt.stdin, s+"\n")
 	return ""
@@ -174,7 +173,7 @@ func (tt *TestCmd) ExpectRegexp(regex string) (*regexp.Regexp, []string) {
 func (tt *TestCmd) ExpectExit() {
 	var output []byte
 	tt.withKillTimeout(func() {
-		output, _ = ioutil.ReadAll(tt.stdout)
+		output, _ = io.ReadAll(tt.stdout)
 	})
 	tt.WaitExit()
 	if tt.Cleanup != nil {

--- a/common/compiler/helpers.go
+++ b/common/compiler/helpers.go
@@ -19,7 +19,7 @@ package compiler
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"regexp"
 )
 
@@ -55,7 +55,7 @@ type ContractInfo struct {
 func slurpFiles(files []string) (string, error) {
 	var concat bytes.Buffer
 	for _, file := range files {
-		content, err := ioutil.ReadFile(file)
+		content, err := os.ReadFile(file)
 		if err != nil {
 			return "", err
 		}

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -26,7 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -145,8 +145,9 @@ func CompileSolidity(solc string, sourcefiles ...string) (map[string]*Contract, 
 // If suitable compiler is not available, try to load combinedJSON stored as file.
 // The combinedJSON file should be named as *.sol.json.
 // Create combinedJSON with following command:
-//   solc --combined-json bin,bin-runtime,srcmap,srcmap-runtime,abi,userdoc,devdoc \
-//       --optimize --allow-paths '., ./, ../' test.sol > test.sol.json
+//
+//	solc --combined-json bin,bin-runtime,srcmap,srcmap-runtime,abi,userdoc,devdoc \
+//	    --optimize --allow-paths '., ./, ../' test.sol > test.sol.json
 func CompileSolidityOrLoad(solc string, sourcefiles ...string) (map[string]*Contract, error) {
 	// Extract solidity version requirements from source codes
 	if len(sourcefiles) == 0 {
@@ -177,7 +178,7 @@ func CompileSolidityOrLoad(solc string, sourcefiles ...string) (map[string]*Cont
 // Search for CombinedJSON at <solidity_file_name>.json
 func loadCombinedJSON(source string, sourcefiles ...string) (map[string]*Contract, error) {
 	path := sourcefiles[0] + ".json"
-	combinedJSON, err := ioutil.ReadFile(path)
+	combinedJSON, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot open combined json at %s", path)
 	}

--- a/common/utils.go
+++ b/common/utils.go
@@ -23,12 +23,12 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // LoadJSON reads the given file and unmarshals its content.
 func LoadJSON(file string, val interface{}) error {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/consensus/gxhash/algorithm_test.go
+++ b/consensus/gxhash/algorithm_test.go
@@ -688,7 +688,7 @@ func TestHashimoto(t *testing.T) {
 /*
 func TestConcurrentDiskCacheGeneration(t *testing.T) {
 	// Create a temp folder to generate the caches into
-	cachedir, err := ioutil.TempDir("", "")
+	cachedir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temporary cache dir: %v", err)
 	}

--- a/consensus/gxhash/gxhash_test.go
+++ b/consensus/gxhash/gxhash_test.go
@@ -21,7 +21,6 @@
 package gxhash
 
 import (
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -45,7 +44,7 @@ func TestTestMode(t *testing.T) {
 // This test checks that cache lru logic doesn't crash under load.
 // It reproduces https://github.com/ethereum/go-ethereum/issues/14943
 func TestCacheFileEvict(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "gxhash-test")
+	tmpdir, err := os.MkdirTemp("", "gxhash-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/console/console.go
+++ b/console/console.go
@@ -23,7 +23,6 @@ package console
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -236,7 +235,7 @@ func (c *Console) init(preload []string) error {
 	}
 	// Configure the console's input prompter for scrollback and tab completion
 	if c.prompter != nil {
-		if content, err := ioutil.ReadFile(c.histPath); err != nil {
+		if content, err := os.ReadFile(c.histPath); err != nil {
 			c.prompter.SetHistory(nil)
 		} else {
 			c.history = strings.Split(string(content), "\n")
@@ -453,7 +452,7 @@ func (c *Console) Execute(path string) error {
 
 // Stop cleans up the console and terminates the runtime environment.
 func (c *Console) Stop(graceful bool) error {
-	if err := ioutil.WriteFile(c.histPath, []byte(strings.Join(c.history, "\n")), 0o600); err != nil {
+	if err := os.WriteFile(c.histPath, []byte(strings.Join(c.history, "\n")), 0o600); err != nil {
 		return err
 	}
 	if err := os.Chmod(c.histPath, 0o600); err != nil { // Force 0600, even if it was different previously

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -89,7 +88,7 @@ type tester struct {
 // Please ensure you call Close() on the returned tester to avoid leaks.
 func newTester(t *testing.T, confOverride func(*cn.Config)) *tester {
 	// Create a temporary storage for the node keys and initialize it
-	workspace, err := ioutil.TempDir("", "console-tester-")
+	workspace, err := os.MkdirTemp("", "console-tester-")
 	if err != nil {
 		t.Fatalf("failed to create temporary keystore: %v", err)
 	}

--- a/console/jsre/jsre.go
+++ b/console/jsre/jsre.go
@@ -25,8 +25,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/klaytn/klaytn/common"
@@ -245,7 +245,7 @@ func (re *JSRE) Stop(waitForCallbacks bool) {
 // Exec(file) loads and runs the contents of a file
 // if a relative path is given, the jsre's assetPath is used
 func (re *JSRE) Exec(file string) error {
-	code, err := ioutil.ReadFile(common.AbsolutePath(re.assetPath, file))
+	code, err := os.ReadFile(common.AbsolutePath(re.assetPath, file))
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func (re *JSRE) loadScript(call otto.FunctionCall) otto.Value {
 		return otto.FalseValue()
 	}
 	file = common.AbsolutePath(re.assetPath, file)
-	source, err := ioutil.ReadFile(file)
+	source, err := os.ReadFile(file)
 	if err != nil {
 		// TODO: throw exception
 		return otto.FalseValue()

--- a/console/jsre/jsre_test.go
+++ b/console/jsre/jsre_test.go
@@ -21,7 +21,6 @@
 package jsre
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -46,12 +45,12 @@ func (no *testNativeObjectBinding) TestMethod(call otto.FunctionCall) otto.Value
 }
 
 func newWithTestJS(t *testing.T, testjs string) (*JSRE, string) {
-	dir, err := ioutil.TempDir("", "jsre-test")
+	dir, err := os.MkdirTemp("", "jsre-test")
 	if err != nil {
 		t.Fatal("cannot create temporary directory:", err)
 	}
 	if testjs != "" {
-		if err := ioutil.WriteFile(path.Join(dir, "test.js"), []byte(testjs), os.ModePerm); err != nil {
+		if err := os.WriteFile(path.Join(dir, "test.js"), []byte(testjs), os.ModePerm); err != nil {
 			t.Fatal("cannot create test.js:", err)
 		}
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"os"
 
@@ -194,7 +193,7 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 // restrictive permissions. The key data is saved hex-encoded.
 func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
 	k := hex.EncodeToString(FromECDSA(key))
-	return ioutil.WriteFile(file, []byte(k), 0o600)
+	return os.WriteFile(file, []byte(k), 0o600)
 }
 
 func GenerateKey() (*ecdsa.PrivateKey, error) {

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"reflect"
@@ -159,7 +158,7 @@ func TestLoadECDSAFile(t *testing.T) {
 		}
 	}
 
-	ioutil.WriteFile(fileName0, []byte(testPrivHex), 0o600)
+	os.WriteFile(fileName0, []byte(testPrivHex), 0o600)
 	defer os.Remove(fileName0)
 
 	key0, err := LoadECDSA(fileName0)

--- a/datasync/chaindatafetcher/kas/repository.go
+++ b/datasync/chaindatafetcher/kas/repository.go
@@ -19,7 +19,7 @@ package kas
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -172,7 +172,7 @@ func (r *repository) InvalidateCacheEOAList(eoaList map[common.Address]struct{})
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			logger.Error("Reading response body is failed", "err", err, "body", res.Body)
 			return

--- a/metrics/librato/client.go
+++ b/metrics/librato/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -97,7 +97,7 @@ func (c *LibratoClient) PostMetrics(batch Batch) (err error) {
 
 	if resp.StatusCode != http.StatusOK {
 		var body []byte
-		if body, err = ioutil.ReadAll(resp.Body); err != nil {
+		if body, err = io.ReadAll(resp.Body); err != nil {
 			body = []byte(fmt.Sprintf("(could not fetch response body for error: %s)", err))
 		}
 		err = fmt.Errorf("Unable to post to Librato: %d %s %s", resp.StatusCode, resp.Status, string(body))

--- a/networks/p2p/discover/database_test.go
+++ b/networks/p2p/discover/database_test.go
@@ -22,7 +22,6 @@ package discover
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -272,7 +271,7 @@ func TestNodeDBSeedQuery(t *testing.T) {
 }
 
 func TestNodeDBPersistency(t *testing.T) {
-	root, err := ioutil.TempDir("", "nodedb-")
+	root, err := os.MkdirTemp("", "nodedb-")
 	if err != nil {
 		t.Fatalf("failed to create temporary data folder: %v", err)
 	}

--- a/networks/p2p/message.go
+++ b/networks/p2p/message.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync/atomic"
 	"time"
 
@@ -66,7 +65,7 @@ func (msg Msg) String() string {
 
 // Discard reads any remaining payload data into a black hole.
 func (msg Msg) Discard() error {
-	_, err := io.Copy(ioutil.Discard, msg.Payload)
+	_, err := io.Copy(io.Discard, msg.Payload)
 	return err
 }
 
@@ -104,12 +103,11 @@ func Send(w MsgWriter, msgcode uint64, data interface{}) error {
 // SendItems writes an RLP with the given code and data elements.
 // For a call such as:
 //
-//    SendItems(w, code, e1, e2, e3)
+//	SendItems(w, code, e1, e2, e3)
 //
 // the message payload will be an RLP list containing the items:
 //
-//    [e1, e2, e3]
-//
+//	[e1, e2, e3]
 func SendItems(w MsgWriter, msgcode uint64, elems ...interface{}) error {
 	return Send(w, msgcode, elems)
 }
@@ -241,7 +239,7 @@ func ExpectMsg(r MsgReader, code uint64, content interface{}) error {
 	if int(msg.Size) != len(contentEnc) {
 		return fmt.Errorf("message size mismatch: got %d, want %d", msg.Size, len(contentEnc))
 	}
-	actualContent, err := ioutil.ReadAll(msg.Payload)
+	actualContent, err := io.ReadAll(msg.Payload)
 	if err != nil {
 		return err
 	}

--- a/networks/p2p/simulations/adapters/docker.go
+++ b/networks/p2p/simulations/adapters/docker.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -148,7 +147,7 @@ const dockerImage = "p2p-node"
 // when executed.
 func buildDockerImage() error {
 	// create a directory to use as the build context
-	dir, err := ioutil.TempDir("", "p2p-docker")
+	dir, err := os.MkdirTemp("", "p2p-docker")
 	if err != nil {
 		return err
 	}
@@ -175,7 +174,7 @@ FROM ubuntu:16.04
 RUN mkdir /data
 ADD self.bin /bin/p2p-node
 	`)
-	if err := ioutil.WriteFile(filepath.Join(dir, "Dockerfile"), dockerfile, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), dockerfile, 0o644); err != nil {
 		return err
 	}
 

--- a/networks/p2p/simulations/examples/ping-pong.go
+++ b/networks/p2p/simulations/examples/ping-pong.go
@@ -26,7 +26,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -69,7 +69,7 @@ func main() {
 		adapter = adapters.NewSimAdapter(services)
 
 	case "exec":
-		tmpdir, err := ioutil.TempDir("", "p2p-example")
+		tmpdir, err := os.MkdirTemp("", "p2p-example")
 		if err != nil {
 			log.Crit("error creating temp dir", "err", err)
 		}
@@ -174,7 +174,7 @@ func (p *pingPongService) Run(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 				errC <- err
 				return
 			}
-			payload, err := ioutil.ReadAll(msg.Payload)
+			payload, err := io.ReadAll(msg.Payload)
 			if err != nil {
 				errC <- err
 				return

--- a/networks/p2p/simulations/http.go
+++ b/networks/p2p/simulations/http.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -115,7 +114,7 @@ func (c *Client) SubscribeNetwork(events chan *Event, opts SubscribeOpts) (event
 		return nil, err
 	}
 	if res.StatusCode != http.StatusOK {
-		response, _ := ioutil.ReadAll(res.Body)
+		response, _ := io.ReadAll(res.Body)
 		res.Body.Close()
 		return nil, fmt.Errorf("unexpected HTTP status: %s: %s", res.Status, response)
 	}
@@ -267,7 +266,7 @@ func (c *Client) Send(method, path string, in, out interface{}) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
-		response, _ := ioutil.ReadAll(res.Body)
+		response, _ := io.ReadAll(res.Body)
 		return fmt.Errorf("unexpected HTTP status: %s: %s", res.Status, response)
 	}
 	if out != nil {

--- a/networks/rpc/http.go
+++ b/networks/rpc/http.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net"
 	"net/http"
@@ -48,8 +47,10 @@ const (
 )
 
 // https://www.jsonrpc.org/historical/json-rpc-over-http.html#id13
-var acceptedContentTypes = []string{contentType, "application/json-rpc", "application/jsonrequest"}
-var nullAddr, _ = net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+var (
+	acceptedContentTypes = []string{contentType, "application/json-rpc", "application/jsonrequest"}
+	nullAddr, _          = net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+)
 
 type httpConn struct {
 	client    *http.Client
@@ -202,7 +203,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", hc.url, ioutil.NopCloser(bytes.NewReader(body)))
+	req, err := http.NewRequestWithContext(ctx, "POST", hc.url, io.NopCloser(bytes.NewReader(body)))
 	if err != nil {
 		return nil, err
 	}

--- a/networks/rpc/http_newrelic.go
+++ b/networks/rpc/http_newrelic.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -127,14 +127,14 @@ func newNewRelicHTTPHandler(nrApp *newrelic.Application, handler http.Handler) h
 // It returns a slice of RPC request, an indication if these requests are in batch, and an error.
 // Ethereum returns []*jsonrpcMessage, which replaces []rpcRequest
 func getRPCRequests(r *http.Request) ([]*jsonrpcMessage, bool, error) {
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		logger.Error("cannot read a request body", "err", err)
 		return nil, false, err
 	}
 
-	r.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
-	conn := &httpServerConn{Reader: ioutil.NopCloser(bytes.NewReader(reqBody)), Writer: bytes.NewBufferString(""), r: r}
+	r.Body = io.NopCloser(bytes.NewReader(reqBody))
+	conn := &httpServerConn{Reader: io.NopCloser(bytes.NewReader(reqBody)), Writer: bytes.NewBufferString(""), r: r}
 
 	codec := NewCodec(conn)
 

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"reflect"
@@ -520,7 +519,7 @@ func (api *API) TraceBlockFromFile(ctx context.Context, file string, config *Tra
 	if !api.unsafeTrace {
 		return nil, errors.New("TraceBlockFromFile is disabled")
 	}
-	blob, err := ioutil.ReadFile(file)
+	blob, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("could not read file: %v", err)
 	}
@@ -740,7 +739,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 			// Generate a unique temporary file to dump it into
 			prefix := fmt.Sprintf("block_%#x-%d-%#x-", block.Hash().Bytes()[:4], i, tx.Hash().Bytes()[:4])
 
-			dump, err = ioutil.TempFile(os.TempDir(), prefix)
+			dump, err = os.CreateTemp(os.TempDir(), prefix)
 			if err != nil {
 				return nil, err
 			}

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -24,8 +24,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -234,7 +234,7 @@ func covertToCallTrace(t *testing.T, internalTx *vm.InternalTxTrace) *callTrace 
 // Iterates over all the input-output datasets in the tracer test harness and
 // runs the JavaScript tracers against them.
 func TestCallTracer(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata")
+	files, err := os.ReadDir("testdata")
 	if err != nil {
 		t.Fatalf("failed to retrieve tracer test suite: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestCallTracer(t *testing.T) {
 			// t.Parallel()
 
 			// Call tracer test found, read if from disk
-			blob, err := ioutil.ReadFile(filepath.Join("testdata", file.Name()))
+			blob, err := os.ReadFile(filepath.Join("testdata", file.Name()))
 			if err != nil {
 				t.Fatalf("failed to read testcase: %v", err)
 			}
@@ -347,7 +347,7 @@ func jsonEqual(t *testing.T, x, y interface{}) {
 // Iterates over all the input-output datasets in the tracer test harness and
 // runs the InternalCallTracer against them.
 func TestInternalCallTracer(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata")
+	files, err := os.ReadDir("testdata")
 	if err != nil {
 		t.Fatalf("failed to retrieve tracer test suite: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestInternalCallTracer(t *testing.T) {
 			// t.Parallel()
 
 			// Call tracer test found, read if from disk
-			blob, err := ioutil.ReadFile(filepath.Join("testdata", file.Name()))
+			blob, err := os.ReadFile(filepath.Join("testdata", file.Name()))
 			if err != nil {
 				t.Fatalf("failed to read testcase: %v", err)
 			}

--- a/node/config.go
+++ b/node/config.go
@@ -23,7 +23,6 @@ package node
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -448,7 +447,7 @@ func makeAccountManager(conf *Config) (*accounts.Manager, string, error) {
 	var ephemeral string
 	if keydir == "" {
 		// There is no datadir.
-		keydir, err = ioutil.TempDir("", "klaytn-keystore")
+		keydir, err = os.MkdirTemp("", "klaytn-keystore")
 		ephemeral = keydir
 	}
 

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -53,13 +53,13 @@ func TestDatadirCreation(t *testing.T) {
 		t.Fatalf("freshly created datadir not accessible: %v", err)
 	}
 	// Verify that an impossible datadir fails creation
-	file, err := os.MkdirTemp("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}
-	defer os.Remove(file)
+	defer os.Remove(file.Name())
 
-	dir = filepath.Join(file, "invalid/path")
+	dir = filepath.Join(file.Name(), "invalid/path")
 	if _, err := New(&Config{DataDir: dir}); err == nil {
 		t.Fatalf("protocol stack created with an invalid datadir")
 	}

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -22,7 +22,6 @@ package node
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -36,7 +35,7 @@ import (
 // ones or automatically generated temporary ones.
 func TestDatadirCreation(t *testing.T) {
 	// Create a temporary data dir and check that it can be used by a node
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create manual data dir: %v", err)
 	}
@@ -54,13 +53,13 @@ func TestDatadirCreation(t *testing.T) {
 		t.Fatalf("freshly created datadir not accessible: %v", err)
 	}
 	// Verify that an impossible datadir fails creation
-	file, err := ioutil.TempFile("", "")
+	file, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}
-	defer os.Remove(file.Name())
+	defer os.Remove(file)
 
-	dir = filepath.Join(file.Name(), "invalid/path")
+	dir = filepath.Join(file, "invalid/path")
 	if _, err := New(&Config{DataDir: dir}); err == nil {
 		t.Fatalf("protocol stack created with an invalid datadir")
 	}
@@ -101,7 +100,7 @@ func TestIPCPathResolution(t *testing.T) {
 // ephemeral.
 func TestNodeKeyPersistency(t *testing.T) {
 	// Create a temporary folder and make sure no key is present
-	dir, err := ioutil.TempDir("", "node-test")
+	dir, err := os.MkdirTemp("", "node-test")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}
@@ -129,7 +128,7 @@ func TestNodeKeyPersistency(t *testing.T) {
 	if _, err = crypto.LoadECDSA(keyfile); err != nil {
 		t.Fatalf("failed to load freshly persisted node key: %v", err)
 	}
-	blob1, err := ioutil.ReadFile(keyfile)
+	blob1, err := os.ReadFile(keyfile)
 	if err != nil {
 		t.Fatalf("failed to read freshly persisted node key: %v", err)
 	}
@@ -137,7 +136,7 @@ func TestNodeKeyPersistency(t *testing.T) {
 	// Configure a new node and ensure the previously persisted key is loaded
 	config = &Config{Name: "unit-test", DataDir: dir}
 	config.NodeKey()
-	blob2, err := ioutil.ReadFile(filepath.Join(keyfile))
+	blob2, err := os.ReadFile(filepath.Join(keyfile))
 	if err != nil {
 		t.Fatalf("failed to read previously persisted node key: %v", err)
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -22,7 +22,6 @@ package node
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -79,7 +78,7 @@ func TestNodeLifeCycle(t *testing.T) {
 // Tests that if the data dir is already in use, an appropriate error is returned.
 func TestNodeUsedDataDir(t *testing.T) {
 	// Create a temporary folder to use as the data directory
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}

--- a/node/sc/bridge_account_test.go
+++ b/node/sc/bridge_account_test.go
@@ -17,7 +17,6 @@
 package sc
 
 import (
-	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -32,7 +31,7 @@ import (
 
 // TestBridgeAccountLockUnlock checks the lock/unlock functionality.
 func TestBridgeAccountLockUnlock(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -49,12 +48,12 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 	assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
 
 	pPwdFilePath := path.Join(tempDir, "parent_bridge_account", bAcc.pAccount.address.String())
-	pPwd, err := ioutil.ReadFile(pPwdFilePath)
+	pPwd, err := os.ReadFile(pPwdFilePath)
 	pPwdStr := string(pPwd)
 	assert.NoError(t, err)
 
 	cPwdFilePath := path.Join(tempDir, "child_bridge_account", bAcc.cAccount.address.String())
-	cPwd, err := ioutil.ReadFile(cPwdFilePath)
+	cPwd, err := os.ReadFile(cPwdFilePath)
 	cPwdStr := string(cPwd)
 	assert.NoError(t, err)
 
@@ -153,7 +152,7 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 
 // TestBridgeAccountInformation checks if the information result is right or not.
 func TestBridgeAccountInformation(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {

--- a/node/sc/bridge_accounts.go
+++ b/node/sc/bridge_accounts.go
@@ -18,7 +18,6 @@ package sc
 
 import (
 	"errors"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -224,7 +223,7 @@ func InitializeBridgeAccountKeystore(keystorePath string) (*keystore.KeyStore, c
 	// If unlocking failed, user should unlock it through API.
 	acc := ks.Accounts()[0]
 	pwdFilePath := path.Join(keystorePath, acc.Address.String())
-	pwdStr, err := ioutil.ReadFile(pwdFilePath)
+	pwdStr, err := os.ReadFile(pwdFilePath)
 	if err == nil {
 		if err := ks.Unlock(acc, string(pwdStr)); err != nil {
 			logger.Warn("bridge account wallet unlock is failed by exist password file.", "address", acc.Address, "err", err)

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -19,7 +19,6 @@ package sc
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"math/rand"
@@ -120,7 +119,7 @@ func handleValueTransfer(t *testing.T, ev IRequestValueTransferEvent, bridgeInfo
 // - consider parent/child chain simulated backend.
 // - separate each test
 func TestBridgeManager(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -349,7 +348,7 @@ func TestBridgeManager(t *testing.T) {
 
 // TestBridgeManagerERC721_notSupportURI tests if bridge can handle an ERC721 which does not support URI.
 func TestBridgeManagerERC721_notSupportURI(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -518,7 +517,7 @@ func TestBridgeManagerERC721_notSupportURI(t *testing.T) {
 
 // TestBridgeManagerWithFee tests the KLAY/ERC20 transfer with fee.
 func TestBridgeManagerWithFee(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -921,7 +920,7 @@ func TestBridgeManagerWithFee(t *testing.T) {
 
 // TestBasicJournal tests basic journal functionality.
 func TestBasicJournal(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1002,7 +1001,7 @@ func TestBasicJournal(t *testing.T) {
 
 // TestMethodRestoreBridges tests restoring bridges from the journal.
 func TestMethodRestoreBridges(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1120,7 +1119,7 @@ func TestMethodRestoreBridges(t *testing.T) {
 
 // TestMethodGetAllBridge tests a method GetAllBridge.
 func TestMethodGetAllBridge(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1151,7 +1150,7 @@ func TestMethodGetAllBridge(t *testing.T) {
 
 // TestErrorDuplication tests if duplication of journal insertion is ignored or not.
 func TestErrorDuplication(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1191,7 +1190,7 @@ func TestErrorDuplication(t *testing.T) {
 
 // TestMethodSetJournal tests if duplication of journal insertion is ignored or not.
 func TestMethodSetJournal(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1228,7 +1227,7 @@ func TestMethodSetJournal(t *testing.T) {
 
 // TestErrorDuplicatedSetBridgeInfo tests if duplication of bridge info insertion.
 func TestErrorDuplicatedSetBridgeInfo(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1295,7 +1294,7 @@ func TestErrorDuplicatedSetBridgeInfo(t *testing.T) {
 
 // TestScenarioSubUnsub tests subscription and unsubscription scenario.
 func TestScenarioSubUnsub(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1370,7 +1369,7 @@ func TestScenarioSubUnsub(t *testing.T) {
 
 // TestErrorEmptyAccount tests empty account error in case of journal insertion.
 func TestErrorEmptyAccount(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1401,7 +1400,7 @@ func TestErrorEmptyAccount(t *testing.T) {
 
 // TestErrorDupSubscription tests duplicated subscription error.
 func TestErrorDupSubscription(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1480,7 +1479,7 @@ func TestErrorDupSubscription(t *testing.T) {
 // 3. start anchoring from the current block
 // 4. accumulated tx counts
 func TestAnchoringBasic(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoring")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "anchoring")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1533,7 +1532,7 @@ func TestAnchoringBasic(t *testing.T) {
 // 3. start anchoring from the current block
 // 4. accumulated tx counts
 func TestAnchoringBasicWithFeePayer(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoring")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "anchoring")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1620,7 +1619,7 @@ func TestAnchoringBasicWithFeePayer(t *testing.T) {
 // TestAnchoringBasicWithBridgeTxPoolMock tests the following :
 // - BridgeTxPool addLocal() fail case.
 func TestAnchoringBasicWithBridgeTxPoolMock(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoring")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "anchoring")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1734,7 +1733,7 @@ func compareBlockAndAnchoringTx(t *testing.T, block *types.Block, tx *types.Tran
 // 1. set anchoring period 4
 // 2. check if tx counting started immediately and accumulated correctly
 func TestAnchoringStart(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoringPeriod")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "anchoringPeriod")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1817,7 +1816,7 @@ func TestAnchoringPeriod(t *testing.T) {
 	const (
 		startTxCount = 100
 	)
-	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoringPeriod")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "anchoringPeriod")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -1941,7 +1940,7 @@ func TestDecodingLegacyAnchoringTx(t *testing.T) {
 		startBlkNum  = 10
 		startTxCount = 100
 	)
-	tempDir, err := ioutil.TempDir(os.TempDir(), "anchoring")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "anchoring")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -2000,7 +1999,7 @@ func TestDecodingLegacyAnchoringTx(t *testing.T) {
 }
 
 func TestBridgeAliasAPIs(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -2414,7 +2413,7 @@ func TestLegacyBridgeJournalDecode(t *testing.T) {
 	}
 
 	tempJournalPath := "legacy-journal-decoding-test"
-	tempFile, err := ioutil.TempFile(".", tempJournalPath)
+	tempFile, err := os.CreateTemp(".", tempJournalPath)
 	assert.NoError(t, err)
 
 	encodedHex, err := hex.DecodeString(encodedJournalHexStr)
@@ -2470,7 +2469,7 @@ func randomHex(n int) (string, error) {
 }
 
 func TestBridgeAddressType(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -2660,7 +2659,7 @@ func isExpectedBalance(t *testing.T, bridgeManager *BridgeManager,
 }
 
 func TestGetBridgeContractBalance(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {

--- a/node/sc/kas/anchor_test.go
+++ b/node/sc/kas/anchor_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"math/rand"
 	"net/http"
@@ -101,7 +101,7 @@ func TestSendRequest(t *testing.T) {
 			Code: 0,
 		}
 		bodyBytes, _ := json.Marshal(expectedRespBody)
-		expectedRes.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
+		expectedRes.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		expectedRes.StatusCode = http.StatusOK
 
 		m.EXPECT().Do(gomock.Any()).Times(1).Return(&expectedRes, nil)

--- a/node/sc/subbridge_test.go
+++ b/node/sc/subbridge_test.go
@@ -18,7 +18,6 @@ package sc
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"reflect"
@@ -37,7 +36,7 @@ import (
 
 // testNewSubBridge returns a test SubBridge.
 func testNewSubBridge(t *testing.T) *SubBridge {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "klaytn-test-sb-")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "klaytn-test-sb-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/sc/vt_contract_test.go
+++ b/node/sc/vt_contract_test.go
@@ -17,7 +17,6 @@
 package sc
 
 import (
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strconv"
@@ -32,7 +31,7 @@ import (
 
 // TestTokenPublicVariables checks the results of the public variables.
 func TestTokenPublicVariables(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -79,7 +78,7 @@ func TestTokenPublicVariables(t *testing.T) {
 
 // TestTokenPublicVariables checks the results of the public variables.
 func TestNFTPublicVariables(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -17,7 +17,6 @@
 package sc
 
 import (
-	"io/ioutil"
 	"log"
 	"math/big"
 	"os"
@@ -99,7 +98,7 @@ var ops = map[uint8]*operations{
 
 // TestBasicKLAYTransferRecovery tests each methods of the value transfer recovery.
 func TestBasicKLAYTransferRecovery(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -237,7 +236,7 @@ func TestKLAYTransferLongRangeRecovery(t *testing.T) {
 
 // TestBasicTokenTransferRecovery tests the token transfer recovery.
 func TestBasicTokenTransferRecovery(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -277,7 +276,7 @@ func TestBasicTokenTransferRecovery(t *testing.T) {
 // TestBasicNFTTransferRecovery tests the NFT transfer recovery.
 // TODO-Klaytn-ServiceChain: implement NFT transfer.
 func TestBasicNFTTransferRecovery(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -316,7 +315,7 @@ func TestBasicNFTTransferRecovery(t *testing.T) {
 
 // TestMethodRecover tests the valueTransferRecovery.Recover() method.
 func TestMethodRecover(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -354,7 +353,7 @@ func TestMethodRecover(t *testing.T) {
 
 // TestMethodStop tests the Stop method for stop the internal goroutine.
 func TestMethodStop(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -391,7 +390,7 @@ func TestMethodStop(t *testing.T) {
 
 // TestFlagVTRecovery tests the disabled vtrecovery option.
 func TestFlagVTRecovery(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -419,7 +418,7 @@ func TestFlagVTRecovery(t *testing.T) {
 
 // TestAlreadyStartedVTRecovery tests the already started VTR error cases.
 func TestAlreadyStartedVTRecovery(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -446,7 +445,7 @@ func TestAlreadyStartedVTRecovery(t *testing.T) {
 
 // TestScenarioMainChainRecovery tests the value transfer recovery of the parent chain to child chain value transfers.
 func TestScenarioMainChainRecovery(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -484,7 +483,7 @@ func TestScenarioMainChainRecovery(t *testing.T) {
 
 // TestScenarioAutomaticRecovery tests the recovery of the internal goroutine.
 func TestScenarioAutomaticRecovery(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -524,7 +523,7 @@ func TestScenarioAutomaticRecovery(t *testing.T) {
 
 // TestMultiOperatorRequestRecovery tests value transfer recovery for the multi-operator.
 func TestMultiOperatorRequestRecovery(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -631,7 +630,7 @@ func TestMultiOperatorRequestRecovery(t *testing.T) {
 func prepare(t *testing.T, vtcallback func(*testInfo)) *testInfo {
 	// Setup configuration.
 	config := &SCConfig{}
-	tempDir, err := ioutil.TempDir(os.TempDir(), "sc")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {

--- a/node/service_test.go
+++ b/node/service_test.go
@@ -22,7 +22,6 @@ package node
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -37,7 +36,7 @@ import (
 // the configured service context.
 func TestContextDatabases(t *testing.T) {
 	// Create a temporary folder and ensure no database is contained within
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"runtime"
 	"sync"
@@ -424,7 +423,7 @@ func TestEncodeToReader(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		return ioutil.ReadAll(r)
+		return io.ReadAll(r)
 	})
 }
 
@@ -465,7 +464,7 @@ func TestEncodeToReaderReturnToPool(t *testing.T) {
 		go func() {
 			for i := 0; i < 1000; i++ {
 				_, r, _ := EncodeToReader("foo")
-				ioutil.ReadAll(r)
+				io.ReadAll(r)
 				r.Read(buf)
 				r.Read(buf)
 				r.Read(buf)

--- a/rlp/rlpgen/gen_test.go
+++ b/rlp/rlpgen/gen_test.go
@@ -24,7 +24,6 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -67,11 +66,11 @@ func TestOutput(t *testing.T) {
 
 			// Set this environment variable to regenerate the test outputs.
 			if os.Getenv("WRITE_TEST_FILES") != "" {
-				ioutil.WriteFile(outputFile, output, 0o644)
+				os.WriteFile(outputFile, output, 0o644)
 			}
 
 			// Check if output matches.
-			wantOutput, err := ioutil.ReadFile(outputFile)
+			wantOutput, err := os.ReadFile(outputFile)
 			if err != nil {
 				t.Fatal("error loading expected test output:", err)
 			}
@@ -84,7 +83,7 @@ func TestOutput(t *testing.T) {
 
 func loadTestSource(file string, typeName string) (*buildContext, *types.Named, error) {
 	// Load the test input.
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/rlp/rlpgen/main.go
+++ b/rlp/rlpgen/main.go
@@ -26,7 +26,6 @@ import (
 	"flag"
 	"fmt"
 	"go/types"
-	"io/ioutil"
 	"os"
 
 	"golang.org/x/tools/go/packages"
@@ -56,7 +55,7 @@ func main() {
 	}
 	if *output == "-" {
 		os.Stdout.Write(code)
-	} else if err := ioutil.WriteFile(*output, code, 0o644); err != nil {
+	} else if err := os.WriteFile(*output, code, 0o644); err != nil {
 		fatal(err)
 	}
 }

--- a/snapshot/disklayer_test.go
+++ b/snapshot/disklayer_test.go
@@ -22,7 +22,6 @@ package snapshot
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -523,7 +522,7 @@ func TestDiskSeek(t *testing.T) {
 	// Create some accounts in the disk layer
 	var db database.DBManager
 
-	if dir, err := ioutil.TempDir("", "disklayer-test"); err != nil {
+	if dir, err := os.MkdirTemp("", "disklayer-test"); err != nil {
 		t.Fatal(err)
 	} else {
 		defer os.RemoveAll(dir)

--- a/storage/database/child_chain_data_test.go
+++ b/storage/database/child_chain_data_test.go
@@ -17,7 +17,6 @@
 package database
 
 import (
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -28,7 +27,7 @@ import (
 )
 
 func TestChildChainData_ReadAndWrite_ChildChainTxHash(t *testing.T) {
-	dir, err := ioutil.TempDir("", "klaytn-test-child-chain-data")
+	dir, err := os.MkdirTemp("", "klaytn-test-child-chain-data")
 	if err != nil {
 		t.Fatalf("cannot create temporary directory: %v", err)
 	}
@@ -58,7 +57,7 @@ func TestChildChainData_ReadAndWrite_ChildChainTxHash(t *testing.T) {
 }
 
 func TestLastIndexedBlockData_ReadAndWrite_AnchoredBlockNumber(t *testing.T) {
-	dir, err := ioutil.TempDir("", "klaytn-test-child-chain-data")
+	dir, err := os.MkdirTemp("", "klaytn-test-child-chain-data")
 	if err != nil {
 		t.Fatalf("cannot create temporary directory: %v", err)
 	}
@@ -84,7 +83,7 @@ func TestLastIndexedBlockData_ReadAndWrite_AnchoredBlockNumber(t *testing.T) {
 }
 
 func TestChildChainData_ReadAndWrite_AnchoredBlockNumber(t *testing.T) {
-	dir, err := ioutil.TempDir("", "klaytn-test-child-chain-data")
+	dir, err := os.MkdirTemp("", "klaytn-test-child-chain-data")
 	if err != nil {
 		t.Fatalf("cannot create temporary directory: %v", err)
 	}
@@ -110,7 +109,7 @@ func TestChildChainData_ReadAndWrite_AnchoredBlockNumber(t *testing.T) {
 }
 
 func TestChildChainData_ReadAndWrite_ReceiptFromParentChain(t *testing.T) {
-	dir, err := ioutil.TempDir("", "klaytn-test-child-chain-data")
+	dir, err := os.MkdirTemp("", "klaytn-test-child-chain-data")
 	if err != nil {
 		t.Fatalf("cannot create temporary directory: %v", err)
 	}
@@ -142,7 +141,7 @@ func TestChildChainData_ReadAndWrite_ReceiptFromParentChain(t *testing.T) {
 }
 
 func TestChildChainData_ReadAndWrite_ValueTransferTxHash(t *testing.T) {
-	dir, err := ioutil.TempDir("", "klaytn-test-child-chain-data")
+	dir, err := os.MkdirTemp("", "klaytn-test-child-chain-data")
 	if err != nil {
 		t.Fatalf("cannot create temporary directory: %v", err)
 	}
@@ -172,7 +171,7 @@ func TestChildChainData_ReadAndWrite_ValueTransferTxHash(t *testing.T) {
 }
 
 func TestChildChainData_ReadAndWrite_OperatorFeePayer(t *testing.T) {
-	dir, err := ioutil.TempDir("", "klaytn-test-child-chain-data")
+	dir, err := os.MkdirTemp("", "klaytn-test-child-chain-data")
 	if err != nil {
 		t.Fatalf("cannot create temporary directory: %v", err)
 	}

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -23,7 +23,6 @@ package database
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"sort"
@@ -39,7 +38,7 @@ import (
 )
 
 func newTestLDB() (Database, func(), string) {
-	dirName, err := ioutil.TempDir(os.TempDir(), "klay_leveldb_test_")
+	dirName, err := os.MkdirTemp(os.TempDir(), "klay_leveldb_test_")
 	if err != nil {
 		panic("failed to create test file: " + err.Error())
 	}
@@ -55,7 +54,7 @@ func newTestLDB() (Database, func(), string) {
 }
 
 func newTestBadgerDB() (Database, func(), string) {
-	dirName, err := ioutil.TempDir(os.TempDir(), "klay_badgerdb_test_")
+	dirName, err := os.MkdirTemp(os.TempDir(), "klay_badgerdb_test_")
 	if err != nil {
 		panic("failed to create test file: " + err.Error())
 	}

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -107,7 +106,7 @@ func createDBManagers(configs []*DBConfig) []DBManager {
 	dbManagers := make([]DBManager, 0, len(configs))
 
 	for i, c := range configs {
-		c.Dir, _ = ioutil.TempDir(os.TempDir(), fmt.Sprintf("test-db-manager-%v", i))
+		c.Dir, _ = os.MkdirTemp(os.TempDir(), fmt.Sprintf("test-db-manager-%v", i))
 		dbManagers = append(dbManagers, NewDBManager(c))
 	}
 
@@ -1152,7 +1151,7 @@ func genTransaction(val uint64) (*types.Transaction, error) {
 
 // getFilesInDir returns all file names containing the substring in the directory
 func getFilesInDir(t *testing.T, dirPath string, substr string) []string {
-	files, err := ioutil.ReadDir(dirPath)
+	files, err := os.ReadDir(dirPath)
 	assert.NoError(t, err)
 
 	var dirNames []string

--- a/storage/database/leveldb_bench_common_test.go
+++ b/storage/database/leveldb_bench_common_test.go
@@ -19,7 +19,6 @@ package database
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -48,7 +47,7 @@ const (
 
 // initTestDB creates the db and inputs the data in db for valSize
 func initTestDB(valueSize int) (string, Database, [][]byte, error) {
-	dir, err := ioutil.TempDir("", "bench-DB")
+	dir, err := os.MkdirTemp("", "bench-DB")
 	if err != nil {
 		return "", nil, nil, errors.New(fmt.Sprintf("can't create temporary directory: %v", err))
 	}

--- a/storage/database/leveldb_bench_multidisks_test.go
+++ b/storage/database/leveldb_bench_multidisks_test.go
@@ -19,8 +19,8 @@
 package database
 
 import (
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -44,7 +44,7 @@ func genDirForMDPTest(b *testing.B, numDisks, numShards int) []string {
 	dirs := make([]string, numShards, numShards)
 	for i := 0; i < numShards; i++ {
 		diskNum := i % numDisks
-		dir, err := ioutil.TempDir(diskPaths[diskNum], "klaytn-db-bench-mdp")
+		dir, err := os.MkdirTemp(diskPaths[diskNum], "klaytn-db-bench-mdp")
 		if err != nil {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
@@ -113,8 +113,10 @@ func benchmark_MDP_Put_NoGoRoutine(b *testing.B, mdo *multiDiskOption) {
 }
 
 // please change below rowSize to change the size of an input row for MDP_Put tests (GoRoutine & NoGoRoutine)
-const rowSizePutMDP = 250
-const numRowsPutMDP = 1000 * 10
+const (
+	rowSizePutMDP = 250
+	numRowsPutMDP = 1000 * 10
+)
 
 var putMDPBenchmarks = [...]struct {
 	name string
@@ -262,8 +264,10 @@ func benchmark_MDP_Batch_NoGoRoutine(b *testing.B, mdo *multiDiskOption) {
 }
 
 // please change below rowSize to change the size of an input row for MDP_Batch tests (GoRoutine & NoGoRoutine)
-const rowSizeBatchMDP = 250
-const numRowsBatchMDP = 1000 * 10
+const (
+	rowSizeBatchMDP = 250
+	numRowsBatchMDP = 1000 * 10
+)
 
 var batchMDPBenchmarks = [...]struct {
 	name string

--- a/storage/database/leveldb_bench_options_test.go
+++ b/storage/database/leveldb_bench_options_test.go
@@ -17,7 +17,6 @@
 package database
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"strconv"
@@ -30,7 +29,7 @@ import (
 )
 
 func genTempDirForTestDB(b *testing.B) string {
-	dir, err := ioutil.TempDir("", "klaytn-db-bench")
+	dir, err := os.MkdirTemp("", "klaytn-db-bench")
 	if err != nil {
 		b.Fatalf("cannot create temporary directory: %v", err)
 	}

--- a/storage/database/rocksdb_database_test.go
+++ b/storage/database/rocksdb_database_test.go
@@ -20,7 +20,6 @@
 package database
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -30,7 +29,7 @@ func init() {
 }
 
 func newTestRocksDB() (Database, func(), string) {
-	dirName, err := ioutil.TempDir(os.TempDir(), "klay_rocksdb_test_")
+	dirName, err := os.MkdirTemp(os.TempDir(), "klay_rocksdb_test_")
 	if err != nil {
 		panic("failed to create test file: " + err.Error())
 	}

--- a/storage/database/s3filedb.go
+++ b/storage/database/s3filedb.go
@@ -27,7 +27,7 @@ package database
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/klaytn/klaytn/common/hexutil"
@@ -142,7 +142,7 @@ func (s3DB *s3FileDB) read(key []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	returnVal, err := ioutil.ReadAll(output.Body)
+	returnVal, err := io.ReadAll(output.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -18,7 +18,6 @@ package database
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -26,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/klaytn/klaytn/common"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,7 +41,7 @@ func testIterator(t *testing.T, checkOrder bool, entryNums []uint, dbConfig []*D
 
 		// create DB and write data for testing
 		for i, config := range dbConfig {
-			config.Dir, _ = ioutil.TempDir(os.TempDir(), "test-shardedDB-iterator")
+			config.Dir, _ = os.MkdirTemp(os.TempDir(), "test-shardedDB-iterator")
 			defer func(dir string) {
 				if err := os.RemoveAll(dir); err != nil {
 					t.Fatalf("fail to delete file %v", err)
@@ -179,7 +177,7 @@ func testShardedIterator_Release(t *testing.T, entryNum int, checkFunc func(db s
 
 	// create DB and write data for testing
 	for _, config := range ShardedDBConfig {
-		config.Dir, _ = ioutil.TempDir(os.TempDir(), "test-shardedDB-iterator")
+		config.Dir, _ = os.MkdirTemp(os.TempDir(), "test-shardedDB-iterator")
 		defer func(dir string) {
 			if err := os.RemoveAll(dir); err != nil {
 				t.Fatalf("fail to delete file %v", err)

--- a/storage/statedb/cache_test.go
+++ b/storage/statedb/cache_test.go
@@ -17,7 +17,6 @@
 package statedb
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"runtime"
@@ -49,7 +48,7 @@ func TestNewTrieNodeCache(t *testing.T) {
 
 func TestFastCache_SaveAndLoad(t *testing.T) {
 	// Create test directory
-	dirName, err := ioutil.TempDir(os.TempDir(), "fastcache_saveandload")
+	dirName, err := os.MkdirTemp(os.TempDir(), "fastcache_saveandload")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/statedb/trie_test.go
+++ b/storage/statedb/trie_test.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -677,7 +676,7 @@ func benchmarkCommitAfterHash(b *testing.B) {
 }
 
 func tempDB() (string, *Database) {
-	dir, err := ioutil.TempDir("", "trie-bench")
+	dir, err := os.MkdirTemp("", "trie-bench")
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory: %v", err))
 	}

--- a/tests/db_write_and_read_test.go
+++ b/tests/db_write_and_read_test.go
@@ -17,7 +17,6 @@
 package tests
 
 import (
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strconv"
@@ -52,7 +51,7 @@ var testEntries = []testEntry{
 // Sometimes 3) and 4) are omitted if such operation is not possible due to some reasons.
 func TestDBManager_WriteAndRead_Functional(t *testing.T) {
 	for _, entry := range testEntries {
-		tempDir, err := ioutil.TempDir("", "klaytn-db-manager-test")
+		tempDir, err := os.MkdirTemp("", "klaytn-db-manager-test")
 		if err != nil {
 			t.Fatalf("cannot create temporary directory: %v", err)
 		}

--- a/tests/hard_fork_test.go
+++ b/tests/hard_fork_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strings"
@@ -63,11 +62,11 @@ func TestHardForkBlock(t *testing.T) {
 	// return
 
 	// load raw data from files.
-	genesisJson, err := ioutil.ReadFile("genesis.json")
+	genesisJson, err := os.ReadFile("genesis.json")
 	require.Equal(t, nil, err)
-	rawb1, err := ioutil.ReadFile("b1.rlp")
+	rawb1, err := os.ReadFile("b1.rlp")
 	require.Equal(t, nil, err)
-	rawb2, err := ioutil.ReadFile("b2.rlp")
+	rawb2, err := os.ReadFile("b2.rlp")
 	require.Equal(t, nil, err)
 
 	err = json.Unmarshal([]byte(genesisJson), &genesis)
@@ -163,7 +162,7 @@ func genBlocks(t *testing.T) {
 	prof.Profile("main_init_blockchain", time.Now().Sub(start))
 
 	b, err := json.Marshal(bcdata.genesis)
-	ioutil.WriteFile("genesis.json", b, 0o755)
+	os.WriteFile("genesis.json", b, 0o755)
 
 	defer bcdata.Shutdown()
 

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -46,7 +45,7 @@ var (
 )
 
 func readJSON(reader io.Reader, value interface{}) error {
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("error reading JSON file: %v", err)
 	}

--- a/tests/klay_blockchain_test.go
+++ b/tests/klay_blockchain_test.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"crypto/ecdsa"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -92,7 +91,7 @@ func TestSimpleBlockchain(t *testing.T) {
 func newBlockchain(t *testing.T, config *params.ChainConfig) (*node.Node, *cn.CN, *TestAccountType, *big.Int, string) {
 	t.Log("Create a new blockchain")
 	// Prepare workspace
-	workspace, err := ioutil.TempDir("", "klaytn-test-state")
+	workspace, err := os.MkdirTemp("", "klaytn-test-state")
 	if err != nil {
 		t.Fatalf("failed to create temporary keystore: %v", err)
 	}

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -178,7 +177,7 @@ func getAddrsAndKeysFromFile(numAccounts int, testDataDir string, run int, fileP
 	addrs := make([]*common.Address, 0, numAccounts)
 	privKeys := make([]*ecdsa.PrivateKey, 0, numAccounts)
 
-	files, err := ioutil.ReadDir(path.Join(testDataDir, addressDirectory))
+	files, err := os.ReadDir(path.Join(testDataDir, addressDirectory))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/utils/build/util.go
+++ b/utils/build/util.go
@@ -25,7 +25,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -77,7 +76,7 @@ func GOPATH() string {
 
 // VERSION returns the content of the VERSION file.
 func VERSION() string {
-	version, err := ioutil.ReadFile("VERSION")
+	version, err := os.ReadFile("VERSION")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -106,7 +105,7 @@ func RunGit(args ...string) string {
 
 // readGitFile returns content of file in .git directory.
 func readGitFile(file string) string {
-	content, err := ioutil.ReadFile(path.Join(".git", file))
+	content, err := os.ReadFile(path.Join(".git", file))
 	if err != nil {
 		return ""
 	}
@@ -167,7 +166,7 @@ func CopyFile(dst, src string, mode os.FileMode) {
 // so that go commands executed by build use the same version of Go as the 'host' that runs
 // build code. e.g.
 //
-//     /usr/lib/go-1.8/bin/go run build/ci.go ...
+//	/usr/lib/go-1.8/bin/go run build/ci.go ...
 //
 // runs using go 1.8 and invokes go 1.8 tools from the same GOROOT. This is also important
 // because runtime.Version checks on the host should match the tools that are run.


### PR DESCRIPTION
## Proposed changes

`ioutil` was deprecated in [Go 1.16](https://go.dev/doc/go1.16#ioutil) (https://github.com/ethereum/go-ethereum/pull/24869)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
