### PR TITLE
[Randao] Added missing Randao fields to header copy

### DIFF
--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -268,6 +268,14 @@ func CopyHeader(h *Header) *Header {
 		cpy.Vote = make([]byte, len(h.Vote))
 		copy(cpy.Vote, h.Vote)
 	}
+	if len(h.RandomReveal) > 0 {
+		cpy.RandomReveal = make([]byte, len(h.RandomReveal))
+		copy(cpy.RandomReveal, h.RandomReveal)
+	}
+	if len(h.MixHash) > 0 {
+		cpy.MixHash = make([]byte, len(h.MixHash))
+		copy(cpy.MixHash, h.MixHash)
+	}
 	return &cpy
 }
 


### PR DESCRIPTION
## Proposed changes

The function `Header()` does not contain `RandomReveal` and `MixHash`. This incorrectly hashes the header.

Added missing both fields in this PR.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
