### PR TITLE
A patch of consensus stability

### DIFF
--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -439,8 +439,8 @@ func requiredMessageCount(valSet istanbul.ValidatorSet) int {
 	// in the certain cases we must receive the messages from all consensus nodes to ensure finality...
 	case 1, 2, 3:
 		return int(size)
-	case 6:
-		return 4 // when the number of valSet is 6 and return value is 2*F+1, the return value(int 3) is not safe. It should return 4 or more.
+	case 5, 6:
+		return 4 // when the number of valSet is 5 or 6 and return value is 2*F+1, the return value(int 3) is not safe. It should return 4 or more.
 	default:
 		return 2*valSet.F() + 1
 	}

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -714,10 +714,11 @@ func simulateChainSplit(t *testing.T, numValidators int) (State, State) {
 //     e.g. if the number of validator is 5, it consists of 3f+2 (f=1)
 // 2) the proposer is malicious; it sends two different blocks to each group
 func TestCore_chainSplit(t *testing.T) {
-	// If the number of validators is not 3f+1, the chain can be split.
+	// After the patch of requiredMessageCount,
+	// Even though the number of validators is not 3f+1, the chain does not split.
 	stateA, stateB := simulateChainSplit(t, 5)
-	assert.Equal(t, StateCommitted, stateA)
-	assert.Equal(t, StateCommitted, stateB)
+	assert.inEqual(t, StatePreprepared, stateA)
+	assert.inEqual(t, StatePreprepared, stateB)
 
 	// If the number of validators is 3f+1, the chain cannot be split.
 	stateA, stateB = simulateChainSplit(t, 7)

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -717,8 +717,8 @@ func TestCore_chainSplit(t *testing.T) {
 	// After the patch of requiredMessageCount,
 	// Even though the number of validators is not 3f+1, the chain does not split.
 	stateA, stateB := simulateChainSplit(t, 5)
-	assert.inEqual(t, StatePreprepared, stateA)
-	assert.inEqual(t, StatePreprepared, stateB)
+	assert.Equal(t, StatePreprepared, stateA)
+	assert.Equal(t, StatePreprepared, stateB)
 
 	// If the number of validators is 3f+1, the chain cannot be split.
 	stateA, stateB = simulateChainSplit(t, 7)


### PR DESCRIPTION
## Proposed changes
This bug fix enhances 5-validator network stability by increasing the required quorum from 3 to 4, mitigating chain splits. This extends the scope of https://github.com/klaytn/klaytn/pull/1462 to cover 5-validator scenarios.


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
