### PR TITLE
Fetch BLS public key info from RPC admin_nodeInfo

### DIFF
--- a/cmd/utils/nodecmd/accountcmd.go
+++ b/cmd/utils/nodecmd/accountcmd.go
@@ -390,7 +390,6 @@ func accountBlsInfo(ctx *cli.Context) error {
 	if err != nil {
 		log.Fatalf("Unable to attach to remote node: %v", err)
 	}
-	_ = client
 
 	var nodeInfo node.NodeInfoOutput
 	err = client.Call(&nodeInfo, "admin_nodeInfo", nil)

--- a/cmd/utils/nodecmd/accountcmd.go
+++ b/cmd/utils/nodecmd/accountcmd.go
@@ -33,7 +33,6 @@ import (
 	"github.com/klaytn/klaytn/accounts/keystore"
 	"github.com/klaytn/klaytn/api/debug"
 	"github.com/klaytn/klaytn/cmd/utils"
-	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/console"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/crypto/bls"
@@ -155,15 +154,12 @@ nodes.
 `,
 		},
 		{
-			Name:   "bls-info",
-			Usage:  "Calculate BLS public key info",
-			Action: accountBlsInfo,
+			Name:      "bls-info",
+			Usage:     "Fetch BLS public key info of the running node",
+			ArgsUsage: "[endpoint]",
+			Action:    accountBlsInfo,
 			Flags: []cli.Flag{
 				utils.DataDirFlag,
-				utils.NodeKeyFileFlag,
-				utils.NodeKeyHexFlag,
-				utils.BlsNodeKeyFileFlag,
-				utils.BlsNodeKeyHexFlag,
 			},
 			Description: `
 Calculate BLS public key info (the public key and proof-of-possession)
@@ -171,12 +167,8 @@ then saves to bls-publicinfo-NODEID.json.
 
 EXAMPLES
 
-# From the bls-nodekey file at the default location (DATADIR/bls-nodekey)
-# (if not exists, will be derived from ECDSA nodekey)
+# From the local node, by attaching to the default IPC endpoint DATADIR/klay.ipc.
 kcn account bls-info
-
-# From the custom BLS key file at a custom location
-kcn account bls-info --bls-nodekey DATADIR/bls-nodekey
 `,
 		},
 		{
@@ -393,22 +385,29 @@ func accountImport(ctx *cli.Context) error {
 }
 
 func accountBlsInfo(ctx *cli.Context) error {
-	// Parse CLI arguments in the same way as running a node.
-	var (
-		_, cfg  = utils.MakeConfigNode(ctx)
-		nodeKey = cfg.Node.NodeKey()
-		blsPriv = cfg.Node.BlsNodeKey()
-	)
+	endpoint := rpcEndpoint(ctx)
+	client, err := dialRPC(endpoint)
+	if err != nil {
+		log.Fatalf("Unable to attach to remote node: %v", err)
+	}
+	_ = client
 
-	// Calculate filename from node address.
-	nodeAddr := crypto.PubkeyToAddress(nodeKey.PublicKey)
-	name := fmt.Sprintf("bls-publicinfo-%s.json", nodeAddr.Hex())
+	var nodeInfo node.NodeInfoOutput
+	err = client.Call(&nodeInfo, "admin_nodeInfo", nil)
+	if err != nil {
+		log.Fatalf("Unable to fetch node info: %v", err)
+	}
 
-	// Write bls-publicinfo-*.json
-	infoJson, err := makeBlsPublicinfo(blsPriv, nodeAddr)
+	infoJson, err := json.MarshalIndent(map[string]interface{}{
+		"address":          nodeInfo.NodeAddress,
+		"blsPublicKeyInfo": nodeInfo.BlsPublicKeyInfo,
+	}, "", "  ")
+	infoJson = append(infoJson, '\n')
 	if err != nil {
 		return err
 	}
+
+	name := fmt.Sprintf("bls-publicinfo-%s.json", nodeInfo.NodeAddress)
 	writeFile(name, infoJson, 0o644) // Ordinary non-secret text file permission.
 	return nil
 }
@@ -456,22 +455,6 @@ func accountBlsExport(ctx *cli.Context) error {
 	}
 	writeFile(name, keystoreJson, 0o600) // Secret file permission.
 	return nil
-}
-
-// Returns publicinfo JSON
-func makeBlsPublicinfo(sk bls.SecretKey, nodeAddr common.Address) ([]byte, error) {
-	pub := sk.PublicKey().Marshal()
-	pop := bls.PopProve(sk).Marshal()
-	info := map[string]interface{}{
-		"address": nodeAddr.Hex(),
-		"blsPublicKeyInfo": map[string]interface{}{
-			"publicKey": hex.EncodeToString(pub),
-			"pop":       hex.EncodeToString(pop),
-		},
-	}
-	infoJson, err := json.MarshalIndent(info, "", "  ")
-	infoJson = append(infoJson, '\n')
-	return infoJson, err
 }
 
 func loadBlsKeystore(ctx *cli.Context) (bls.SecretKey, error) {

--- a/cmd/utils/nodecmd/consolecmd.go
+++ b/cmd/utils/nodecmd/consolecmd.go
@@ -104,19 +104,7 @@ func localConsole(ctx *cli.Context) error {
 // console to it.
 func remoteConsole(ctx *cli.Context) error {
 	// Attach to a remotely running node instance and start the JavaScript console
-	endpoint := ctx.Args().First()
-	if endpoint == "" {
-		path := node.DefaultDataDir()
-		if ctx.IsSet(utils.DataDirFlag.Name) {
-			path = ctx.String(utils.DataDirFlag.Name)
-		}
-		if path != "" {
-			if ctx.Bool(utils.BaobabFlag.Name) {
-				path = filepath.Join(path, "baobab")
-			}
-		}
-		endpoint = fmt.Sprintf("%s/klay.ipc", path)
-	}
+	endpoint := rpcEndpoint(ctx)
 	client, err := dialRPC(endpoint)
 	if err != nil {
 		log.Fatalf("Unable to attach to remote node: %v", err)
@@ -144,6 +132,23 @@ func remoteConsole(ctx *cli.Context) error {
 	console.Interactive()
 
 	return nil
+}
+
+func rpcEndpoint(ctx *cli.Context) string {
+	endpoint := ctx.Args().First()
+	if endpoint == "" {
+		path := node.DefaultDataDir()
+		if ctx.IsSet(utils.DataDirFlag.Name) {
+			path = ctx.String(utils.DataDirFlag.Name)
+		}
+		if path != "" {
+			if ctx.Bool(utils.BaobabFlag.Name) {
+				path = filepath.Join(path, "baobab")
+			}
+		}
+		endpoint = fmt.Sprintf("%s/klay.ipc", path)
+	}
+	return endpoint
 }
 
 // dialRPC returns a RPC client which connects to the given endpoint.

--- a/node/api.go
+++ b/node/api.go
@@ -22,12 +22,14 @@ package node
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/crypto/bls"
 	"github.com/klaytn/klaytn/networks/p2p"
 	"github.com/klaytn/klaytn/networks/p2p/discover"
 	"github.com/klaytn/klaytn/networks/rpc"
@@ -291,14 +293,49 @@ func (api *PublicAdminAPI) Peers() ([]*p2p.PeerInfo, error) {
 	return server.PeersInfo(), nil
 }
 
+// BlsPublicKeyInfoOutput has string fields unlike system.BlsPublicKeyInfo.
+type BlsPublicKeyInfoOutput struct {
+	PublicKey string `json:"publicKey"`
+	Pop       string `json:"pop"`
+}
+
+// NodeInfoOutput extends p2p.NodeInfo with additional fields.
+type NodeInfoOutput struct {
+	p2p.NodeInfo
+
+	// Node address derived from node key
+	NodeAddress string `json:"nodeAddress"`
+
+	// BLS public key information for consensus
+	BlsPublicKeyInfo BlsPublicKeyInfoOutput `json:"blsPublicKeyInfo"`
+}
+
 // NodeInfo retrieves all the information we know about the host node at the
 // protocol granularity.
-func (api *PublicAdminAPI) NodeInfo() (*p2p.NodeInfo, error) {
+func (api *PublicAdminAPI) NodeInfo() (*NodeInfoOutput, error) {
 	server := api.node.Server()
 	if server == nil {
 		return nil, ErrNodeStopped
 	}
-	return server.NodeInfo(), nil
+
+	var (
+		nodeKey  = api.node.config.NodeKey()
+		nodeAddr = crypto.PubkeyToAddress(nodeKey.PublicKey)
+
+		blsPriv = api.node.config.BlsNodeKey()
+		blsPub  = blsPriv.PublicKey().Marshal()
+		blsPop  = bls.PopProve(blsPriv).Marshal()
+	)
+
+	info := &NodeInfoOutput{
+		NodeInfo:    *server.NodeInfo(),
+		NodeAddress: nodeAddr.Hex(),
+		BlsPublicKeyInfo: BlsPublicKeyInfoOutput{
+			PublicKey: hex.EncodeToString(blsPub),
+			Pop:       hex.EncodeToString(blsPop),
+		},
+	}
+	return info, nil
 }
 
 // Datadir retrieves the current data directory the node is using.


### PR DESCRIPTION
## Proposed changes

- Problem
  - `kcn account bls-info` is too confusing because it tries to load nodekey and bls-nodekey from the "default datadir", which usually differs from production DATA_DIR.
  - If `kcn --nodekey` or `kcn --nodekeyhex` option is used to launch a node, the `DATADIR/nodekey` file is not created. In this situation, `kcn account bls-info` cannot read the `DATADIR/nodekey`.
- Solution
  - Fetch BLS info from the running node via RPC. The RPC must be the most correct place to query such information.
- Changes
  - RPC `admin_nodeInfo` outputs additional fields: `nodeAddress` and `blsPublicKeyInfo`
	```
	> admin.nodeInfo.nodeAddress
	"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
	> admin.nodeInfo.blsPublicKeyInfo
	{
	  pop: "ac7886654439a16c53be123d1956bb1bfe4a04b118ac50d9d4a56aef8a8e1e23128a8d720a9290a4dfa411df2384f5dc0bf9ee9861846fe1bd3f0fbd998935deda91cb28ceefe5ff8f307b43c0559dfbc96d7f2b6361980edb0298f28479908e",
	  publicKey: "876006073c4ef19d23df948fea3e7e95398d6a7b5acc6a510f24e2d5160bbbd9f636a58cdfe69c8eba42b1cfce0fa60a"
	}
	```
  - Command `kcn account bls-info` now queries the RPC. (it looked up for DATADIR before)
	```
	$ kcn account bls-info /var/kcnd/data/klay.ipc
	Successfully wrote 'bls-publicinfo-0x9333358724a6904eb14f689732adCD0878d56073.json'
	```
  - Fix TestBlsInfo to conform to #2052

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

Issue reported by @ian0371 at https://github.com/klaytn/klaytn/issues/2043#issuecomment-1825382761

## Further comments
