### PR TITLE
vm: add vm.opdebug flag

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1112,6 +1112,10 @@ func (bc *BlockChain) Stop() {
 		_ = triedb.TrieNodeCache().Close()
 	}
 
+	if bc.vmConfig.EnableOpDebug {
+		vm.PrintOpCodeExecTime()
+	}
+
 	logger.Info("Blockchain manager stopped")
 }
 

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -187,7 +187,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 		allocatedMemorySize = uint64(mem.Len()) // Currently allocated memory size
 
 		// used for collecting opcode execution time
-		globalTimer time.Time
+		opExecStart time.Time
 	)
 	contract.Input = input
 
@@ -212,7 +212,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 	// parent context.
 	for atomic.LoadInt32(&in.evm.abort) == 0 {
 		if in.evm.Config.EnableOpDebug {
-			globalTimer = time.Now()
+			opExecStart = time.Now()
 		}
 		if in.cfg.Debug {
 			// Capture pre-execution values for tracing.
@@ -306,7 +306,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 			verifyIntegerPool(in.intPool)
 		}
 		if in.evm.Config.EnableOpDebug {
-			opTime[op] += uint64(time.Since(globalTimer).Nanoseconds())
+			opTime[op] += uint64(time.Since(opExecStart).Nanoseconds())
 			opCnt[op] += 1
 		}
 		if err != nil {

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -658,6 +658,7 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 		}
 	}
 	cfg.EnableInternalTxTracing = ctx.Bool(VMTraceInternalTxFlag.Name)
+	cfg.EnableOpDebug = ctx.Bool(VMOpDebugFlag.Name)
 
 	cfg.AutoRestartFlag = ctx.Bool(AutoRestartFlag.Name)
 	cfg.RestartTimeOutFlag = ctx.Duration(RestartTimeOutFlag.Name)

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -262,6 +262,7 @@ var FlagGroups = []FlagGroup{
 			VMEnableDebugFlag,
 			VMLogTargetFlag,
 			VMTraceInternalTxFlag,
+			VMOpDebugFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -748,6 +748,13 @@ var (
 		EnvVars:  []string{"KLAYTN_VM_INTERNALTX"},
 		Category: "VIRTUAL MACHINE",
 	}
+	VMOpDebugFlag = &cli.BoolFlag{
+		Name:     "vm.opdebug",
+		Usage:    "Collect and print the execution time of opcodes when node stops",
+		Aliases:  []string{},
+		EnvVars:  []string{"KLAYTN_VM_OPDEBUG"},
+		Category: "VIRTUAL MACHINE",
+	}
 
 	// Logging and debug settings
 	MetricsEnabledFlag = &cli.BoolFlag{

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -249,6 +249,7 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewBoolFlag(VMEnableDebugFlag),
 	altsrc.NewIntFlag(VMLogTargetFlag),
 	altsrc.NewBoolFlag(VMTraceInternalTxFlag),
+	altsrc.NewBoolFlag(VMOpDebugFlag),
 	altsrc.NewUint64Flag(NetworkIdFlag),
 	altsrc.NewBoolFlag(MetricsEnabledFlag),
 	altsrc.NewBoolFlag(PrometheusExporterFlag),

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -149,6 +149,9 @@ type Config struct {
 	EnablePreimageRecording bool
 	// Enables collecting internal transaction data during processing a block
 	EnableInternalTxTracing bool
+	// Enables collecting and printing opcode execution time when node stops
+	EnableOpDebug bool
+
 	// Istanbul options
 	Istanbul istanbul.Config
 
@@ -197,5 +200,6 @@ func (c *Config) getVMConfig() vm.Config {
 	return vm.Config{
 		EnablePreimageRecording: c.EnablePreimageRecording,
 		EnableInternalTxTracing: c.EnableInternalTxTracing,
+		EnableOpDebug:           c.EnableOpDebug,
 	}
 }


### PR DESCRIPTION
## Proposed changes

- This PR adds `vm.opdebug` flag which enables collecting and printing the execution time of the opcodes when node stops. This flag is for debugging purpose when measuring execution time and deciding computation cost of the opcodes.
- Originally, the collecting of the execution time is done by uncommenting the debug code in `blockchain/vm/interpreter.go`. This PR removes the uncommented debug code and add a similar debug code which is run if the `vm.opdebug` flag is set.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
