### PR TITLE
istanbul: Validate message signer address

### DIFF
--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -39,4 +39,6 @@ var (
 	errInvalidMessage = errors.New("invalid message")
 	// errFailedDecodeMessageSet is returned when the message set is malformed.
 	errFailedDecodeMessageSet = errors.New("failed to decode message set")
+	// errInvalidSigner is returned when the message is signed by a validator different than message sender
+	errInvalidSigner = errors.New("message not signed by the sender")
 )

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -21,6 +21,7 @@
 package core
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -58,9 +59,10 @@ func (s State) String() string {
 }
 
 // Cmp compares s and y and returns:
-//   -1 if s is the previous state of y
-//    0 if s and y are the same state
-//   +1 if s is the next state of y
+//
+//	-1 if s is the previous state of y
+//	 0 if s and y are the same state
+//	+1 if s is the next state of y
 func (s State) Cmp(y State) int {
 	if uint64(s) < uint64(y) {
 		return -1
@@ -134,10 +136,15 @@ func (m *message) FromPayload(b []byte, validateFn func([]byte, []byte) (common.
 			return err
 		}
 
-		_, err = validateFn(payload, m.Signature)
+		signerAdd, err := validateFn(payload, m.Signature)
+		if err != nil {
+			return err
+		}
+		if bytes.Compare(signerAdd.Bytes(), m.Address.Bytes()) != 0 {
+			return errInvalidSigner
+		}
 	}
-	// Still return the message even the err is not nil
-	return err
+	return nil
 }
 
 func (m *message) Payload() ([]byte, error) {

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -136,11 +136,11 @@ func (m *message) FromPayload(b []byte, validateFn func([]byte, []byte) (common.
 			return err
 		}
 
-		signerAdd, err := validateFn(payload, m.Signature)
+		signerAddr, err := validateFn(payload, m.Signature)
 		if err != nil {
 			return err
 		}
-		if bytes.Compare(signerAdd.Bytes(), m.Address.Bytes()) != 0 {
+		if !bytes.Equal(signerAddr.Bytes(), m.Address.Bytes()) {
 			return errInvalidSigner
 		}
 	}


### PR DESCRIPTION
## Proposed changes

- Add the missing validation of Istanbul messages. Ensures that the message is indeed sent by the `msg.Address`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
