### PR TITLE
[API] New CreateAccessList API

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1489,7 +1489,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	}
 
 	if args.Gas == nil {
-		// Set gaslimit to maximum to if the gas is not specified
+		// Set gaslimit to maximum if the gas is not specified
 		upperGasLimit := hexutil.Uint64(params.UpperGasLimit)
 		args.Gas = &upperGasLimit
 	}

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -462,10 +462,8 @@ type AccessListResult struct {
 
 // CreateAccessList creates a EIP-2930 type AccessList for the given transaction.
 // Reexec and BlockNrOrHash can be specified to create the accessList on top of a certain state.
-// TODO-Klaytn: Have to implement logic. For now, Klaytn does not implement actual access list logic, so return empty access list result.
-func (s *PublicBlockChainAPI) CreateAccessList(ctx context.Context, args SendTxArgs, blockNrOrHash *rpc.BlockNumberOrHash) (*AccessListResult, error) {
-	result := &AccessListResult{Accesslist: &types.AccessList{}, GasUsed: hexutil.Uint64(0)}
-	return result, nil
+func (s *PublicBlockChainAPI) CreateAccessList(ctx context.Context, args EthTransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash) (interface{}, error) {
+	return doCreateAccessList(ctx, s.b, args, blockNrOrHash)
 }
 
 // StructLogRes stores a structured log emitted by the EVM while replaying a

--- a/blockchain/vm/access_list_tracer.go
+++ b/blockchain/vm/access_list_tracer.go
@@ -1,0 +1,182 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"math/big"
+
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
+)
+
+// accessList is an accumulator for the set of accounts and storage slots an EVM
+// contract execution touches.
+type accessList map[common.Address]accessListSlots
+
+// accessListSlots is an accumulator for the set of storage slots within a single
+// contract that an EVM contract execution touches.
+type accessListSlots map[common.Hash]struct{}
+
+// newAccessList creates a new accessList.
+func newAccessList() accessList {
+	return make(map[common.Address]accessListSlots)
+}
+
+// addAddress adds an address to the accesslist.
+func (al accessList) addAddress(address common.Address) {
+	// Set address if not previously present
+	if _, present := al[address]; !present {
+		al[address] = make(map[common.Hash]struct{})
+	}
+}
+
+// addSlot adds a storage slot to the accesslist.
+func (al accessList) addSlot(address common.Address, slot common.Hash) {
+	// Set address if not previously present
+	al.addAddress(address)
+
+	// Set the slot on the surely existent storage set
+	al[address][slot] = struct{}{}
+}
+
+// equal checks if the content of the current access list is the same as the
+// content of the other one.
+func (al accessList) equal(other accessList) bool {
+	// Cross reference the accounts first
+	if len(al) != len(other) {
+		return false
+	}
+	// Given that len(al) == len(other), we only need to check that
+	// all the items from al are in other.
+	for addr := range al {
+		if _, ok := other[addr]; !ok {
+			return false
+		}
+	}
+
+	// Accounts match, cross reference the storage slots too
+	for addr, slots := range al {
+		otherslots := other[addr]
+
+		if len(slots) != len(otherslots) {
+			return false
+		}
+		// Given that len(slots) == len(otherslots), we only need to check that
+		// all the items from slots are in otherslots.
+		for hash := range slots {
+			if _, ok := otherslots[hash]; !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// accesslist converts the accesslist to a types.AccessList.
+func (al accessList) accessList() types.AccessList {
+	acl := make(types.AccessList, 0, len(al))
+	for addr, slots := range al {
+		tuple := types.AccessTuple{Address: addr, StorageKeys: []common.Hash{}}
+		for slot := range slots {
+			tuple.StorageKeys = append(tuple.StorageKeys, slot)
+		}
+		acl = append(acl, tuple)
+	}
+	return acl
+}
+
+// AccessListTracer is a tracer that accumulates touched accounts and storage
+// slots into an internal set.
+type AccessListTracer struct {
+	excl map[common.Address]struct{} // Set of account to exclude from the list
+	list accessList                  // Set of accounts and storage slots touched
+}
+
+// NewAccessListTracer creates a new tracer that can generate AccessLists.
+// An optional AccessList can be specified to occupy slots and addresses in
+// the resulting accesslist.
+func NewAccessListTracer(acl types.AccessList, from, to common.Address, precompiles []common.Address) *AccessListTracer {
+	excl := map[common.Address]struct{}{
+		from: {}, to: {},
+	}
+	for _, addr := range precompiles {
+		excl[addr] = struct{}{}
+	}
+	list := newAccessList()
+	for _, al := range acl {
+		if _, ok := excl[al.Address]; !ok {
+			list.addAddress(al.Address)
+		}
+		for _, slot := range al.StorageKeys {
+			list.addSlot(al.Address, slot)
+		}
+	}
+	return &AccessListTracer{
+		excl: excl,
+		list: list,
+	}
+}
+
+func (a *AccessListTracer) CaptureStart(env *EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+}
+
+// CaptureState captures all opcodes that touch storage or addresses and adds them to the accesslist.
+func (a *AccessListTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error) {
+	stack := scope.Stack
+	stackData := stack.Data()
+	stackLen := len(stackData)
+	if (op == SLOAD || op == SSTORE) && stackLen >= 1 {
+		slot := common.Hash(stackData[stackLen-1].Bytes32())
+		a.list.addSlot(scope.Contract.Address(), slot)
+	}
+	if (op == EXTCODECOPY || op == EXTCODEHASH || op == EXTCODESIZE || op == BALANCE || op == SELFDESTRUCT) && stackLen >= 1 {
+		addr := common.Address(stackData[stackLen-1].Bytes20())
+		if _, ok := a.excl[addr]; !ok {
+			a.list.addAddress(addr)
+		}
+	}
+	if (op == DELEGATECALL || op == CALL || op == STATICCALL || op == CALLCODE) && stackLen >= 5 {
+		addr := common.Address(stackData[stackLen-2].Bytes20())
+		if _, ok := a.excl[addr]; !ok {
+			a.list.addAddress(addr)
+		}
+	}
+}
+
+func (*AccessListTracer) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error) {
+}
+
+func (*AccessListTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {}
+
+func (*AccessListTracer) CaptureEnter(typ OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+}
+
+func (*AccessListTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
+
+func (*AccessListTracer) CaptureTxStart(gasLimit uint64) {}
+
+func (*AccessListTracer) CaptureTxEnd(restGas uint64) {}
+
+// AccessList returns the current accesslist maintained by the tracer.
+func (a *AccessListTracer) AccessList() types.AccessList {
+	return a.list.accessList()
+}
+
+// Equal returns if the content of two access list traces are equal.
+func (a *AccessListTracer) Equal(other *AccessListTracer) bool {
+	return a.list.equal(other.list)
+}

--- a/blockchain/vm/access_list_tracer.go
+++ b/blockchain/vm/access_list_tracer.go
@@ -1,3 +1,4 @@
+// Modifications Copyright 2023 The klaytn Authors
 // Copyright 2021 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
@@ -13,6 +14,9 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// This file is derived from eth/tracers/logger/access_list_tracer.go (2023/11/10).
+// Modified and improved for the klaytn development.
 
 package vm
 

--- a/blockchain/vm/contracts.go
+++ b/blockchain/vm/contracts.go
@@ -143,16 +143,9 @@ func init() {
 	for k := range PrecompiledContractsByzantium {
 		PrecompiledAddressesByzantium = append(PrecompiledAddressesByzantium, k)
 	}
-
-	// After istanbulCompatible hf, need to support for vmversion0 contracts, too.
-	// VmVersion0 contracts are deployed before istanbulCompatible and they use byzantiumCompatible precompiled contracts.
-	// VmVersion0 contracts are the contracts deployed before istanbulCompatible hf.
 	for k := range PrecompiledContractsIstanbul {
 		PrecompiledAddressIstanbul = append(PrecompiledAddressIstanbul, k)
 	}
-	PrecompiledAddressIstanbul = append(PrecompiledAddressIstanbul,
-		[]common.Address{common.BytesToAddress([]byte{10}), common.BytesToAddress([]byte{11})}...)
-
 	for k := range PrecompiledContractsCancun {
 		PrecompiledAddressCancun = append(PrecompiledAddressCancun, k)
 	}
@@ -160,13 +153,24 @@ func init() {
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
+	var precompiledContractAddrs []common.Address
 	switch {
 	case rules.IsCancun:
-		return PrecompiledAddressCancun
+		precompiledContractAddrs = PrecompiledAddressCancun
 	case rules.IsIstanbul:
-		return PrecompiledAddressIstanbul
+		precompiledContractAddrs = PrecompiledAddressIstanbul
 	default:
-		return PrecompiledAddressesByzantium
+		precompiledContractAddrs = PrecompiledAddressesByzantium
+	}
+
+	// After istanbulCompatible hf, need to support for vmversion0 contracts, too.
+	// VmVersion0 contracts are deployed before istanbulCompatible and they use byzantiumCompatible precompiled contracts.
+	// VmVersion0 contracts are the contracts deployed before istanbulCompatible hf.
+	if rules.IsIstanbul {
+		return append(precompiledContractAddrs,
+			[]common.Address{common.BytesToAddress([]byte{10}), common.BytesToAddress([]byte{11})}...)
+	} else {
+		return precompiledContractAddrs
 	}
 }
 

--- a/blockchain/vm/contracts.go
+++ b/blockchain/vm/contracts.go
@@ -64,9 +64,9 @@ type PrecompiledContract interface {
 	Run(input []byte, contract *Contract, evm *EVM) ([]byte, error)
 }
 
-// PrecompiledContractsByzantiumCompatible contains the default set of pre-compiled Klaytn
+// PrecompiledContractsByzantium contains the default set of pre-compiled Klaytn
 // contracts based on Ethereum Byzantium.
-var PrecompiledContractsByzantiumCompatible = map[common.Address]PrecompiledContract{
+var PrecompiledContractsByzantium = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{1}):  &ecrecover{},
 	common.BytesToAddress([]byte{2}):  &sha256hash{},
 	common.BytesToAddress([]byte{3}):  &ripemd160hash{},
@@ -82,9 +82,9 @@ var PrecompiledContractsByzantiumCompatible = map[common.Address]PrecompiledCont
 
 // DO NOT USE 0x3FD, 0x3FE, 0x3FF ADDRESSES BEFORE ISTANBUL CHANGE ACTIVATED.
 
-// PrecompiledContractsIstanbulCompatible contains the default set of pre-compiled Klaytn
+// PrecompiledContractsIstanbul contains the default set of pre-compiled Klaytn
 // contracts based on Ethereum Istanbul.
-var PrecompiledContractsIstanbulCompatible = map[common.Address]PrecompiledContract{
+var PrecompiledContractsIstanbul = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{1}):      &ecrecover{},
 	common.BytesToAddress([]byte{2}):      &sha256hash{},
 	common.BytesToAddress([]byte{3}):      &ripemd160hash{},
@@ -140,18 +140,20 @@ var (
 )
 
 func init() {
-	for k := range PrecompiledContractsByzantiumCompatible {
+	for k := range PrecompiledContractsByzantium {
 		PrecompiledAddressesByzantium = append(PrecompiledAddressesByzantium, k)
 	}
 
 	// After istanbulCompatible hf, need to support for vmversion0 contracts, too.
 	// VmVersion0 contracts are deployed before istanbulCompatible and they use byzantiumCompatible precompiled contracts.
 	// VmVersion0 contracts are the contracts deployed before istanbulCompatible hf.
-	for k := range PrecompiledContractsIstanbulCompatible {
+	for k := range PrecompiledContractsIstanbul {
 		PrecompiledAddressIstanbul = append(PrecompiledAddressIstanbul, k)
 	}
+	PrecompiledAddressIstanbul = append(PrecompiledAddressIstanbul,
+		[]common.Address{common.BytesToAddress([]byte{10}), common.BytesToAddress([]byte{11})}...)
 
-	for k := range PrecompiledContractsIstanbulCompatible {
+	for k := range PrecompiledContractsCancun {
 		PrecompiledAddressCancun = append(PrecompiledAddressCancun, k)
 	}
 }

--- a/blockchain/vm/contracts.go
+++ b/blockchain/vm/contracts.go
@@ -116,33 +116,55 @@ var PrecompiledContractsKore = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{3, 255}): &validateSender{},
 }
 
+// PrecompiledContractsCancun contains the default set of pre-compiled Klaytn
+// Have the same list with Kore
+var PrecompiledContractsCancun = map[common.Address]PrecompiledContract{
+	common.BytesToAddress([]byte{1}):      &ecrecover{},
+	common.BytesToAddress([]byte{2}):      &sha256hash{},
+	common.BytesToAddress([]byte{3}):      &ripemd160hash{},
+	common.BytesToAddress([]byte{4}):      &dataCopy{},
+	common.BytesToAddress([]byte{5}):      &bigModExp{eip2565: true},
+	common.BytesToAddress([]byte{6}):      &bn256AddIstanbul{},
+	common.BytesToAddress([]byte{7}):      &bn256ScalarMulIstanbul{},
+	common.BytesToAddress([]byte{8}):      &bn256PairingIstanbul{},
+	common.BytesToAddress([]byte{9}):      &blake2F{},
+	common.BytesToAddress([]byte{3, 253}): &vmLog{},
+	common.BytesToAddress([]byte{3, 254}): &feePayer{},
+	common.BytesToAddress([]byte{3, 255}): &validateSender{},
+}
+
 var (
-	PrecompiledAddressesIstanbulCompatible  []common.Address
-	PrecompiledAddressesByzantiumCompatible []common.Address
+	PrecompiledAddressCancun      []common.Address
+	PrecompiledAddressIstanbul    []common.Address
+	PrecompiledAddressesByzantium []common.Address
 )
 
 func init() {
 	for k := range PrecompiledContractsByzantiumCompatible {
-		PrecompiledAddressesByzantiumCompatible = append(PrecompiledAddressesByzantiumCompatible, k)
+		PrecompiledAddressesByzantium = append(PrecompiledAddressesByzantium, k)
 	}
 
 	// After istanbulCompatible hf, need to support for vmversion0 contracts, too.
 	// VmVersion0 contracts are deployed before istanbulCompatible and they use byzantiumCompatible precompiled contracts.
 	// VmVersion0 contracts are the contracts deployed before istanbulCompatible hf.
 	for k := range PrecompiledContractsIstanbulCompatible {
-		PrecompiledAddressesIstanbulCompatible = append(PrecompiledAddressesIstanbulCompatible, k)
+		PrecompiledAddressIstanbul = append(PrecompiledAddressIstanbul, k)
 	}
-	PrecompiledAddressesIstanbulCompatible = append(PrecompiledAddressesIstanbulCompatible,
-		[]common.Address{common.BytesToAddress([]byte{10}), common.BytesToAddress([]byte{11})}...)
+
+	for k := range PrecompiledContractsIstanbulCompatible {
+		PrecompiledAddressCancun = append(PrecompiledAddressCancun, k)
+	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
+	case rules.IsCancun:
+		return PrecompiledAddressCancun
 	case rules.IsIstanbul:
-		return PrecompiledAddressesIstanbulCompatible
+		return PrecompiledAddressIstanbul
 	default:
-		return PrecompiledAddressesByzantiumCompatible
+		return PrecompiledAddressesByzantium
 	}
 }
 

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -651,6 +651,8 @@ func (evm *EVM) GetPrecompiledContractMap(addr common.Address) map[common.Addres
 
 	switch {
 	case evm.chainRules.IsKore:
+		return PrecompiledContractsCancun
+	case evm.chainRules.IsKore:
 		return PrecompiledContractsKore
 	case evm.chainRules.IsIstanbul:
 		return PrecompiledContractsIstanbulCompatible

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -646,7 +646,7 @@ func (evm *EVM) GetPrecompiledContractMap(addr common.Address) map[common.Addres
 	if vmVersion, ok := evm.StateDB.GetVmVersion(addr); ok && vmVersion == params.VmVersion0 {
 		// Without VmVersion0, precompiled contract address 0x09-0x0b won't work properly
 		// with the contracts deployed before istanbulHF
-		return PrecompiledContractsByzantiumCompatible
+		return PrecompiledContractsByzantium
 	}
 
 	switch {
@@ -655,9 +655,9 @@ func (evm *EVM) GetPrecompiledContractMap(addr common.Address) map[common.Addres
 	case evm.chainRules.IsKore:
 		return PrecompiledContractsKore
 	case evm.chainRules.IsIstanbul:
-		return PrecompiledContractsIstanbulCompatible
+		return PrecompiledContractsIstanbul
 	default:
-		return PrecompiledContractsByzantiumCompatible
+		return PrecompiledContractsByzantium
 	}
 }
 

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -650,7 +650,7 @@ func (evm *EVM) GetPrecompiledContractMap(addr common.Address) map[common.Addres
 	}
 
 	switch {
-	case evm.chainRules.IsKore:
+	case evm.chainRules.IsCancun:
 		return PrecompiledContractsCancun
 	case evm.chainRules.IsKore:
 		return PrecompiledContractsKore

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -282,7 +282,7 @@ func (t *InternalTxTracer) step(log *tracerLog) error {
 
 		// Skip any pre-compile invocations, those are just fancy opcodes
 		toAddr := common.HexToAddress(log.stack.Back(1).Hex())
-		if _, ok := PrecompiledContractsByzantiumCompatible[toAddr]; ok {
+		if _, ok := PrecompiledContractsByzantium[toAddr]; ok {
 			return nil
 		}
 

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -138,7 +138,7 @@ web3._extend({
 			name: 'createAccessList',
 			call: 'eth_createAccessList',
 			params: 2,
-			inputFormatter: [null, web3._extend.formatters.inputBlockNumberFormatter],
+			inputFormatter: [web3._extend.formatters.inputCallFormatter, web3._extend.formatters.inputBlockNumberFormatter],
 		}),
 		new web3._extend.Method({
 			name: 'feeHistory',
@@ -1059,7 +1059,7 @@ web3._extend({
 			name: 'createAccessList',
 			call: 'klay_createAccessList',
 			params: 2,
-			inputFormatter: [null, web3._extend.formatters.inputBlockNumberFormatter],
+			inputFormatter: [web3._extend.formatters.inputCallFormatter, web3._extend.formatters.inputBlockNumberFormatter],
 		}),
 		new web3._extend.Method({
 			name: 'feeHistory',

--- a/node/cn/tracers/tracer.go
+++ b/node/cn/tracers/tracer.go
@@ -511,7 +511,7 @@ func New(code string, ctx *Context, unsafeTrace bool) (*Tracer, error) {
 		return 1
 	})
 	tracer.vm.PushGlobalGoFunction("isPrecompiled", func(ctx *duktape.Context) int {
-		_, ok := vm.PrecompiledContractsByzantiumCompatible[common.BytesToAddress(popSlice(ctx))]
+		_, ok := vm.PrecompiledContractsByzantium[common.BytesToAddress(popSlice(ctx))]
 		ctx.PushBoolean(ok)
 		return 1
 	})


### PR DESCRIPTION
## Proposed changes

Ported https://github.com/ethereum/go-ethereum/pull/22550.

- This PR is a post-PR of #2024. Most of the changes were from there. I did refactoring `contracts.go`, resulting in getting rid of unmapped contract addresses L135-L136. @yoomee1313  PTAL.

- This API mirrors `{klay,eth}.estimateGas` usage, returning storage slot lists confined by the provided contract address. It captures all accessed storage slots during EVM execution by detecting storage opcodes i.e., `SLOAD` and `SSTORE`

- Confirmed the correctness of this porting with the latest `geth`.

- The `{klay,eth}.createAccessList` shares the same implementation with the structure of `EthTransactionArgs`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #1976 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
