### PR TITLE
ci: Fix Dockerfile-go1.20.6-rpmbuild-gcc7

### DIFF
--- a/build/Dockerfile-go1.20.6-rpmbuild-gcc7
+++ b/build/Dockerfile-go1.20.6-rpmbuild-gcc7
@@ -10,4 +10,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 RUN yum install -y centos-release-scl scl-utils && yum install -y devtoolset-7-gcc
 
 # Add gcc 7.x in $PATH
-CMD ["/usr/bin/scl", "enable", "devtoolset-7", "/bin/sh"]
+ENV PATH="/opt/rh/devtoolset-7/root/usr/bin:$PATH"
+ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-7/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
## Proposed changes

- Fixes #2045 
- CMD is not respected in CI environment. Instead of `scl enable` CMD, Set `$PATH` in the Dockerfile.
- Failed job: https://app.circleci.com/pipelines/github/klaytn/klaytn/11387/workflows/f46e9f09-6c65-4fe7-b4ac-d2b7464d20e0/jobs/60941
- Succeeded job: https://app.circleci.com/pipelines/github/klaytn/klaytn/11387/workflows/89539a71-b790-4e5d-aa3c-74d641c28bef/jobs/60943

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
