### PR TITLE
BLS PopProve and PopVerify use different DomainSeparationTag

### DIFF
--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -176,14 +176,10 @@ func VerifyMultipleSignatures(sigs [][]byte, msgs [][32]byte, pubKeys []PublicKe
 // PopProve calculates the proof-of-possession for the secret key,
 // which is the signature with its public key as message.
 func PopProve(sk SecretKey) Signature {
-	// draft-irtf-cfrg-bls-signature-05 section 3.3.2. PopProve
-	msg := sk.PublicKey().Marshal()
-	return blst.Sign(sk, msg)
+	return blst.PopProve(sk)
 }
 
 // PopVerify verifies the proof-of-possession for the public key.
-func PopVerify(pk PublicKey, proof Signature) bool {
-	// draft-irtf-cfrg-bls-signature-05 section 3.3.3. PopVerify
-	msg := pk.Marshal()
-	return blst.Verify(proof, msg, pk)
+func PopVerify(pk PublicKey, sig Signature) bool {
+	return blst.PopVerify(pk, sig)
 }

--- a/crypto/bls/blst/signature_test.go
+++ b/crypto/bls/blst/signature_test.go
@@ -171,6 +171,28 @@ func TestSignVerify(t *testing.T) {
 	assert.False(t, Verify(Sign(sk, msg), msg, pk2))
 }
 
+func TestPopProveVerify(t *testing.T) {
+	var (
+		// https://github.com/Chia-Network/bls-signatures/blob/2.0.2/src/test.cpp
+		// "Chia test vector 3 (PoP)"
+		// Note: `skb` is the result of PopSchemeMPL().KeyGen(seed1) in the testcase
+		skb  = common.FromHex("0x258787ef728c898e43bc76244d70f468c9c7e1338a107b18b42da0d86b663c26")
+		popb = common.FromHex("0x84f709159435f0dc73b3e8bf6c78d85282d19231555a8ee3b6e2573aaf66872d9203fefa1ef700e34e7c3f3fb28210100558c6871c53f1ef6055b9f06b0d1abe22ad584ad3b957f3018a8f58227c6c716b1e15791459850f2289168fa0cf9115")
+
+		sk, _ = SecretKeyFromBytes(skb)
+		pk    = sk.PublicKey()
+		pop   = PopProve(sk)
+	)
+	assert.Equal(t, popb, pop.Marshal())
+	assert.True(t, PopVerify(pk, pop))
+
+	sk2, _ := RandKey()
+	pk2 := sk2.PublicKey()
+	assert.True(t, PopVerify(pk2, PopProve(sk2)))
+	assert.False(t, PopVerify(pk2, PopProve(sk)))
+	assert.False(t, PopVerify(pk, PopProve(sk2)))
+}
+
 func TestAggregateVerify(t *testing.T) {
 	var (
 		// https://github.com/ethereum/bls12-381-tests

--- a/crypto/bls/types/bls_types.go
+++ b/crypto/bls/types/bls_types.go
@@ -29,7 +29,8 @@ var (
 	// draft-irtf-cfrg-pairing-friendly-curves-11#4.2.1 BLS12_381
 	CurveOrderHex = "0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
 	// draft-irtf-cfrg-bls-signature-05#4.2.3
-	DomainSeparationTag = []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_")
+	DomainSeparationTagSig = []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_")
+	DomainSeparationTagPop = []byte("BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_")
 )
 
 var (


### PR DESCRIPTION
## Proposed changes

- Fix `bls.PopProve` and `bls.PopVerify` to use the standard domain separation tag for proof-of-poessession purpose.
- According to https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-4.2.3,
  ```
  use BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_ for message signing and
  use BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_ for proof-of-possession
  ```
- Added a test case from https://github.com/Chia-Network/bls-signatures/blob/2.0.2/src/test.cpp,
  which is the underlying library of python `blspy` and node.js `bls-signatures`.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

Problem spotted by @ian0371 at https://github.com/klaytn/klaytn/issues/2043#issuecomment-1825382761.

## Further comments