### PR TITLE
Allocate missing storage to kip113 logic contract

### DIFF
--- a/blockchain/system/kip113.go
+++ b/blockchain/system/kip113.go
@@ -77,7 +77,7 @@ type AllocKip113Init struct {
 	Owner common.Address
 }
 
-func AllocKip113(init AllocKip113Init) map[common.Hash]common.Hash {
+func AllocKip113Proxy(init AllocKip113Init) map[common.Hash]common.Hash {
 	if init.Infos == nil {
 		return nil
 	}
@@ -139,6 +139,15 @@ func AllocKip113(init AllocKip113Init) map[common.Hash]common.Hash {
 			storage[k] = v
 		}
 	}
+
+	return storage
+}
+
+func AllocKip113Logic() map[common.Hash]common.Hash {
+	storage := make(map[common.Hash]common.Hash)
+
+	// We only need to case about _initialized, which is max(uint8).
+	storage[lpad32(0)] = lpad32([]byte{0xff})
 
 	return storage
 }

--- a/cmd/homi/genesis/options.go
+++ b/cmd/homi/genesis/options.go
@@ -202,18 +202,19 @@ func RegistryMock() Option {
 	}
 }
 
-func AllocateKip113(kip113ProxyAddr, kip113LogicAddr common.Address, storage map[common.Hash]common.Hash) Option {
+func AllocateKip113(kip113ProxyAddr, kip113LogicAddr common.Address, proxyStorage, logicStorage map[common.Hash]common.Hash) Option {
 	return func(genesis *blockchain.Genesis) {
 		proxyCode := system.ERC1967ProxyCode
 		logicCode := system.Kip113Code
 
 		genesis.Alloc[kip113ProxyAddr] = blockchain.GenesisAccount{
 			Code:    proxyCode,
-			Storage: storage,
+			Storage: proxyStorage,
 			Balance: big.NewInt(0),
 		}
 		genesis.Alloc[kip113LogicAddr] = blockchain.GenesisAccount{
 			Code:    logicCode,
+			Storage: logicStorage,
 			Balance: big.NewInt(0),
 		}
 	}

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -604,10 +604,11 @@ func allocateKip113(ctx *cli.Context, genesisJson *blockchain.Genesis, init syst
 	}
 
 	allocProxyStorage := system.AllocProxy(kip113LogicAddr)
-	allocKip113Storage := system.AllocKip113(init)
+	allocKip113Storage := system.AllocKip113Proxy(init)
 	allocStorage := system.MergeStorage(allocProxyStorage, allocKip113Storage)
+	allocLogicStorage := system.AllocKip113Logic()
 
-	allocationFunction := genesis.AllocateKip113(kip113ProxyAddr, kip113LogicAddr, allocStorage)
+	allocationFunction := genesis.AllocateKip113(kip113ProxyAddr, kip113LogicAddr, allocStorage, allocLogicStorage)
 	allocationFunction(genesisJson)
 
 	return &kip113ProxyAddr, &kip113LogicAddr

--- a/tests/randao_fork_test.go
+++ b/tests/randao_fork_test.go
@@ -190,17 +190,19 @@ func testRandao_allocKip113(numNodes int, ownerAddr, kip113Addr common.Address) 
 		logicAddr = common.HexToAddress("0x0000000000000000000000000000000000000402")
 		owner     = crypto.PubkeyToAddress(deriveTestAccount(5).PublicKey)
 
-		proxyStorage = system.AllocProxy(logicAddr)
-		logicStorage = system.AllocKip113(system.AllocKip113Init{
+		proxyStorage       = system.AllocProxy(logicAddr)
+		kip113ProxyStorage = system.AllocKip113Proxy(system.AllocKip113Init{
 			Infos: infos,
 			Owner: owner,
 		})
-		storage = system.MergeStorage(proxyStorage, logicStorage)
+		kip113LogicStorage = system.AllocKip113Logic()
+		storage            = system.MergeStorage(proxyStorage, kip113ProxyStorage)
 	)
 
 	return blockchain.GenesisAlloc{
 		logicAddr: {
 			Code:    system.Kip113MockCode,
+			Storage: kip113LogicStorage,
 			Balance: common.Big0,
 		},
 		kip113Addr: {


### PR DESCRIPTION
## Proposed changes

The KIP113 implementation contract also has `_initialized = 0xff` by `_disableInitializers` to prevent reinitialize attacks. This is only affected when using KIP113 with bytecode injection(RandaoCompatibleBlock == 0).

- Allocate storage for implementation contract.
- Update test cases accordingly.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
