### PR TITLE
Fix handle stakinginfo

### DIFF
--- a/datasync/downloader/downloader_fake.go
+++ b/datasync/downloader/downloader_fake.go
@@ -23,6 +23,7 @@ import (
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
 	"github.com/klaytn/klaytn/node/cn/snap"
+	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/reward"
 )
 
@@ -61,3 +62,5 @@ func (*FakeDownloader) Cancel()                     {}
 func (*FakeDownloader) GetSnapSyncer() *snap.Syncer                      { return nil }
 func (*FakeDownloader) SyncStakingInfo(id string, from, to uint64) error { return nil }
 func (*FakeDownloader) SyncStakingInfoStatus() *SyncingStatus            { return nil }
+
+func (*FakeDownloader) Config() *params.ChainConfig { return params.TestChainConfig }

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -356,6 +356,11 @@ func (dl *downloadTester) CurrentBlock() *types.Block {
 	return dl.genesis
 }
 
+// Config retrieves the chain configuration of the tester.
+func (dl *downloadTester) Config() *params.ChainConfig {
+	return params.TestChainConfig
+}
+
 // CurrentFastBlock retrieves the current head fast-sync block from the canonical chain.
 func (dl *downloadTester) CurrentFastBlock() *types.Block {
 	dl.lock.RLock()

--- a/datasync/downloader/resultstore.go
+++ b/datasync/downloader/resultstore.go
@@ -80,7 +80,7 @@ func (r *resultStore) SetThrottleThreshold(threshold uint64) uint64 {
 //	throttled - if true, the store is at capacity, this particular header is not prior now
 //	item      - the result to store data into
 //	err       - any error that occurred
-func (r *resultStore) AddFetch(header *types.Header, mode SyncMode, proposerPolicy uint64) (stale, throttled bool, item *fetchResult, err error) {
+func (r *resultStore) AddFetch(header *types.Header, mode SyncMode, proposerPolicy uint64, isKaiaFork bool) (stale, throttled bool, item *fetchResult, err error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -90,7 +90,7 @@ func (r *resultStore) AddFetch(header *types.Header, mode SyncMode, proposerPoli
 		return stale, throttled, item, err
 	}
 	if item == nil {
-		item = newFetchResult(header, mode, proposerPolicy)
+		item = newFetchResult(header, mode, proposerPolicy, isKaiaFork)
 		r.items[index] = item
 	}
 	return stale, throttled, item, err

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1044,7 +1044,16 @@ func handleStakingInfoRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error
 		if header == nil {
 			continue
 		}
-		result := reward.GetStakingInfoOnStakingBlock(header.Number.Uint64())
+		var result *reward.StakingInfo
+		number := header.Number.Uint64()
+		if pm.chainconfig.IsKaiaForkEnabled(header.Number) {
+			if number > 0 {
+				number--
+			}
+			result = reward.GetStakingInfoForKaiaBlock(number)
+		} else {
+			result = reward.GetStakingInfoOnStakingBlock(number)
+		}
 		if result == nil {
 			continue
 		}

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -246,7 +246,7 @@ func updateKaiaStakingInfo(blockNum uint64) (*StakingInfo, error) {
 	}
 
 	addStakingInfoToCache(stakingInfo)
-	logger.Info("Add a new stakingInfo to stakingInfoCache", "blockNum", blockNum)
+	logger.Debug("Add a new stakingInfo to stakingInfoCache", "blockNum", blockNum)
 
 	logger.Debug("Added stakingInfo", "stakingInfo", stakingInfo)
 	return stakingInfo, nil


### PR DESCRIPTION
## Proposed changes

This PR suggests:
1. Lower the log level when adding staking info only to cache (after kaia fork) 
2.  Make `SyncStakingInfo` for CNAPI work only before kaia block.
3. Fix staking info handler to return correct staking info after kaia fork.
4. Do not schedule staking info after kaia fork.

Although we expect there's no staking info requests since snap sync was disabled, it needs to return correct data. So if the requested staking info is for kaia fork, it returns staking info at previous block.

At downloader, queue still pushes tasks for staking info if it's `IsStakingUpdateInterval` even after kaia fork. This PR makes it only push task for before kaia fork block. (Eventually, to enable snap sync, the staking info after kaia fork also needs to be fetched. This has been implemented in this PR #2160.)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
