### PR TITLE
[API] Error response refined for the API `klay_estimateComputationCost`

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -407,9 +407,8 @@ func (s *PublicBlockChainAPI) EstimateComputationCost(ctx context.Context, args 
 			return 0, err
 		}
 		rules := s.b.ChainConfig().Rules(block.Number())
-		errStr := fmt.Sprintf("%s (opcodeComputationCostSum = %d), (computationCostLimit = %d)",
+		errStr := fmt.Sprintf("%s (computationCostLimit = %d)",
 			vm.ErrOpcodeComputationCostLimitReached.Error(),
-			cc,
 			vm.GetComputationCost(rules, 0),
 		)
 		return cc, errors.New(errStr)

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -123,25 +123,30 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 		cfg.JumpTable = jt
 	}
 
-	// Enable the opcode computation cost limit
-	if cfg.ComputationCostLimit == 0 {
-		switch {
-		case evm.chainRules.IsCancun:
-			cfg.ComputationCostLimit = uint64(params.OpcodeComputationCostLimitCancun)
-		default:
-			cfg.ComputationCostLimit = uint64(params.OpcodeComputationCostLimit)
-		}
-	}
-
-	// It is an experimental feature.
-	if params.OpcodeComputationCostLimitOverride != 0 {
-		cfg.ComputationCostLimit = params.OpcodeComputationCostLimitOverride
-	}
+	cfg.ComputationCostLimit = GetComputationCost(evm.chainRules, cfg.ComputationCostLimit)
 
 	return &EVMInterpreter{
 		evm: evm,
 		cfg: cfg,
 	}
+}
+
+func GetComputationCost(rules params.Rules, cc uint64) uint64 {
+	if cc == 0 {
+		// Enable the opcode computation cost limit
+		switch {
+		case rules.IsCancun:
+			cc = uint64(params.OpcodeComputationCostLimitCancun)
+		default:
+			cc = uint64(params.OpcodeComputationCostLimit)
+		}
+	}
+
+	// It is an experimental feature.
+	if params.OpcodeComputationCostLimitOverride != 0 {
+		cc = params.OpcodeComputationCostLimitOverride
+	}
+	return cc
 }
 
 // count values and execution time of the opcodes are collected until the node is turned off.


### PR DESCRIPTION
## Proposed changes

Raised from #2081.

Added two values computation cost (CC) sum and cc limit.

For example, in a given environment with the setting `--opcode-computation-cost-limit=100000` the following error message returns.
```
Error: reached the opcode computation cost limit (opcodeComputationCostSum = 184311), (computationCostLimit = 100000)
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
