### PR TITLE
vm: modify computation cost and its limit after cancun

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -398,7 +398,7 @@ func (s *PublicBlockChainAPI) EstimateComputationCost(ctx context.Context, args 
 	if rpcGasCap := s.b.RPCGasCap(); rpcGasCap != nil {
 		gasCap = rpcGasCap
 	}
-	_, computationCost, err := DoCall(ctx, s.b, args, blockNrOrHash, vm.Config{UseOpcodeComputationCost: true}, s.b.RPCEVMTimeout(), gasCap)
+	_, computationCost, err := DoCall(ctx, s.b, args, blockNrOrHash, vm.Config{}, s.b.RPCEVMTimeout(), gasCap)
 	return (hexutil.Uint64)(computationCost), err
 }
 

--- a/blockchain/state_processor.go
+++ b/blockchain/state_processor.go
@@ -72,9 +72,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		processStats     ProcessStats
 	)
 
-	// Enable the opcode computation cost limit
-	cfg.UseOpcodeComputationCost = true
-
 	// Extract author from the header
 	author, _ := p.bc.Engine().Author(header) // Ignore error, we're past header validation
 

--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -350,8 +350,8 @@ func enable7516(jt *JumpTable) {
 	}
 }
 
-// As the cpu performance has been improved a lot,
-// recalculate the computation cost of some opcodes
+// As the cpu performance has been improved a lot, and as the storage size has increased a lot
+// recalculated the computation cost of some opcodes
 func enableCancunComputationCostModification(jt *JumpTable) {
 	jt[SDIV].computationCost = params.SdivComputationCostCancun
 	jt[MOD].computationCost = params.ModComputationCostCancun

--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -349,3 +349,22 @@ func enable7516(jt *JumpTable) {
 		computationCost: params.BlobBaseFeeComputationCost,
 	}
 }
+
+// As the cpu performance has been improved a lot,
+// recalculate the computation cost of some opcodes
+func enableCancunComputationCostModification(jt *JumpTable) {
+	jt[SDIV].computationCost = params.SdivComputationCostCancun
+	jt[MOD].computationCost = params.ModComputationCostCancun
+	jt[ADDMOD].computationCost = params.AddmodComputationCostCancun
+	jt[MULMOD].computationCost = params.MulmodComputationCostCancun
+	jt[EXP].computationCost = params.ExpComputationCostCancun
+	jt[SHA3].computationCost = params.Sha3ComputationCostCancun
+	jt[MSTORE8].computationCost = params.Mstore8ComputationCostCancun
+
+	jt[SLOAD].computationCost = params.SloadComputationCostCancun
+	jt[SSTORE].computationCost = params.SstoreComputationCostCancun
+	jt[LOG1].computationCost = params.Log1ComputationCostCancun
+	jt[LOG2].computationCost = params.Log2ComputationCostCancun
+	jt[LOG3].computationCost = params.Log3ComputationCostCancun
+	jt[LOG4].computationCost = params.Log4ComputationCostCancun
+}

--- a/blockchain/vm/errors.go
+++ b/blockchain/vm/errors.go
@@ -22,9 +22,6 @@ package vm
 
 import (
 	"errors"
-	"fmt"
-
-	"github.com/klaytn/klaytn/params"
 )
 
 // List execution errors
@@ -35,7 +32,7 @@ var (
 	ErrInsufficientBalance               = errors.New("insufficient balance for transfer")
 	ErrContractAddressCollision          = errors.New("contract address collision")
 	ErrTotalTimeLimitReached             = errors.New("reached the total execution time limit for txs in a block")
-	ErrOpcodeComputationCostLimitReached = errors.New(fmt.Sprintf("reached the opcode computation cost limit (%d) for tx", params.OpcodeComputationCostLimit))
+	ErrOpcodeComputationCostLimitReached = errors.New("reached the opcode computation cost limit")
 	ErrFailedOnSetCode                   = errors.New("failed on setting code to an account")
 
 	// EVM internal errors

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -136,8 +136,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	}
 
 	// It is an experimental feature.
-	if params.ExperimentOpcodeComputationCostLimit != 0 {
-		cfg.ComputationCostLimit = params.ExperimentOpcodeComputationCostLimit
+	if params.OpcodeComputationCostLimitOverride != 0 {
+		cfg.ComputationCostLimit = params.OpcodeComputationCostLimitOverride
 	}
 
 	return &EVMInterpreter{

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -44,7 +44,7 @@ type Config struct {
 	// RunningEVM is to indicate the running EVM and used to stop the EVM.
 	RunningEVM chan *EVM
 
-	// ComputationCostLimit is the limit of the total computation cost of a transaction.
+	// ComputationCostLimit is the limit of the total computation cost of a transaction. Set to Zero of Infinite to disable the computation cost limit.
 	ComputationCostLimit uint64
 
 	// Enables collecting internal transaction data during processing a block

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -44,7 +44,7 @@ type Config struct {
 	// RunningEVM is to indicate the running EVM and used to stop the EVM.
 	RunningEVM chan *EVM
 
-	// ComputationCostLimit is the limit of the total computation cost of a transaction. Set to Zero of Infinite to disable the computation cost limit.
+	// ComputationCostLimit is the limit of the total computation cost of a transaction. Set infinite to disable the computation cost limit.
 	ComputationCostLimit uint64
 
 	// Enables collecting internal transaction data during processing a block
@@ -127,10 +127,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	if cfg.ComputationCostLimit == 0 {
 		switch {
 		case evm.chainRules.IsCancun:
-			// approximately 120 ms
 			cfg.ComputationCostLimit = uint64(params.OpcodeComputationCostLimitCancun)
 		default:
-			// approximately 100 ms
 			cfg.ComputationCostLimit = uint64(params.OpcodeComputationCostLimit)
 		}
 	}

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -73,6 +73,7 @@ func newCancunInstructionSet() JumpTable {
 	enable5656(&instructionSet) // EIP-5656 (MCOPY opcode)
 	enable6780(&instructionSet) // EIP-6780 SELFDESTRUCT only in same transaction
 	enable1153(&instructionSet) // EIP-1153 (Tload, Tstore opcode)
+	enableCancunComputationCostModification(&instructionSet)
 	return instructionSet
 }
 

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -679,8 +679,9 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 	if ctx.IsSet(BlockGenerationTimeLimitFlag.Name) {
 		params.BlockGenerationTimeLimit = ctx.Duration(BlockGenerationTimeLimitFlag.Name)
 	}
-
-	params.OpcodeComputationCostLimit = ctx.Uint64(OpcodeComputationCostLimitFlag.Name)
+	if ctx.IsSet(OpcodeComputationCostLimitFlag.Name) {
+		params.ExperimentOpcodeComputationCostLimit = ctx.Uint64(OpcodeComputationCostLimitFlag.Name)
+	}
 
 	if ctx.IsSet(SnapshotFlag.Name) {
 		cfg.SnapshotCacheSize = ctx.Int(SnapshotCacheSizeFlag.Name)

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -680,7 +680,7 @@ func (kCfg *KlayConfig) SetKlayConfig(ctx *cli.Context, stack *node.Node) {
 		params.BlockGenerationTimeLimit = ctx.Duration(BlockGenerationTimeLimitFlag.Name)
 	}
 	if ctx.IsSet(OpcodeComputationCostLimitFlag.Name) {
-		params.ExperimentOpcodeComputationCostLimit = ctx.Uint64(OpcodeComputationCostLimitFlag.Name)
+		params.OpcodeComputationCostLimitOverride = ctx.Uint64(OpcodeComputationCostLimitFlag.Name)
 	}
 
 	if ctx.IsSet(SnapshotFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1966,7 +1966,6 @@ var (
 		Name: "opcode-computation-cost-limit",
 		Usage: "(experimental option) Set the computation cost limit for a tx. " +
 			"Should set the same value within the network",
-		Value:    params.DefaultOpcodeComputationCostLimit,
 		Aliases:  []string{"experimental.opcode-computation-cost-limit"},
 		EnvVars:  []string{"KLAYTN_OPCODE_COMPUTATION_COST_LIMIT"},
 		Category: "KLAY",

--- a/node/cn/state_accessor.go
+++ b/node/cn/state_accessor.go
@@ -128,7 +128,7 @@ func (cn *CN) stateAtBlock(block *types.Block, reexec uint64, base *state.StateD
 		if current = cn.blockchain.GetBlockByNumber(next); current == nil {
 			return nil, fmt.Errorf("block #%d not found", next)
 		}
-		_, _, _, _, _, err := cn.blockchain.Processor().Process(current, statedb, vm.Config{UseOpcodeComputationCost: true})
+		_, _, _, _, _, err := cn.blockchain.Processor().Process(current, statedb, vm.Config{})
 		if err != nil {
 			return nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
 		}
@@ -190,7 +190,7 @@ func (cn *CN) stateAtTransaction(block *types.Block, txIndex int, reexec uint64)
 			return msg, blockContext, txContext, statedb, nil
 		}
 		// Not yet the searched for transaction, execute on top of the current state
-		vmenv := vm.NewEVM(blockContext, txContext, statedb, cn.blockchain.Config(), &vm.Config{UseOpcodeComputationCost: true})
+		vmenv := vm.NewEVM(blockContext, txContext, statedb, cn.blockchain.Config(), &vm.Config{})
 		if _, err := blockchain.ApplyMessage(vmenv, msg); err != nil {
 			return nil, vm.BlockContext{}, vm.TxContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -657,7 +657,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 
 		txCtx := blockchain.NewEVMTxContext(msg, block.Header())
 		blockCtx := blockchain.NewEVMBlockContext(block.Header(), newChainContext(ctx, api.backend), nil)
-		vmenv := vm.NewEVM(blockCtx, txCtx, statedb, api.backend.ChainConfig(), &vm.Config{UseOpcodeComputationCost: true})
+		vmenv := vm.NewEVM(blockCtx, txCtx, statedb, api.backend.ChainConfig(), &vm.Config{})
 		if _, err = blockchain.ApplyMessage(vmenv, msg); err != nil {
 			failed = err
 			break
@@ -747,10 +747,9 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 
 			// Swap out the noop logger to the standard tracer
 			vmConf = vm.Config{
-				Debug:                    true,
-				Tracer:                   vm.NewJSONLogger(&logConfig, bufio.NewWriter(dump)),
-				EnablePreimageRecording:  true,
-				UseOpcodeComputationCost: true,
+				Debug:                   true,
+				Tracer:                  vm.NewJSONLogger(&logConfig, bufio.NewWriter(dump)),
+				EnablePreimageRecording: true,
 			}
 		}
 		// Execute the transaction and flush any traces to disk
@@ -935,7 +934,7 @@ func (api *API) traceTx(ctx context.Context, message blockchain.Message, blockCt
 		tracer = vm.NewStructLogger(config.LogConfig)
 	}
 	// Run the transaction with tracing enabled.
-	vmenv := vm.NewEVM(blockCtx, txCtx, statedb, api.backend.ChainConfig(), &vm.Config{Debug: true, Tracer: tracer, UseOpcodeComputationCost: true})
+	vmenv := vm.NewEVM(blockCtx, txCtx, statedb, api.backend.ChainConfig(), &vm.Config{Debug: true, Tracer: tracer})
 
 	ret, err := blockchain.ApplyMessage(vmenv, message)
 	if err != nil {

--- a/params/computation_cost_params.go
+++ b/params/computation_cost_params.go
@@ -20,6 +20,8 @@
 
 package params
 
+import "github.com/klaytn/klaytn/common/math"
+
 const (
 	// Computation cost for opcodes
 	ExtCodeHashComputationCost    = 1000
@@ -199,6 +201,11 @@ const (
 	Log3ComputationCostCancun   = 500
 	Log4ComputationCostCancun   = 500
 
-	OpcodeComputationCostLimit       = 100000000 // 100ms
-	OpcodeComputationCostLimitCancun = 150000000 // 150ms
+	OpcodeComputationCostLimit         = 100000000      // 100ms
+	OpcodeComputationCostLimitCancun   = 150000000      // 150ms
+	OpcodeComputationCostLimitInfinite = math.MaxUint64 // pass it to disable computation cost checks
 )
+
+// OpcodeComputationCostLimitOverride set by --opcode-computation-cost-limit.
+// Overrides chain default settings above.
+var OpcodeComputationCostLimitOverride = uint64(0)

--- a/params/computation_cost_params.go
+++ b/params/computation_cost_params.go
@@ -37,7 +37,12 @@ const (
 	SdivComputationCost           = 739
 	ModComputationCost            = 812
 	SmodComputationCost           = 560
+	AddmodComputationCost         = 3349
+	MulmodComputationCost         = 4757
 	ExpComputationCost            = 5000
+	ShlComputationCost            = 1603
+	ShrComputationCost            = 1346
+	SarComputationCost            = 1815
 	SignExtendComputationCost     = 481
 	LtComputationCost             = 201
 	GtComputationCost             = 264
@@ -46,7 +51,9 @@ const (
 	EqComputationCost             = 220
 	IszeroComputationCost         = 165
 	AndComputationCost            = 288
+	XorComputationCost            = 657
 	OrComputationCost             = 160
+	NotComputationCost            = 1289
 	ByteComputationCost           = 589
 	Sha3ComputationCost           = 2465
 	AddressComputationCost        = 284
@@ -154,22 +161,6 @@ const (
 	// computation cost added at londonCompatible
 	BaseFeeComputationCost = 198
 
-	// Opcode Computation Cost Modification
-	AddmodComputationCost         = 3349
-	AddmodComputationCostIstanbul = 1410
-	MulmodComputationCost         = 4757
-	MulmodComputationCostIstanbul = 1760
-	NotComputationCost            = 1289
-	NotComputationCostIstanbul    = 364
-	ShlComputationCost            = 1603
-	ShlComputationCostIstanbul    = 478
-	ShrComputationCost            = 1346
-	ShrComputationCostIstanbul    = 498
-	SarComputationCost            = 1815
-	SarComputationCostIstanbul    = 834
-	XorComputationCost            = 657
-	XorComputationCostIstanbul    = 454
-
 	// computation cost added at KoreCompatible
 	RandomComputationCost = 1498
 
@@ -182,4 +173,32 @@ const (
 	TstoreComputationCost      = 280
 	BlobHashComptationCost     = 165
 	BlobBaseFeeComputationCost = 120
+
+	// opcode computation cost modification - istanbul
+	AddmodComputationCostIstanbul = 1410
+	MulmodComputationCostIstanbul = 1760
+	ShlComputationCostIstanbul    = 478
+	ShrComputationCostIstanbul    = 498
+	SarComputationCostIstanbul    = 834
+	XorComputationCostIstanbul    = 454
+	NotComputationCostIstanbul    = 364
+
+	// opcode computation cost codification - cancun
+	SdivComputationCostCancun    = 360
+	ModComputationCostCancun     = 320
+	AddmodComputationCostCancun  = 360
+	MulmodComputationCostCancun  = 700
+	ExpComputationCostCancun     = 720
+	Sha3ComputationCostCancun    = 560
+	Mstore8ComputationCostCancun = 230
+
+	SloadComputationCostCancun  = 2550
+	SstoreComputationCostCancun = 2510
+	Log1ComputationCostCancun   = 500
+	Log2ComputationCostCancun   = 500
+	Log3ComputationCostCancun   = 500
+	Log4ComputationCostCancun   = 500
+
+	OpcodeComputationCostLimit       = 100000000 // 100ms
+	OpcodeComputationCostLimitCancun = 150000000 // 150ms
 )

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 	"math/big"
 	"time"
-
-	"github.com/klaytn/klaytn/common/math"
 )
 
 var TargetGasLimit = GenesisGasLimit // The artificial target
@@ -192,9 +190,6 @@ const (
 const (
 	DefaultBlockGenerationInterval  = int64(1) // unit: seconds
 	DefaultBlockGenerationTimeLimit = 250 * time.Millisecond
-
-	OpcodeComputationCostLimitInfinite = math.MaxUint64
-	OpcodeComputationCostLimitOverride = uint64(0)
 )
 
 var (
@@ -202,8 +197,7 @@ var (
 	ZeroRandomReveal = make([]byte, 96)
 	ZeroMixHash      = make([]byte, 32)
 
-	TxGasHumanReadable                   uint64 = 4000000000 // NOTE: HumanReadable related functions are inactivated now
-	ExperimentOpcodeComputationCostLimit        = OpcodeComputationCostLimitOverride
+	TxGasHumanReadable uint64 = 4000000000 // NOTE: HumanReadable related functions are inactivated now
 
 	// TODO-Klaytn Change the variables used in GXhash to more appropriate values for Klaytn Network
 	BlockScoreBoundDivisor = big.NewInt(2048)   // The bound divisor of the blockscore, used in the update calculations.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"math/big"
 	"time"
+
+	"github.com/klaytn/klaytn/common/math"
 )
 
 var TargetGasLimit = GenesisGasLimit // The artificial target
@@ -188,9 +190,11 @@ const (
 )
 
 const (
-	DefaultBlockGenerationInterval    = int64(1) // unit: seconds
-	DefaultBlockGenerationTimeLimit   = 250 * time.Millisecond
-	DefaultOpcodeComputationCostLimit = uint64(100000000)
+	DefaultBlockGenerationInterval  = int64(1) // unit: seconds
+	DefaultBlockGenerationTimeLimit = 250 * time.Millisecond
+
+	OpcodeComputationCostLimitInfinite = math.MaxUint64
+	OpcodeComputationCostLimitOverride = uint64(0)
 )
 
 var (
@@ -198,7 +202,8 @@ var (
 	ZeroRandomReveal = make([]byte, 96)
 	ZeroMixHash      = make([]byte, 32)
 
-	TxGasHumanReadable uint64 = 4000000000 // NOTE: HumanReadable related functions are inactivated now
+	TxGasHumanReadable                   uint64 = 4000000000 // NOTE: HumanReadable related functions are inactivated now
+	ExperimentOpcodeComputationCostLimit        = OpcodeComputationCostLimitOverride
 
 	// TODO-Klaytn Change the variables used in GXhash to more appropriate values for Klaytn Network
 	BlockScoreBoundDivisor = big.NewInt(2048)   // The bound divisor of the blockscore, used in the update calculations.
@@ -216,8 +221,6 @@ var (
 	// TODO-Klaytn-Governance Change the following variables to governance items which requires consensus of CCN
 	// Block generation interval in seconds. It should be equal or larger than 1
 	BlockGenerationInterval = DefaultBlockGenerationInterval
-	// Computation cost limit for a tx. For now, it is approximately 100 ms
-	OpcodeComputationCostLimit = DefaultOpcodeComputationCostLimit
 )
 
 // istanbul BFT

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/klaytn/klaytn/blockchain/vm"
+	"github.com/klaytn/klaytn/params"
 )
 
 func TestState(t *testing.T) {
@@ -76,7 +77,8 @@ func TestState(t *testing.T) {
 const traceErrorLimit = 400000
 
 func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
-	err := test(vm.Config{})
+	// Set ComputationCostLimit as infinite
+	err := test(vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
 	if err == nil {
 		return
 	}
@@ -86,7 +88,7 @@ func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
 		return
 	}
 	tracer := vm.NewStructLogger(nil)
-	err2 := test(vm.Config{Debug: true, Tracer: tracer})
+	err2 := test(vm.Config{Debug: true, Tracer: tracer, ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
 	if !reflect.DeepEqual(err, err2) {
 		t.Errorf("different error for second run: %v", err2)
 	}

--- a/work/worker.go
+++ b/work/worker.go
@@ -709,8 +709,7 @@ func (env *Task) ApplyTransactions(txs *types.TransactionsByTimeAndNonce, bc Blo
 	}()
 
 	vmConfig := &vm.Config{
-		RunningEVM:               chEVM,
-		UseOpcodeComputationCost: true,
+		RunningEVM: chEVM,
 	}
 
 	var numTxsChecked int64 = 0


### PR DESCRIPTION
## Proposed changes

- As the cpu performance has been improved a lot, this PR apply the recalculated computation cost of several opcodes. Please refer to the PDF file below to see why and what has changed.
- Also, in this PR, the computation cost limit has been increased: 50% increased (100,000,000 -> 150,000,000)

## Types of changes

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

- Adjusting individual computation costs based on `kcn --vm.opdebug` on blocks 129,000,000 to 139,000,000
[ComputationCost adjustment Cancun.pdf](https://github.com/klaytn/klaytn/files/13405463/ComputationCost.adjustment.Cancun.pdf)
- Adjusting computation cost limit
  - The goal was to make the following transaction succeed, which [previously failed with ErrOpcodeComputationCostLimitReached(0xa)](https://baobab.klaytnscope.com/tx/0xde9963e035a963e3762e98f3a73d1a030e5eef2a8d581bd6ac1286479ba041db?tabId=internalTx). Transaction consumed 135,695,448 computation cost before PR, and will consume 135,062,316 after PR.
  - Increasing the limit with some margin to 150,000,000.
	```
	debug.traceCall({ "from":"0x80b2b44FC3F390E1CB0a53b4b0b4a01F17F7aDf8", "to":"0x542a3903c7F2dD47a7F31b08Bd1C6791e3C43784", "input":"0x528be0a9000000000000000000000000000000000000000000000000000001d1a94a2260"},107853657,{tracer: "unigramTracer"})
	```