### PR TITLE
Simplify error handling in interpreter loop

### DIFF
--- a/blockchain/vm/errors.go
+++ b/blockchain/vm/errors.go
@@ -45,4 +45,8 @@ var (
 	ErrMaxCodeSizeExceeded   = errors.New("evm: max code size exceeded")
 	ErrInvalidJump           = errors.New("evm: invalid jump destination")
 	ErrInvalidCode           = errors.New("invalid code: must not begin with 0xef")
+
+	// errStopToken is an internal token indicating interpreter loop termination,
+	// never returned to outside callers.
+	errStopToken = errors.New("stop token")
 )

--- a/blockchain/vm/instructions.go
+++ b/blockchain/vm/instructions.go
@@ -653,7 +653,7 @@ func opJump(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	if !scope.Contract.validJumpdest(pos) {
 		return nil, ErrInvalidJump
 	}
-	*pc = pos.Uint64()
+	*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop
 
 	evm.interpreter.intPool.put(pos)
 	return nil, nil
@@ -665,9 +665,7 @@ func opJumpi(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 		if !scope.Contract.validJumpdest(pos) {
 			return nil, ErrInvalidJump
 		}
-		*pc = pos.Uint64()
-	} else {
-		*pc++
+		*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop
 	}
 
 	evm.interpreter.intPool.put(pos, cond)
@@ -719,8 +717,10 @@ func opCreate(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	evm.interpreter.intPool.put(value, offset, size)
 
 	if suberr == ErrExecutionReverted {
+		evm.interpreter.returnData = res // set REVERT data to return data buffer
 		return res, nil
 	}
+	evm.interpreter.returnData = nil // clear dirty return data buffer
 	return nil, nil
 }
 
@@ -747,8 +747,10 @@ func opCreate2(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	evm.interpreter.intPool.put(endowment, offset, size, salt)
 
 	if suberr == ErrExecutionReverted {
+		evm.interpreter.returnData = res // set REVERT data to return data buffer
 		return res, nil
 	}
+	evm.interpreter.returnData = nil // clear dirty return data buffer
 	return nil, nil
 }
 
@@ -779,6 +781,7 @@ func opCall(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	scope.Contract.Gas += returnGas
 
 	evm.interpreter.intPool.put(addr, value, inOffset, inSize, retOffset, retSize)
+	evm.interpreter.returnData = ret
 	return ret, nil
 }
 
@@ -809,6 +812,7 @@ func opCallCode(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	scope.Contract.Gas += returnGas
 
 	evm.interpreter.intPool.put(addr, value, inOffset, inSize, retOffset, retSize)
+	evm.interpreter.returnData = ret
 	return ret, nil
 }
 
@@ -835,6 +839,7 @@ func opDelegateCall(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	scope.Contract.Gas += returnGas
 
 	evm.interpreter.intPool.put(addr, inOffset, inSize, retOffset, retSize)
+	evm.interpreter.returnData = ret
 	return ret, nil
 }
 
@@ -861,6 +866,7 @@ func opStaticCall(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	scope.Contract.Gas += returnGas
 
 	evm.interpreter.intPool.put(addr, inOffset, inSize, retOffset, retSize)
+	evm.interpreter.returnData = ret
 	return ret, nil
 }
 
@@ -869,7 +875,7 @@ func opReturn(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	ret := scope.Memory.GetPtr(offset.Int64(), size.Int64())
 
 	evm.interpreter.intPool.put(offset, size)
-	return ret, nil
+	return ret, errStopToken
 }
 
 func opRevert(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
@@ -877,11 +883,12 @@ func opRevert(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	ret := scope.Memory.GetPtr(offset.Int64(), size.Int64())
 
 	evm.interpreter.intPool.put(offset, size)
-	return ret, nil
+	evm.interpreter.returnData = ret
+	return ret, ErrExecutionReverted
 }
 
 func opStop(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
-	return nil, nil
+	return nil, errStopToken
 }
 
 func opSelfdestruct(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
@@ -896,7 +903,7 @@ func opSelfdestruct(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	// 	evm.interpreter.cfg.Tracer.CaptureExit([]byte{}, 0, nil)
 	// }
 
-	return nil, nil
+	return nil, errStopToken
 }
 
 // opPush1 is a specialized version of pushN
@@ -930,7 +937,7 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 	// 	tracer.CaptureExit([]byte{}, 0, nil)
 	// }
 
-	return nil, nil
+	return nil, errStopToken
 }
 
 // following functions are used by the instruction jump  table

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -53,11 +53,7 @@ type operation struct {
 	// This value will be used to limit the execution time of a transaction on EVM.
 	computationCost uint64
 
-	halts   bool // indicates whether the operation should halt further execution
-	jumps   bool // indicates whether the program counter should not increment
 	writes  bool // determines whether this a state modifying operation
-	reverts bool // determines whether the operation reverts state (implicitly halts)
-	returns bool // determines whether the operations sets the return data content
 }
 
 var (
@@ -153,7 +149,6 @@ func newConstantinopleInstructionSet() JumpTable {
 		maxStack:        maxStack(4, 1),
 		memorySize:      memoryCreate2,
 		writes:          true,
-		returns:         true,
 		computationCost: params.Create2ComputationCost,
 	}
 	return instructionSet
@@ -171,7 +166,6 @@ func newByzantiumInstructionSet() JumpTable {
 		minStack:        minStack(6, 1),
 		maxStack:        maxStack(6, 1),
 		memorySize:      memoryStaticCall,
-		returns:         true,
 		computationCost: params.StaticCallComputationCost,
 	}
 	instructionSet[RETURNDATASIZE] = &operation{
@@ -196,8 +190,6 @@ func newByzantiumInstructionSet() JumpTable {
 		minStack:        minStack(2, 0),
 		maxStack:        maxStack(2, 0),
 		memorySize:      memoryRevert,
-		reverts:         true,
-		returns:         true,
 		computationCost: params.RevertComputationCost,
 	}
 	return instructionSet
@@ -214,7 +206,6 @@ func newHomesteadInstructionSet() JumpTable {
 		minStack:        minStack(6, 1),
 		maxStack:        maxStack(6, 1),
 		memorySize:      memoryDelegateCall,
-		returns:         true,
 		computationCost: params.DelegateCallComputationCost,
 	}
 	return instructionSet
@@ -229,7 +220,6 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas:     0,
 			minStack:        minStack(0, 0),
 			maxStack:        maxStack(0, 0),
-			halts:           true,
 			computationCost: params.StopComputationCost,
 		},
 		ADD: {
@@ -588,7 +578,6 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas:     GasMidStep,
 			minStack:        minStack(1, 0),
 			maxStack:        maxStack(1, 0),
-			jumps:           true,
 			computationCost: params.JumpComputationCost,
 		},
 		JUMPI: {
@@ -596,7 +585,6 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas:     GasSlowStep,
 			minStack:        minStack(2, 0),
 			maxStack:        maxStack(2, 0),
-			jumps:           true,
 			computationCost: params.JumpiComputationCost,
 		},
 		PC: {
@@ -1128,7 +1116,6 @@ func newFrontierInstructionSet() JumpTable {
 			maxStack:        maxStack(3, 1),
 			memorySize:      memoryCreate,
 			writes:          true,
-			returns:         true,
 			computationCost: params.CreateComputationCost,
 		},
 		CALL: {
@@ -1138,7 +1125,6 @@ func newFrontierInstructionSet() JumpTable {
 			minStack:        minStack(7, 1),
 			maxStack:        maxStack(7, 1),
 			memorySize:      memoryCall,
-			returns:         true,
 			computationCost: params.CallComputationCost,
 		},
 		CALLCODE: {
@@ -1148,7 +1134,6 @@ func newFrontierInstructionSet() JumpTable {
 			minStack:        minStack(7, 1),
 			maxStack:        maxStack(7, 1),
 			memorySize:      memoryCall,
-			returns:         true,
 			computationCost: params.CallCodeComputationCost,
 		},
 		RETURN: {
@@ -1157,7 +1142,6 @@ func newFrontierInstructionSet() JumpTable {
 			minStack:        minStack(2, 0),
 			maxStack:        maxStack(2, 0),
 			memorySize:      memoryReturn,
-			halts:           true,
 			computationCost: params.ReturnComputationCost,
 		},
 		SELFDESTRUCT: {
@@ -1165,7 +1149,6 @@ func newFrontierInstructionSet() JumpTable {
 			dynamicGas:      gasSelfdestruct,
 			minStack:        minStack(1, 0),
 			maxStack:        maxStack(1, 0),
-			halts:           true,
 			writes:          true,
 			computationCost: params.SelfDestructComputationCost,
 		},


### PR DESCRIPTION
## Proposed changes

https://github.com/ethereum/go-ethereum/pull/23952

This simplifies interpreter loop exit condition to just `err != nil`. This catches:

- reverting instructions (i.e. just `REVERT`),
- halting instructions (by them returning `errStopToken`).

Also `operation.jumps` check is removed by setting `pc - 1` inside the jump instruction and doing pc++ in the loop unconditionally.

Finally, instructions manipulating return data are handling this themselves. This eliminates another `operation.returns` check.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/klaytn/klaytn/pull/1986

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
