### PR TITLE
Fix mismatching debug rate limit

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1063,7 +1063,7 @@ var (
 	HeavyDebugRequestLimitFlag = &cli.IntFlag{
 		Name:     "rpc.unsafe-debug.heavy-debug.request-limit",
 		Usage:    "Limit the maximum number of heavy debug api requests. Works with unsafe-debug only.",
-		Value:    50,
+		Value:    500,
 		Aliases:  []string{},
 		EnvVars:  []string{"KLAYTN_RPC_UNSAFE_DEBUG_HEAVY_DEBUG_REQUEST_LIMIT"},
 		Category: "API AND CONSOLE",

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -76,7 +76,7 @@ const (
 )
 
 var (
-	HeavyAPIRequestLimit int32 // HeavyDebugRequestLimitFlag
+	HeavyAPIRequestLimit int32 = 500 // WARN: changing this value will have no effect. This value is for test. See HeavyDebugRequestLimitFlag
 	heavyAPIRequestCount int32 = 0
 )
 

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -76,7 +76,7 @@ const (
 )
 
 var (
-	HeavyAPIRequestLimit int32 = 500
+	HeavyAPIRequestLimit int32 // HeavyDebugRequestLimitFlag
 	heavyAPIRequestCount int32 = 0
 )
 


### PR DESCRIPTION
## Proposed changes

`node/cn/tracers/api.go` defines `HeavyAPIRequestLimit` to 500, but this value is never used. Instead, it is always overridden with 50 defined by `HeavyDebugRequestLimitFlag`:

https://github.com/klaytn/klaytn/blob/1f02226a32b040e57a6aa19e43b27718869dbe3f/cmd/utils/config.go#L700

This PR updates the default to 500 and removes the confusing initialization.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments
