### PR TITLE
[API] Adjust gasLimit value when not specified

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -691,7 +691,7 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 	// Set default gas & gas price if none were set
 	gas := globalGasCap
 	if gas == 0 {
-		gas = uint64(math.MaxUint64 / 2)
+		gas = JS_SAFE_MAX_INTEGER
 	}
 	if args.Gas != 0 {
 		gas = uint64(args.Gas)

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -691,7 +691,7 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 	// Set default gas & gas price if none were set
 	gas := globalGasCap
 	if gas == 0 {
-		gas = JS_SAFE_MAX_INTEGER
+		gas = params.UpperGasLimit
 	}
 	if args.Gas != 0 {
 		gas = uint64(args.Gas)

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -47,10 +47,6 @@ var (
 	errTxArgNilGas           = errors.New("gas limit is not set")
 	errTxArgNilGasPrice      = errors.New("gas price is not set")
 	errNotForFeeDelegationTx = errors.New("fee-delegation type transactions are not allowed to use this API")
-
-	// Javascript console can express integer at maximum, `Number.JS_SAFE_MAX_INTEGER`, where
-	// Number.MAX_SAFE_INTEGER(2**53 - 1) = 9007199254740991
-	JS_SAFE_MAX_INTEGER = uint64(9000000000000000)
 )
 
 // isTxField checks whether the string is a field name of the specific txType.
@@ -734,7 +730,7 @@ func (args *EthTransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int,
 	// Set default gas & gas price if none were set
 	gas := globalGasCap
 	if gas == 0 {
-		gas = JS_SAFE_MAX_INTEGER
+		gas = params.UpperGasLimit
 	}
 	if args.Gas != nil {
 		gas = uint64(*args.Gas)

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -32,7 +32,6 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types/accountkey"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/common/hexutil"
-	"github.com/klaytn/klaytn/common/math"
 	"github.com/klaytn/klaytn/networks/rpc"
 	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
@@ -48,6 +47,10 @@ var (
 	errTxArgNilGas           = errors.New("gas limit is not set")
 	errTxArgNilGasPrice      = errors.New("gas price is not set")
 	errNotForFeeDelegationTx = errors.New("fee-delegation type transactions are not allowed to use this API")
+
+	// Javascript console can express integer at maximum, `Number.JS_SAFE_MAX_INTEGER`, where
+	// Number.MAX_SAFE_INTEGER(2**53 - 1) = 9007199254740991
+	JS_SAFE_MAX_INTEGER = uint64(9000000000000000)
 )
 
 // isTxField checks whether the string is a field name of the specific txType.
@@ -731,7 +734,7 @@ func (args *EthTransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int,
 	// Set default gas & gas price if none were set
 	gas := globalGasCap
 	if gas == 0 {
-		gas = uint64(math.MaxUint64 / 2)
+		gas = JS_SAFE_MAX_INTEGER
 	}
 	if args.Gas != nil {
 		gas = uint64(*args.Gas)


### PR DESCRIPTION
## Proposed changes

Klaytn console(JS) cannot recognize big numbers correctly. The allowed maximum value is [2**53 - 1](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). Default gas value has been initialized with a big number which cannot correctly be handled in the console. This PR adjusted this value so that the value can be fit into the range of representable values. 

To be closed https://github.com/klaytn/klaytn/issues/2098

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
