### PR TITLE
[API] Early exit during `SetHead` operation

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -520,7 +520,7 @@ func (bc *BlockChain) SetHead(head uint64) error {
 	// If the check below satisfied, `SetHead` exit early to avoid unncessary
 	// exhaustive loop
 	if lastPruned, err := bc.db.ReadLastPrunedBlockNumber(); err == nil {
-		if head < lastPruned {
+		if head <= lastPruned {
 			return fmt.Errorf("[SetHead] Rewinding is failed because no state trie exist beyond the target number. lastPrunedr=%d, targetHead=%d",
 				lastPruned, head)
 		}

--- a/blockchain/blockchain_sethead_test.go
+++ b/blockchain/blockchain_sethead_test.go
@@ -299,6 +299,13 @@ func testSetHeadEarlyExit(t *testing.T, tt *rewindTest) {
 	if _, err := chain.InsertChain(canonblocks); err != nil {
 		t.Fatalf("Failed to import canonical chain start: %v", err)
 	}
+
 	db.WriteLastPrunedBlockNumber(tt.setheadBlock + 1)
-	assert.NotNil(t, chain.SetHead(tt.setheadBlock))
+	assert.Error(t, chain.SetHead(tt.setheadBlock))
+
+	db.WriteLastPrunedBlockNumber(tt.setheadBlock)
+	assert.Error(t, chain.SetHead(tt.setheadBlock))
+
+	db.WriteLastPrunedBlockNumber(tt.setheadBlock - 1)
+	assert.Nil(t, chain.SetHead(tt.setheadBlock))
 }

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -178,6 +178,8 @@ type DBManager interface {
 	ReadPruningMarks(startNumber, endNumber uint64) []PruningMark
 	DeletePruningMarks(marks []PruningMark)
 	PruneTrieNodes(marks []PruningMark)
+	WriteLastPrunedBlockNumber(blockNumber uint64)
+	ReadLastPrunedBlockNumber() (uint64, error)
 
 	// from accessors_indexes.go
 	ReadTxLookupEntry(hash common.Hash) (common.Hash, uint64, uint64)
@@ -2016,6 +2018,24 @@ func (dbm *databaseManager) PruneTrieNodes(marks []PruningMark) {
 	if err := batch.Write(); err != nil {
 		logger.Crit("Failed to batch prune trie node", "err", err)
 	}
+}
+
+// WriteLastPrunedBlockNumber records a block number of the most recent pruning block
+func (dbm *databaseManager) WriteLastPrunedBlockNumber(blockNumber uint64) {
+	db := dbm.getDatabase(MiscDB)
+	if err := db.Put(lastPrunedBlockNumberKey, common.Int64ToByteLittleEndian(blockNumber)); err != nil {
+		logger.Crit("Failed to record the last pruned block number", "err", err)
+	}
+}
+
+// ReadLastPrunedBlockNumber reads a block number of the most recent pruning block
+func (dbm *databaseManager) ReadLastPrunedBlockNumber() (uint64, error) {
+	db := dbm.getDatabase(MiscDB)
+	lastPruned, err := db.Get(lastPrunedBlockNumberKey)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint64(lastPruned), nil
 }
 
 // ReadTxLookupEntry retrieves the positional metadata associated with a transaction

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -93,10 +93,11 @@ var (
 	preimagePrefix = []byte("secure-key-")  // preimagePrefix + hash -> preimage
 	configPrefix   = []byte("klay-config-") // config prefix for the db
 
-	pruningEnabledKey = []byte("PruningEnabled")
-	pruningMarkPrefix = []byte("Pruning-")                                // KIP-111 pruning markings
-	pruningMarkValue  = []byte{0x01}                                      // A nonempty value to store a pruning mark
-	pruningMarkKeyLen = len(pruningMarkPrefix) + 8 + common.ExtHashLength // prefix + num (uint64) + node hash
+	pruningEnabledKey        = []byte("PruningEnabled")
+	pruningMarkPrefix        = []byte("Pruning-")                                // KIP-111 pruning markings
+	pruningMarkValue         = []byte{0x01}                                      // A nonempty value to store a pruning mark
+	pruningMarkKeyLen        = len(pruningMarkPrefix) + 8 + common.ExtHashLength // prefix + num (uint64) + node hash
+	lastPrunedBlockNumberKey = []byte("lastPrunedBlockNumber")
 
 	// Chain index prefixes (use `i` + single byte to avoid mixing data types).
 	BloomBitsIndexPrefix = []byte("iB") // BloomBitsIndexPrefix is the data table of a chain indexer to track its progress
@@ -129,8 +130,6 @@ var (
 	stakingInfoPrefix = []byte("stakingInfo")
 
 	chaindatafetcherCheckpointKey = []byte("chaindatafetcherCheckpoint")
-
-	lastPrunedBlockNumberKey = []byte("lastPrunedBlockNumber")
 )
 
 // TxLookupEntry is a positional metadata to help looking up the data content of

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -129,6 +129,8 @@ var (
 	stakingInfoPrefix = []byte("stakingInfo")
 
 	chaindatafetcherCheckpointKey = []byte("chaindatafetcherCheckpoint")
+
+	lastPrunedBlockNumberKey = []byte("lastPrunedBlockNumber")
 )
 
 // TxLookupEntry is a positional metadata to help looking up the data content of


### PR DESCRIPTION
## Proposed changes

A new feature, live-pruning, removes all dirty nodes beyond a specified boundary in the configuration, ensuring no state exists beyond that boundary. If the 'SetHead' operation is called with a block number beyond the last pruned block, the operation becomes ineffective. The issue lies in the running loop, which can potentially run infinitely.

For instance, if the latest block number is `135723243`, and the target is set to `135723243 - 1000`, the node's state is only available up to `135723243 - 500` due to aggressive retention settings. The 'SetHead' loop subtracts one from the current block number until it reaches a block with retained state, potentially leading to an infinite or non-terminating loop.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
