### PR TITLE
Install Registry at Randao hardfork

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -546,7 +546,7 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 
 	// The Registry contract must be immediately available from the fork block.
 	// So it is installed at block (RandaoCompatibleBlock - 1) which is before the fork block.
-	if chain.Config().IsRandaoForkBlockParent(header.Number) {
+	if chain.Config().IsRandaoForkBlock(header.Number) {
 		system.InstallRegistry(state, chain.Config().RandaoRegistry)
 	}
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -547,7 +547,10 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 	// The Registry contract must be immediately available from the fork block.
 	// So it is installed at block (RandaoCompatibleBlock - 1) which is before the fork block.
 	if chain.Config().IsRandaoForkBlock(header.Number) {
-		system.InstallRegistry(state, chain.Config().RandaoRegistry)
+		err := system.InstallRegistry(state, chain.Config().RandaoRegistry)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	header.Root = state.IntermediateRoot(true)

--- a/consensus/istanbul/backend/randao.go
+++ b/consensus/istanbul/backend/randao.go
@@ -61,9 +61,15 @@ func (p *ChainBlsPubkeyProvider) getAllCached(chain consensus.ChainReader, num *
 	}
 
 	backend := backends.NewBlockchainContractBackend(chain, nil, nil)
+	if common.Big0.Cmp(num) == 0 {
+		return nil, errors.New("num cannot be zero")
+	}
 	parentNum := new(big.Int).Sub(num, common.Big1)
 
 	var kip113Addr common.Address
+	// Because the system contract Registry is installed at Finalize() of RandaoForkBlock,
+	// it is not possible to read KIP113 address from the Registry at RandaoForkBlock.
+	// Hence the ChainConfig fallback.
 	if chain.Config().IsRandaoForkBlock(num) {
 		var ok bool
 		kip113Addr, ok = chain.Config().RandaoRegistry.Records[system.Kip113Name]

--- a/consensus/istanbul/backend/randao.go
+++ b/consensus/istanbul/backend/randao.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"bytes"
+	"errors"
 	"math/big"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -18,6 +19,8 @@ import (
 
 // For testing without KIP-113 contract setup
 type BlsPubkeyProvider interface {
+	// num should be the header number of the block to be verified.
+	// Thus, since the state of num does not exist, the state of num-1 must be used.
 	GetBlsPubkey(chain consensus.ChainReader, proposer common.Address, num *big.Int) (bls.PublicKey, error)
 	ResetBlsCache()
 }
@@ -58,12 +61,27 @@ func (p *ChainBlsPubkeyProvider) getAllCached(chain consensus.ChainReader, num *
 	}
 
 	backend := backends.NewBlockchainContractBackend(chain, nil, nil)
-	kip113Addr, err := system.ReadRegistryActiveAddr(backend, system.Kip113Name, num)
-	if err != nil {
-		return nil, err
+	parentNum := new(big.Int).Sub(num, common.Big1)
+
+	var kip113Addr common.Address
+	if chain.Config().IsRandaoForkBlock(num) {
+		var ok bool
+		kip113Addr, ok = chain.Config().RandaoRegistry.Records[system.Kip113Name]
+		if !ok {
+			return nil, errors.New("KIP113 address not set in ChainConfig")
+		}
+	} else if chain.Config().IsRandaoForkEnabled(num) {
+		var err error
+		kip113Addr, err = system.ReadRegistryActiveAddr(backend, system.Kip113Name, parentNum)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		logger.Crit("num", num.Uint64())
+		return nil, errors.New("Not a Randao fork block")
 	}
 
-	infos, err := system.ReadKip113All(backend, kip113Addr, num)
+	infos, err := system.ReadKip113All(backend, kip113Addr, parentNum)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +122,6 @@ func (sb *backend) VerifyRandao(chain consensus.ChainReader, header *types.Heade
 	if header.Number.Sign() == 0 {
 		return nil // Do not verify genesis block
 	}
-	parentNum := new(big.Int).Sub(header.Number, common.Big1)
 
 	proposer, err := sb.Author(header)
 	if err != nil {
@@ -113,7 +130,7 @@ func (sb *backend) VerifyRandao(chain consensus.ChainReader, header *types.Heade
 
 	// [proposerPubkey, proposerPop] = get_proposer_pubkey_pop()
 	// if not pop_verify(proposerPubkey, proposerPop): return False
-	proposerPub, err := sb.blsPubkeyProvider.GetBlsPubkey(chain, proposer, parentNum)
+	proposerPub, err := sb.blsPubkeyProvider.GetBlsPubkey(chain, proposer, header.Number)
 	if err != nil {
 		return err
 	}

--- a/consensus/istanbul/backend/randao.go
+++ b/consensus/istanbul/backend/randao.go
@@ -77,8 +77,7 @@ func (p *ChainBlsPubkeyProvider) getAllCached(chain consensus.ChainReader, num *
 			return nil, err
 		}
 	} else {
-		logger.Crit("num", num.Uint64())
-		return nil, errors.New("Not a Randao fork block")
+		return nil, errors.New("Cannot read KIP113 address from registry before Randao fork")
 	}
 
 	infos, err := system.ReadKip113All(backend, kip113Addr, parentNum)

--- a/params/config.go
+++ b/params/config.go
@@ -409,6 +409,14 @@ func (c *ChainConfig) IsRandaoForkBlockParent(num *big.Int) bool {
 	return c.RandaoCompatibleBlock.Cmp(nextNum) == 0 // randao == num + 1
 }
 
+// IsRandaoForkBlock returns whether num is equal to the randao block.
+func (c *ChainConfig) IsRandaoForkBlock(num *big.Int) bool {
+	if c.RandaoCompatibleBlock == nil || num == nil {
+		return false
+	}
+	return c.RandaoCompatibleBlock.Cmp(num) == 0
+}
+
 // CheckCompatible checks whether scheduled fork transitions have been imported
 // with a mismatching chain configuration.
 func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64) *ConfigCompatError {

--- a/tests/randao_fork_test.go
+++ b/tests/randao_fork_test.go
@@ -277,8 +277,8 @@ func testRandao_checkRegistry(t *testing.T, ctx *blockchainTestContext, ownerAdd
 	if forkNum == 0 {
 		after = common.Big0
 	} else {
-		before = big.NewInt(forkNum - 2)
-		after = big.NewInt(forkNum - 1)
+		before = big.NewInt(forkNum - 1)
+		after = big.NewInt(forkNum)
 	}
 
 	// Registry code is installed exactly at forkParentNum


### PR DESCRIPTION
## Proposed changes

To facilitate the activation of Randao hardfork and Registry installation at the same block, this PR installs the Registry contact at `randao hardfork` (previously, at `randao hardfork - 1`).
It necessitates reading KIP113 address from ChainConfig for the verification of the Randao hardfork block because during the verification, the Registry does not exist at the latest block.

In short, previously,
```
GetBlsPubkey(num, ...):
	fetch kip113Addr from registry at state{num}

VerifyRandao(header, ...):
	GetBlsPubkey(header.Number - 1)
```

In this PR,
```
GetBlsPubkey(num, ...):
	if num == hf: fetch kip113Addr from ChainConfig
	if num > hf: fetch kip113Addr from registry at state{num-1}
 
VerifyRandao(header, ...):
	GetBlsPubkey(header.Number)
```

Note that the actual change is in `getAllCached`, not `GetBlsPubkey`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Tested that hardfork block passes in the expected scenario and unexpected scenario.
In expected scenario, `randaoRegistry` field in ChainConfig is set before the hardfork pass.
In unexpected scenario, `randaoRegistry` field in ChainConfig is not set at the hardfork, so the operator updates the `randaoCompatibleBlock` to postpone the hardfork.