### PR TITLE
Unsubsribe chain head if over kaia fork

### DIFF
--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -466,7 +466,12 @@ func handleChainHeadEvent() {
 			}
 			if pset.Policy() == params.WeightedRandom {
 				// check and update if staking info is not valid before for the next update interval blocks
-				stakingInfo := GetStakingInfo(ev.Block.NumberU64() + pset.StakeUpdateInterval())
+				targetBlock := ev.Block.NumberU64() + pset.StakeUpdateInterval()
+				// After kaia fork, do not need to check staking info for the next update interval blocks.
+				if isKaiaForkEnabled(targetBlock) {
+					break
+				}
+				stakingInfo := GetStakingInfo(targetBlock)
 				if stakingInfo == nil {
 					logger.Error("unable to fetch staking info", "blockNum", ev.Block.NumberU64())
 				}


### PR DESCRIPTION
## Proposed changes

At PR #2154, staking manager no longer subscribes chain header when CN starts. But once it subscribes, it didn't unsubscribe after kaia fork. This PR fixes staking manager to unsubscribe if it passes kaia fork block.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
