### PR TITLE
contracts: Add hardhat tests for service_chain Bridge contracts

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -12,3 +12,6 @@ node_modules
 # solidity-coverage files
 /coverage
 /coverage.json
+
+# Temporary symlinks
+@openzeppelin

--- a/contracts/.solcover.js
+++ b/contracts/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: ["libs", "service_chain", "testing"],
+  skipFiles: ["libs", "testing"],
 };

--- a/contracts/@openzeppelin
+++ b/contracts/@openzeppelin
@@ -1,1 +1,0 @@
-node_modules/@openzeppelin

--- a/contracts/abigenw
+++ b/contracts/abigenw
@@ -1,0 +1,69 @@
+#!/bin/bash
+# abigen wrapper. Mainly to deal with solidity version and node_modules imports
+
+PKG=
+SOL=
+OUT=
+VER=
+OTHER_ARGS=
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --pkg)
+      PKG="$2"
+      shift; shift; ;;
+    --sol)
+      SOL="$2"
+      shift; shift; ;;
+    --out)
+      OUT="$2"
+      shift; shift; ;;
+    --ver)
+      VER="$2"
+      shift; shift; ;;
+    *)
+      OTHER_ARGS="$OTHER_ARGS $1"
+      shift; ;;
+  esac
+done
+
+if [ -z "$PKG" ]; then
+  echo "missing --pkg"
+  exit 1
+fi
+if [ -z "$SOL" ]; then
+  echo "missing --sol"
+  exit 1
+fi
+if [ -z "$OUT" ]; then
+  echo "missing --out"
+  exit 1
+fi
+if [ -n "$VER" ]; then
+  if ! solc --version | grep -q "$VER"; then
+    # Try https://github.com/crytic/solc-select if installed
+    if command -v solc-select >/dev/null; then
+      solc-select use $VER
+    # Try https://github.com/alloy-rs/svm-rs if installed
+    elif command -v svm >/dev/null; then
+      svm use $VER
+    fi
+  fi
+  # Check again
+  if ! solc --version | grep -q "$VER"; then
+    echo "wrong solc version. required: $VER"
+    exit 1
+  fi
+fi
+
+# abigen can't handle node_modules imports, so we symlink them
+ln -sf node_modules/@openzeppelin ./@openzeppelin
+cleanup() {
+  # This symlink interferes with hardhat; delete after abigen.
+  rm -f ./@openzeppelin
+}
+trap cleanup EXIT
+
+set -x
+abigen --pkg $PKG --sol $SOL --out $OUT $OTHER_ARGS
+{ set +x; } 2>/dev/null

--- a/contracts/generate.go
+++ b/contracts/generate.go
@@ -17,35 +17,37 @@
 package contracts
 
 /*
-You can use solc-select or svm-rs to quickly switch solc versions.
-Example:
-	solc-select use 0.4.24
+Recommended to install solc-select or svm-rs to switch solc versions within abigenw.
+
+	solc-select install 0.4.24 0.5.6 0.8.19
+	go generate
+
+Othewise, you can manually switch solc versions and run go generate for each solc version.
+
 	go generate --run 0.4.24
-	solc-select use 0.5.6
 	go generate --run 0.5.6
-	solc-select use 0.8.19
 	go generate --run 0.8.19
 */
 
 // These files were compiled with solidity 0.4.24.
 
-//go:generate abigen --pkg misc --sol ./contracts/system_contracts/misc/credit.sol --out ./contracts/system_contracts/misc/credit.go # 0.4.24
-//go:generate abigen --pkg consensus --sol ./contracts/system_contracts/consensus/consensus.sol --out ./contracts/system_contracts/consensus/consensus.go # 0.4.24
-//go:generate abigen --pkg reward --sol ./contracts/testing/reward/all.sol --out ./contracts/testing/reward/all.go # 0.4.24
+//go:generate ./abigenw --pkg misc --sol ./contracts/system_contracts/misc/credit.sol --out ./contracts/system_contracts/misc/credit.go --ver 0.4.24
+//go:generate ./abigenw --pkg consensus --sol ./contracts/system_contracts/consensus/consensus.sol --out ./contracts/system_contracts/consensus/consensus.go --ver 0.4.24
+//go:generate ./abigenw --pkg reward --sol ./contracts/testing/reward/all.sol --out ./contracts/testing/reward/all.go --ver 0.4.24
 
 // These files were compiled with solidity 0.5.6.
 
-//go:generate abigen --pkg bridge --sol ./contracts/service_chain/bridge/Bridge.sol --out ./contracts/service_chain/bridge/bridge.go # 0.5.6
-//go:generate abigen --pkg sc_erc20 --sol ./contracts/testing/sc_erc20/sc_token.sol --out ./contracts/testing/sc_erc20/sc_token.go # 0.5.6
-//go:generate abigen --pkg sc_erc721 --sol ./contracts/testing/sc_erc721/sc_nft.sol --out ./contracts/testing/sc_erc721/sc_nft.go # 0.5.6
-//go:generate abigen --pkg sc_erc721_no_uri --sol ./contracts/testing/sc_erc721_no_uri/sc_nft_no_uri.sol --out ./contracts/testing/sc_erc721_no_uri/sc_nft_no_uri.go # 0.5.6
-//go:generate abigen --pkg extbridge --sol ./contracts/testing/extbridge/ext_bridge.sol --out ./contracts/testing/extbridge/ext_bridge.go # 0.5.6
+//go:generate ./abigenw --pkg bridge --sol ./contracts/service_chain/bridge/Bridge.sol --out ./contracts/service_chain/bridge/bridge.go --ver 0.5.6
+//go:generate ./abigenw --pkg sc_erc20 --sol ./contracts/testing/sc_erc20/sc_token.sol --out ./contracts/testing/sc_erc20/sc_token.go --ver 0.5.6
+//go:generate ./abigenw --pkg sc_erc721 --sol ./contracts/testing/sc_erc721/sc_nft.sol --out ./contracts/testing/sc_erc721/sc_nft.go --ver 0.5.6
+//go:generate ./abigenw --pkg sc_erc721_no_uri --sol ./contracts/testing/sc_erc721_no_uri/sc_nft_no_uri.sol --out ./contracts/testing/sc_erc721_no_uri/sc_nft_no_uri.go --ver 0.5.6
+//go:generate ./abigenw --pkg extbridge --sol ./contracts/testing/extbridge/ext_bridge.sol --out ./contracts/testing/extbridge/ext_bridge.go --ver 0.5.6
 
 // These files were compiled with solidity 0.8.19.
 
-//go:generate abigen --pkg gov --sol ./contracts/system_contracts/gov/GovParam.sol --out ./contracts/system_contracts/gov/GovParam.go # 0.8.19
-//go:generate abigen --pkg kip103 --sol ./contracts/system_contracts/kip103/TreasuryRebalance.sol --out ./contracts/system_contracts/kip103/TreasuryRebalance.go # 0.8.19
-//go:generate abigen --pkg kip113 --sol ./contracts/system_contracts/kip113/SimpleBlsRegistry.sol --out ./contracts/system_contracts/kip113/SimpleBlsRegistry.go # 0.8.19
-//go:generate abigen --pkg kip149 --sol ./contracts/system_contracts/kip149/Registry.sol --out ./contracts/system_contracts/kip149/Registry.go # 0.8.19
-//go:generate abigen --pkg proxy --sol ./contracts/system_contracts/proxy/proxy.sol --out ./contracts/system_contracts/proxy/proxy.go # 0.8.19
-//go:generate abigen --pkg system_contracts --sol ./contracts/testing/system_contracts/all.sol --out ./contracts/testing/system_contracts/all.go # 0.8.19
+//go:generate ./abigenw --pkg gov --sol ./contracts/system_contracts/gov/GovParam.sol --out ./contracts/system_contracts/gov/GovParam.go --ver 0.8.19
+//go:generate ./abigenw --pkg kip103 --sol ./contracts/system_contracts/kip103/TreasuryRebalance.sol --out ./contracts/system_contracts/kip103/TreasuryRebalance.go --ver 0.8.19
+//go:generate ./abigenw --pkg kip113 --sol ./contracts/system_contracts/kip113/SimpleBlsRegistry.sol --out ./contracts/system_contracts/kip113/SimpleBlsRegistry.go --ver 0.8.19
+//go:generate ./abigenw --pkg kip149 --sol ./contracts/system_contracts/kip149/Registry.sol --out ./contracts/system_contracts/kip149/Registry.go --ver 0.8.19
+//go:generate ./abigenw --pkg proxy --sol ./contracts/system_contracts/proxy/proxy.sol --out ./contracts/system_contracts/proxy/proxy.go --ver 0.8.19
+//go:generate ./abigenw --pkg system_contracts --sol ./contracts/testing/system_contracts/all.sol --out ./contracts/testing/system_contracts/all.go --ver 0.8.19

--- a/contracts/test/Bridge/bridge.test.ts
+++ b/contracts/test/Bridge/bridge.test.ts
@@ -1,0 +1,679 @@
+import { ethers } from "hardhat";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { Bridge, ServiceChainNFT, ServiceChainToken } from "../../typechain-types";
+import { ContractTransaction, Transaction } from "ethers";
+
+const VoteType = {
+  ValueTransfer: 0,
+  Configuration: 1,
+};
+
+const TokenType = {
+  KLAY: 0,
+  ERC20: 1,
+  ERC721: 2,
+}
+
+const AddressZero = ethers.constants.AddressZero;
+const parseEther = ethers.utils.parseEther;
+const txhash = "0x1111111111111111111111111111111111111111111111111111111111111111";
+const blockNum = 2222;
+
+interface BridgeFixture {
+  bridge: Bridge;
+  token: ServiceChainToken;
+  nft: ServiceChainNFT;
+  owner: SignerWithAddress;
+  op1: SignerWithAddress;
+  op2: SignerWithAddress;
+  op3: SignerWithAddress;
+  feeReceiver: SignerWithAddress;
+  user1: SignerWithAddress;
+  user2: SignerWithAddress;
+}
+
+async function deployBridgeFixture(modeMintBurn: boolean = false) {
+  const [owner, op1, op2, op3, cBridge, cToken, cNFT, feeReceiver, user1, user2] = await ethers.getSigners();
+
+  const BridgeFactory = await ethers.getContractFactory("Bridge");
+  const bridge = await BridgeFactory.connect(owner).deploy(modeMintBurn);
+
+  const TokenFactory = await ethers.getContractFactory("ServiceChainToken");
+  const token = await TokenFactory.deploy(bridge.address);
+
+  const NFTFactory = await ethers.getContractFactory("ServiceChainNFT");
+  const nft = await NFTFactory.deploy(bridge.address);
+
+  return { bridge, token, nft, owner, op1, op2, op3, cBridge, cToken, cNFT, feeReceiver, user1, user2 };
+}
+
+async function deployBridgeConfiguredFixture(modeMintBurn: boolean = false) {
+  const fixture = await deployBridgeFixture(modeMintBurn);
+  const { bridge, token, nft, owner, op1, op2, op3, cBridge, cToken, cNFT, feeReceiver, user1, user2 } = fixture;
+
+  await bridge.connect(owner).setCounterPartBridge(cBridge.address);
+  await bridge.connect(owner).registerToken(token.address, cToken.address);
+  await bridge.connect(owner).registerToken(nft.address, cNFT.address);
+
+  await bridge.connect(owner).setKLAYFee(parseEther("0.4"), 0);
+  await bridge.connect(owner).setERC20Fee(token.address, parseEther("0.3"), 1);
+  await bridge.connect(owner).setFeeReceiver(feeReceiver.address);
+
+  await bridge.connect(owner).registerOperator(op1.address);
+  await bridge.connect(owner).registerOperator(op2.address);
+  await bridge.connect(owner).registerOperator(op3.address);
+  await bridge.connect(owner).deregisterOperator(owner.address);
+  await bridge.connect(owner).setOperatorThreshold(VoteType.ValueTransfer, 2);
+  await bridge.connect(owner).setOperatorThreshold(VoteType.Configuration, 2);
+
+  await ethers.provider.send("hardhat_setBalance", [user1.address, parseEther("5.0").toHexString()]);
+  await ethers.provider.send("hardhat_setBalance", [user2.address, "0x0"]);
+  await ethers.provider.send("hardhat_setBalance", [feeReceiver.address, "0x0"]);
+  await token.connect(owner).transfer(user1.address, parseEther("5.0"));
+  await nft.connect(owner).mintWithTokenURI(user1.address, 42, "example.com");
+
+  return fixture;
+}
+
+async function deployBridgeConfiguredMintBurnFixture() {
+  const fixture = await deployBridgeConfiguredFixture(true);
+  const { bridge, owner, token, nft } = fixture;
+
+  token.connect(owner).addMinter(bridge.address);
+  nft.connect(owner).addMinter(bridge.address);
+
+  return fixture;
+}
+
+describe("Bridge", function () {
+  describe("BridgeCounterpart", function () {
+    it("set counterpart bridge", async function () {
+      const { bridge, owner, cBridge, user1 } = await loadFixture(deployBridgeFixture);
+      expect(await bridge.counterpartBridge()).to.equal(AddressZero);
+      await bridge.connect(owner).setCounterPartBridge(cBridge.address);
+      expect(await bridge.counterpartBridge()).to.equal(cBridge.address);
+
+      expect(bridge.connect(user1).setCounterPartBridge(user1.address)).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+  });
+
+  describe("BridgeFee", function () {
+    it("set configuration", async function () {
+      const { bridge, token, owner, op1, feeReceiver, user1 } = await loadFixture(deployBridgeFixture);
+      await bridge.connect(owner).registerOperator(op1.address);
+      await bridge.connect(owner).setOperatorThreshold(VoteType.Configuration, 2);
+
+      expect(await bridge.feeOfKLAY()).to.equal(0);
+      expect(await bridge.feeReceiver()).to.equal(AddressZero);
+
+      await bridge.connect(owner).setKLAYFee(7, 0);
+      await bridge.connect(op1).setKLAYFee(7, 0);
+      expect(await bridge.feeOfKLAY()).to.equal(7);
+
+      await bridge.connect(owner).setERC20Fee(token.address, 77, 1);
+      await bridge.connect(op1).setERC20Fee(token.address, 77, 1);
+      expect(await bridge.feeOfERC20(token.address)).to.equal(77);
+
+      await bridge.connect(owner).setFeeReceiver(feeReceiver.address);
+      expect(await bridge.feeReceiver()).to.equal(feeReceiver.address);
+
+      expect(bridge.connect(user1).setKLAYFee(token.address, 7)).to.be.revertedWith("msg.sender is not an operator");
+      expect(bridge.connect(user1).setERC20Fee(token.address, 77, 1)).to.be.revertedWith("msg.sender is not an operator");
+      expect(bridge.connect(op1).setFeeReceiver(feeReceiver.address)).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+  });
+
+  describe("BridgeOperator", function () {
+    it("initial configuration with the only owner/operator", async function () {
+      const { bridge, owner } = await loadFixture(deployBridgeFixture);
+
+      expect(await bridge.owner()).to.equal(owner.address);
+      expect(await bridge.MAX_OPERATOR()).to.equal(12);
+      expect(await bridge.operators(owner.address)).to.equal(true);
+      expect(await bridge.getOperatorList()).to.deep.equal([owner.address]);
+      expect(await bridge.operatorThresholds(VoteType.ValueTransfer)).to.equal(1);
+      expect(await bridge.operatorThresholds(VoteType.Configuration)).to.equal(1);
+    });
+    it("register operator", async function () {
+      const { bridge, owner, op1, op2 } = await loadFixture(deployBridgeFixture);
+
+      expect(await bridge.operators(op1.address)).to.equal(false);
+      await bridge.connect(owner).registerOperator(op1.address);
+      expect(await bridge.operators(op1.address)).to.equal(true);
+      expect(await bridge.getOperatorList()).to.deep.equal([owner.address, op1.address]);
+
+      expect(bridge.connect(op1).registerOperator(op2.address)).to.be.revertedWith("Ownable: caller is not the owner");
+      expect(bridge.connect(owner).registerOperator(op1.address)).to.be.revertedWith("exist operator");
+    });
+    it("deregister operator", async function () {
+      const { bridge, owner, op1, op2, op3 } = await loadFixture(deployBridgeFixture);
+      await bridge.connect(owner).registerOperator(op1.address);
+      await bridge.connect(owner).registerOperator(op2.address);
+      await bridge.connect(owner).registerOperator(op3.address);
+      expect(await bridge.getOperatorList()).to.deep.equal([owner.address, op1.address, op2.address, op3.address]);
+
+      expect(await bridge.operators(op3.address)).to.equal(true);
+      await bridge.connect(owner).deregisterOperator(op3.address);
+      expect(await bridge.operators(op3.address)).to.equal(false);
+      expect(await bridge.getOperatorList()).to.deep.equal([owner.address, op1.address, op2.address]);
+
+      expect(bridge.connect(op1).deregisterOperator(op2.address)).to.be.revertedWith("Ownable: caller is not the owner");
+      expect(bridge.connect(owner).deregisterOperator(op3.address)).to.be.revertedWith("");
+    });
+    it("set operator threshold", async function () {
+      const { bridge, owner, op1 } = await loadFixture(deployBridgeFixture);
+      await bridge.connect(owner).registerOperator(op1.address);
+
+      expect(await bridge.operatorThresholds(VoteType.ValueTransfer)).to.equal(1);
+      await bridge.connect(owner).setOperatorThreshold(VoteType.ValueTransfer, 2);
+      expect(await bridge.operatorThresholds(VoteType.ValueTransfer)).to.equal(2);
+
+      expect(bridge.connect(op1).setOperatorThreshold(VoteType.ValueTransfer, 1)).to.be.revertedWith("Ownable: caller is not the owner");
+      expect(bridge.connect(owner).setOperatorThreshold(VoteType.ValueTransfer, 0)).to.be.revertedWith("zero threshold");
+      expect(bridge.connect(owner).setOperatorThreshold(VoteType.ValueTransfer, 3)).to.be.revertedWith("bigger than num of operators");
+    });
+    it("vote configuration", async function () {
+      const { bridge, owner, op1, op2, op3, user1 } = await loadFixture(deployBridgeFixture);
+      await bridge.connect(owner).registerOperator(op1.address);
+      await bridge.connect(owner).registerOperator(op2.address);
+      await bridge.connect(owner).registerOperator(op3.address);
+      await bridge.connect(owner).deregisterOperator(owner.address);
+      await bridge.connect(owner).setOperatorThreshold(VoteType.ValueTransfer, 2);
+      await bridge.connect(owner).setOperatorThreshold(VoteType.Configuration, 2);
+
+      expect(bridge.connect(owner).setKLAYFee(7, 0)).to.be.revertedWith("msg.sender is not an operator");
+      expect(bridge.connect(user1).setKLAYFee(7, 0)).to.be.revertedWith("msg.sender is not an operator");
+      expect(bridge.connect(op1).setKLAYFee(7, 1)).to.be.revertedWith("nonce mismatch");
+
+      expect(await bridge.configurationNonce()).to.equal(0);
+      expect(await bridge.feeOfKLAY()).to.equal(0);
+
+      await bridge.connect(op1).setKLAYFee(7, 0);
+      expect(await bridge.configurationNonce()).to.equal(0);
+      expect(await bridge.feeOfKLAY()).to.equal(0);
+
+      await bridge.connect(op2).setKLAYFee(7, 0);
+      expect(await bridge.configurationNonce()).to.equal(1);
+      expect(await bridge.feeOfKLAY()).to.equal(7);
+    });
+  });
+
+  describe("BridgeToken", function () {
+    it("register and deregister token", async function () {
+      const { bridge, token, owner, cToken, user1 } = await loadFixture(deployBridgeFixture);
+      expect(await bridge.registeredTokens(token.address)).to.equal(AddressZero);
+
+      // Test register
+      expect(bridge.connect(user1).registerToken(token.address, cToken.address)).to.be.revertedWith("Ownable: caller is not the owner");
+
+      await bridge.connect(owner).registerToken(token.address, cToken.address);
+      expect(await bridge.registeredTokens(token.address)).to.equal(cToken.address);
+      expect(await bridge.getRegisteredTokenList()).to.deep.equal([token.address]);
+
+      expect(bridge.connect(owner).registerToken(token.address, cToken.address)).to.be.revertedWith("allowed token");
+
+      // Test deregister
+      expect(bridge.connect(user1).deregisterToken(token.address)).to.be.revertedWith("Ownable: caller is not the owner");
+      expect(bridge.connect(owner).deregisterToken(user1.address)).to.be.revertedWith("not allowed token");
+
+      await bridge.connect(owner).deregisterToken(token.address);
+      expect(await bridge.registeredTokens(token.address)).to.equal(AddressZero);
+      expect(await bridge.getRegisteredTokenList()).to.deep.equal([]);
+    });
+    it("lock and unlock token", async function () {
+      const { bridge, token, owner, cToken, user1 } = await loadFixture(deployBridgeFixture);
+      await bridge.connect(owner).registerToken(token.address, cToken.address);
+      expect(await bridge.getRegisteredTokenList()).to.deep.equal([token.address]);
+
+      // Test lock
+      expect(bridge.connect(user1).lockToken(token.address)).to.be.revertedWith("Ownable: caller is not the owner");
+      expect(bridge.connect(owner).lockToken(user1.address)).to.be.revertedWith("not allowed token");
+
+      await bridge.connect(owner).lockToken(token.address);
+      expect(await bridge.lockedTokens(token.address)).to.equal(true);
+
+      expect(bridge.connect(owner).lockToken(token.address)).to.be.revertedWith("locked token");
+
+      // Test unlock
+      expect(bridge.connect(user1).unlockToken(token.address)).to.be.revertedWith("Ownable: caller is not the owner");
+      expect(bridge.connect(owner).unlockToken(user1.address)).to.be.revertedWith("not allowed token");
+
+      await bridge.connect(owner).unlockToken(token.address);
+      expect(await bridge.lockedTokens(token.address)).to.equal(false);
+
+      expect(bridge.connect(owner).unlockToken(token.address)).to.be.revertedWith("unlocked token");
+    });
+  });
+
+  describe("BridgeTransfer", function () {
+    it("start", async function () {
+      const { bridge, owner, user1 } = await loadFixture(deployBridgeFixture);
+
+      expect(bridge.connect(user1).start(false)).to.be.revertedWith("Ownable: caller is not the owner");
+
+      expect(await bridge.isRunning()).to.equal(true);
+      await bridge.connect(owner).start(false);
+      expect(await bridge.isRunning()).to.equal(false);
+    });
+  });
+
+  describe("BridgeTransferERC20", function () {
+    //               before after
+    // user          5.0    3.7
+    // feeReceiver   0.0    0.3
+    // bridge        0.0    1.0 or 0.0 depending on modeMintBurn
+    async function expectSendERC20(fixture: BridgeFixture, tx: any) {
+      const { bridge, token, feeReceiver, user1, user2 } = fixture;
+      const modeMintBurn = await bridge.modeMintBurn();
+
+      const expectTx = expect(await tx)
+        .to.emit(bridge, "RequestValueTransfer")
+        .withArgs(
+          TokenType.ERC20,
+          user1.address,
+          user2.address,
+          token.address,
+          parseEther("1.0"),
+          0,
+          parseEther("0.3"),
+          "0x",
+        )
+        .to.emit(token, "Transfer").withArgs(user1.address, bridge.address, parseEther("1.5")) // Send value + feeLimit
+        .to.emit(token, "Transfer").withArgs(user1.address, feeReceiver.address, parseEther("0.3")) // Takeout fee
+        .to.emit(token, "Transfer").withArgs(bridge.address, user1.address, parseEther("0.2")); // Refund (feeLimit - fee)
+      if (modeMintBurn) {
+        expectTx.to.emit(token, "Burn").withArgs(bridge.address, parseEther("1.0")); // Burn value
+      } else {
+        expectTx.to.not.emit(token, "Burn"); // No burn
+      }
+
+      expect(await bridge.requestNonce()).to.equal(1);
+      expect(await token.balanceOf(user1.address)).to.equal(parseEther("3.7"));
+      expect(await token.balanceOf(feeReceiver.address)).to.equal(parseEther("0.3"));
+      if (modeMintBurn) {
+        expect(await token.balanceOf(bridge.address)).to.equal(parseEther("0.0")); // Value is burned
+      } else {
+        expect(await token.balanceOf(bridge.address)).to.equal(parseEther("1.0")); // Bridge holds value
+      }
+    }
+    // 2-step: first approve then request bridge
+    async function expectSendERC20_2step(fixture: BridgeFixture) {
+      const { bridge, token, user1, user2 } = fixture;
+
+      await token.connect(user1).approve(bridge.address, parseEther("9999.0"));
+      await expectSendERC20(fixture, bridge.connect(user1).requestERC20Transfer(
+        token.address, user2.address, parseEther("1.0"), parseEther("0.5"), "0x"));
+    }
+    // 1-step: request directly but requires request feature in ERC20
+    async function expectSendERC20_1step(fixture: BridgeFixture) {
+      const { token, user1, user2 } = fixture;
+
+      await expectSendERC20(fixture, token.connect(user1).requestValueTransfer(
+        parseEther("1.0"), user2.address, parseEther("0.5"), "0x"));
+    }
+
+    async function expectReceiveERC20(fixture: BridgeFixture) {
+      const { bridge, op1, op2, token, user1, user2 } = fixture;
+      const modeMintBurn = await bridge.modeMintBurn();
+
+      await bridge.connect(op1).handleERC20Transfer(txhash, user1.address, user2.address, token.address, parseEther("1.0"), 0, blockNum, "0x");
+      const expectTx = expect(await bridge.connect(op2).handleERC20Transfer(txhash, user1.address, user2.address, token.address, parseEther("1.0"), 0, blockNum, "0x"))
+        .to.emit(bridge, "HandleValueTransfer")
+        .withArgs(
+          txhash,
+          TokenType.ERC20,
+          user1.address,
+          user2.address,
+          token.address,
+          parseEther("1.0"),
+          0, // requestNonce
+          0, // lowerHandleNonce
+          "0x",
+        );
+      if (modeMintBurn) {
+        expectTx.to.emit(token, "Mint").withArgs(user2.address, parseEther("1.0"));
+      } else {
+        expectTx.to.emit(token, "Transfer").withArgs(bridge.address, user2.address, parseEther("1.0"));
+      }
+
+      expect(await token.balanceOf(user2.address)).to.equal(parseEther("1.0"));
+    }
+
+    it("send 2-step no burn", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      await expectSendERC20_2step(fixture);
+    });
+    it("send 2-step burn", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredMintBurnFixture);
+      await expectSendERC20_2step(fixture);
+    });
+    it("send 1-step no burn", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      await expectSendERC20_1step(fixture);
+    });
+    it("send 1-step burn", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredMintBurnFixture);
+      await expectSendERC20_1step(fixture);
+    });
+    it("send zero fee", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, token, op1, op2, feeReceiver, user1, user2 } = fixture;
+
+      await bridge.connect(op1).setERC20Fee(token.address, 0, 2);
+      await bridge.connect(op2).setERC20Fee(token.address, 0, 2);
+
+      await expect(token.connect(user1).requestValueTransfer(parseEther("1.0"), user2.address, parseEther("0.0"), "0x"))
+        .to.emit(token, "Transfer").withArgs(user1.address, bridge.address, parseEther("1.0"));
+      expect(await bridge.requestNonce()).to.equal(1);
+      expect(await token.balanceOf(user1.address)).to.equal(parseEther("4.0"));
+      expect(await token.balanceOf(feeReceiver.address)).to.equal(parseEther("0.0"));
+      expect(await token.balanceOf(bridge.address)).to.equal(parseEther("1.0"));
+    });
+    it("receive no mint", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, token } = fixture;
+
+      // Add liquidity
+      await token.connect(owner).transfer(bridge.address, parseEther("9999.0"));
+      await expectReceiveERC20(fixture);
+      expect(await token.balanceOf(bridge.address)).to.equal(parseEther("9998.0"));
+    });
+    it("receive mint", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredMintBurnFixture);
+      const { bridge, token } = fixture;
+
+      // No liquidity needed
+      await expectReceiveERC20(fixture);
+      expect(await token.balanceOf(bridge.address)).to.equal(parseEther("0.0"));
+    });
+    it("insufficient feeLimit", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { token, user1, user2 } = fixture;
+
+      expect(token.connect(user1).requestValueTransfer(parseEther("1.0"), user2.address, parseEther("0.01"), "0x"))
+        .to.be.revertedWith("insufficient feeLimit");
+    });
+    it("unregistered token", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, token, user1, user2 } = fixture;
+
+      await bridge.connect(owner).deregisterToken(token.address);
+      expect(token.connect(user1).requestValueTransfer(parseEther("1.0"), user2.address, parseEther("0.5"), "0x"))
+        .to.be.revertedWith("not allowed token");
+    });
+    it("locked token", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, token, user1, user2 } = fixture;
+
+      await bridge.connect(owner).lockToken(token.address);
+      expect(token.connect(user1).requestValueTransfer(parseEther("1.0"), user2.address, parseEther("0.5"), "0x"))
+        .to.be.revertedWith("locked token");
+    });
+    it("stopped bridge", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, token, user1, user2 } = fixture;
+
+      await bridge.connect(owner).start(false);
+      expect(token.connect(user1).requestValueTransfer(parseEther("1.0"), user2.address, parseEther("0.5"), "0x"))
+        .to.be.revertedWith("stopped bridge");
+    });
+    it("zero value", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, token, user1, user2 } = fixture;
+
+      await bridge.connect(owner).start(false);
+      expect(token.connect(user1).requestValueTransfer(0, user2.address, 0, "0x"))
+        .to.be.revertedWith("zero msg.value");
+    });
+  });
+
+  describe("BridgeTransferERC721", function () {
+    async function expectSendERC721(fixture: BridgeFixture, tx: any) {
+      const { bridge, nft, user1, user2 } = fixture;
+      const modeMintBurn = await bridge.modeMintBurn();
+
+      const expectTx = expect(await tx)
+        .to.emit(bridge, "RequestValueTransferEncoded")
+        .withArgs(
+          TokenType.ERC721,
+          user1.address,
+          user2.address,
+          nft.address,
+          42,
+          0,
+          0,
+          "0x",
+          2,
+          "example.com",
+        )
+        .to.emit(nft, "Transfer").withArgs(user1.address, bridge.address, 42);
+      if (modeMintBurn) {
+        expectTx.to.emit(nft, "Burn").withArgs(bridge.address, 42);
+      } else {
+        expectTx.to.not.emit(nft, "Burn");
+      }
+
+      expect(await bridge.requestNonce()).to.equal(1);
+      if (modeMintBurn) {
+        expect(nft.ownerOf(42)).to.be.revertedWith("ERC721: owner query for nonexistent token");
+      } else {
+        expect(await nft.ownerOf(42)).to.equal(bridge.address);
+      }
+    }
+    // 2-step: first approve then request bridge
+    async function expectSendERC721_2step(fixture: BridgeFixture) {
+      const { bridge, nft, user1, user2 } = fixture;
+
+      await nft.connect(user1).approve(bridge.address, 42);
+      await expectSendERC721(fixture, bridge.connect(user1).requestERC721Transfer(nft.address, user2.address, 42, "0x"));
+    }
+    // 1-step: request directly but requires request feature in ERC721
+    async function expectSendERC721_1step(fixture: BridgeFixture) {
+      const { nft, user1, user2 } = fixture;
+
+      await expectSendERC721(fixture, nft.connect(user1).requestValueTransfer(42, user2.address, "0x"));
+    }
+
+    async function expectReceiveERC721(fixture: BridgeFixture) {
+      const { bridge, op1, op2, nft, user1, user2 } = fixture;
+      const modeMintBurn = await bridge.modeMintBurn();
+
+      await bridge.connect(op1).handleERC721Transfer(txhash, user1.address, user2.address, nft.address, 99, 0, blockNum, "example.com", "0x");
+      const expectTx = expect(await bridge.connect(op2).handleERC721Transfer(txhash, user1.address, user2.address, nft.address, 99, 0, blockNum, "example.com", "0x"))
+        .to.emit(bridge, "HandleValueTransfer")
+        .withArgs(
+          txhash,
+          TokenType.ERC721,
+          user1.address,
+          user2.address,
+          nft.address,
+          99,
+          0, // requestNonce
+          0, // lowerHandleNonce
+          "0x",
+        )
+      if (modeMintBurn) {
+        expectTx.to.emit(nft, "Mint").withArgs(user2.address, 99);
+      } else {
+        expectTx.to.emit(nft, "Transfer").withArgs(bridge.address, user2.address, 99);
+      }
+
+      expect(await nft.ownerOf(99)).to.equal(user2.address);
+      expect(await nft.tokenURI(99)).to.equal("example.com");
+    }
+
+    it("send 2-step no burn", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      await expectSendERC721_2step(fixture);
+    });
+    it("send 2-step burn", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredMintBurnFixture);
+      await expectSendERC721_2step(fixture);
+    });
+    it("send 1-step no burn", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      await expectSendERC721_1step(fixture);
+    });
+    it("send 1-step burn", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredMintBurnFixture);
+      await expectSendERC721_1step(fixture);
+    });
+    it("receive no mint", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, nft } = fixture;
+
+      // Bridge must have the token beforehand
+      await nft.connect(owner).mintWithTokenURI(bridge.address, 99, "example.com");
+      await expectReceiveERC721(fixture);
+    });
+    it("receive mint", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredMintBurnFixture);
+      await expectReceiveERC721(fixture);
+    });
+    it("unregistered token", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, nft, user1, user2 } = fixture;
+
+      await bridge.connect(owner).deregisterToken(nft.address);
+      expect(nft.connect(user1).requestValueTransfer(42, user2.address, "0x"))
+        .to.be.revertedWith("not allowed token");
+    });
+    it("locked token", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, nft, user1, user2 } = fixture;
+
+      await bridge.connect(owner).lockToken(nft.address);
+      expect(nft.connect(user1).requestValueTransfer(42, user2.address, "0x"))
+        .to.be.revertedWith("locked token");
+    });
+    it("stopped bridge", async function () {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, nft, user1, user2 } = fixture;
+
+      await bridge.connect(owner).start(false);
+      expect(nft.connect(user1).requestValueTransfer(42, user2.address, "0x"))
+        .to.be.revertedWith("stopped bridge");
+    });
+  });
+
+  describe("BridgeTransferKLAY", function () {
+    //               before after
+    // user          5.0    3.6 - gasFee
+    // feeReceiver   0.0    0.4
+    // bridge        0.0    1.0
+    async function expectSendKLAY(fixture: BridgeFixture, tx: Promise<ContractTransaction>) {
+      const { bridge, feeReceiver, user1 } = fixture;
+
+      const sentTx = await tx;
+      expect(sentTx)
+        .to.emit(bridge, "RequestValueTransfer")
+        .withArgs(
+          TokenType.KLAY,
+          user1.address,
+          user1.address,
+          AddressZero,
+          parseEther("1.0"), // -- eventArg
+          0,
+          parseEther("0.4"),
+          "0x",
+        )
+      // When using requestKLAYTransfer, eventArg = msg.value - feeLimit = msg.value - (msg.value - _value) = _value
+      // When using fallback, eventArg = msg.value - feeLimit = msg.value - fee.
+
+      const receipt = await sentTx.wait();
+      const gasFee = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+      const expectedBalance = parseEther("3.6").sub(gasFee);
+
+      expect(await bridge.requestNonce()).to.equal(1);
+      expect(await ethers.provider.getBalance(user1.address)).to.equal(expectedBalance);
+      expect(await ethers.provider.getBalance(feeReceiver.address)).to.equal(parseEther("0.4"));
+      expect(await ethers.provider.getBalance(bridge.address)).to.equal(parseEther("1.0"));
+    }
+
+    it("send function", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, user1, user2 } = fixture;
+
+      // _value = 1.0, msg.value = 1.5 => feeLimit = 0.5, eventArg = 1.0
+      await expectSendKLAY(fixture, bridge.connect(user1).requestKLAYTransfer(
+        user2.address,
+        parseEther("1.0"),
+        "0x",
+        {value: parseEther("1.5")})
+      );
+    });
+    it("send fallback", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, user1 } = fixture;
+
+      await expectSendKLAY(fixture, bridge.connect(user1).fallback({value: parseEther("1.4")}));
+    });
+    it("send zero fee", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, op1, op2, feeReceiver, user1 } = fixture;
+
+      await bridge.connect(op1).setKLAYFee(0, 2);
+      await bridge.connect(op2).setKLAYFee(0, 2);
+
+      const sentTx = await bridge.connect(user1).fallback({value: parseEther("1.0")});
+      const receipt = await sentTx.wait();
+      const gasFee = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+      const expectedBalance = parseEther("4.0").sub(gasFee);
+
+      expect(await ethers.provider.getBalance(user1.address)).to.equal(expectedBalance);
+      expect(await ethers.provider.getBalance(feeReceiver.address)).to.equal(parseEther("0.0"));
+      expect(await ethers.provider.getBalance(bridge.address)).to.equal(parseEther("1.0"));
+    });
+    it("receive", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, op1, op2, user1, user2 } = fixture;
+
+      // Add liquidity
+      await ethers.provider.send("hardhat_setBalance", [bridge.address, parseEther("1000.0").toHexString()]);
+
+      await bridge.connect(op1).handleKLAYTransfer(txhash, user1.address, user2.address, parseEther("1.0"), 0, blockNum, "0x");
+      expect(await bridge.connect(op2).handleKLAYTransfer(txhash, user1.address, user2.address, parseEther("1.0"), 0, blockNum, "0x"))
+        .to.emit(bridge, "HandleValueTransfer")
+        .withArgs(
+          txhash,
+          TokenType.KLAY,
+          user1.address,
+          user2.address,
+          AddressZero,
+          parseEther("1.0"),
+          0, // requestNonce
+          0, // lowerHandleNonce
+          "0x",
+        );
+
+      expect(await ethers.provider.getBalance(user2.address)).to.equal(parseEther("1.0"));
+    });
+    it("insufficient feeLimit", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, user1, user2 } = fixture;
+
+      expect(bridge.connect(user1).fallback({value: parseEther("0.01")}))
+        .to.be.revertedWith("insufficient feeLimit");
+      expect(bridge.connect(user1).requestKLAYTransfer(user2.address, parseEther("1.0"), "0x", {value: parseEther("1.01")}))
+        .to.be.revertedWith("insufficient feeLimit");
+    });
+    it("locked KLAY", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, user1 } = fixture;
+
+      await bridge.connect(owner).lockKLAY();
+      expect(bridge.connect(user1).fallback({value: parseEther("1.0")}))
+        .to.be.revertedWith("locked");
+    });
+    it("stopped bridge", async function() {
+      const fixture = await loadFixture(deployBridgeConfiguredFixture);
+      const { bridge, owner, user1 } = fixture;
+
+      await bridge.connect(owner).start(false);
+      expect(bridge.connect(user1).fallback({value: parseEther("1.0")}))
+        .to.be.revertedWith("stopped bridge");
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

- Fix abigen vs. hardhat conflict issue
  - generate.go and abigen needs the `@openzeppelin` symlink to compile because abigen doesn't support source remap.
  - hardhat breaks when the `@openzeppelin` symlink exists at the hardhat project root
  - The solution is to temporarily create the symlink only during `go generate` using the wrapper script `abigenw`. (named after gradle wrapper `gradlew`)
- Add hardhat tests for `service_chain/bridge/Bridge.sol`

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

![image](https://github.com/klaytn/klaytn/assets/5933330/cffa0d8b-d43d-441e-b00e-65e882582c63)
