### PR TITLE
[API] Show computation costs to StructLog transaction trace

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -473,19 +473,21 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 // StructLogRes stores a structured log emitted by the EVM while replaying a
 // transaction in debug mode
 type StructLogRes struct {
-	Pc      uint64             `json:"pc"`
-	Op      string             `json:"op"`
-	Gas     uint64             `json:"gas"`
-	GasCost uint64             `json:"gasCost"`
-	Depth   int                `json:"depth"`
-	Error   error              `json:"error,omitempty"`
-	Stack   *[]string          `json:"stack,omitempty"`
-	Memory  *[]string          `json:"memory,omitempty"`
-	Storage *map[string]string `json:"storage,omitempty"`
+	Pc                   uint64             `json:"pc"`
+	Op                   string             `json:"op"`
+	Gas                  uint64             `json:"gas"`
+	GasCost              uint64             `json:"gasCost"`
+	Depth                int                `json:"depth"`
+	Error                error              `json:"error,omitempty"`
+	Stack                *[]string          `json:"stack,omitempty"`
+	Memory               *[]string          `json:"memory,omitempty"`
+	Storage              *map[string]string `json:"storage,omitempty"`
+	ComputationCostTotal uint64             `json:"computationCostTotal"`
+	ComputationCostUsed  uint64             `json:"computationCostUsed"`
 }
 
 // formatLogs formats EVM returned structured logs for json output
-func FormatLogs(timeout time.Duration, logs []vm.StructLog) ([]StructLogRes, error) {
+func FormatLogs(timeout time.Duration, logs []vm.StructLog, cc uint64) ([]StructLogRes, error) {
 	logTimeout := false
 	deadlineCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	go func() {
@@ -501,12 +503,14 @@ func FormatLogs(timeout time.Duration, logs []vm.StructLog) ([]StructLogRes, err
 			return nil, fmt.Errorf("trace logger timeout")
 		}
 		formatted[index] = StructLogRes{
-			Pc:      trace.Pc,
-			Op:      trace.Op.String(),
-			Gas:     trace.Gas,
-			GasCost: trace.GasCost,
-			Depth:   trace.Depth,
-			Error:   trace.Err,
+			Pc:                   trace.Pc,
+			Op:                   trace.Op.String(),
+			Gas:                  trace.Gas,
+			GasCost:              trace.GasCost,
+			Depth:                trace.Depth,
+			Error:                trace.Err,
+			ComputationCostTotal: cc,
+			ComputationCostUsed:  trace.ComputationCostUsed,
 		}
 		if trace.Stack != nil {
 			stack := make([]string, len(trace.Stack))

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -473,17 +473,17 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 // StructLogRes stores a structured log emitted by the EVM while replaying a
 // transaction in debug mode
 type StructLogRes struct {
-	Pc                   uint64             `json:"pc"`
-	Op                   string             `json:"op"`
-	Gas                  uint64             `json:"gas"`
-	GasCost              uint64             `json:"gasCost"`
-	Depth                int                `json:"depth"`
-	Error                error              `json:"error,omitempty"`
-	Stack                *[]string          `json:"stack,omitempty"`
-	Memory               *[]string          `json:"memory,omitempty"`
-	Storage              *map[string]string `json:"storage,omitempty"`
-	ComputationCostTotal uint64             `json:"computationCostTotal"`
-	ComputationCostUsed  uint64             `json:"computationCostUsed"`
+	Pc              uint64             `json:"pc"`
+	Op              string             `json:"op"`
+	Gas             uint64             `json:"gas"`
+	GasCost         uint64             `json:"gasCost"`
+	Depth           int                `json:"depth"`
+	Error           error              `json:"error,omitempty"`
+	Stack           *[]string          `json:"stack,omitempty"`
+	Memory          *[]string          `json:"memory,omitempty"`
+	Storage         *map[string]string `json:"storage,omitempty"`
+	Computation     uint64             `json:"computation"`
+	ComputationCost uint64             `json:"computationCost"`
 }
 
 // formatLogs formats EVM returned structured logs for json output
@@ -503,14 +503,14 @@ func FormatLogs(timeout time.Duration, logs []vm.StructLog, cc uint64) ([]Struct
 			return nil, fmt.Errorf("trace logger timeout")
 		}
 		formatted[index] = StructLogRes{
-			Pc:                   trace.Pc,
-			Op:                   trace.Op.String(),
-			Gas:                  trace.Gas,
-			GasCost:              trace.GasCost,
-			Depth:                trace.Depth,
-			Error:                trace.Err,
-			ComputationCostTotal: cc,
-			ComputationCostUsed:  trace.ComputationCostUsed,
+			Pc:              trace.Pc,
+			Op:              trace.Op.String(),
+			Gas:             trace.Gas,
+			GasCost:         trace.GasCost,
+			Depth:           trace.Depth,
+			Error:           trace.Err,
+			Computation:     trace.Computation,
+			ComputationCost: trace.ComputationCost,
 		}
 		if trace.Stack != nil {
 			stack := make([]string, len(trace.Stack))

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -487,7 +487,7 @@ type StructLogRes struct {
 }
 
 // formatLogs formats EVM returned structured logs for json output
-func FormatLogs(timeout time.Duration, logs []vm.StructLog, cc uint64) ([]StructLogRes, error) {
+func FormatLogs(timeout time.Duration, logs []vm.StructLog) ([]StructLogRes, error) {
 	logTimeout := false
 	deadlineCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	go func() {

--- a/blockchain/vm/logger.go
+++ b/blockchain/vm/logger.go
@@ -69,7 +69,7 @@ type StructLog struct {
 	Storage         map[common.Hash]common.Hash `json:"-"`
 	Depth           int                         `json:"depth"`
 	RefundCounter   uint64                      `json:"refund"`
-	Computation     uint64                      `json:"computation`
+	Computation     uint64                      `json:"computation"`
 	ComputationCost uint64                      `json:"computationCost"`
 	Err             error                       `json:"-"`
 }

--- a/blockchain/vm/logger.go
+++ b/blockchain/vm/logger.go
@@ -59,18 +59,19 @@ type LogConfig struct {
 // StructLog is emitted to the EVM each cycle and lists information about the current internal state
 // prior to the execution of the statement.
 type StructLog struct {
-	Pc                  uint64                      `json:"pc"`
-	Op                  OpCode                      `json:"op"`
-	Gas                 uint64                      `json:"gas"`
-	GasCost             uint64                      `json:"gasCost"`
-	Memory              []byte                      `json:"memory"`
-	MemorySize          int                         `json:"memSize"`
-	Stack               []*big.Int                  `json:"stack"`
-	Storage             map[common.Hash]common.Hash `json:"-"`
-	Depth               int                         `json:"depth"`
-	RefundCounter       uint64                      `json:"refund"`
-	Err                 error                       `json:"-"`
-	ComputationCostUsed uint64                      `json:"computationCostUsed"`
+	Pc              uint64                      `json:"pc"`
+	Op              OpCode                      `json:"op"`
+	Gas             uint64                      `json:"gas"`
+	GasCost         uint64                      `json:"gasCost"`
+	Memory          []byte                      `json:"memory"`
+	MemorySize      int                         `json:"memSize"`
+	Stack           []*big.Int                  `json:"stack"`
+	Storage         map[common.Hash]common.Hash `json:"-"`
+	Depth           int                         `json:"depth"`
+	RefundCounter   uint64                      `json:"refund"`
+	Computation     uint64                      `json:"computation`
+	ComputationCost uint64                      `json:"computationCost"`
+	Err             error                       `json:"-"`
 }
 
 // overrides for gencodec
@@ -192,7 +193,11 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 		storage = l.changedValues[contract.Address()].Copy()
 	}
 	// create a new snapshot of the EVM.
-	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), err, env.GetOpCodeComputationCost()}
+	var (
+		availableCC = env.Config.ComputationCostLimit - env.opcodeComputationCostSum
+		opcodeCC    = env.interpreter.cfg.JumpTable[op].computationCost
+	)
+	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), availableCC, opcodeCC, err}
 
 	l.logs = append(l.logs, log)
 }

--- a/blockchain/vm/logger.go
+++ b/blockchain/vm/logger.go
@@ -70,7 +70,7 @@ type StructLog struct {
 	Depth               int                         `json:"depth"`
 	RefundCounter       uint64                      `json:"refund"`
 	Err                 error                       `json:"-"`
-	ComputationCostUsed uint64                      `json:computationCostUsed`
+	ComputationCostUsed uint64                      `json:"computationCostUsed"`
 }
 
 // overrides for gencodec

--- a/blockchain/vm/logger.go
+++ b/blockchain/vm/logger.go
@@ -59,17 +59,18 @@ type LogConfig struct {
 // StructLog is emitted to the EVM each cycle and lists information about the current internal state
 // prior to the execution of the statement.
 type StructLog struct {
-	Pc            uint64                      `json:"pc"`
-	Op            OpCode                      `json:"op"`
-	Gas           uint64                      `json:"gas"`
-	GasCost       uint64                      `json:"gasCost"`
-	Memory        []byte                      `json:"memory"`
-	MemorySize    int                         `json:"memSize"`
-	Stack         []*big.Int                  `json:"stack"`
-	Storage       map[common.Hash]common.Hash `json:"-"`
-	Depth         int                         `json:"depth"`
-	RefundCounter uint64                      `json:"refund"`
-	Err           error                       `json:"-"`
+	Pc                  uint64                      `json:"pc"`
+	Op                  OpCode                      `json:"op"`
+	Gas                 uint64                      `json:"gas"`
+	GasCost             uint64                      `json:"gasCost"`
+	Memory              []byte                      `json:"memory"`
+	MemorySize          int                         `json:"memSize"`
+	Stack               []*big.Int                  `json:"stack"`
+	Storage             map[common.Hash]common.Hash `json:"-"`
+	Depth               int                         `json:"depth"`
+	RefundCounter       uint64                      `json:"refund"`
+	Err                 error                       `json:"-"`
+	ComputationCostUsed uint64                      `json:computationCostUsed`
 }
 
 // overrides for gencodec
@@ -191,7 +192,7 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 		storage = l.changedValues[contract.Address()].Copy()
 	}
 	// create a new snapshot of the EVM.
-	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), err}
+	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), err, env.GetOpCodeComputationCost()}
 
 	l.logs = append(l.logs, log)
 }

--- a/blockchain/vm/logger.go
+++ b/blockchain/vm/logger.go
@@ -194,10 +194,10 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 	}
 	// create a new snapshot of the EVM.
 	var (
-		availableCC = env.Config.ComputationCostLimit - env.opcodeComputationCostSum
-		opcodeCC    = env.interpreter.cfg.JumpTable[op].computationCost
+		remainingComputationCost = env.Config.ComputationCostLimit - env.opcodeComputationCostSum
+		opcodeComputationCost    = env.interpreter.cfg.JumpTable[op].computationCost
 	)
-	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), availableCC, opcodeCC, err}
+	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), remainingComputationCost, opcodeComputationCost, err}
 
 	l.logs = append(l.logs, log)
 }

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -948,7 +948,7 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 				return nil, err
 			}
 		}
-		if logs, err := klaytnapi.FormatLogs(loggerTimeout, tracer.StructLogs(), vmenv.Config.ComputationCostLimit); err == nil {
+		if logs, err := klaytnapi.FormatLogs(loggerTimeout, tracer.StructLogs()); err == nil {
 			return &klaytnapi.ExecutionResult{
 				Gas:         ret.UsedGas,
 				Failed:      ret.Failed(),

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -948,7 +948,7 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 				return nil, err
 			}
 		}
-		if logs, err := klaytnapi.FormatLogs(loggerTimeout, tracer.StructLogs()); err == nil {
+		if logs, err := klaytnapi.FormatLogs(loggerTimeout, tracer.StructLogs(), vmenv.Config.ComputationCostLimit); err == nil {
 			return &klaytnapi.ExecutionResult{
 				Gas:         ret.UsedGas,
 				Failed:      ret.Failed(),


### PR DESCRIPTION
## Proposed changes

Added two fields, `computationCostTotal` and `computationCostUsed` in `debug.trace*` APIs.

```
> debug.traceTransaction("0x58c1096e91560a0aae81332241168d1515729d29098e6899dcb22804ef1635a9")
{
  failed: false,
  gas: 21546,
  returnValue: "000000000000000000000000000000000000000000000000000000000000007b",
  structLogs: [{
      computationCostTotal: 150000000,
      computationCostUsed: 120,
      gas: 146,
      gasCost: 3,
      ...
  }, {
      computationCostTotal: 150000000,
      computationCostUsed: 310,
      gas: 143,
      gasCost: 3,
      memory: [],
      op: "DUP1",
      ...
  }, 
  ...
```


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
