### PR TITLE
Add homi for randao system contracts

### DIFF
--- a/blockchain/system/constant.go
+++ b/blockchain/system/constant.go
@@ -48,6 +48,9 @@ var (
 	// Some system contracts are allocated at special addresses.
 	AddressBookAddr = common.HexToAddress("0x0000000000000000000000000000000000000400") // TODO: replace contracts/reward/contract/utils.go
 	RegistryAddr    = common.HexToAddress("0x0000000000000000000000000000000000000401")
+	// The following addresses are only used for testing.
+	Kip113ProxyAddrMock = common.HexToAddress("0x0000000000000000000000000000000000000402")
+	Kip113LogicAddrMock = common.HexToAddress("0x0000000000000000000000000000000000000403")
 
 	// System contract binaries to be injected at hardfork or used in testing.
 	RegistryCode     = hexutil.MustDecode("0x" + contracts.RegistryBinRuntime)

--- a/blockchain/system/kip113_test.go
+++ b/blockchain/system/kip113_test.go
@@ -73,7 +73,7 @@ func TestAllocKip113(t *testing.T) {
 		senderKey, _ = crypto.GenerateKey()
 		sender       = bind.NewKeyedTransactor(senderKey)
 
-		KIP113MockAddr = common.HexToAddress("0x0000000000000000000000000000000000000402")
+		KIP113MockAddr = Kip113LogicAddrMock
 
 		nodeId1       = common.HexToAddress("0xaaaa")
 		nodeId2       = common.HexToAddress("0xbbbb")

--- a/cmd/homi/genesis/options.go
+++ b/cmd/homi/genesis/options.go
@@ -191,7 +191,7 @@ func RegistryMock() Option {
 
 		registry, ok := genesis.Alloc[registryAddr]
 		if !ok {
-			log.Fatalf("No AddressBook to patch")
+			log.Fatalf("No registry to patch")
 		}
 
 		genesis.Alloc[registryAddr] = blockchain.GenesisAccount{
@@ -225,7 +225,7 @@ func Kip113Mock(kip113LogicAddr common.Address) Option {
 
 		_, ok := genesis.Alloc[kip113LogicAddr]
 		if !ok {
-			log.Fatalf("No AddressBook to patch")
+			log.Fatalf("No kip113 to patch")
 		}
 
 		genesis.Alloc[kip113LogicAddr] = blockchain.GenesisAccount{

--- a/cmd/homi/genesis/options.go
+++ b/cmd/homi/genesis/options.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/klaytn/klaytn/blockchain/system"
 	"github.com/klaytn/klaytn/cmd/homi/extra"
 	"github.com/klaytn/klaytn/consensus/clique"
 	"github.com/klaytn/klaytn/contracts/reward/contract"
@@ -166,6 +167,70 @@ func AddressBookMock() Option {
 		genesis.Alloc[contractAddr] = blockchain.GenesisAccount{
 			Code:    common.FromHex(code),
 			Balance: contractAccount.Balance,
+		}
+	}
+}
+
+func AllocateRegistry(storage map[common.Hash]common.Hash) Option {
+	return func(genesis *blockchain.Genesis) {
+		registryCode := system.RegistryCode
+		registryAddr := system.RegistryAddr
+
+		genesis.Alloc[registryAddr] = blockchain.GenesisAccount{
+			Code:    registryCode,
+			Storage: storage,
+			Balance: big.NewInt(0),
+		}
+	}
+}
+
+func RegistryMock() Option {
+	return func(genesis *blockchain.Genesis) {
+		registryMockCode := system.RegistryMockCode
+		registryAddr := system.RegistryAddr
+
+		registry, ok := genesis.Alloc[registryAddr]
+		if !ok {
+			log.Fatalf("No AddressBook to patch")
+		}
+
+		genesis.Alloc[registryAddr] = blockchain.GenesisAccount{
+			Code:    registryMockCode,
+			Storage: registry.Storage,
+			Balance: big.NewInt(0),
+		}
+	}
+}
+
+func AllocateKip113(kip113ProxyAddr, kip113LogicAddr common.Address, storage map[common.Hash]common.Hash) Option {
+	return func(genesis *blockchain.Genesis) {
+		proxyCode := system.ERC1967ProxyCode
+		logicCode := system.Kip113Code
+
+		genesis.Alloc[kip113ProxyAddr] = blockchain.GenesisAccount{
+			Code:    proxyCode,
+			Storage: storage,
+			Balance: big.NewInt(0),
+		}
+		genesis.Alloc[kip113LogicAddr] = blockchain.GenesisAccount{
+			Code:    logicCode,
+			Balance: big.NewInt(0),
+		}
+	}
+}
+
+func Kip113Mock(kip113LogicAddr common.Address) Option {
+	return func(genesis *blockchain.Genesis) {
+		kip113MockCode := system.Kip113MockCode
+
+		_, ok := genesis.Alloc[kip113LogicAddr]
+		if !ok {
+			log.Fatalf("No AddressBook to patch")
+		}
+
+		genesis.Alloc[kip113LogicAddr] = blockchain.GenesisAccount{
+			Code:    kip113MockCode,
+			Balance: big.NewInt(0),
 		}
 	}
 }

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -565,7 +565,7 @@ func allocateRegistry(ctx *cli.Context, genesisJson *blockchain.Genesis, owner c
 	}
 
 	if kip113Addr != nil {
-		registryConfig.Records["SimpleBlsRegistry"] = *kip113Addr
+		registryConfig.Records[system.Kip113Name] = *kip113Addr
 	}
 
 	allocRegistryStorage := system.AllocRegistry(registryConfig)

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/accounts/keystore"
 	"github.com/klaytn/klaytn/blockchain"
+	"github.com/klaytn/klaytn/blockchain/system"
 	istcommon "github.com/klaytn/klaytn/cmd/homi/common"
 	"github.com/klaytn/klaytn/cmd/homi/docker/compose"
 	"github.com/klaytn/klaytn/cmd/homi/docker/service"
@@ -128,6 +129,11 @@ var HomiFlags = []cli.Flag{
 	altsrc.NewInt64Flag(cancunCompatibleBlockNumberFlag),
 	altsrc.NewInt64Flag(kip103CompatibleBlockNumberFlag),
 	altsrc.NewStringFlag(kip103ContractAddressFlag),
+	altsrc.NewInt64Flag(randaoCompatibleBlockNumberFlag),
+	altsrc.NewStringFlag(kip113ProxyAddressFlag),
+	altsrc.NewStringFlag(kip113LogicAddressFlag),
+	altsrc.NewBoolFlag(kip113MockFlag),
+	altsrc.NewBoolFlag(registryMockFlag),
 }
 
 var SetupCommand = &cli.Command{
@@ -548,6 +554,77 @@ func useAddressBookMock(ctx *cli.Context, genesisJson *blockchain.Genesis) {
 	allocationFunction(genesisJson)
 }
 
+func allocateRegistry(ctx *cli.Context, genesisJson *blockchain.Genesis, owner common.Address, kip113Addr *common.Address) {
+	if randaoCompatibleBlock := ctx.Int64(randaoCompatibleBlockNumberFlag.Name); randaoCompatibleBlock != 0 {
+		return
+	}
+
+	registryConfig := &params.RegistryConfig{
+		Records: make(map[string]common.Address),
+		Owner:   owner,
+	}
+
+	if kip113Addr != nil {
+		registryConfig.Records["SimpleBlsRegistry"] = *kip113Addr
+	}
+
+	allocRegistryStorage := system.AllocRegistry(registryConfig)
+
+	allocationFunction := genesis.AllocateRegistry(allocRegistryStorage)
+	allocationFunction(genesisJson)
+}
+
+func useRegistryMock(ctx *cli.Context, genesisJson *blockchain.Genesis) {
+	if useMock := ctx.Bool(registryMockFlag.Name); !useMock {
+		return
+	}
+
+	allocationFunction := genesis.RegistryMock()
+	allocationFunction(genesisJson)
+}
+
+func allocateKip113(ctx *cli.Context, genesisJson *blockchain.Genesis, init system.AllocKip113Init) (*common.Address, *common.Address) {
+	if randaoCompatibleBlock := ctx.Int64(randaoCompatibleBlockNumberFlag.Name); randaoCompatibleBlock != 0 {
+		return nil, nil
+	}
+	if len(init.Infos) == 0 {
+		return nil, nil
+	}
+
+	kip113ProxyAddr := common.HexToAddress(ctx.String(kip113ProxyAddressFlag.Name))
+	kip113LogicAddr := common.HexToAddress(ctx.String(kip113LogicAddressFlag.Name))
+
+	if !common.IsHexAddress(ctx.String(kip113ProxyAddressFlag.Name)) {
+		log.Fatalf("Kip113 proxy address is not a valid hex address", "value", kip113ProxyAddr)
+		kip113ProxyAddr = system.Kip113ProxyAddrMock
+	}
+	if !common.IsHexAddress(ctx.String(kip113LogicAddressFlag.Name)) {
+		log.Fatalf("Kip113 logic address is not a valid hex address", "value", kip113LogicAddr)
+		kip113LogicAddr = system.Kip113LogicAddrMock
+	}
+
+	allocProxyStorage := system.AllocProxy(kip113LogicAddr)
+	allocKip113Storage := system.AllocKip113(init)
+	allocStorage := system.MergeStorage(allocProxyStorage, allocKip113Storage)
+
+	allocationFunction := genesis.AllocateKip113(kip113ProxyAddr, kip113LogicAddr, allocStorage)
+	allocationFunction(genesisJson)
+
+	return &kip113ProxyAddr, &kip113LogicAddr
+}
+
+func useKip113Mock(ctx *cli.Context, genesisJson *blockchain.Genesis, kip113LogicAddr *common.Address) {
+	if useMock := ctx.Bool(kip113MockFlag.Name); !useMock {
+		return
+	}
+	if kip113LogicAddr == nil {
+		return
+	}
+
+	allocationFunction := genesis.Kip113Mock(*kip113LogicAddr)
+	allocationFunction(genesisJson)
+}
+
 func RandStringRunes(n int) string {
 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*()_+{}|[]")
 
@@ -644,6 +721,7 @@ func Gen(ctx *cli.Context) error {
 	}
 
 	testPrivKeys, testKeys, testAddrs := istcommon.GenerateKeys(numTestAccs)
+	kip113Init := istcommon.GenerateKip113Init(privKeys[:numValidators], nodeAddrs[0])
 
 	var (
 		genesisJson      *blockchain.Genesis
@@ -675,6 +753,12 @@ func Gen(ctx *cli.Context) error {
 	patchGenesisAddressBook(ctx, genesisJson, validatorNodeAddrs)
 	useAddressBookMock(ctx, genesisJson)
 
+	// Randao hardfork related system contracts
+	kip113ProxyAddr, kip113LogicAddr := allocateKip113(ctx, genesisJson, kip113Init)
+	allocateRegistry(ctx, genesisJson, nodeAddrs[0], kip113ProxyAddr)
+	useKip113Mock(ctx, genesisJson, kip113LogicAddr)
+	useRegistryMock(ctx, genesisJson)
+
 	genesisJson.Config.IstanbulCompatibleBlock = big.NewInt(ctx.Int64(istanbulCompatibleBlockNumberFlag.Name))
 	genesisJson.Config.LondonCompatibleBlock = big.NewInt(ctx.Int64(londonCompatibleBlockNumberFlag.Name))
 	genesisJson.Config.EthTxTypeCompatibleBlock = big.NewInt(ctx.Int64(ethTxTypeCompatibleBlockNumberFlag.Name))
@@ -686,6 +770,8 @@ func Gen(ctx *cli.Context) error {
 	// KIP103 hardfork is optional
 	genesisJson.Config.Kip103CompatibleBlock = big.NewInt(ctx.Int64(kip103CompatibleBlockNumberFlag.Name))
 	genesisJson.Config.Kip103ContractAddress = common.HexToAddress(ctx.String(kip103ContractAddressFlag.Name))
+
+	genesisJson.Config.RandaoCompatibleBlock = big.NewInt(ctx.Int64(randaoCompatibleBlockNumberFlag.Name))
 
 	genesisJsonBytes, _ = json.MarshalIndent(genesisJson, "", "    ")
 	genValidatorKeystore(privKeys)

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -18,6 +18,7 @@
 package setup
 
 import (
+	"github.com/klaytn/klaytn/blockchain/system"
 	"github.com/klaytn/klaytn/params"
 	"github.com/urfave/cli/v2"
 )
@@ -504,5 +505,36 @@ var (
 		Name:    "kip103-contract-address",
 		Usage:   "kip103 contract address",
 		Aliases: []string{"genesis.hardfork.kip103-contract-address"},
+	}
+
+	randaoCompatibleBlockNumberFlag = &cli.Int64Flag{
+		Name:    "randao-compatible-blocknumber",
+		Usage:   "randaoCompatible blockNumber",
+		Value:   0,
+		Aliases: []string{"genesis.hardfork.randao-compatible-blocknumber"},
+	}
+
+	kip113ProxyAddressFlag = &cli.StringFlag{
+		Name:    "kip113-proxy-contract-address",
+		Usage:   "kip113 proxy contract address",
+		Value:   system.Kip113ProxyAddrMock.String(),
+		Aliases: []string{"genesis.hardfork.kip113-proxy-contract-address"},
+	}
+
+	kip113LogicAddressFlag = &cli.StringFlag{
+		Name:    "kip113-logic-contract-address",
+		Usage:   "kip113 logic contract address",
+		Value:   system.Kip113LogicAddrMock.String(),
+		Aliases: []string{"genesis.hardfork.kip113-logic-contract-address"},
+	}
+
+	kip113MockFlag = &cli.BoolFlag{
+		Name:  "kip113-mock",
+		Usage: "Allocate an Kip113Mock at the genesis block",
+	}
+
+	registryMockFlag = &cli.BoolFlag{
+		Name:  "registry-mock",
+		Usage: "Allocate an RegistryMock at the genesis block",
 	}
 )


### PR DESCRIPTION
## Proposed changes

Add the following homi flags for randao system contracts. The registry and kip113(SimpleBlsRegistry) will be allocated at the genesis block automatically if `randaoCompatibleBlock == 0` is satisfied.

1. Registry:
* Deploy registry to 0x401 address.
* If the Kip113 contract is available, the registry will register it.
* Mock supported.

2. Kip113:
* Deploy Kip113(proxy and logic) to addresses set by flags or testing addresses(0x402, 403 respectively).
* Generate BLS info based on node keys.
* Mock supported.

<details>
<summary>Test</summary>

```
> const caver = new Caver("http://localhost:8551/");
> ...
> await registry.methods.getActiveAddr(“SimpleBlsRegistry”).call();
‘0x0000000000000000000000000000000000000402’
> await registry.methods.getAllRecords(“SimpleBlsRegistry”).call();
[
  [
    ‘0x0000000000000000000000000000000000000402’,
    ‘0’,
    addr: ‘0x0000000000000000000000000000000000000402’,
    activation: ‘0’
  ]
]
> await sbr.methods.getAllBlsInfo().call()
Result {
  ‘0’: [
    ‘0xa5ad1Cf43AD32aFf2213811478A69ABA07D01d82’,
    ‘0xDfe6773414F3B80c7C4fE92e4e5Ee95835fB9f05’,
    ‘0x0a17A750eDe57413614BB9E26ebec3A8c4F38cBA’,
    ‘0x0202333321c49E5746EDB7b1CC77ca0FD1271E28’
  ],
  ‘1’: [
    [
      ‘0x8cc6d70f9e47d758ea04ee9de0dd06b423b7c9aa57df3b3bbf88fad69385f9f098f5914e37d0bec83fe828056e8f4e80’,
      ‘0xa7456b3dc1be2452e8e5d952eef9c1ee8ac17cf55cd93347ef559878b3ffec1c4cfcf219ef1f8a57c1c57327fb574a93156287dbe61a6f47e8aea142e32cb7be1bfab2cc22a8422d2843515ee1d87da88cd2e481661f54d1686a158bbc0336af’,
      publicKey: ‘0x8cc6d70f9e47d758ea04ee9de0dd06b423b7c9aa57df3b3bbf88fad69385f9f098f5914e37d0bec83fe828056e8f4e80’
    ],
    [
      ‘0x8674cf1feb1ed3a47228a72935371907b60a985c439eb5d056eb07d564b482e37d0145bc9999744962d7a5aaeb1c2e1d’,
      ‘0x974a9a54ebe0e7bcc9e6e1ad5c0656fdd263025c5231678701915d5659760fbcaf2fb42fe91ec97880d05092c88f04fc141aee961fe25d6df70a08e38296fcb997df70d052f18c0ccdb67056249a3b9c507b90ab7c2eb999c1d31c5d493f0c51’,
      publicKey: ‘0x8674cf1feb1ed3a47228a72935371907b60a985c439eb5d056eb07d564b482e37d0145bc9999744962d7a5aaeb1c2e1d’
    ],
    [
      ‘0x832e6b02339b2af816d5d68d08a0005690ab661ae5dfbcedbc973793d5607bd89e66e4d00ed09574c3b55a3b02fce2ae’,
      ‘0xad39aae1825cf4bc09bd366257f72a5dddc5db815d20ba4f779076d022648bb893550cd61df3b0dc2dd995334b263b370189a653e0b317f8cdfd4dd8cc5b63938ab2cc89a9aa8af47547bf774a457f3f442ef2fac44b34d82b60165058bd8304’,
      publicKey: ‘0x832e6b02339b2af816d5d68d08a0005690ab661ae5dfbcedbc973793d5607bd89e66e4d00ed09574c3b55a3b02fce2ae’
    ],
    [
      ‘0xb9c64bd2790ded3ac27de9ae45d266ee53ab6b999918a5c9f556279973fc697e7a5c2784fe5151ca7f556036aee3394f’,
      ‘0x8c146497384cb20b1269fec31bdd372f28f04657ab5e4b58b0b2f6a5799a6f31cf712fe8c1ee7e7db54e354489559b2c05cdde99b7fad05344145c373c83de44db8f8d5581a37fa610dcb352e7225760b1c1caabaf582a0b51a14dd079d61e29’,
      publicKey: ‘0xb9c64bd2790ded3ac27de9ae45d266ee53ab6b999918a5c9f556279973fc697e7a5c2784fe5151ca7f556036aee3394f’
    ]
  ],
  nodeIdList: [
    ‘0xa5ad1Cf43AD32aFf2213811478A69ABA07D01d82’,
    ‘0xDfe6773414F3B80c7C4fE92e4e5Ee95835fB9f05’,
    ‘0x0a17A750eDe57413614BB9E26ebec3A8c4F38cBA’,
    ‘0x0202333321c49E5746EDB7b1CC77ca0FD1271E28’
  ],
  pubkeyList: [
    [
      ‘0x8cc6d70f9e47d758ea04ee9de0dd06b423b7c9aa57df3b3bbf88fad69385f9f098f5914e37d0bec83fe828056e8f4e80’,
      ‘0xa7456b3dc1be2452e8e5d952eef9c1ee8ac17cf55cd93347ef559878b3ffec1c4cfcf219ef1f8a57c1c57327fb574a93156287dbe61a6f47e8aea142e32cb7be1bfab2cc22a8422d2843515ee1d87da88cd2e481661f54d1686a158bbc0336af’,
      publicKey: ‘0x8cc6d70f9e47d758ea04ee9de0dd06b423b7c9aa57df3b3bbf88fad69385f9f098f5914e37d0bec83fe828056e8f4e80’
    ],
    [
      ‘0x8674cf1feb1ed3a47228a72935371907b60a985c439eb5d056eb07d564b482e37d0145bc9999744962d7a5aaeb1c2e1d’,
      ‘0x974a9a54ebe0e7bcc9e6e1ad5c0656fdd263025c5231678701915d5659760fbcaf2fb42fe91ec97880d05092c88f04fc141aee961fe25d6df70a08e38296fcb997df70d052f18c0ccdb67056249a3b9c507b90ab7c2eb999c1d31c5d493f0c51’,
      publicKey: ‘0x8674cf1feb1ed3a47228a72935371907b60a985c439eb5d056eb07d564b482e37d0145bc9999744962d7a5aaeb1c2e1d’
    ],
    [
      ‘0x832e6b02339b2af816d5d68d08a0005690ab661ae5dfbcedbc973793d5607bd89e66e4d00ed09574c3b55a3b02fce2ae’,
      ‘0xad39aae1825cf4bc09bd366257f72a5dddc5db815d20ba4f779076d022648bb893550cd61df3b0dc2dd995334b263b370189a653e0b317f8cdfd4dd8cc5b63938ab2cc89a9aa8af47547bf774a457f3f442ef2fac44b34d82b60165058bd8304’,
      publicKey: ‘0x832e6b02339b2af816d5d68d08a0005690ab661ae5dfbcedbc973793d5607bd89e66e4d00ed09574c3b55a3b02fce2ae’
    ],
    [
      ‘0xb9c64bd2790ded3ac27de9ae45d266ee53ab6b999918a5c9f556279973fc697e7a5c2784fe5151ca7f556036aee3394f’,
      ‘0x8c146497384cb20b1269fec31bdd372f28f04657ab5e4b58b0b2f6a5799a6f31cf712fe8c1ee7e7db54e354489559b2c05cdde99b7fad05344145c373c83de44db8f8d5581a37fa610dcb352e7225760b1c1caabaf582a0b51a14dd079d61e29’,
      publicKey: ‘0xb9c64bd2790ded3ac27de9ae45d266ee53ab6b999918a5c9f556279973fc697e7a5c2784fe5151ca7f556036aee3394f’
    ]
  ]
}
> await sbr.methods.owner().call()
‘0x0202333321c49E5746EDB7b1CC77ca0FD1271E28’
```
</details>

<details>
<summary>genesis config</summary>

```
"alloc": {
        // Registry
        "0000000000000000000000000000000000000401": {
            "code": "0x608060...",
            "storage": {
                "0x0000000000000000000000000000000000000000000000000000000000000001": "0x0000000000000000000000000000000000000000000000000000000000000001",
                "0x0000000000000000000000000000000000000000000000000000000000000002": "0x000000000000000000000000671a73b88fb5d2ad43d46b691363b73d9a7ae41f",
                "0x84a4f6f2f8d3c590bc46e9eaac0fa584dd23297cbf41579f6e4d6c8409e9ad48": "0x0000000000000000000000000000000000000000000000000000000000000001",
                "0xb0f7f296c28cb1e012b03503335a15611641a9ab4260dc07951b6fa1cddab6ea": "0x0000000000000000000000000000000000000000000000000000000000000402",
                "0xb0f7f296c28cb1e012b03503335a15611641a9ab4260dc07951b6fa1cddab6eb": "0x0000000000000000000000000000000000000000000000000000000000000000",
                "0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6": "0x53696d706c65426c735265676973747279000000000000000000000000000022"
            },
            "balance": "0x0"
        },
        // Kip113 proxy
        "0000000000000000000000000000000000000402": {
            "code": "0x608060...",
            "storage": {
                "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000001",
                "0x0000000000000000000000000000000000000000000000000000000000000097": "0x000000000000000000000000671a73b88fb5d2ad43d46b691363b73d9a7ae41f",
                "0x00000000000000000000000000000000000000000000000000000000000000c9": "0x0000000000000000000000000000000000000000000000000000000000000004",
                "0x0cf6e510e0972d5f6ddd4b89b6cb90b5602d7fd3bde13bd016a5b60299094a0a": "0x0000000000000000000000000000000000000000000000000000000000000061",
                "0x0cf6e510e0972d5f6ddd4b89b6cb90b5602d7fd3bde13bd016a5b60299094a0b": "0x00000000000000000000000000000000000000000000000000000000000000c1",
                "0x16e9af54d45371db1d46d45feea218ebbb499d4fdd150f2324ac2dd110f3d096": "0x8c1867de26bf396d54c7a97a42b2a7211302d3322b08851f49b78f389269d78d",
                "0x16e9af54d45371db1d46d45feea218ebbb499d4fdd150f2324ac2dd110f3d097": "0x923e84077c583f3c26b4d6ac1ac0c4440b2439d09bd321fa47e17d0df581082d",
                "0x16e9af54d45371db1d46d45feea218ebbb499d4fdd150f2324ac2dd110f3d098": "0x8ac147641c751208c9e81bd48dd15987c0305193361ee9509eb2f5d9ec0372a9",
                "0x20cfec5472d4aa9b6a442e0297ae6c09dc1517d1dad1bca0b8b0c6cd5d4d095f": "0x0000000000000000000000000000000000000000000000000000000000000061",
                "0x20cfec5472d4aa9b6a442e0297ae6c09dc1517d1dad1bca0b8b0c6cd5d4d0960": "0x00000000000000000000000000000000000000000000000000000000000000c1",
                "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc": "0x0000000000000000000000000000000000000000000000000000000000000403",
                "0x452185d703958a92922a085a281d5f3d34a522ffb0b4affb2063cae2c2a98e65": "0x0000000000000000000000000000000000000000000000000000000000000061",
                "0x452185d703958a92922a085a281d5f3d34a522ffb0b4affb2063cae2c2a98e66": "0x00000000000000000000000000000000000000000000000000000000000000c1",
                "0x66be4f155c5ef2ebd3772b228f2f00681e4ed5826cdb3b1943cc11ad15ad1d28": "0x0000000000000000000000007d8daf441e811b2d99d9c6e4aad7e44fffa53d4b",
                "0x66be4f155c5ef2ebd3772b228f2f00681e4ed5826cdb3b1943cc11ad15ad1d29": "0x0000000000000000000000007ccfc4292de9f88c4269b0780375036ae4a549b2",
                "0x66be4f155c5ef2ebd3772b228f2f00681e4ed5826cdb3b1943cc11ad15ad1d2a": "0x000000000000000000000000671a73b88fb5d2ad43d46b691363b73d9a7ae41f",
                "0x66be4f155c5ef2ebd3772b228f2f00681e4ed5826cdb3b1943cc11ad15ad1d2b": "0x0000000000000000000000000e4b0051831a4de85a77355ce4d8e2646a4d82c2",
                "0x78fe6affa97aa50a1b9741d1f0ec8cbdae21e1b567d2451d9460aa5cb99af3c3": "0x0000000000000000000000000000000000000000000000000000000000000061",
                "0x78fe6affa97aa50a1b9741d1f0ec8cbdae21e1b567d2451d9460aa5cb99af3c4": "0x00000000000000000000000000000000000000000000000000000000000000c1",
                "0x7aabba549a10626626c405d3ff97ea544101fe3598fb0194607deb6ceac2ee6b": "0xafbda00e2327b6b444da0bdcbc8d70b8309ba96ee4ef35b67def24dc59ca046e",
                "0x7aabba549a10626626c405d3ff97ea544101fe3598fb0194607deb6ceac2ee6c": "0x43041c095c38391c4752825eeda32f2a00000000000000000000000000000000",
                "0xa86c9f1a6b916c39cc43edb180cc9b3daf3eed7a5a83c2b5a52ef3685500eff7": "0x953e085c90ab9f6173352b64e95114f4b9f2d77a7cb79df5f5321a389ec4d7cc",
                "0xa86c9f1a6b916c39cc43edb180cc9b3daf3eed7a5a83c2b5a52ef3685500eff8": "0xb6a4afb9242e78a60e914fddeed0e75300000000000000000000000000000000",
                "0xd9e3c01734d0a03261eeeb4fb0eb0db8db64c326f4cdb7bd5af81034da5490b0": "0x955c9afa92ed2c6701f4d9c1c74d268bd4739a6be097693870d309f6cd9066eb",
                "0xd9e3c01734d0a03261eeeb4fb0eb0db8db64c326f4cdb7bd5af81034da5490b1": "0x78abe584c759a6659a2b3467e13dfa5d09b8b890a538d5bb92a818b50b7941b3",
                "0xd9e3c01734d0a03261eeeb4fb0eb0db8db64c326f4cdb7bd5af81034da5490b2": "0x9778a22c4827ab3a5b376a6f537783703cb181fbcec2c02bd015e8ad7e3254a5",
                "0xdedbbf2c9b666c6bc1a518122a71b8be4234e6f1633a01b9e7daf334500e9112": "0x81871e4a87dac6f469371f886812cd3745e7593bf2fe06b6885df8515698c40f",
                "0xdedbbf2c9b666c6bc1a518122a71b8be4234e6f1633a01b9e7daf334500e9113": "0xa211ae07148a0c8658a332bf3a52887a00000000000000000000000000000000",
                "0xf0ac1b7b2818167611a70aa47dada321af5d39f96e513b098989811c8ef1208f": "0x885a23fdca5b89ff71b0bd1db81cd6dcab0721c766794194d49c74dd13e44af1",
                "0xf0ac1b7b2818167611a70aa47dada321af5d39f96e513b098989811c8ef12090": "0x7c0dc8fab39209f0d8a37851228bd9dd10f13d51e2e81424eb00ae0cb11cfae2",
                "0xf0ac1b7b2818167611a70aa47dada321af5d39f96e513b098989811c8ef12091": "0xc6f0560e44e80bc15bde1044823601138a003432d00617f1feea6c1d60a71281",
                "0xf1d7e330eb83885446bcd69d5a586f0b2b60a95659a3c65aa5de4e77b36f573a": "0x8559127921623127c32ea204d22f23f1b303654ca553f4797dc1cf5328080705",
                "0xf1d7e330eb83885446bcd69d5a586f0b2b60a95659a3c65aa5de4e77b36f573b": "0x52bc82211420eaddb02298d0e8f39be700000000000000000000000000000000",
                "0xf6965ac809a382cd5363bccca6cd85f04af7b22750e260de21134c8d2f0048c4": "0x8f606849e2e167b72a8026b99e87d95a96a5f5fd29ec4bdcd57f893c471a6b60",
                "0xf6965ac809a382cd5363bccca6cd85f04af7b22750e260de21134c8d2f0048c5": "0x91d6e6f9ec32d9f8f9f3f8805e342977182bffb960f17be3faee1b7a76a6c3cd",
                "0xf6965ac809a382cd5363bccca6cd85f04af7b22750e260de21134c8d2f0048c6": "0xcf88fd4ed20d1c56adf116f6ef8b5ea47df965ece348a0e419f0246ec406a593"
            },
            "balance": "0x0"
        },
        // Kip113 logic
        "0000000000000000000000000000000000000403": {
            "code": "0x608060...",
            "balance": "0x0"
        },
```
</details>

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
