### PR TITLE
ci: Platform-independent sed command usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,12 +110,9 @@ commands:
             if [[ $CIRCLE_TAG =~ $pat ]]; then
               echo "this is rc version $CIRCLE_TAG"
               rc_num=$(echo $CIRCLE_TAG | cut -d '-' -f 2)
-              if [[ << parameters.os-network >> =~ .*"darwin".* ]]; then
-                sed -i '' 's/%d.%d.%d/%d.%d.%d~'$rc_num'/' params/version.go
-              else
-                sed -i 's/%d.%d.%d/%d.%d.%d~'$rc_num'/' params/version.go
-              fi
 
+              sed 's/%d.%d.%d/%d.%d.%d~'$rc_num'/' params/version.go > params/version.go.tmp
+              mv params/version.go.tmp params/version.go
               sed -n '/%d.%d.%d/p' params/version.go
             else
               echo "this is not RC version"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,10 +64,6 @@ executors:
     macos:
       xcode: 14.2.0
     resource_class: macos.x86.medium.gen2
-    parameters:
-      os-network:
-        type: string
-        default: "darwin-amd64"
   rpm-executor: # this executor is for packaging rpm binaries
     working_directory: /go/src/github.com/klaytn/klaytn
     docker:
@@ -95,10 +91,6 @@ commands:
             tar -C $HOME/go1.20.6 -xzf go1.20.6.darwin-amd64.tar.gz
   pre-build:
     description: "before build, set version"
-    parameters:
-      os-network:
-        type: string
-        default: "linux-amd64"
     steps:
       - run:
           name: "set variables"
@@ -336,7 +328,7 @@ commands:
           name: "Run rpc-tester on 1CN private network"
           no_output_timeout: 30m
           command: |
-            make kcn 
+            make kcn
             git clone https://$TEST_TOKEN@github.com/klaytn/klaytn-rpc-tester.git
             cd klaytn-rpc-tester
             cp ../build/bin/kcn script/cn/bin/
@@ -514,7 +506,8 @@ jobs:
       - checkout
       - install-darwin-dependencies
       - pre-build
-      - build-packaging
+      - build-packaging:
+          os-network: "darwin-amd64"
       - upload-repo
 
   packaging-darwin-baobab:
@@ -524,6 +517,7 @@ jobs:
       - install-darwin-dependencies
       - pre-build
       - build-packaging:
+          os-network: "darwin-amd64"
           baobab: "-b"
       - upload-repo:
           item: "kcn kpn ken"


### PR DESCRIPTION
## Proposed changes

- Fix the CircleCI job `packaging-darwin:pre-build:set variable` where `sed -i` command is used.
- Instead of clumsy OS check, use platform-independent command without the `-i` flag.
- Failed job: https://app.circleci.com/pipelines/github/klaytn/klaytn/11370/workflows/5cab07e5-73d0-4a5a-a3db-a493f868afb6/jobs/60805
- Succeeded job: https://app.circleci.com/pipelines/github/klaytn/klaytn/11377/workflows/9fd6c22f-967c-4fb9-8669-ca62f19eef1a/jobs/60854 (correctly uploads `kcn-v1.12.0~rc.1-0-darwin-10.10-amd64.tar.gz`)

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments