### PR TITLE
VerifyRandao returns proper error when parent state is unavailable

### DIFF
--- a/consensus/istanbul/backend/randao.go
+++ b/consensus/istanbul/backend/randao.go
@@ -15,6 +15,7 @@ import (
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/crypto/bls"
 	"github.com/klaytn/klaytn/params"
+	"github.com/klaytn/klaytn/storage/statedb"
 )
 
 // For testing without KIP-113 contract setup
@@ -80,7 +81,13 @@ func (p *ChainBlsPubkeyProvider) getAllCached(chain consensus.ChainReader, num *
 		var err error
 		kip113Addr, err = system.ReadActiveAddressFromRegistry(backend, system.Kip113Name, parentNum)
 		if err != nil {
-			return nil, err
+			if _, ok := err.(*statedb.MissingNodeError); ok {
+				parentNum = nil
+				kip113Addr, err = system.ReadActiveAddressFromRegistry(backend, system.Kip113Name, parentNum)
+				if err != nil {
+					return nil, err
+				}
+			}
 		}
 	} else {
 		return nil, errors.New("Cannot read KIP113 address from registry before Randao fork")

--- a/consensus/istanbul/backend/randao.go
+++ b/consensus/istanbul/backend/randao.go
@@ -83,7 +83,7 @@ func (p *ChainBlsPubkeyProvider) getAllCached(chain consensus.ChainReader, num *
 		if pHeader == nil {
 			return nil, consensus.ErrUnknownAncestor
 		}
-		_, err := chain.StateAt(pHeader.Hash())
+		_, err := chain.StateAt(pHeader.Root)
 		if err != nil {
 			return nil, consensus.ErrPrunedAncestor
 		}


### PR DESCRIPTION
## Proposed changes

Make `VerifyRandao()` return an appropriate error when the parent block state is not found.

Currently, the `VerifyRandao()` may return a "missing trie node" error when the parent state is not found. Specifically, the error may be triggered after a rewinding by `debug_setHead`, leading to downloader requests for older blocks lacking the required state. As these blocks undergo verification, they reach `VerifyRandao()`, but in full mode node the parent states are not stored, thereby throwing the "missing trie node" error.

The parent state is needed to determine the proposer's BLS public key, which is then used to verify the `randomReveal` field.

If the parent state is not found, `VerifyHeader()` now returns a `consensus.ErrPrunedAncestor` error so that `BlockChain.InsertChain` can take state regeneration path in https://github.com/klaytn/klaytn/blob/v1.12.0/blockchain/blockchain.go#L1992-L2017.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
