### PR TITLE
[API] Fix CALL gas cost in debug traces

### DIFF
--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -297,11 +297,10 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 					args := mem.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
 					// TODO: Takes a second return value (computation cost) and makes visible in capture state
 					precompiledGasCost, _ := p.GetRequiredGasAndComputationCost(args)
-					in.cfg.Tracer.CaptureState(in.evm, pc, op, gasCopy, cost-dynamicCost+precompiledGasCost, callContext, in.evm.depth, err)
+					cost = cost - dynamicCost + precompiledGasCost
 				}
-			} else {
-				in.cfg.Tracer.CaptureState(in.evm, pc, op, gasCopy, cost, callContext, in.evm.depth, err)
 			}
+			in.cfg.Tracer.CaptureState(in.evm, pc, op, gasCopy, cost, callContext, in.evm.depth, err)
 			logged = true
 		}
 

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -295,7 +295,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 				//    this portion is stored in evm.callGasTemp (see gasCall*()).
 				//
 				// In the debug traces, we want to show deterministic components 1 and 2. So we subtract 3 from `cost`.
-				cost -= in.evm.callGasTemp
 				// If the toAddr is a precompile, add the precompile's gas cost and computation cost in the debug trace.
 				// TODO: Add the precompile's computation cost and feed into CaptureState
 				var (
@@ -312,7 +311,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 					}
 					input := mem.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
 					precompileGas, _ := p.GetRequiredGasAndComputationCost(input)
-					cost += precompileGas
+					cost += precompileGas - in.evm.callGasTemp
 				}
 			}
 			in.cfg.Tracer.CaptureState(in.evm, pc, op, gasCopy, cost, callContext, in.evm.depth, err)

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -271,8 +271,8 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 		// Dynamic portion of gas
 		// consume the gas and return an error if not enough gas is available.
 		// cost is explicitly set so that the capture state defer method can get the proper cost
-		var dynamicCost uint64 = 0
 		if operation.dynamicGas != nil {
+			var dynamicCost uint64
 			dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
 			cost += dynamicCost // total cost, for debug tracing
 			if err != nil || !contract.UseGas(dynamicCost) {


### PR DESCRIPTION
## Proposed changes

This PR deals with the two problems.
1. In the debug traces, the `gasCost` property of `*CALL` opcodes is sometimes inappropriately large.
2. In the debug traces, the `gasCost` property does not include precompiled contract costs.

This PR does not interfere with transaction gas metering. It only deals with debug traces.

```json
    {
      "pc": 628,
      "op": "CALL",
      "gas": 9999974784,
      "gasCost": 9843725180, // includes the gas available to the callee
      "depth": 1,
    },
    {
      "pc": 0,
      "op": "PUSH1",
      "gas": 9843725080,
      "gasCost": 3,
      "depth": 2,
    },
```

### gasCost too large

The problem arises from the multi-modal structure of `*CALL` opcode gas cost.
1. The constant opcode cost (e.g. 100)
2. Not-refunded dynamic costs. Memory expansion (memoryGasCost), account creation (CallNewAccountGas), value transfer (CallValueTransferGas). See https://github.com/klaytn/klaytn/blob/v1.12.0/blockchain/vm/gas_table.go#L312-L331
3. Refundable dynamic costs. The gas available to the callee. After the call returns, the remaining gas is refunded to the caller. See https://github.com/klaytn/klaytn/blob/v1.12.0/blockchain/vm/gas_table.go#L333-L336 and [EIP-150](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md).

Because part 3 is usually 63/64 of the remaining gas, the `gasCost` property is very big number. However, in most cases, part 3 is mostly refunded. In debug traces, it's more helpful to show the actual cost, or close to actual cost not the maximum possible cost. This PR subtracts part 3 (conveniently stored in `evm.callGasTemp`) before adding a debug trace.

### precompile costs not included

The precompiled contracts incur their own gas costs on top of `*CALL` costs. In regular contract calls, the callee's operation is visible in traces so we can know which operation took much gas. But in precompile calls, the gas cost is invisible in debug traces. This PR adds the precompile gas cost in the `gasCost` of the `*CALL` opcodes.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

The Klaytn console may not correctly print big integers (usually happens with `debug.traceCall` where gasLimit is 2^63 by default). (#2098)

The computation costs for precompiles are not accounted to debug traces (#2097)

## Further comments

Examples using [hardhat-utils](https://github.com/klaytn/hardhat-utils)
- Calling another contract
  - Note
    - CALL opcode costs 100 (post-EIP-2929)
    - Gas available to caller 9843725080 = (9999974784 - 100) * 63/64
  - Before PR
	```
	  pc    opcode              gasCost    gasLeft     ccCost     ccLeft
	  00626 POP                       2 9999974788        140  149917064
	  00627 GAS                       2 9999974786        230  149916834
	  00628 CALL             9843725180 9999974784       5000  149911834
	    00000 PUSH1                     3 9843725080        120  149911714
	    00002 PUSH1                     3 9843725077        120  149911594
	```
  - After PR
	```
	  00626 POP                       2 9999974788        140  149917064
	  00627 GAS                       2 9999974786        230  149916834
	  00628 CALL                    100 9999974784       5000  149911834
	    00000 PUSH1                     3 9843725080        120  149911714
	    00002 PUSH1                     3 9843725077        120  149911594
	```
- Calling precompile
  - Note
    - STATICCALL opcode costs 100 (post-EIP-2929)
    - sha256 precompile costs 72 (for 32-byte input)
  - Before PR
	```
	  pc    opcode              gasCost    gasLeft     ccCost     ccLeft
	  00473 DUP6                      3 9999977928        165  149968494
	  00474 GAS                       2 9999977925        230  149968264
	  00475 STATICCALL       9843728270 9999977923      10000  149958264
	  00476 ISZERO                    3 9999977751        165  149956999
	  00477 DUP1                      3 9999977748        190  149956809
	```
  - After PR
	```
	  00473 DUP6                      3 9999977928        165  149968494
	  00474 GAS                       2 9999977925        230  149968264
	  00475 STATICCALL              172 9999977923      10000  149958264
	  00476 ISZERO                    3 9999977751        165  149956999
	  00477 DUP1                      3 9999977748        190  149956809
	```