### PR TITLE
ci: Use gcc7 in rpmbuild

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ executors:
   rpm-executor: # this executor is for packaging rpm binaries
     working_directory: /go/src/github.com/klaytn/klaytn
     docker:
-      - image: klaytn/circleci-rpmbuild:1.20.6
+      - image: klaytn/circleci-rpmbuild:1.20.6-gcc7
         auth:
           username: $DOCKER_LOGIN
           password: $DOCKER_PASSWORD

--- a/build/Dockerfile-go1.20.6-rpmbuild-gcc7
+++ b/build/Dockerfile-go1.20.6-rpmbuild-gcc7
@@ -1,0 +1,13 @@
+FROM centos:centos7
+
+RUN curl https://dl.google.com/go/go1.20.6.linux-amd64.tar.gz | tar xzvf - -C /usr/local
+RUN yum install -y make rpm-build git createrepo python3 gcc unzip
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip
+ENV PATH=$PATH:/usr/local/go/bin
+
+# yum installed gcc is too old (4.8.5). Install 7.x to enable c99 (actually gnu11) by default.
+# devtoolset-7 must be installed after centos-release-scl
+RUN yum install -y centos-release-scl scl-utils && yum install -y devtoolset-7-gcc
+
+# Add gcc 7.x in $PATH
+CMD ["/usr/bin/scl", "enable", "devtoolset-7", "/bin/sh"]


### PR DESCRIPTION
## Proposed changes

- Fix the CircleCI job `rpm-tagged:rpm-tagging:rpm tagging` where CGO build fails with an error:
	```
	# github.com/supranational/blst/bindings/go
	../../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go: In function 'go_pairing_init':
	../../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:44:10: error: 'for' loop initial declarations are only allowed in C99 mode
	 //         for(size_t i = 0; i < DST_len; i++) dst[i] = DST[i];
	          ^
	../../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:44:10: note: use option -std=c99 or -std=gnu99 to compile your code
	```
- Install gcc 7.x where [c99 is enabled by default](https://stackoverflow.com/a/14737642)
  - Added Dockerfile-go1.20.6-rpmbuild-gcc7
  - Modified circleci config to use the image
- Failed job: https://app.circleci.com/pipelines/github/klaytn/klaytn/11370/workflows/5cab07e5-73d0-4a5a-a3db-a493f868afb6/jobs/60804

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

Should I update existing `Dockerfile-go1.20.6-rpmbuild`? or add new `Dockerfile-go1.20.6-rpmbuild-gcc7`?