### PR TITLE
ci: reduce coverage test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-others:
 	$(GORUN) build/ci.go test -p 1 -exclude datasync,networks,node,tests
 
 cover:
-	$(GORUN) build/ci.go cover -coverprofile=coverage.out
+	$(GORUN) build/ci.go cover -p 1 -coverprofile=coverage.out
 	go tool cover -func=coverage.out -o coverage_report.txt
 	go tool cover -html=coverage.out -o coverage_report.html
 	@echo "Two coverage reports coverage_report.txt and coverage_report.html are generated."

--- a/build/ci.go
+++ b/build/ci.go
@@ -335,7 +335,7 @@ func doCover(cmdline []string) {
 
 	gotest.Args = append(gotest.Args, "-cover", "-covermode=atomic", "-coverprofile="+*outputFile)
 	gotest.Args = append(gotest.Args, "-coverpkg", coverPackagesString)
-	gotest.Args = append(gotest.Args, "--timeout=30m")
+	gotest.Args = append(gotest.Args, "--timeout=60m")
 	gotest.Args = append(gotest.Args, packages...)
 	build.MustRun(gotest)
 }

--- a/snapshot/difflayer.go
+++ b/snapshot/difflayer.go
@@ -276,9 +276,14 @@ func (dl *diffLayer) Account(hash common.Hash) (account.Account, error) {
 //
 // Note the returned account is not a copy, please don't modify it.
 func (dl *diffLayer) AccountRLP(hash common.Hash) ([]byte, error) {
+	dl.lock.RLock()
+	// Check staleness before reaching further.
+	if dl.Stale() {
+		dl.lock.RUnlock()
+		return nil, ErrSnapshotStale
+	}
 	// Check the bloom filter first whether there's even a point in reaching into
 	// all the maps in all the layers below
-	dl.lock.RLock()
 	hit := dl.diffed.Contains(accountBloomHasher(hash))
 	if !hit {
 		hit = dl.diffed.Contains(destructBloomHasher(hash))
@@ -345,6 +350,11 @@ func (dl *diffLayer) Storage(accountHash, storageHash common.Hash) ([]byte, erro
 	// Check the bloom filter first whether there's even a point in reaching into
 	// all the maps in all the layers below
 	dl.lock.RLock()
+	// Check staleness before reaching further.
+	if dl.Stale() {
+		dl.lock.RUnlock()
+		return nil, ErrSnapshotStale
+	}
 	hit := dl.diffed.Contains(storageBloomHasher{accountHash, storageHash})
 	if !hit {
 		hit = dl.diffed.Contains(destructBloomHasher(accountHash))

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -197,6 +197,9 @@ func TestDiskLayerExternalInvalidationPartialFlatten(t *testing.T) {
 // be returned with junk data. This version of the test retains the bottom diff
 // layer to check the usual mode of operation where the accumulator is retained.
 func TestDiffLayerExternalInvalidationPartialFlatten(t *testing.T) {
+	// Un-commenting this triggers the bloom set to be deterministic. The values below
+	// were used to trigger the flaw described in https://github.com/ethereum/go-ethereum/issues/27254.
+	// bloomDestructHasherOffset, bloomAccountHasherOffset, bloomStorageHasherOffset = 14, 24, 5
 	// Create an empty base layer and a snapshot tree out of it
 	base := &diskLayer{
 		diskdb: database.NewMemoryDBManager(),


### PR DESCRIPTION
- make coverage test sequential and double the time limit(30m -> 60m) for the test
- remove TestDiffLayer failure. referenced https://github.com/ethereum/go-ethereum/issues/27254

The sequential execution time of coverage is about 43m, so 60m time limit would be enough.
In the future, if it exceeds 60m, we can still double up. Or we can fix some tests which are allocated ports. (console tests, randao fork tests, etc)

## Proposed changes

- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
