### PR TITLE
vm: Cancun ExtCodeHash returns zero for empty account

### DIFF
--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -350,6 +350,16 @@ func enable7516(jt *JumpTable) {
 	}
 }
 
+func enable1052(jt *JumpTable) {
+	jt[EXTCODEHASH] = &operation{
+		execute:         opExtCodeHash1052,
+		constantGas:     params.ExtcodeHashGasConstantinople,
+		minStack:        minStack(1, 1),
+		maxStack:        maxStack(1, 1),
+		computationCost: params.ExtCodeHashComputationCost,
+	}
+}
+
 // As the cpu performance has been improved a lot, and as the storage size has increased a lot
 // recalculated the computation cost of some opcodes
 func enableCancunComputationCostModification(jt *JumpTable) {

--- a/blockchain/vm/instructions.go
+++ b/blockchain/vm/instructions.go
@@ -418,7 +418,7 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 //
 //  6. Caller tries to get the code hash for an account which is marked as deleted, this
 //     account should be regarded as a non-existent account and zero should be returned.
-func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+func opExtCodeHash1052(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
 	address := common.Address(slot.Bytes20())
 	if interpreter.evm.StateDB.Empty(address) {
@@ -426,6 +426,15 @@ func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	} else {
 		slot.SetBytes(interpreter.evm.StateDB.GetCodeHash(address).Bytes())
 	}
+	return nil, nil
+}
+
+// opExtCodeHash before Cancun hardfork did not conform to EIP-1052
+// in that it returned emptyCodeHash (0xc5d246..) when the account is empty.
+func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	slot := scope.Stack.peek()
+	address := common.Address(slot.Bytes20())
+	slot.SetBytes(interpreter.evm.StateDB.GetCodeHash(address).Bytes())
 	return nil, nil
 }
 

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -69,10 +69,11 @@ type JumpTable [256]*operation
 func newCancunInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
 	enable4844(&instructionSet) // EIP-4844 BLOBHASH opcode
-	enable7516(&instructionSet) // EIP-7516 (BLOBBASEFEE opcode)
-	enable5656(&instructionSet) // EIP-5656 (MCOPY opcode)
+	enable7516(&instructionSet) // EIP-7516 BLOBBASEFEE opcode
+	enable5656(&instructionSet) // EIP-5656 MCOPY opcode
 	enable6780(&instructionSet) // EIP-6780 SELFDESTRUCT only in same transaction
-	enable1153(&instructionSet) // EIP-1153 (Tload, Tstore opcode)
+	enable1153(&instructionSet) // EIP-1153 TLOAD, TSTORE opcode
+	enable1052(&instructionSet) // EIP-1052 EXTCODEHASH fix
 	enableCancunComputationCostModification(&instructionSet)
 	return instructionSet
 }


### PR DESCRIPTION
## Proposed changes

The [EIP-1052](https://eips.ethereum.org/EIPS/eip-1052) stipulates that `EXTCODEHASH` opcode shall
1. keccak256 hash of the code of the account
2. In case the account does not exist or is empty, push 0.
3. In case the account does not have code, push empty hash (c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)

Klaytn until v1.11.1 (see [code1](https://github.com/klaytn/klaytn/blob/v1.11.1/blockchain/vm/instructions.go#L543) [code2](https://github.com/klaytn/klaytn/blob/v1.11.1/blockchain/state/statedb.go#L318)) has implemented (1) and (3), but not (2).
The fix (#2024) was made to implement (2), but breaks previous blocks.
This PR implements (2) only after Cancun hardfork.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
