### PR TITLE
Handle staking info since kaia fork in downloader.

### DIFF
--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -351,7 +351,6 @@ func (d *Downloader) GetSnapSyncer() *snap.Syncer {
 // adding various sanity checks as well as wrapping it with various logger entries.
 func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode SyncMode) error {
 	err := d.synchronise(id, head, td, mode)
-
 	switch err {
 	case nil, errBusy, errCanceled:
 		return err
@@ -432,7 +431,6 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 			d.snapSync = true
 		}
 	}
-
 	// Reset the queue, peer set and wake channels to clean any internal leftover state
 	d.queue.Reset(blockCacheMaxItems, blockCacheInitialItems)
 	d.peers.Reset()
@@ -1847,7 +1845,6 @@ func (d *Downloader) processFastSyncContent() error {
 				continue
 			}
 		}
-
 		// Fast sync done, pivot commit done, full import
 		if err := d.importBlockResults(afterP); err != nil {
 			return err

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -351,6 +351,7 @@ func (d *Downloader) GetSnapSyncer() *snap.Syncer {
 // adding various sanity checks as well as wrapping it with various logger entries.
 func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode SyncMode) error {
 	err := d.synchronise(id, head, td, mode)
+
 	switch err {
 	case nil, errBusy, errCanceled:
 		return err
@@ -422,6 +423,14 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 			d.snapSync = true
 		}
 	}
+
+	// Delete staking info needed after kaia fork
+	for _, blockNum := range d.queue.stakingInfoStoredBlocks {
+		if d.blockchain.Config().IsKaiaForkEnabled(big.NewInt(int64(blockNum) + 1)) {
+			reward.DeleteStakingInfoFromDB(blockNum)
+		}
+	}
+
 	// Reset the queue, peer set and wake channels to clean any internal leftover state
 	d.queue.Reset(blockCacheMaxItems, blockCacheInitialItems)
 	d.peers.Reset()
@@ -1685,19 +1694,13 @@ func (d *Downloader) processFullSyncContent() error {
 		if d.chainInsertHook != nil {
 			d.chainInsertHook(results)
 		}
-		if err := d.importBlockResults(results, d.stakingInfoRemover(results)); err != nil {
+		if err := d.importBlockResults(results); err != nil {
 			return err
 		}
 	}
 }
 
-func (d *Downloader) importBlockResults(results []*fetchResult, deleteFn func()) error {
-	defer func() {
-		if deleteFn != nil {
-			deleteFn()
-		}
-	}()
-
+func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	// Check for any early termination requests
 	if len(results) == 0 {
 		return nil
@@ -1844,19 +1847,8 @@ func (d *Downloader) processFastSyncContent() error {
 		}
 
 		// Fast sync done, pivot commit done, full import
-		if err := d.importBlockResults(afterP, d.stakingInfoRemover(results)); err != nil {
+		if err := d.importBlockResults(afterP); err != nil {
 			return err
-		}
-	}
-}
-
-func (d *Downloader) stakingInfoRemover(results []*fetchResult) func() {
-	return func() {
-		for _, result := range results {
-			if result.StakingInfo != nil && d.queue.IsKaiaFork(big.NewInt(int64(result.StakingInfo.BlockNum+1))) {
-				// Ignore error, as we don't want to stop the sync process due to staking info deletion failure
-				reward.DeleteStakingInfoFromDB(result.StakingInfo.BlockNum)
-			}
 		}
 	}
 }

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -398,7 +398,9 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 	}
 	defer func() {
 		atomic.StoreInt32(&d.synchronising, 0)
-		// Remove staking info for kaia block from DB after syncing
+		// Staking info for kaia block has been temporarily stored in DB for post-download VerifyHeader.
+		// Now that the download and sync are complete, remove staking info for kaia block from DB
+		// to save space. They might stay in the cache though.
 		for _, blockNum := range d.queue.stakingInfoStoredBlocks {
 			if d.blockchain.Config().IsKaiaForkEnabled(big.NewInt(int64(blockNum) + 1)) {
 				reward.DeleteStakingInfoFromDB(blockNum)

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -360,9 +360,7 @@ func (dl *downloadTester) CurrentBlock() *types.Block {
 // Config retrieves the chain configuration of the tester.
 func (dl *downloadTester) Config() *params.ChainConfig {
 	config := params.TestChainConfig
-	if kaiaCompatibleBlock != nil {
-		config.KaiaCompatibleBlock = kaiaCompatibleBlock
-	}
+	config.KaiaCompatibleBlock = kaiaCompatibleBlock
 	return config
 }
 
@@ -1041,16 +1039,13 @@ func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 }
 
 func testBoundedForkedSync65FastOnKaia(t *testing.T, protocol int, mode SyncMode) {
-	t.Parallel()
-
-	originalKaiaFork := kaiaCompatibleBlock
 	originalStakingUpdateInterval := testStakingUpdateInterval
 	kaiaCompatibleBlock = big.NewInt(0)
 	testStakingUpdateInterval = 1
 	tester := newTester()
 	defer func() {
 		tester.terminate()
-		kaiaCompatibleBlock = originalKaiaFork
+		kaiaCompatibleBlock = nil
 		testStakingUpdateInterval = originalStakingUpdateInterval
 	}()
 

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -58,6 +58,7 @@ var (
 	lock                      sync.Mutex
 	setter                    *govSetter
 	testStakingUpdateInterval = uint64(4)
+	kaiaCompatibleBlock       *big.Int
 )
 
 // govSetter sets governance items for testing purpose
@@ -358,7 +359,11 @@ func (dl *downloadTester) CurrentBlock() *types.Block {
 
 // Config retrieves the chain configuration of the tester.
 func (dl *downloadTester) Config() *params.ChainConfig {
-	return params.TestChainConfig
+	config := params.TestChainConfig
+	if kaiaCompatibleBlock != nil {
+		config.KaiaCompatibleBlock = kaiaCompatibleBlock
+	}
+	return config
 }
 
 // CurrentFastBlock retrieves the current head fast-sync block from the canonical chain.
@@ -772,7 +777,12 @@ func assertOwnForkedChain(t *testing.T, tester *downloadTester, common int, leng
 		receipts += length - common - fsMinFullBlocks
 		stakingInfos += length - common - fsMinFullBlocks
 	}
-	stakingInfos = stakingInfos / int(testStakingUpdateInterval) // assuming that staking information update interval is 4
+	stakingInfos = stakingInfos / int(testStakingUpdateInterval) // assuming that staking information update interval is 4 or 1 (kaia fork)
+	if testStakingUpdateInterval == 1 {
+		// Since staking information is a previous block on kaia fork, it needs to be subtracted by 1
+		// [common = 1, 2, 3, 4, 5] => We need staking information at [1, 2, 3, 4], not [1, 2, 3, 4, 5]
+		stakingInfos = stakingInfos - 1
+	}
 	switch tester.downloader.getMode() {
 	case FullSync:
 		receipts, stakingInfos = 1, 0
@@ -1000,6 +1010,11 @@ func TestBoundedForkedSync64Light(t *testing.T) { testBoundedForkedSync(t, 64, L
 func TestBoundedForkedSync65Full(t *testing.T)  { testBoundedForkedSync(t, 65, FullSync) }
 func TestBoundedForkedSync65Fast(t *testing.T)  { testBoundedForkedSync(t, 65, FastSync) }
 
+// The staking info after kaia should be deleted after finishing the sync process.
+func TestBoundedForkedSync65FastOnKaia(t *testing.T) {
+	testBoundedForkedSync65FastOnKaia(t, 65, FastSync)
+}
+
 func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
 
@@ -1022,6 +1037,40 @@ func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	// Synchronise with the second peer and ensure that the fork is rejected to being too old
 	if err := tester.sync("rewriter", nil, mode); err != errInvalidAncestor {
 		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidAncestor)
+	}
+}
+
+func testBoundedForkedSync65FastOnKaia(t *testing.T, protocol int, mode SyncMode) {
+	t.Parallel()
+
+	originalKaiaFork := kaiaCompatibleBlock
+	originalStakingUpdateInterval := testStakingUpdateInterval
+	kaiaCompatibleBlock = big.NewInt(0)
+	testStakingUpdateInterval = 1
+	tester := newTester()
+	defer func() {
+		tester.terminate()
+		kaiaCompatibleBlock = originalKaiaFork
+		testStakingUpdateInterval = originalStakingUpdateInterval
+	}()
+
+	// Create a long enough forked chain
+	common, fork := 13, int(MaxForkAncestry+17)
+	hashesA, _, headersA, _, blocksA, _, receiptsA, _, stakingInfoA, _ := tester.makeChainFork(common+fork, fork, tester.genesis, nil, true)
+
+	tester.newPeer("original", protocol, hashesA, headersA, blocksA, receiptsA, stakingInfoA)
+
+	// Synchronise with the peer and make sure all blocks were retrieved
+	if err := tester.sync("original", nil, mode); err != nil {
+		t.Fatalf("failed to synchronise blocks: %v", err)
+	}
+	assertOwnChain(t, tester, common+fork+1)
+
+	for _, stakingInfo := range tester.ownStakingInfo {
+		has, _ := reward.HasStakingInfoFromDB(stakingInfo.BlockNum)
+		if has {
+			t.Fatalf("staking info should be deleted after sync process")
+		}
 	}
 }
 

--- a/datasync/downloader/queue.go
+++ b/datasync/downloader/queue.go
@@ -922,7 +922,6 @@ func (q *queue) DeliverStakingInfos(id string, stakingInfoList []*reward.Staking
 	}
 
 	reconstruct := func(index int, result *fetchResult) {
-		q.stakingInfoStoredBlocks = append(q.stakingInfoStoredBlocks, result.StakingInfo.BlockNum)
 		result.StakingInfo = stakingInfoList[index]
 		result.SetStakingInfoDone()
 	}

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -177,10 +177,6 @@ func senderTxHashIndexer(db database.DBManager, chainEvent <-chan blockchain.Cha
 }
 
 func checkSyncMode(config *Config) error {
-	// TODO-Kaia: allow snap sync after resolving the staking info sync issue
-	if config.SyncMode == downloader.SnapSync {
-		return errors.New("snap sync is temporarily disabled")
-	}
 	if !config.SyncMode.IsValid() {
 		return fmt.Errorf("invalid sync mode %d", config.SyncMode)
 	}

--- a/reward/staking_info_db.go
+++ b/reward/staking_info_db.go
@@ -27,6 +27,7 @@ type stakingInfoDB interface {
 	HasStakingInfo(blockNum uint64) (bool, error)
 	ReadStakingInfo(blockNum uint64) ([]byte, error)
 	WriteStakingInfo(blockNum uint64, stakingInfo []byte) error
+	DeleteStakingInfo(blockNum uint64)
 }
 
 // HasStakingInfoFromDB returns existence of staking information from miscdb.
@@ -69,5 +70,14 @@ func AddStakingInfoToDB(stakingInfo *StakingInfo) error {
 		return err
 	}
 
+	return nil
+}
+
+func DeleteStakingInfoFromDB(blockNum uint64) error {
+	if stakingManager.stakingInfoDB == nil {
+		return ErrStakingDBNotSet
+	}
+
+	stakingManager.stakingInfoDB.DeleteStakingInfo(blockNum)
 	return nil
 }

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -141,7 +141,17 @@ func GetStakingInfo(blockNum uint64) *StakingInfo {
 		if blockNum > 0 {
 			stakingBlockNumber--
 		}
-		stakingInfo = GetStakingInfoForKaiaBlock(stakingBlockNumber)
+		if stakingInfo = GetStakingInfoForKaiaBlock(stakingBlockNumber); stakingInfo == nil {
+			// Get staking info from DB if it exists.
+			// The staking info stored in DB is for downloader to verify the header.
+			// After downloader verifies all headers, the staking info in DB will be removed.
+			if stakingInfo, err := getStakingInfoFromDB(stakingBlockNumber); stakingInfo != nil && err == nil {
+				// Fill in Gini coeff before adding to cache.
+				if err := fillMissingGiniCoefficient(stakingInfo, stakingBlockNumber); err != nil {
+					logger.Warn("Cannot fill in gini coefficient", "staking block number", stakingBlockNumber, "err", err)
+				}
+			}
+		}
 	} else {
 		stakingBlockNumber = params.CalcStakingBlockNumber(blockNum)
 		stakingInfo = GetStakingInfoOnStakingBlock(stakingBlockNumber)
@@ -168,17 +178,6 @@ func GetStakingInfoForKaiaBlock(blockNum uint64) *StakingInfo {
 	// Get staking info from cache
 	if cachedStakingInfo := getStakingInfoFromCache(blockNum); cachedStakingInfo != nil {
 		return cachedStakingInfo
-	}
-
-	// Get staking info from DB if it exists.
-	// The staking info stored in DB is for downloader to verify the header.
-	// After downloader verifies all headers, the staking info in DB will be removed.
-	if storedStakingInfo, err := getStakingInfoFromDB(blockNum); storedStakingInfo != nil && err == nil {
-		// Fill in Gini coeff before adding to cache.
-		if err := fillMissingGiniCoefficient(storedStakingInfo, blockNum); err != nil {
-			logger.Warn("Cannot fill in gini coefficient", "staking block number", blockNum, "err", err)
-		}
-		return storedStakingInfo
 	}
 
 	stakingInfo, err := updateKaiaStakingInfo(blockNum)

--- a/reward/staking_manager_test.go
+++ b/reward/staking_manager_test.go
@@ -162,6 +162,25 @@ func TestStakingManager_GetFromDB(t *testing.T) {
 	checkGetStakingInfo(t)
 }
 
+// Check that StakingInfo are deleted from database
+func TestStakingManager_DeleteFromDB(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
+	resetStakingManagerForTest(t)
+
+	for _, testdata := range stakingManagerTestData {
+		AddStakingInfoToDB(testdata)
+	}
+
+	for _, testdata := range stakingManagerTestData {
+		DeleteStakingInfoFromDB(testdata.BlockNum)
+	}
+
+	for _, testdata := range stakingManagerTestData {
+		res, _ := getStakingInfoFromDB(testdata.BlockNum)
+		assert.Nil(t, res)
+	}
+}
+
 // Even if Gini was -1 in the cache, GetStakingInfo returns valid Gini
 func TestStakingManager_FillGiniFromCache(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)


### PR DESCRIPTION
## Proposed changes

After kaia fork, the staking info for block `N` is determined at block `N-1`. Also, staking info is no longer stored in DB after kaia fork. This breaks current implementation of downloader to fetch staking info to verify headers (especially in snap sync). In this PR, all necessary staking info for block verification even after kaia fork will be requested to peer and stored in DB temporary. The stored staking info after kaia fork will be deleted after committing blocks to blockchain.

When kaia fork block is `N` and downloader tries to fetch staking info from `N-10` to `N+10` when staking interval is 4:
| Sync state | Fetched staking info | Stored staking info |
|--|--|--|
| While syncing | `N-10`, `N-6`, `N-2`, `N-1`, `N`, `N+1`, ... `N+9` | All 14 fetched |
| After sync | - |  `N-10`, `N-6`, `N-2` |

It enables snap sync which was disabled at #2154.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
