### PR TITLE
Delete deprecated math/rand function calls

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1912,7 +1912,6 @@ func TestBlockChain_SetCanonicalBlock(t *testing.T) {
 	blockchain, _ := NewBlockChain(db, cacheConfig, testGenesis.Config, gxhash.NewFaker(), vm.Config{Debug: true, EnableInternalTxTracing: true})
 	defer blockchain.Stop()
 
-	rand.Seed(time.Now().UnixNano())
 	chainLength := rand.Int63n(500) + 100
 
 	// generate blocks

--- a/blockchain/tx_list_test.go
+++ b/blockchain/tx_list_test.go
@@ -25,7 +25,6 @@ import (
 	"math/rand"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/crypto"
@@ -80,7 +79,6 @@ func TestTxListReadyWithGasPriceBasic(t *testing.T) {
 
 	// Insert the transactions in a random order
 	list := newTxList(true)
-	rand.Seed(time.Now().UnixNano())
 	for _, v := range rand.Perm(len(txs)) {
 		list.Add(txs[v], DefaultTxPoolConfig.PriceBump, true)
 	}

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -22,6 +22,7 @@ package blockchain
 
 import (
 	"crypto/ecdsa"
+	crand "crypto/rand"
 	"fmt"
 	"io"
 	"math/big"
@@ -113,7 +114,7 @@ func pricedTransaction(nonce uint64, gaslimit uint64, gasprice *big.Int, key *ec
 
 func pricedDataTransaction(nonce uint64, gaslimit uint64, gasprice *big.Int, key *ecdsa.PrivateKey, bytes uint64) *types.Transaction {
 	data := make([]byte, bytes)
-	rand.Read(data)
+	crand.Read(data)
 
 	tx, _ := types.SignTx(types.NewTransaction(nonce, common.HexToAddress("0xAAAA"), big.NewInt(0), gaslimit, gasprice, data),
 		types.LatestSignerForChainID(params.TestChainConfig.ChainID), key)

--- a/blockchain/types/anchoring_data_test.go
+++ b/blockchain/types/anchoring_data_test.go
@@ -21,7 +21,6 @@ import (
 	"math/big"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/crypto"
@@ -37,7 +36,6 @@ func genRandomAddress() *common.Address {
 }
 
 func genRandomHash() (h common.Hash) {
-	rand.Seed(time.Now().UnixNano())
 	hasher := sha3.NewKeccak256()
 
 	r := rand.Uint64()

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -900,7 +900,6 @@ func TestIsSorted(t *testing.T) {
 	}
 
 	// Shuffle transactions.
-	rand.Seed(time.Now().Unix())
 	rand.Shuffle(len(batches), func(i, j int) {
 		batches[i], batches[j] = batches[j], batches[i]
 	})
@@ -972,7 +971,6 @@ func benchmarkTxSortByTime(b *testing.B, size int) {
 	}
 
 	// Shuffle transactions.
-	rand.Seed(time.Now().Unix())
 	rand.Shuffle(len(batches), func(i, j int) {
 		batches[i], batches[j] = batches[j], batches[i]
 	})

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -636,8 +636,6 @@ func useKip113Mock(ctx *cli.Context, genesisJson *blockchain.Genesis, kip113Logi
 func RandStringRunes(n int) string {
 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*()_+{}|[]")
 
-	rand.Seed(time.Now().UnixNano())
-
 	b := make([]rune, n)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/klaytn/klaytn/blockchain/types"
@@ -149,7 +148,6 @@ func TestSubjectCmp(t *testing.T) {
 		return r
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	min, max, n := 1, 9999, 10000
 	var identity bool
 	var s1, s2 *istanbul.Subject

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	crand "crypto/rand"
 	"math/big"
 	"math/rand"
 	"reflect"
@@ -118,7 +119,7 @@ func BenchmarkMsgCmp(b *testing.B) {
 func TestSubjectCmp(t *testing.T) {
 	genRandomHash := func(n int) common.Hash {
 		b := make([]byte, n)
-		_, err := rand.Read(b)
+		_, err := crand.Read(b)
 		assert.Nil(t, err)
 		return common.BytesToHash(b)
 	}

--- a/crypto/create_address_test.go
+++ b/crypto/create_address_test.go
@@ -66,7 +66,6 @@ func BenchmarkCreateAddress(b *testing.B) {
 
 func randCode(codeSize uint) []byte {
 	code := make([]byte, 0, codeSize)
-	rand.Seed(0)
 	r := rand.Uint64()
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, r)

--- a/datasync/chaindatafetcher/kafka/checkpoint_db_test.go
+++ b/datasync/chaindatafetcher/kafka/checkpoint_db_test.go
@@ -19,14 +19,12 @@ package kafka
 import (
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/klaytn/klaytn/storage/database"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckpointDB_ReadCheckpoint(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	testDB := database.NewMemoryDBManager()
 	db := NewCheckpointDB()
 	db.SetComponent(testDB)

--- a/datasync/chaindatafetcher/kafka/consumer_test.go
+++ b/datasync/chaindatafetcher/kafka/consumer_test.go
@@ -35,7 +35,6 @@ import (
 
 func Test_newSegment_Success_LegacyMessage(t *testing.T) {
 	value := common.MakeRandomBytes(100)
-	rand.Seed(time.Now().UnixNano())
 	total := uint64(10)
 	idx := rand.Uint64() % total
 	totalBytes := common.Int64ToByteBigEndian(total)
@@ -61,7 +60,6 @@ func Test_newSegment_Success_LegacyMessage(t *testing.T) {
 
 func Test_newSegment_Success_Version1Message(t *testing.T) {
 	value := common.MakeRandomBytes(100)
-	rand.Seed(time.Now().UnixNano())
 	total := uint64(10)
 	idx := rand.Uint64() % total
 	totalBytes := common.Int64ToByteBigEndian(total)

--- a/datasync/chaindatafetcher/kafka/kafka_test.go
+++ b/datasync/chaindatafetcher/kafka/kafka_test.go
@@ -98,7 +98,6 @@ func (s *KafkaSuite) TestKafka_split() {
 func (s *KafkaSuite) TestKafka_makeProducerV1Message() {
 	// make test data
 	data := common.MakeRandomBytes(100)
-	rand.Seed(time.Now().UnixNano())
 	totalSegments := rand.Uint64()
 	idx := rand.Uint64() % totalSegments
 
@@ -117,7 +116,6 @@ func (s *KafkaSuite) TestKafka_makeProducerV1Message() {
 func (s *KafkaSuite) TestKafka_makeProducerMessage() {
 	// make test data
 	data := common.MakeRandomBytes(100)
-	rand.Seed(time.Now().UnixNano())
 	totalSegments := rand.Uint64()
 	idx := rand.Uint64() % totalSegments
 

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -104,7 +104,6 @@ func TestSubscribeDuplicateType(t *testing.T) {
 }
 
 func TestMuxConcurrent(t *testing.T) {
-	rand.Seed(time.Now().Unix())
 	mux := new(TypeMux)
 	defer mux.Stop()
 

--- a/networks/p2p/discover/udp_test.go
+++ b/networks/p2p/discover/udp_test.go
@@ -160,7 +160,6 @@ func TestUDP_responseTimeouts(t *testing.T) {
 	test := newUDPTest(t)
 	defer test.table.Close()
 
-	rand.Seed(time.Now().UnixNano())
 	randomDuration := func(max time.Duration) time.Duration {
 		return time.Duration(rand.Int63n(int64(max)))
 	}

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -1037,7 +1037,6 @@ func TestBroadcastTxsSortedByTime(t *testing.T) {
 	}
 
 	// Shuffle transactions.
-	rand.Seed(time.Now().Unix())
 	rand.Shuffle(len(txs), func(i, j int) {
 		txs[i], txs[j] = txs[j], txs[i]
 	})
@@ -1098,7 +1097,6 @@ func TestReBroadcastTxsSortedByTime(t *testing.T) {
 	}
 
 	// Shuffle transactions.
-	rand.Seed(time.Now().Unix())
 	rand.Shuffle(len(txs), func(i, j int) {
 		txs[i], txs[j] = txs[j], txs[i]
 	})

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -23,12 +23,10 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/klaytn/klaytn/crypto"
 
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/networks/p2p"
 	"github.com/stretchr/testify/assert"
 )
@@ -385,7 +383,6 @@ func TestBasePeer_SendTransactionWithSortedByTime(t *testing.T) {
 	}
 
 	// Shuffle transactions.
-	rand.Seed(time.Now().Unix())
 	rand.Shuffle(len(txs), func(i, j int) {
 		txs[i], txs[j] = txs[j], txs[i]
 	})
@@ -445,7 +442,6 @@ func TestBasePeer_ReSendTransactionWithSortedByTime(t *testing.T) {
 	}
 
 	// Shuffle transactions.
-	rand.Seed(time.Now().Unix())
 	rand.Shuffle(len(txs), func(i, j int) {
 		txs[i], txs[j] = txs[j], txs[i]
 	})
@@ -500,7 +496,6 @@ func TestMultiChannelPeer_SendTransactionWithSortedByTime(t *testing.T) {
 	}
 
 	// Shuffle transactions.
-	rand.Seed(time.Now().Unix())
 	rand.Shuffle(len(txs), func(i, j int) {
 		txs[i], txs[j] = txs[j], txs[i]
 	})
@@ -562,7 +557,6 @@ func TestMultiChannelPeer_ReSendTransactionWithSortedByTime(t *testing.T) {
 	}
 
 	// Shuffle transactions.
-	rand.Seed(time.Now().Unix())
 	rand.Shuffle(len(txs), func(i, j int) {
 		txs[i], txs[j] = txs[j], txs[i]
 	})

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -2717,7 +2717,6 @@ func TestGetBridgeContractBalance(t *testing.T) {
 
 	// Case 2 - ? (Random)
 	{
-		rand.Seed(time.Now().UnixNano())
 		for i := 0; i < 10; i++ {
 			initialChildbridgeBalance, initialParentbridgeBalance := rand.Int63n(10000), rand.Int63n(10000)
 			cBridgeAddr, err := bm.DeployBridgeTest(sim, initialChildbridgeBalance, true)

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -18,6 +18,7 @@ package sc
 
 import (
 	"context"
+	crand "crypto/rand"
 	"encoding/hex"
 	"log"
 	"math/big"
@@ -2462,7 +2463,7 @@ func checkRegisterMultipleToken(t *testing.T, bm *BridgeManager, cBridgeAddr, pB
 
 func randomHex(n int) (string, error) {
 	bytes := make([]byte, n)
-	if _, err := rand.Read(bytes); err != nil {
+	if _, err := crand.Read(bytes); err != nil {
 		return "", err
 	}
 	return hex.EncodeToString(bytes), nil

--- a/snapshot/difflayer_test.go
+++ b/snapshot/difflayer_test.go
@@ -22,6 +22,7 @@ package snapshot
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"math/rand"
 	"testing"
 
@@ -76,7 +77,7 @@ func TestMergeBasics(t *testing.T) {
 		if rand.Intn(2) == 0 {
 			accStorage := make(map[common.Hash][]byte)
 			value := make([]byte, 32)
-			rand.Read(value)
+			crand.Read(value)
 			accStorage[randomHash()] = value
 			storage[h] = accStorage
 		}

--- a/snapshot/iterator_test.go
+++ b/snapshot/iterator_test.go
@@ -22,6 +22,7 @@ package snapshot
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"math/rand"
@@ -51,7 +52,7 @@ func TestAccountIteratorBasics(t *testing.T) {
 		if rand.Intn(2) == 0 {
 			accStorage := make(map[common.Hash][]byte)
 			value := make([]byte, 32)
-			rand.Read(value)
+			crand.Read(value)
 			accStorage[randomHash()] = value
 			storage[h] = accStorage
 		}
@@ -83,7 +84,7 @@ func TestStorageIteratorBasics(t *testing.T) {
 
 		var nilstorage int
 		for i := 0; i < 100; i++ {
-			rand.Read(value)
+			crand.Read(value)
 			if rand.Intn(2) == 0 {
 				accStorage[randomHash()] = common.CopyBytes(value)
 			} else {

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -47,8 +47,6 @@ func randomHash() common.Hash {
 
 // randomAccount generates a random account and returns it RLP encoded.
 func randomAccount() []byte {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	var (
 		acc  account.Account
 		root = randomHash()

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -21,6 +21,7 @@
 package snapshot
 
 import (
+	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"math/big"
@@ -28,19 +29,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/klaytn/klaytn/blockchain/types/account"
-
 	"github.com/VictoriaMetrics/fastcache"
-	"github.com/klaytn/klaytn/storage/database"
-
+	"github.com/klaytn/klaytn/blockchain/types/account"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/rlp"
+	"github.com/klaytn/klaytn/storage/database"
 )
 
 // randomHash generates a random blob of data and returns it as a hash.
 func randomHash() common.Hash {
 	var hash common.Hash
-	if n, err := rand.Read(hash[:]); n != common.HashLength || err != nil {
+	if n, err := crand.Read(hash[:]); n != common.HashLength || err != nil {
 		panic(err)
 	}
 	return hash

--- a/storage/database/leveldb_bench_multidisks_test.go
+++ b/storage/database/leveldb_bench_multidisks_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"sync"
 	"testing"
-	"time"
 )
 
 type multiDiskOption struct {
@@ -471,7 +470,6 @@ func Benchmark_MDP_Parallel_Get(b *testing.B) {
 				db.Put(keys[k], values[k])
 			}
 
-			rand.Seed(time.Now().UnixNano())
 			b.StartTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
@@ -506,7 +504,6 @@ func Benchmark_MDP_Parallel_Put(b *testing.B) {
 
 			keys, values := genKeysAndValues(numBytes, numRows)
 
-			rand.Seed(time.Now().UnixNano())
 			b.StartTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
@@ -541,7 +538,6 @@ func Benchmark_MDP_Parallel_Batch(b *testing.B) {
 
 			keys, values := genKeysAndValues(numBytes, numRows)
 
-			rand.Seed(time.Now().UnixNano())
 			b.StartTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -1128,7 +1128,6 @@ func (db *Database) SaveTrieNodeCacheToFile(filePath string, concurrency int) {
 
 // DumpPeriodically atomically saves fast cache data to the given dir with the specified interval.
 func (db *Database) SaveCachePeriodically(c *TrieNodeCacheConfig, stopCh <-chan struct{}) {
-	rand.Seed(time.Now().UnixNano())
 	randomVal := 0.5 + rand.Float64()/2.0 // 0.5 <= randomVal < 1.0
 	startTime := time.Duration(int(randomVal * float64(c.FastCacheSavePeriod)))
 	logger.Info("first periodic cache saving will be triggered", "after", startTime)

--- a/storage/statedb/proof_test.go
+++ b/storage/statedb/proof_test.go
@@ -27,16 +27,11 @@ import (
 	mrand "math/rand"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/storage/database"
 )
-
-func init() {
-	mrand.Seed(time.Now().Unix())
-}
 
 func TestProof(t *testing.T) {
 	trie, vals := randomTrie(500)

--- a/storage/statedb/trie_test.go
+++ b/storage/statedb/trie_test.go
@@ -22,6 +22,7 @@ package statedb
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"math/big"
@@ -902,8 +903,8 @@ func TestDecodeNode(t *testing.T) {
 		elems = make([]byte, 20)
 	)
 	for i := 0; i < 5000000; i++ {
-		rand.Read(hash)
-		rand.Read(elems)
+		crand.Read(hash)
+		crand.Read(elems)
 		decodeNode(hash, elems)
 	}
 }

--- a/tests/pregenerated_data_generation_test.go
+++ b/tests/pregenerated_data_generation_test.go
@@ -28,7 +28,6 @@ import (
 	"runtime/pprof"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/blockchain/state"
@@ -39,10 +38,6 @@ import (
 	"github.com/otiai10/copy"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 var errNoOriginalDataDir = errors.New("original data directory does not exist, aborting the test")
 


### PR DESCRIPTION
## Proposed changes

- This PR removes the deprecated math/rand function calls.
  - https://github.com/klaytn/klaytn/commit/678683c2029da9d104714aa6ab68a80d9db6e7d1: replace math/rand.Read to crypto/rand.Read
  - https://github.com/klaytn/klaytn/commit/2bc387e5df8a1a0bd019803d7e409b914ea5562a: delelte math/rand.Seed calls. no longer needed.
  - See https://tip.golang.org/doc/go1.22

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
