### PR TITLE
Add eth_getBlockReceipts API

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -96,13 +96,14 @@ func (s *PublicBlockChainAPI) IsContractAccount(ctx context.Context, address com
 //	return state.IsHumanReadable(address), state.Error()
 // }
 
-// GetBlockReceipts returns all the transaction receipts for the given block hash.
-func (s *PublicBlockChainAPI) GetBlockReceipts(ctx context.Context, blockHash common.Hash) ([]map[string]interface{}, error) {
-	receipts := s.b.GetBlockReceipts(ctx, blockHash)
-	block, err := s.b.BlockByHash(ctx, blockHash)
+// GetBlockReceipts returns the receipts of all transactions in the block identified by number or hash.
+func (s *PublicBlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]map[string]interface{}, error) {
+	block, err := s.b.BlockByNumberOrHash(ctx, blockNrOrHash)
 	if err != nil {
 		return nil, err
 	}
+	blockHash := block.Hash()
+	receipts := s.b.GetBlockReceipts(ctx, blockHash)
 	txs := block.Transactions()
 	if receipts.Len() != txs.Len() {
 		return nil, fmt.Errorf("the size of transactions and receipts is different in the block (%s)", blockHash.String())

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -108,6 +108,14 @@ web3._extend({
 			inputFormatter: [null, function (val) { return !!val; }]
 		}),
 		new web3._extend.Method({
+			name: 'getBlockReceipts',
+			call: 'eth_getBlockReceipts',
+			params: 1,
+			outputFormatter: function(receipts) {
+				return receipts.map(web3._extend.formatters.outputTransactionReceiptFormatter);
+			}
+		}),
+		new web3._extend.Method({
 			name: 'getRawTransaction',
 			call: 'eth_getRawTransactionByHash',
 			params: 1
@@ -840,11 +848,7 @@ web3._extend({
 			call: 'klay_getBlockReceipts',
 			params: 1,
 			outputFormatter: function(receipts) {
-				var formatted = [];
-				for (var i = 0; i < receipts.length; i++) {
-					formatted.push(web3._extend.formatters.outputTransactionReceiptFormatter(receipts[i]));
-				}
-				return formatted;
+				return receipts.map(web3._extend.formatters.outputTransactionReceiptFormatter);
 			}
 		}),
 		new web3._extend.Method({


### PR DESCRIPTION
## Proposed changes

Resolves #2006.

- Add `eth_getBlockReceipts` JSON-RPC API. Accepts block number or hash.
- Modify `klay_getBlockReceipts` to accept block number or hash.
- Some eth_getBlockReceipts implementations [accept block numbers](https://docs.alchemy.com/reference/eth-getblockreceipts), whereas klay_getBlockReceipts has been accepting block hash only. But it is [standard to accept both](https://github.com/ethereum/execution-apis/issues/393). Therefore Klaytn's eth_ and klay_ APIs accept both block number and hash.

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments