### PR TITLE
[Database] Make a panic if database commit is failed

### DIFF
--- a/consensus/clique/snapshot.go
+++ b/consensus/clique/snapshot.go
@@ -110,7 +110,8 @@ func (s *Snapshot) store(db database.DBManager) error {
 	if err != nil {
 		return err
 	}
-	return db.WriteCliqueSnapshot(s.Hash, blob)
+	db.WriteCliqueSnapshot(s.Hash, blob)
+	return nil
 }
 
 // copy creates a deep copy of the snapshot, though not the individual votes.

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -108,7 +108,8 @@ func (s *Snapshot) store(db database.DBManager) error {
 		return err
 	}
 
-	return db.WriteIstanbulSnapshot(s.Hash, blob)
+	db.WriteIstanbulSnapshot(s.Hash, blob)
+	return nil
 }
 
 // copy creates a deep copy of the snapshot, though not the individual votes.

--- a/datasync/chaindatafetcher/kafka/checkpoint_db.go
+++ b/datasync/chaindatafetcher/kafka/checkpoint_db.go
@@ -34,7 +34,8 @@ func (db *CheckpointDB) ReadCheckpoint() (int64, error) {
 }
 
 func (db *CheckpointDB) WriteCheckpoint(checkpoint int64) error {
-	return db.manager.WriteChainDataFetcherCheckpoint(uint64(checkpoint))
+	db.manager.WriteChainDataFetcherCheckpoint(uint64(checkpoint))
+	return nil
 }
 
 func (db *CheckpointDB) SetComponent(component interface{}) {

--- a/governance/default.go
+++ b/governance/default.go
@@ -1048,16 +1048,12 @@ func (gov *Governance) WriteGovernanceState(num uint64, isCheckpoint bool) error
 		logger.Error("Error in marshaling governance state", "err", err)
 		return err
 	} else {
-		if err = gov.db.WriteGovernanceState(b); err != nil {
-			logger.Error("Error in writing governance state", "err", err)
-			return err
-		} else {
-			if isCheckpoint {
-				atomic.StoreUint64(&gov.lastGovernanceStateBlock, num)
-			}
-			logger.Info("Successfully stored governance state", "num", num)
-			return nil
+		gov.db.WriteGovernanceState(b)
+		if isCheckpoint {
+			atomic.StoreUint64(&gov.lastGovernanceStateBlock, num)
 		}
+		logger.Info("Successfully stored governance state", "num", num)
+		return nil
 	}
 }
 

--- a/node/cn/api_backend_test.go
+++ b/node/cn/api_backend_test.go
@@ -784,8 +784,7 @@ func headerGovTest(t *testing.T, tt *rewindTest) {
 	snap := backend.Snapshot{Number: params.CheckpointInterval, Hash: chain.GetHeaderByNumber(params.CheckpointInterval).Hash()}
 	blob, err := json.Marshal(snap)
 	assert.Nil(t, err)
-	err = db.WriteIstanbulSnapshot(snap.Hash, blob)
-	assert.Nil(t, err)
+	db.WriteIstanbulSnapshot(snap.Hash, blob)
 	_, err = db.ReadIstanbulSnapshot(snap.Hash)
 	assert.Nil(t, err)
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -161,12 +161,7 @@ func senderTxHashIndexer(db database.DBManager, chainEvent <-chan blockchain.Cha
 				}
 
 				txHash := tx.Hash()
-
-				if err = db.PutSenderTxHashToTxHashToBatch(batch, senderTxHash, txHash); err != nil {
-					logger.Error("Failed to store senderTxHash to txHash mapping to database",
-						"blockNum", event.Block.Number(), "senderTxHash", senderTxHash, "txHash", txHash, "err", err)
-					break
-				}
+				db.PutSenderTxHashToTxHashToBatch(batch, senderTxHash, txHash)
 			}
 
 			if err == nil {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -1690,7 +1690,7 @@ func (dbm *databaseManager) WriteBadBlock(block *types.Block) {
 func (dbm *databaseManager) DeleteBadBlocks() {
 	db := dbm.getDatabase(MiscDB)
 	if err := db.Delete(badBlockKey); err != nil {
-		logger.Error("Failed to delete bad blocks", "err", err)
+		logger.Crit("Failed to delete bad blocks", "err", err)
 	}
 }
 
@@ -2151,7 +2151,9 @@ func putTxLookupEntriesToPutter(putter KeyValueWriter, block *types.Block) {
 // DeleteTxLookupEntry removes all transaction data associated with a hash.
 func (dbm *databaseManager) DeleteTxLookupEntry(hash common.Hash) {
 	db := dbm.getDatabase(TxLookUpEntryDB)
-	db.Delete(TxLookupKey(hash))
+	if err := db.Delete(TxLookupKey(hash)); err != nil {
+		logger.Crit("Failed to delete tx lookup key", "err", err)
+	}
 }
 
 // ReadTxAndLookupInfo retrieves a specific transaction from the database, along with

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -132,7 +132,7 @@ type DBManager interface {
 	FindCommonAncestor(a, b *types.Header) *types.Header
 
 	ReadIstanbulSnapshot(hash common.Hash) ([]byte, error)
-	WriteIstanbulSnapshot(hash common.Hash, blob []byte) error
+	WriteIstanbulSnapshot(hash common.Hash, blob []byte)
 	DeleteIstanbulSnapshot(hash common.Hash)
 
 	WriteMerkleProof(key, value []byte)
@@ -191,11 +191,11 @@ type DBManager interface {
 	ReadTxAndLookupInfo(hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64)
 
 	NewSenderTxHashToTxHashBatch() Batch
-	PutSenderTxHashToTxHashToBatch(batch Batch, senderTxHash, txHash common.Hash) error
+	PutSenderTxHashToTxHashToBatch(batch Batch, senderTxHash, txHash common.Hash)
 	ReadTxHashFromSenderTxHash(senderTxHash common.Hash) common.Hash
 
 	ReadBloomBits(bloomBitsKey []byte) ([]byte, error)
-	WriteBloomBits(bloomBitsKey []byte, bits []byte) error
+	WriteBloomBits(bloomBitsKey []byte, bits []byte)
 
 	ReadValidSections() ([]byte, error)
 	WriteValidSections(encodedSections []byte)
@@ -278,7 +278,7 @@ type DBManager interface {
 	ReadTxReceiptInCache(txHash common.Hash) *types.Receipt
 
 	// snapshot in clique(ConsensusClique) consensus
-	WriteCliqueSnapshot(snapshotBlockHash common.Hash, encodedSnapshot []byte) error
+	WriteCliqueSnapshot(snapshotBlockHash common.Hash, encodedSnapshot []byte)
 	ReadCliqueSnapshot(snapshotBlockHash common.Hash) ([]byte, error)
 
 	// Governance related functions
@@ -287,7 +287,7 @@ type DBManager interface {
 	ReadGovernance(num uint64) (map[string]interface{}, error)
 	ReadRecentGovernanceIdx(count int) ([]uint64, error)
 	ReadGovernanceAtNumber(num uint64, epoch uint64) (uint64, map[string]interface{}, error)
-	WriteGovernanceState(b []byte) error
+	WriteGovernanceState(b []byte)
 	ReadGovernanceState() ([]byte, error)
 	DeleteGovernance(num uint64)
 	// TODO-Klaytn implement governance DB deletion methods.
@@ -302,7 +302,7 @@ type DBManager interface {
 	StartDBMigration(DBManager) error
 
 	// ChainDataFetcher checkpoint function
-	WriteChainDataFetcherCheckpoint(checkpoint uint64) error
+	WriteChainDataFetcherCheckpoint(checkpoint uint64)
 	ReadChainDataFetcherCheckpoint() (uint64, error)
 
 	TryCatchUpWithPrimary() error
@@ -681,6 +681,7 @@ func (stdBatch *stateTrieDBBatch) ValueSize() int {
 	return maxSize
 }
 
+// TODO
 // Write passes the list of batch to WriteBatchesParallel for writing batches.
 func (stdBatch *stateTrieDBBatch) Write() error {
 	_, err := WriteBatchesParallel(stdBatch.batches...)
@@ -1728,9 +1729,11 @@ func (dbm *databaseManager) ReadIstanbulSnapshot(hash common.Hash) ([]byte, erro
 	return db.Get(snapshotKey(hash))
 }
 
-func (dbm *databaseManager) WriteIstanbulSnapshot(hash common.Hash, blob []byte) error {
+func (dbm *databaseManager) WriteIstanbulSnapshot(hash common.Hash, blob []byte) {
 	db := dbm.getDatabase(MiscDB)
-	return db.Put(snapshotKey(hash), blob)
+	if err := db.Put(snapshotKey(hash), blob); err != nil {
+		logger.Crit("Failed to write istanbul snapshot", "err", err)
+	}
 }
 
 func (dbm *databaseManager) DeleteIstanbulSnapshot(hash common.Hash) {
@@ -2119,7 +2122,7 @@ func (dbm *databaseManager) WriteAndCacheTxLookupEntries(block *types.Block) err
 		dbm.cm.writeTxAndLookupInfoCache(tx.Hash(), &TransactionLookup{tx, &entry})
 	}
 	if err := batch.Write(); err != nil {
-		logger.Error("Failed to write TxLookupEntries in batch", "err", err, "blockNumber", block.Number())
+		logger.Crit("Failed to write TxLookupEntries in batch", "err", err, "blockNumber", block.Number())
 		return err
 	}
 	return nil
@@ -2174,19 +2177,19 @@ func (dbm *databaseManager) NewSenderTxHashToTxHashBatch() Batch {
 
 // PutSenderTxHashToTxHashToBatch 1) puts the given senderTxHash and txHash to the given batch and
 // 2) writes the information to the cache.
-func (dbm *databaseManager) PutSenderTxHashToTxHashToBatch(batch Batch, senderTxHash, txHash common.Hash) error {
+func (dbm *databaseManager) PutSenderTxHashToTxHashToBatch(batch Batch, senderTxHash, txHash common.Hash) {
 	if err := batch.Put(SenderTxHashToTxHashKey(senderTxHash), txHash.Bytes()); err != nil {
-		return err
+		logger.Crit("Failed to write sender tx hash", "err", err)
 	}
 
 	dbm.cm.writeSenderTxHashToTxHashCache(senderTxHash, txHash)
 
 	if batch.ValueSize() > IdealBatchSize {
-		batch.Write()
+		if err := batch.Write(); err != nil {
+			logger.Crit("Failed to write sender tx hash", "err", err)
+		}
 		batch.Reset()
 	}
-
-	return nil
 }
 
 // ReadTxHashFromSenderTxHash retrieves a txHash corresponding to the given senderTxHash.
@@ -2215,9 +2218,11 @@ func (dbm *databaseManager) ReadBloomBits(bloomBitsKey []byte) ([]byte, error) {
 
 // WriteBloomBits stores the compressed bloom bits vector belonging to the given
 // section and bit index.
-func (dbm *databaseManager) WriteBloomBits(bloomBitsKey, bits []byte) error {
+func (dbm *databaseManager) WriteBloomBits(bloomBitsKey, bits []byte) {
 	db := dbm.getDatabase(MiscDB)
-	return db.Put(bloomBitsKey, bits)
+	if err := db.Put(bloomBitsKey, bits); err != nil {
+		logger.Crit("Failed to write bloom bits", "err", err)
+	}
 }
 
 // ValidSections operation.
@@ -2228,7 +2233,9 @@ func (dbm *databaseManager) ReadValidSections() ([]byte, error) {
 
 func (dbm *databaseManager) WriteValidSections(encodedSections []byte) {
 	db := dbm.getDatabase(MiscDB)
-	db.Put(validSectionKey, encodedSections)
+	if err := db.Put(validSectionKey, encodedSections); err != nil {
+		logger.Crit("Failed to write section data", "err", err)
+	}
 }
 
 // SectionHead operation.
@@ -2239,12 +2246,16 @@ func (dbm *databaseManager) ReadSectionHead(encodedSection []byte) ([]byte, erro
 
 func (dbm *databaseManager) WriteSectionHead(encodedSection []byte, hash common.Hash) {
 	db := dbm.getDatabase(MiscDB)
-	db.Put(sectionHeadKey(encodedSection), hash.Bytes())
+	if err := db.Put(sectionHeadKey(encodedSection), hash.Bytes()); err != nil {
+		logger.Crit("Failed to write section head", "err", err)
+	}
 }
 
 func (dbm *databaseManager) DeleteSectionHead(encodedSection []byte) {
 	db := dbm.getDatabase(MiscDB)
-	db.Delete(sectionHeadKey(encodedSection))
+	if err := db.Delete(sectionHeadKey(encodedSection)); err != nil {
+		logger.Crit("Failed to delete section head", "err", err)
+	}
 }
 
 // ReadDatabaseVersion retrieves the version number of the database.
@@ -2694,9 +2705,11 @@ func (dbm *databaseManager) ReadTxReceiptInCache(txHash common.Hash) *types.Rece
 	return dbm.cm.readTxReceiptInCache(txHash)
 }
 
-func (dbm *databaseManager) WriteCliqueSnapshot(snapshotBlockHash common.Hash, encodedSnapshot []byte) error {
+func (dbm *databaseManager) WriteCliqueSnapshot(snapshotBlockHash common.Hash, encodedSnapshot []byte) {
 	db := dbm.getDatabase(MiscDB)
-	return db.Put(snapshotKey(snapshotBlockHash), encodedSnapshot)
+	if err := db.Put(snapshotKey(snapshotBlockHash), encodedSnapshot); err != nil {
+		logger.Crit("Failed to write clique snapshot", "err", err)
+	}
 }
 
 func (dbm *databaseManager) ReadCliqueSnapshot(snapshotBlockHash common.Hash) ([]byte, error) {
@@ -2834,9 +2847,11 @@ func (dbm *databaseManager) ReadGovernanceAtNumber(num uint64, epoch uint64) (ui
 	return 0, nil, errors.New("No governance data found")
 }
 
-func (dbm *databaseManager) WriteGovernanceState(b []byte) error {
+func (dbm *databaseManager) WriteGovernanceState(b []byte) {
 	db := dbm.getDatabase(MiscDB)
-	return db.Put(governanceStateKey, b)
+	if err := db.Put(governanceStateKey, b); err != nil {
+		logger.Crit("Failed to write governance state", "err", err)
+	}
 }
 
 func (dbm *databaseManager) ReadGovernanceState() ([]byte, error) {
@@ -2844,9 +2859,11 @@ func (dbm *databaseManager) ReadGovernanceState() ([]byte, error) {
 	return db.Get(governanceStateKey)
 }
 
-func (dbm *databaseManager) WriteChainDataFetcherCheckpoint(checkpoint uint64) error {
+func (dbm *databaseManager) WriteChainDataFetcherCheckpoint(checkpoint uint64) {
 	db := dbm.getDatabase(MiscDB)
-	return db.Put(chaindatafetcherCheckpointKey, common.Int64ToByteBigEndian(checkpoint))
+	if err := db.Put(chaindatafetcherCheckpointKey, common.Int64ToByteBigEndian(checkpoint)); err != nil {
+		logger.Crit("Failed to wrtie chaindata fetcher checkpoint", "err", err)
+	}
 }
 
 func (dbm *databaseManager) ReadChainDataFetcherCheckpoint() (uint64, error) {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -681,7 +681,6 @@ func (stdBatch *stateTrieDBBatch) ValueSize() int {
 	return maxSize
 }
 
-// TODO
 // Write passes the list of batch to WriteBatchesParallel for writing batches.
 func (stdBatch *stateTrieDBBatch) Write() error {
 	_, err := WriteBatchesParallel(stdBatch.batches...)

--- a/storage/database/db_manager_test.go
+++ b/storage/database/db_manager_test.go
@@ -612,9 +612,7 @@ func TestDBManager_TxLookupEntry(t *testing.T) {
 		assert.Equal(t, uint64(0), entryIndex)
 
 		batch := dbm.NewSenderTxHashToTxHashBatch()
-		if err := dbm.PutSenderTxHashToTxHashToBatch(batch, hash1, hash2); err != nil {
-			t.Fatal("Failed while calling PutSenderTxHashToTxHashToBatch", "err", err)
-		}
+		dbm.PutSenderTxHashToTxHashToBatch(batch, hash1, hash2)
 
 		if err := batch.Write(); err != nil {
 			t.Fatal("Failed writing SenderTxHashToTxHashToBatch", "err", err)
@@ -634,21 +632,15 @@ func TestDBManager_BloomBits(t *testing.T) {
 		sh, _ := dbm.ReadBloomBits(hash1[:])
 		assert.Nil(t, sh)
 
-		err := dbm.WriteBloomBits(hash1[:], hash1[:])
-		if err != nil {
-			t.Fatal("Failed to write bloom bits", "err", err)
-		}
+		dbm.WriteBloomBits(hash1[:], hash1[:])
 
-		sh, err = dbm.ReadBloomBits(hash1[:])
+		sh, err := dbm.ReadBloomBits(hash1[:])
 		if err != nil {
 			t.Fatal("Failed to read bloom bits", "err", err)
 		}
 		assert.Equal(t, hash1[:], sh)
 
-		err = dbm.WriteBloomBits(hash1[:], hash2[:])
-		if err != nil {
-			t.Fatal("Failed to write bloom bits", "err", err)
-		}
+		dbm.WriteBloomBits(hash1[:], hash2[:])
 
 		sh, err = dbm.ReadBloomBits(hash1[:])
 		if err != nil {
@@ -801,14 +793,12 @@ func TestDBManager_CliqueSnapshot(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Nil(t, data)
 
-		err = dbm.WriteCliqueSnapshot(hash1, hash1[:])
-		assert.Nil(t, err)
+		dbm.WriteCliqueSnapshot(hash1, hash1[:])
 
 		data, _ = dbm.ReadCliqueSnapshot(hash1)
 		assert.Equal(t, hash1[:], data)
 
-		err = dbm.WriteCliqueSnapshot(hash1, hash2[:])
-		assert.Nil(t, err)
+		dbm.WriteCliqueSnapshot(hash1, hash2[:])
 
 		data, _ = dbm.ReadCliqueSnapshot(hash1)
 		assert.Equal(t, hash2[:], data)


### PR DESCRIPTION
## Proposed changes

This PR refactored `DBManager` interface.  On committing the database (e..g, `Write()` and `Put()`), make a crash if its operations fail somehow.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
