### PR TITLE
Homi has new flag *nodekey-dir

### DIFF
--- a/cmd/homi/common/utils.go
+++ b/cmd/homi/common/utils.go
@@ -148,6 +148,39 @@ func GenerateKip113Init(privKeys []*ecdsa.PrivateKey, owner common.Address) syst
 	return init
 }
 
+func LoadNodekey(dir string) (keys []*ecdsa.PrivateKey, nodekeys []string, addrs []common.Address) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		logger.Error("Failed to read directory", "dir", dir, "err", err)
+		return nil, nil, nil
+	}
+
+	// files are sorted by filename
+	for _, file := range files {
+		fn := file.Name()
+		if strings.HasPrefix(fn, "nodekey") {
+			b, err := os.ReadFile(filepath.Join(dir, fn))
+			if err != nil {
+				logger.Error("Failed to load key", "file", fn, "err", err)
+				return nil, nil, nil
+			}
+			nodekey := string(b)
+			nodekeys = append(nodekeys, nodekey)
+			key, err := crypto.HexToECDSA(nodekey)
+			if err != nil {
+				logger.Error("Failed to generate key", "err", err)
+				return nil, nil, nil
+			}
+			keys = append(keys, key)
+
+			addr := crypto.PubkeyToAddress(key.PublicKey)
+			addrs = append(addrs, addr)
+		}
+	}
+
+	return keys, nodekeys, addrs
+}
+
 func RandomHex() string {
 	b, _ := RandomBytes(32)
 	return common.BytesToHash(b).Hex()

--- a/cmd/homi/common/utils.go
+++ b/cmd/homi/common/utils.go
@@ -166,6 +166,7 @@ func LoadNodekey(dir string) (keys []*ecdsa.PrivateKey, nodekeys []string, addrs
 			}
 			nodekey := string(b)
 			nodekeys = append(nodekeys, nodekey)
+
 			key, err := crypto.HexToECDSA(nodekey)
 			if err != nil {
 				logger.Error("Failed to generate key", "err", err)

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -78,8 +78,8 @@ var HomiFlags = []cli.Flag{
 	altsrc.NewIntFlag(numOfSPNsFlag),
 	altsrc.NewIntFlag(numOfSENsFlag),
 	altsrc.NewIntFlag(numOfTestKeyFlag),
-	altsrc.NewStringFlag(mnemonic),
-	altsrc.NewStringFlag(mnemonicPath),
+	altsrc.NewStringFlag(mnemonicFlag),
+	altsrc.NewStringFlag(mnemonicPathFlag),
 	altsrc.NewStringFlag(cnNodeKeyDirFlag),
 	altsrc.NewStringFlag(pnNodeKeyDirFlag),
 	altsrc.NewStringFlag(enNodeKeyDirFlag),
@@ -707,14 +707,14 @@ func Gen(ctx *cli.Context) error {
 	if len(ctx.String(cnNodeKeyDirFlag.Name)) > 0 {
 		keydir := ctx.String(cnNodeKeyDirFlag.Name)
 		privKeys, nodeKeys, nodeAddrs = istcommon.LoadNodekey(keydir)
-	} else if len(ctx.String(mnemonic.Name)) > 0 {
-		mnemonic := ctx.String(mnemonic.Name)
+	} else if len(ctx.String(mnemonicFlag.Name)) > 0 {
+		mnemonic := ctx.String(mnemonicFlag.Name)
 		mnemonic = strings.ReplaceAll(mnemonic, ",", " ")
 		// common keys used by web3 tools such as hardhat, foundry, etc.
 		if mnemonic == "test junk" {
 			mnemonic = "test test test test test test test test test test test junk"
 		}
-		path := strings.ToLower(ctx.String(mnemonicPath.Name))
+		path := strings.ToLower(ctx.String(mnemonicPathFlag.Name))
 		if !strings.HasPrefix(path, "m") {
 			switch path {
 			case "klay":

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -706,8 +706,8 @@ func Gen(ctx *cli.Context) error {
 
 	if keydir := ctx.String(cnNodeKeyDirFlag.Name); len(keydir) > 0 {
 		privKeys, nodeKeys, nodeAddrs = istcommon.LoadNodekey(keydir)
-		if len(nodeKeys) != numValidators {
-			log.Fatalf("The number of nodekey files (%d) does not match the given CN num (%d)", len(nodeKeys), numValidators)
+		if len(nodeKeys) != cnNum {
+			log.Fatalf("The number of nodekey files (%d) does not match the given CN num (%d)", len(nodeKeys), cnNum)
 		}
 	} else if mnemonic := ctx.String(mnemonicFlag.Name); len(mnemonic) > 0 {
 		mnemonic = strings.ReplaceAll(mnemonic, ",", " ")

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -706,6 +706,9 @@ func Gen(ctx *cli.Context) error {
 
 	if keydir := ctx.String(cnNodeKeyDirFlag.Name); len(keydir) > 0 {
 		privKeys, nodeKeys, nodeAddrs = istcommon.LoadNodekey(keydir)
+		if len(nodeKeys) != numValidators {
+			log.Fatalf("The number of nodekey files (%d) does not match the given CN num (%d)", len(nodeKeys), numValidators)
+		}
 	} else if mnemonic := ctx.String(mnemonicFlag.Name); len(mnemonic) > 0 {
 		mnemonic = strings.ReplaceAll(mnemonic, ",", " ")
 		// common keys used by web3 tools such as hardhat, foundry, etc.

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -704,11 +704,9 @@ func Gen(ctx *cli.Context) error {
 		nodeAddrs []common.Address
 	)
 
-	if len(ctx.String(cnNodeKeyDirFlag.Name)) > 0 {
-		keydir := ctx.String(cnNodeKeyDirFlag.Name)
+	if keydir := ctx.String(cnNodeKeyDirFlag.Name); len(keydir) > 0 {
 		privKeys, nodeKeys, nodeAddrs = istcommon.LoadNodekey(keydir)
-	} else if len(ctx.String(mnemonicFlag.Name)) > 0 {
-		mnemonic := ctx.String(mnemonicFlag.Name)
+	} else if mnemonic := ctx.String(mnemonicFlag.Name); len(mnemonic) > 0 {
 		mnemonic = strings.ReplaceAll(mnemonic, ",", " ")
 		// common keys used by web3 tools such as hardhat, foundry, etc.
 		if mnemonic == "test junk" {

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -131,13 +131,14 @@ var (
 		Usage:   "Set the type of genesis.json to generate (cypress-test, cypress, baobab-test, baobab, clique, servicechain, servicechain-test, istanbul)",
 		Aliases: []string{"genesis.type"},
 	}
-	mnemonic = &cli.StringFlag{
+
+	mnemonicFlag = &cli.StringFlag{
 		Name:  "mnemonic",
 		Usage: "Use given mnemonic to derive node keys",
 		Value: "",
 	}
 
-	mnemonicPath = &cli.StringFlag{
+	mnemonicPathFlag = &cli.StringFlag{
 		Name:  "mnemonic-path",
 		Usage: "Use given path/coin to derive node keys (format: m/44'/60'/0'/0/). Effective only if --mnemonic is given",
 		Value: "eth",

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -143,6 +143,24 @@ var (
 		Value: "eth",
 	}
 
+	cnNodeKeyDirFlag = &cli.StringFlag{
+		Name:  "cn-nodekey-dir",
+		Usage: "CN nodekey dir containing nodekey*",
+		Value: "",
+	}
+
+	pnNodeKeyDirFlag = &cli.StringFlag{
+		Name:  "pn-nodekey-dir",
+		Usage: "PN nodekey dir containing nodekey*",
+		Value: "",
+	}
+
+	enNodeKeyDirFlag = &cli.StringFlag{
+		Name:  "en-nodekey-dir",
+		Usage: "EN nodekey dir containing nodekey*",
+		Value: "",
+	}
+
 	chainIDFlag = &cli.Uint64Flag{
 		Name:    "chainID",
 		Usage:   "ChainID",


### PR DESCRIPTION
## Proposed changes

New flags `{c,p,e}n-nodekey-dir` has been added to `homi`. See further comments for a sample input.
With the flags, `homi` uses the given keys for nodes instead of generating random keys.

Priority for CN keys: `cn-nodekey-dir` > `mnemonic` > randomly generated nodekeys
Priority for PN,EN keys: `{p,e}n-nodekey-dir` > randomly generated nodekeys
(fyi, see `mnemonic` flag from #1813)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules



## Further comments

How to test:

1. Create keys

```bash
#!/bin/bash
NUM_CN=1
NUM_PN=2
NUM_EN=4

mkdir -p keys
for i in $(seq 1 $NUM_CN); do
    xxd -l 32 -c 32 -p /dev/urandom | tr -d '\n' > keys/nodekey$i
done

mkdir -p keys_pn
for i in $(seq 1 $NUM_PN); do
    xxd -l 32 -c 32 -p /dev/urandom | tr -d '\n' > keys_pn/nodekey$i
done

mkdir -p keys_en
for i in $(seq 1 $NUM_EN); do
    xxd -l 32 -c 32 -p /dev/urandom | tr -d '\n' > keys_en/nodekey$i
done
```

2. Run homi
```bash
homi --cn-num 1 --pn-num 2 --en-num 4 --cn-nodekey-dir keys/ --pn-nodekey-dir keys_pn/ --en-nodekey-dir keys_en/ docker
```

3. Run network
```bash
cd homi-output
docker compose up
```