### PR TITLE
accounts/keystore: Replace uuid library

### DIFF
--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -32,10 +32,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/crypto"
-	"github.com/pborman/uuid"
 )
 
 // Key represents a keystore storing private keys of an account.
@@ -133,7 +133,11 @@ func (k *KeyV3) UnmarshalJSON(j []byte) (err error) {
 	}
 
 	u := new(uuid.UUID)
-	*u = uuid.Parse(keyJSON.Id)
+	*u, err = uuid.Parse(keyJSON.Id)
+	if err != nil {
+		return err
+	}
+
 	k.Id = *u
 	addr, err := hex.DecodeString(keyJSON.Address)
 	if err != nil {
@@ -175,7 +179,10 @@ func (k *KeyV3) ResetPrivateKey() {
 }
 
 func newKeyFromECDSAWithAddress(privateKeyECDSA *ecdsa.PrivateKey, address common.Address) Key {
-	id := uuid.NewRandom()
+	id, err := uuid.NewRandom()
+	if err != nil {
+		panic(fmt.Sprintf("Could not create random uuid: %v", err))
+	}
 	key := &KeyV4{
 		Id:          id,
 		Address:     address,
@@ -185,7 +192,11 @@ func newKeyFromECDSAWithAddress(privateKeyECDSA *ecdsa.PrivateKey, address commo
 }
 
 func newKeyFromECDSA(privateKeyECDSA *ecdsa.PrivateKey) Key {
-	id := uuid.NewRandom()
+	id, err := uuid.NewRandom()
+	if err != nil {
+		panic(fmt.Sprintf("Could not create random uuid: %v", err))
+	}
+
 	key := &KeyV4{
 		Id:          id,
 		Address:     crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),

--- a/accounts/keystore/key2335.go
+++ b/accounts/keystore/key2335.go
@@ -23,9 +23,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/klaytn/klaytn/crypto/bls"
-	"github.com/pborman/uuid"
 	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 )
 
@@ -50,8 +51,12 @@ type encryptedKeyEIP2335JSON struct {
 
 // NewKeyEIP2335 creates a new EIP-2335 keystore Key type using a BLS private key.
 func NewKeyEIP2335(blsKey bls.SecretKey) *KeyEIP2335 {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		panic(fmt.Sprintf("Could not create random uuid: %v", err))
+	}
 	return &KeyEIP2335{
-		ID:        uuid.NewRandom(),
+		ID:        id,
 		PublicKey: blsKey.PublicKey(),
 		SecretKey: blsKey,
 	}
@@ -64,8 +69,8 @@ func DecryptKeyEIP2335(keyJSON []byte, password string) (*KeyEIP2335, error) {
 		return nil, err
 	}
 
-	id := uuid.Parse(k.ID)
-	if id == nil {
+	id, err := uuid.Parse(k.ID)
+	if err != nil {
 		return nil, errors.New("Invalid UUID")
 	}
 

--- a/accounts/keystore/keystore_passphrase_test.go
+++ b/accounts/keystore/keystore_passphrase_test.go
@@ -25,11 +25,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/klaytn/klaytn/crypto"
-	"github.com/pborman/uuid"
-	"github.com/stretchr/testify/require"
-
+	"github.com/google/uuid"
 	"github.com/klaytn/klaytn/common"
+	"github.com/klaytn/klaytn/crypto"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -75,8 +74,11 @@ func TestEncryptDecryptV4Single(t *testing.T) {
 
 	auth := string("password")
 
+	id, err := uuid.NewRandom()
+	require.NoError(t, err)
+
 	key := &KeyV4{
-		Id:          uuid.NewRandom(),
+		Id:          id,
 		Address:     crypto.PubkeyToAddress(pk.PublicKey),
 		PrivateKeys: [][]*ecdsa.PrivateKey{{pk}},
 	}
@@ -99,10 +101,12 @@ func TestEncryptDecryptV4Multiple(t *testing.T) {
 		pks[i] = k
 	}
 
+	id, err := uuid.NewRandom()
+	require.NoError(t, err)
 	auth := "password"
 
 	key := &KeyV4{
-		Id:          uuid.NewRandom(),
+		Id:          id,
 		Address:     crypto.PubkeyToAddress(pks[0].PublicKey),
 		PrivateKeys: [][]*ecdsa.PrivateKey{pks},
 	}
@@ -129,10 +133,12 @@ func TestEncryptDecryptV4RoleBased(t *testing.T) {
 		}
 	}
 
+	id, err := uuid.NewRandom()
+	require.NoError(t, err)
 	auth := "password"
 
 	key := &KeyV4{
-		Id:          uuid.NewRandom(),
+		Id:          id,
 		Address:     crypto.PubkeyToAddress(pks[0][0].PublicKey),
 		PrivateKeys: pks,
 	}

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -31,14 +31,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klaytn/klaytn/accounts"
 	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/crypto"
+	"github.com/klaytn/klaytn/event"
 	"github.com/klaytn/klaytn/params"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/klaytn/klaytn/accounts"
-	"github.com/klaytn/klaytn/common"
-	"github.com/klaytn/klaytn/event"
 )
 
 var testSigData = make([]byte, 32)

--- a/accounts/keystore/keyv4.go
+++ b/accounts/keystore/keyv4.go
@@ -21,9 +21,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
+	"github.com/google/uuid"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/crypto"
-	"github.com/pborman/uuid"
 )
 
 type KeyV4 struct {
@@ -81,7 +81,10 @@ func (k *KeyV4) UnmarshalJSON(j []byte) (err error) {
 		return err
 	}
 
-	k.Id = uuid.Parse(keyJSON.Id)
+	k.Id, err = uuid.Parse(keyJSON.Id)
+	if err != nil {
+		return err
+	}
 
 	addr, err := hex.DecodeString(keyJSON.Address)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/newrelic/go-agent/v3 v3.11.0
 	github.com/otiai10/copy v1.0.1
 	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
-	github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1
@@ -75,6 +74,7 @@ require (
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/dop251/goja v0.0.0-20231014103939-873a1496dc8e
+	github.com/google/uuid v1.6.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/tyler-smith/go-bip32 v1.0.0
 	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1
@@ -109,7 +109,6 @@ require (
 	github.com/golang/glog v1.1.0 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/jcmturner/gofork v1.0.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -448,8 +448,6 @@ github.com/otiai10/mint v1.2.4/go.mod h1:d+b7n/0R3tdyUYYylALXpWQ/kTN+QobSq/4SRGB
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4 h1:MfIUBZ1bz7TgvQLVa/yPJZOGeKEgs6eTKUjz3zB4B+U=
 github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4/go.mod h1:RMU2gJXhratVxBDTFeOdNhd540tG57lt9FIUV0YLvIQ=
-github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c h1:MUyE44mTvnI5A0xrxIxaMqoWFzPfQvtE2IWUollMDMs=
-github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 h1:oYW+YCJ1pachXTQmzR3rNLYGGz4g/UgFcjb28p/viDM=


### PR DESCRIPTION
## Proposed changes

- [ethereum/go-ethereum@`eb7ed78` (#22217)](https://github.com/ethereum/go-ethereum/pull/22217/commits/eb7ed78a57f9e4f918aa0cb92ac097574ae5a9de)
- Stop using the deprecated https://github.com/pborman/uuid
- Migrate to the maintained https://github.com/google/uuid

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
