### PR TITLE
api: remove computationcost limit at call/estimate apis

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1436,7 +1436,7 @@ func EthDoCall(ctx context.Context, b Backend, args EthTransactionArgs, blockNrO
 	if msg.Gas() < intrinsicGas {
 		return nil, fmt.Errorf("%w: msg.gas %d, want %d", blockchain.ErrIntrinsicGas, msg.Gas(), intrinsicGas)
 	}
-	evm, vmError, err := b.GetEVM(ctx, msg, state, header, vm.Config{})
+	evm, vmError, err := b.GetEVM(ctx, msg, state, header, vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
 	if err != nil {
 		return nil, err
 	}

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1491,7 +1491,7 @@ func EthDoEstimateGas(ctx context.Context, b Backend, args EthTransactionArgs, b
 
 	executable := func(gas uint64) (bool, *blockchain.ExecutionResult, error) {
 		args.Gas = (*hexutil.Uint64)(&gas)
-		result, err := EthDoCall(ctx, b, args, rpc.NewBlockNumberOrHashWithNumber(rpc.LatestBlockNumber), nil, 0, gasCap)
+		result, err := EthDoCall(ctx, b, args, rpc.NewBlockNumberOrHashWithNumber(rpc.LatestBlockNumber), nil, b.RPCEVMTimeout(), gasCap)
 		if err != nil {
 			if errors.Is(err, blockchain.ErrIntrinsicGas) {
 				return true, nil, nil // Special case, raise gas limit

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -12,9 +12,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/klaytn/klaytn/accounts"
 	mock_accounts "github.com/klaytn/klaytn/accounts/mocks"
 	mock_api "github.com/klaytn/klaytn/api/mocks"
@@ -34,6 +31,8 @@ import (
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 	"github.com/klaytn/klaytn/storage/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var dummyChainConfigForEthereumAPITest = &params.ChainConfig{

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -9,14 +9,12 @@ import (
 	"math/big"
 	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/klaytn/klaytn/consensus"
-	"github.com/klaytn/klaytn/crypto"
-	"github.com/klaytn/klaytn/governance"
+	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/klaytn/klaytn/accounts"
 	mock_accounts "github.com/klaytn/klaytn/accounts/mocks"
 	mock_api "github.com/klaytn/klaytn/api/mocks"
@@ -27,13 +25,15 @@ import (
 	"github.com/klaytn/klaytn/blockchain/vm"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
+	"github.com/klaytn/klaytn/consensus"
 	"github.com/klaytn/klaytn/consensus/gxhash"
 	"github.com/klaytn/klaytn/consensus/mocks"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/governance"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 	"github.com/klaytn/klaytn/storage/database"
-	"github.com/stretchr/testify/assert"
 )
 
 var dummyChainConfigForEthereumAPITest = &params.ChainConfig{
@@ -2489,6 +2489,7 @@ func testEstimateGas(t *testing.T, mockBackend *mock_api.MockBackend, fnEstimate
 	}
 	mockBackend.EXPECT().ChainConfig().Return(chainConfig).AnyTimes()
 	mockBackend.EXPECT().RPCGasCap().Return(common.Big0).AnyTimes()
+	mockBackend.EXPECT().RPCEVMTimeout().Return(5 * time.Second).AnyTimes()
 	mockBackend.EXPECT().StateAndHeaderByNumber(any, any).DoAndReturn(getStateAndHeader).AnyTimes()
 	mockBackend.EXPECT().StateAndHeaderByNumberOrHash(any, any).DoAndReturn(getStateAndHeader).AnyTimes()
 	mockBackend.EXPECT().GetEVM(any, any, any, any, any).DoAndReturn(getEVM).AnyTimes()

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -428,7 +428,7 @@ func (s *PublicBlockChainAPI) DoEstimateGas(ctx context.Context, b Backend, args
 	// Create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (bool, *blockchain.ExecutionResult, error) {
 		args.Gas = hexutil.Uint64(gas)
-		result, _, err := DoCall(ctx, b, args, rpc.NewBlockNumberOrHashWithNumber(rpc.LatestBlockNumber), vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite}, 0, gasCap)
+		result, _, err := DoCall(ctx, b, args, rpc.NewBlockNumberOrHashWithNumber(rpc.LatestBlockNumber), vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite}, s.b.RPCEVMTimeout(), gasCap)
 		if err != nil {
 			if errors.Is(err, blockchain.ErrIntrinsicGas) {
 				return true, nil, nil // Special case, raise gas limit

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -382,7 +382,7 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 	if rpcGasCap := s.b.RPCGasCap(); rpcGasCap != nil {
 		gasCap = rpcGasCap
 	}
-	result, _, err := DoCall(ctx, s.b, args, blockNrOrHash, vm.Config{}, s.b.RPCEVMTimeout(), gasCap)
+	result, _, err := DoCall(ctx, s.b, args, blockNrOrHash, vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite}, s.b.RPCEVMTimeout(), gasCap)
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +398,7 @@ func (s *PublicBlockChainAPI) EstimateComputationCost(ctx context.Context, args 
 	if rpcGasCap := s.b.RPCGasCap(); rpcGasCap != nil {
 		gasCap = rpcGasCap
 	}
-	_, computationCost, err := DoCall(ctx, s.b, args, blockNrOrHash, vm.Config{}, s.b.RPCEVMTimeout(), gasCap)
+	_, computationCost, err := DoCall(ctx, s.b, args, blockNrOrHash, vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite}, s.b.RPCEVMTimeout(), gasCap)
 	return (hexutil.Uint64)(computationCost), err
 }
 
@@ -428,7 +428,7 @@ func (s *PublicBlockChainAPI) DoEstimateGas(ctx context.Context, b Backend, args
 	// Create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (bool, *blockchain.ExecutionResult, error) {
 		args.Gas = hexutil.Uint64(gas)
-		result, _, err := DoCall(ctx, b, args, rpc.NewBlockNumberOrHashWithNumber(rpc.LatestBlockNumber), vm.Config{}, 0, gasCap)
+		result, _, err := DoCall(ctx, b, args, rpc.NewBlockNumberOrHashWithNumber(rpc.LatestBlockNumber), vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite}, 0, gasCap)
 		if err != nil {
 			if errors.Is(err, blockchain.ErrIntrinsicGas) {
 				return true, nil, nil // Special case, raise gas limit

--- a/api/backend.go
+++ b/api/backend.go
@@ -54,9 +54,9 @@ type Backend interface {
 	ChainDB() database.DBManager
 	EventMux() *event.TypeMux
 	AccountManager() accounts.AccountManager
-	RPCEVMTimeout() time.Duration // global timeout for klay_call
-	RPCGasCap() *big.Int          // global gas cap for klay_call over rpc: DoS protection
-	RPCTxFeeCap() float64         // global tx fee cap for all transaction related APIs
+	RPCEVMTimeout() time.Duration // global timeout for eth/klay_call/estimateGas/estimateComputationCost
+	RPCGasCap() *big.Int          // global gas cap for eth/klay_call/estimateGas/estimateComputationCost
+	RPCTxFeeCap() float64         // global tx fee cap in eth_signTransaction
 	Engine() consensus.Engine
 	FeeHistory(ctx context.Context, blockCount int, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error)
 

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -123,7 +123,7 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 		cfg.JumpTable = jt
 	}
 
-	// Enable the opcode computation cost limit
+	// Set the opcode computation cost limit by the default value
 	if cfg.ComputationCostLimit == 0 {
 		switch {
 		case evm.chainRules.IsCancun:
@@ -131,11 +131,10 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 		default:
 			cfg.ComputationCostLimit = uint64(params.OpcodeComputationCostLimit)
 		}
-	}
-
-	// It is an experimental feature.
-	if params.OpcodeComputationCostLimitOverride != 0 {
-		cfg.ComputationCostLimit = params.OpcodeComputationCostLimitOverride
+		// It is an experimental feature.
+		if params.OpcodeComputationCostLimitOverride != 0 {
+			cfg.ComputationCostLimit = params.OpcodeComputationCostLimitOverride
+		}
 	}
 
 	return &EVMInterpreter{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -830,21 +830,21 @@ var (
 	}
 	RPCGlobalGasCap = &cli.Uint64Flag{
 		Name:     "rpc.gascap",
-		Usage:    "Sets a cap on gas that can be used in klay_call/estimateGas",
+		Usage:    "Sets a cap on gas in {eth,klay}_{call,estimateGas,estimateComputationCost} (0 = no cap)",
 		Aliases:  []string{"http-rpc.gascap"},
 		EnvVars:  []string{"KLAYTN_RPC_GASCAP"},
 		Category: "API AND CONSOLE",
 	}
 	RPCGlobalEVMTimeoutFlag = &cli.DurationFlag{
 		Name:     "rpc.evmtimeout",
-		Usage:    "Sets a timeout used for eth_call (0=infinite)",
+		Usage:    "Sets a timeout in {eth,klay}_{call,estimateGas,estimateComputationCost}. (0 = apply http-rpc.execution.timeout)",
 		Aliases:  []string{"http-rpc.evmtimeout"},
 		EnvVars:  []string{"KLAYTN_RPC_EVMTIMEOUT"},
 		Category: "API AND CONSOLE",
 	}
 	RPCGlobalEthTxFeeCapFlag = &cli.Float64Flag{
 		Name:     "rpc.ethtxfeecap",
-		Usage:    "Sets a cap on transaction fee (in klay) that can be sent via the eth namespace RPC APIs (0 = no cap)",
+		Usage:    "Sets a cap on transaction fee (=gasLimit*gasPrice) (in klay) in eth_signTransaction (0 = no cap)",
 		Aliases:  []string{"http-rpc.eth-tx-feecap"},
 		EnvVars:  []string{"KLAYTN_RPC_ETHTXFEECAP"},
 		Category: "API AND CONSOLE",


### PR DESCRIPTION
## Proposed changes

- Lift computation cost limit at klay_call, klay_estimateGas, klay_estimateComputationCost, eth_call, eth_estimateGas.
- No need to use experimental computation cost flag (`--opcode-computation-cost-limit`) as an attempt to bypass the cost limit. The limit is always infinite in such APIs.

- Computation cost limit after this PR:
  - block syncing & other APIs: Use hard-coded limit (`params.OpcodeComputationCostLimit`).
  - block syncing & other APIs, with `--opcode-computation-cost-limit`: Use the specified number
  - call/estimate APIs: always infinite

```
> eth.estimateGas({"to":"0xE46888D56CfE7804d045aDcdaFEc548E0329c965", "data": "0x53ae5a540000000000000000000000000000000000000000000000000000000000013e00"})
27873306
> klay.estimateComputationCost({"to":"0xE46888D56CfE7804d045aDcdaFEc548E0329c965", "data": "0x53ae5a540000000000000000000000000000000000000000000000000000000000013e00"})
"0x37574e27"
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/klaytn/klaytn/issues/2081
- https://github.com/klaytn/klaytn/issues/2083

## Further comments
- Reimpose the evmtimeout on the estimateGas api and it was once erased in #1408.
