### PR TITLE
BugFix: quorum 

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -73,7 +73,7 @@ func New(rewardbase common.Address, config *istanbul.Config, privateKey *ecdsa.P
 		rewardDistributor: reward.NewRewardDistributor(governance),
 	}
 	backend.currentView.Store(&istanbul.View{Sequence: big.NewInt(0), Round: big.NewInt(0)})
-	backend.core = istanbulCore.New(backend, backend.config)
+	backend.core = istanbulCore.New(backend)
 	return backend
 }
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -357,7 +357,7 @@ func (sb *backend) verifyCommittedSeals(chain consensus.ChainReader, header *typ
 	}
 
 	// The length of validSeal should be larger than number of faulty node + 1
-	if validSeal <= 2*snap.ValSet.F() {
+	if validSeal <= istanbulCore.RequiredMessageCount(snap.ValSet) {
 		return errInvalidCommittedSeals
 	}
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -357,7 +357,7 @@ func (sb *backend) verifyCommittedSeals(chain consensus.ChainReader, header *typ
 	}
 
 	// The length of validSeal should be larger than number of faulty node + 1
-	if validSeal <= istanbulCore.RequiredMessageCount(snap.ValSet) {
+	if validSeal < istanbulCore.RequiredMessageCount(snap.ValSet, header.Number) {
 		return errInvalidCommittedSeals
 	}
 

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	ProposerPolicy ProposerPolicy `toml:",omitempty"` // The policy for proposer selection
 	Epoch          uint64         `toml:",omitempty"` // The number of blocks after which to checkpoint and reset the pending votes
 	SubGroupSize   uint64         `toml:",omitempty"`
+	// ChainConfig	chainconfig
 }
 
 // TODO-Klaytn-Istanbul: Do not use DefaultConfig except for assigning new config

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -109,7 +109,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 			logger.Warn("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() >= RequiredMessageCount(c.valSet) {
+		} else if c.current.GetPrepareOrCommitSize() >= RequiredMessageCount(c.valSet, commit.View.Sequence) {
 			logger.Info("received a quorum of the messages and change state to prepared", "msgType", msgCommit, "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
@@ -122,7 +122,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 	// If we already have a proposal, we may have chance to speed up the consensus process
 	// by committing the proposal without PREPARE messages.
 	//logger.Error("### consensus check","len(commits)",c.current.Commits.Size(),"f(2/3)",2*c.valSet.F(),"state",c.state.Cmp(StateCommitted))
-	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() >= RequiredMessageCount(c.valSet) {
+	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() >= RequiredMessageCount(c.valSet, commit.View.Sequence) {
 		// Still need to call LockHash here since state can skip Prepared state and jump directly to the Committed state.
 		c.current.LockHash()
 		c.commit()

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -109,7 +109,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 			logger.Warn("received commit of the hash locked proposal and change state to prepared", "msgType", msgCommit)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() >= requiredMessageCount(c.valSet) {
+		} else if c.current.GetPrepareOrCommitSize() >= RequiredMessageCount(c.valSet) {
 			logger.Info("received a quorum of the messages and change state to prepared", "msgType", msgCommit, "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)
@@ -122,7 +122,7 @@ func (c *core) handleCommit(msg *message, src istanbul.Validator) error {
 	// If we already have a proposal, we may have chance to speed up the consensus process
 	// by committing the proposal without PREPARE messages.
 	//logger.Error("### consensus check","len(commits)",c.current.Commits.Size(),"f(2/3)",2*c.valSet.F(),"state",c.state.Cmp(StateCommitted))
-	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() >= requiredMessageCount(c.valSet) {
+	if c.state.Cmp(StateCommitted) < 0 && c.current.Commits.Size() >= RequiredMessageCount(c.valSet) {
 		// Still need to call LockHash here since state can skip Prepared state and jump directly to the Committed state.
 		c.current.LockHash()
 		c.commit()

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -22,7 +22,7 @@ func TestCore_sendCommit(t *testing.T) {
 	istConfig := istanbul.DefaultConfig
 	istConfig.ProposerPolicy = istanbul.WeightedRandom
 
-	istCore := New(mockBackend, istConfig).(*core)
+	istCore := New(mockBackend).(*core)
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -22,6 +22,7 @@ package core
 
 import (
 	"bytes"
+	"github.com/klaytn/klaytn/fork"
 	"math"
 	"math/big"
 	"sync"
@@ -428,7 +429,10 @@ func PrepareCommittedSeal(hash common.Hash) []byte {
 }
 
 // Minimum required number of consensus messages to proceed
-func RequiredMessageCount(valSet istanbul.ValidatorSet) int {
+func RequiredMessageCount(valSet istanbul.ValidatorSet, num *big.Int) int {
+	if fork.Rules(num).IsCancun {
+		return int(math.Ceil(float64(2*valSet.Size()) / 3))
+	}
 	var size uint64
 	if valSet.IsSubSet() {
 		size = valSet.SubGroupSize()

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -428,7 +428,7 @@ func PrepareCommittedSeal(hash common.Hash) []byte {
 }
 
 // Minimum required number of consensus messages to proceed
-func requiredMessageCount(valSet istanbul.ValidatorSet) int {
+func RequiredMessageCount(valSet istanbul.ValidatorSet) int {
 	var size uint64
 	if valSet.IsSubSet() {
 		size = valSet.SubGroupSize()

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -443,8 +443,8 @@ func RequiredMessageCount(valSet istanbul.ValidatorSet, num *big.Int) int {
 	// in the certain cases we must receive the messages from all consensus nodes to ensure finality...
 	case 1, 2, 3:
 		return int(size)
-	case 5, 6:
-		return 4 // when the number of valSet is 5 or 6 and return value is 2*F+1, the return value(int 3) is not safe. It should return 4 or more.
+	case 6:
+		return 4 // when the number of valSet is 6 and return value is 2*F+1, the return value(int 3) is not safe. It should return 4 or more.
 	default:
 		return 2*valSet.F() + 1
 	}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -439,8 +439,8 @@ func requiredMessageCount(valSet istanbul.ValidatorSet) int {
 	// in the certain cases we must receive the messages from all consensus nodes to ensure finality...
 	case 1, 2, 3:
 		return int(size)
-	case 6:
-		return 4 // when the number of valSet is 6 and return value is 2*F+1, the return value(int 3) is not safe. It should return 4 or more.
+	case 5, 6:
+		return 4 // when the number of valSet is 5 or 6 and return value is 2*F+1, the return value(int 3) is not safe. It should return 4 or more.
 	default:
 		return 2*valSet.F() + 1
 	}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -22,12 +22,13 @@ package core
 
 import (
 	"bytes"
-	"github.com/klaytn/klaytn/fork"
 	"math"
 	"math/big"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/klaytn/klaytn/fork"
 
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -41,9 +42,9 @@ import (
 var logger = log.NewModuleLogger(log.ConsensusIstanbulCore)
 
 // New creates an Istanbul consensus core
-func New(backend istanbul.Backend, config *istanbul.Config) Engine {
+func New(backend istanbul.Backend) Engine {
 	c := &core{
-		config:             config,
+		// config:             config,
 		address:            backend.Address(),
 		state:              StateAcceptRequest,
 		handlerWg:          new(sync.WaitGroup),
@@ -70,7 +71,8 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 // ----------------------------------------------------------------------------
 
 type core struct {
-	config  *istanbul.Config
+	// config  *istanbul.Config
+
 	address common.Address
 	state   State
 	logger  log.Logger
@@ -433,6 +435,7 @@ func RequiredMessageCount(valSet istanbul.ValidatorSet, num *big.Int) int {
 	if fork.Rules(num).IsCancun {
 		return int(math.Ceil(float64(2*valSet.Size()) / 3))
 	}
+	// fork.Rules(num) chainConfig.Rules(num)
 	var size uint64
 	if valSet.IsSubSet() {
 		size = valSet.SubGroupSize()

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -714,10 +714,11 @@ func simulateChainSplit(t *testing.T, numValidators int) (State, State) {
 //     e.g. if the number of validator is 5, it consists of 3f+2 (f=1)
 // 2) the proposer is malicious; it sends two different blocks to each group
 func TestCore_chainSplit(t *testing.T) {
-	// If the number of validators is not 3f+1, the chain can be split.
+	// After the patch of requiredMessageCount,
+	// Even though the number of validators is not 3f+1, the chain does not split.
 	stateA, stateB := simulateChainSplit(t, 5)
-	assert.Equal(t, StateCommitted, stateA)
-	assert.Equal(t, StateCommitted, stateB)
+	assert.inEqual(t, StatePreprepared, stateA)
+	assert.inEqual(t, StatePreprepared, stateB)
 
 	// If the number of validators is 3f+1, the chain cannot be split.
 	stateA, stateB = simulateChainSplit(t, 7)

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -249,7 +249,7 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 	istConfig.ProposerPolicy = istanbul.WeightedRandom
 
 	// When the istanbul core started, a message handling loop in `handleEvents()` waits istanbul messages
-	istCore := New(mockBackend, istConfig).(*core)
+	istCore := New(mockBackend).(*core)
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +427,7 @@ func TestCore_handlerMsg(t *testing.T) {
 	istConfig := istanbul.DefaultConfig
 	istConfig.ProposerPolicy = istanbul.WeightedRandom
 
-	istCore := New(mockBackend, istConfig).(*core)
+	istCore := New(mockBackend).(*core)
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -556,7 +556,7 @@ func simulateMaliciousCN(t *testing.T, numValidators int, numMalicious int) Stat
 	// Start istanbul core
 	istConfig := istanbul.DefaultConfig
 	istConfig.ProposerPolicy = istanbul.WeightedRandom
-	istCore := New(mockBackend, istConfig).(*core)
+	istCore := New(mockBackend).(*core)
 	err := istCore.Start()
 	require.Nil(t, err)
 	defer istCore.Stop()
@@ -645,9 +645,9 @@ func simulateChainSplit(t *testing.T, numValidators int) (State, State) {
 	// Start istanbul core
 	istConfig := istanbul.DefaultConfig
 	istConfig.ProposerPolicy = istanbul.WeightedRandom
-	coreProposer := New(mockBackend, istConfig).(*core)
-	coreA := New(mockBackend, istConfig).(*core)
-	coreB := New(mockBackend, istConfig).(*core)
+	coreProposer := New(mockBackend).(*core)
+	coreA := New(mockBackend).(*core)
+	coreB := New(mockBackend).(*core)
 	require.Nil(t,
 		coreProposer.Start(),
 		coreA.Start(),
@@ -710,9 +710,9 @@ func simulateChainSplit(t *testing.T, numValidators int) (State, State) {
 }
 
 // TestCore_chainSplit tests whether a chain split occurs in a certain conditions:
-// 1) the number of validators does not consist of 3f+1;
+//  1. the number of validators does not consist of 3f+1;
 //     e.g. if the number of validator is 5, it consists of 3f+2 (f=1)
-// 2) the proposer is malicious; it sends two different blocks to each group
+//  2. the proposer is malicious; it sends two different blocks to each group
 func TestCore_chainSplit(t *testing.T) {
 	// After the patch of RequiredMessageCount,
 	// If the number of validators is not 3f+1, the chain can be split.
@@ -766,7 +766,7 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 	istConfig := istanbul.DefaultConfig
 	istConfig.ProposerPolicy = istanbul.WeightedRandom
 
-	istCore := New(mockBackend, istConfig).(*core)
+	istCore := New(mockBackend).(*core)
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -714,7 +714,7 @@ func simulateChainSplit(t *testing.T, numValidators int) (State, State) {
 //     e.g. if the number of validator is 5, it consists of 3f+2 (f=1)
 // 2) the proposer is malicious; it sends two different blocks to each group
 func TestCore_chainSplit(t *testing.T) {
-	// After the patch of requiredMessageCount,
+	// After the patch of RequiredMessageCount,
 	// Even though the number of validators is not 3f+1, the chain does not split.
 	stateA, stateB := simulateChainSplit(t, 5)
 	assert.Equal(t, StatePreprepared, stateA)

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -717,8 +717,8 @@ func TestCore_chainSplit(t *testing.T) {
 	// After the patch of requiredMessageCount,
 	// Even though the number of validators is not 3f+1, the chain does not split.
 	stateA, stateB := simulateChainSplit(t, 5)
-	assert.inEqual(t, StatePreprepared, stateA)
-	assert.inEqual(t, StatePreprepared, stateB)
+	assert.Equal(t, StatePreprepared, stateA)
+	assert.Equal(t, StatePreprepared, stateB)
 
 	// If the number of validators is 3f+1, the chain cannot be split.
 	stateA, stateB = simulateChainSplit(t, 7)

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -715,10 +715,10 @@ func simulateChainSplit(t *testing.T, numValidators int) (State, State) {
 // 2) the proposer is malicious; it sends two different blocks to each group
 func TestCore_chainSplit(t *testing.T) {
 	// After the patch of RequiredMessageCount,
-	// Even though the number of validators is not 3f+1, the chain does not split.
+	// If the number of validators is not 3f+1, the chain can be split.
 	stateA, stateB := simulateChainSplit(t, 5)
-	assert.Equal(t, StatePreprepared, stateA)
-	assert.Equal(t, StatePreprepared, stateB)
+	assert.Equal(t, StateCommitted, stateA)
+	assert.Equal(t, StateCommitted, stateB)
 
 	// If the number of validators is 3f+1, the chain cannot be split.
 	stateA, stateB = simulateChainSplit(t, 7)

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -85,7 +85,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			logger.Warn("received prepare of the hash locked proposal and change state to prepared", "msgType", msgPrepare)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() >= requiredMessageCount(c.valSet) {
+		} else if c.current.GetPrepareOrCommitSize() >= RequiredMessageCount(c.valSet) {
 			logger.Info("received a quorum of the messages and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size(), "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -85,7 +85,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 			logger.Warn("received prepare of the hash locked proposal and change state to prepared", "msgType", msgPrepare)
 			c.setState(StatePrepared)
 			c.sendCommit()
-		} else if c.current.GetPrepareOrCommitSize() >= RequiredMessageCount(c.valSet) {
+		} else if c.current.GetPrepareOrCommitSize() >= RequiredMessageCount(c.valSet, prepare.View.Sequence) {
 			logger.Info("received a quorum of the messages and change state to prepared", "msgType", msgPrepare, "prepareMsgNum", c.current.Prepares.Size(), "commitMsgNum", c.current.Commits.Size(), "valSet", c.valSet.Size())
 			c.current.LockHash()
 			c.setState(StatePrepared)

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -27,7 +27,7 @@ func TestCore_sendPrepare(t *testing.T) {
 	istConfig := istanbul.DefaultConfig
 	istConfig.ProposerPolicy = istanbul.WeightedRandom
 
-	istCore := New(mockBackend, istConfig).(*core)
+	istCore := New(mockBackend).(*core)
 	if err := istCore.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// If the number of validators is 6 or less, the chain could be forked by round change if the required minimum consensus message is "2f+1".
-	// So, the exceptional case such as number of validator is 6, gather more messages than "2f+1". See requiredMessageCount for more specific information.
+	// So, the exceptional case such as number of validator is 6, gather more messages than "2f+1". See RequiredMessageCount for more specific information.
 	exceptionalValidatorsNumber = 6
 )
 
@@ -120,15 +120,16 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 
 	var numCatchUp, numStartNewRound int
 	if c.valSet.Size() <= exceptionalValidatorsNumber {
-		n := requiredMessageCount(c.valSet)
+		n := RequiredMessageCount(c.valSet)
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n
 		// N - 1 ROUND CHANGE messages can catch up the round.
 		numCatchUp = n - 1
 	} else {
+		n := RequiredMessageCount(c.valSet)
 		f := int(c.valSet.F())
-		// 2*F + 1 ROUND CHANGE messages can start new round.
-		numStartNewRound = 2*f + 1
+		// N ROUND CHANGE messages can start new round.
+		numStartNewRound = n
 		// F + 1 ROUND CHANGE messages can start catch up the round.
 		numCatchUp = f + 1
 	}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -120,13 +120,13 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 
 	var numCatchUp, numStartNewRound int
 	if c.valSet.Size() <= exceptionalValidatorsNumber {
-		n := RequiredMessageCount(c.valSet)
+		n := RequiredMessageCount(c.valSet, rc.View.Sequence)
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n
 		// N - 1 ROUND CHANGE messages can catch up the round.
 		numCatchUp = n - 1
 	} else {
-		n := RequiredMessageCount(c.valSet)
+		n := RequiredMessageCount(c.valSet, rc.View.Sequence)
 		f := int(c.valSet.F())
 		// N ROUND CHANGE messages can start new round.
 		numStartNewRound = n


### PR DESCRIPTION
## Proposed changes
This PR addresses a consensus instability issue in networks with 4x+1 validators. It updates the quorum calculation from the previous 2F+1 to math.Ceil(float64(2*valSet.Size())/3), aligning with QBFT requirements for enhanced network stability and Byzantine fault tolerance.

Closes https://github.com/klaytn/klaytn/issues/2023.
## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments
This fix requires a hard fork.