### PR TITLE
Implement allocation contracts

### DIFF
--- a/contracts/contracts/system_contracts/allocation/Airdrop.sol
+++ b/contracts/contracts/system_contracts/allocation/Airdrop.sol
@@ -1,0 +1,88 @@
+// Copyright 2024 The kaia Authors
+// This file is part of the kaia library.
+//
+// The kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.25;
+
+import "./IAirdrop.sol";
+import "openzeppelin-contracts-5.0/access/Ownable.sol";
+
+contract Airdrop is Ownable, IAirdrop {
+    /* ========== CONSTANTS ========== */
+
+    uint256 public constant KAIA_UNIT = 1e18;
+
+    uint256 public constant TOTAL_AIRDROP_AMOUNT = 80_000_000 * KAIA_UNIT;
+
+    /* ========== STATE VARIABLES ========== */
+
+    mapping(address => uint256) public claims;
+
+    mapping(address => bool) public claimed;
+
+    /* ========== CONSTRUCTOR ========== */
+
+    constructor() Ownable(msg.sender) {}
+
+    /* ========== OPERATOR FUNCTIONS ========== */
+
+    function addClaim(address _beneficiary, uint256 _amount) external override onlyOwner {
+        claims[_beneficiary] = _amount;
+    }
+
+    function addBatchClaims(
+        address[] calldata _beneficiaries,
+        uint256[] calldata _amounts
+    ) external override onlyOwner {
+        require(_beneficiaries.length == _amounts.length, "Airdrop: invalid input length");
+
+        for (uint256 i = 0; i < _beneficiaries.length; i++) {
+            claims[_beneficiaries[i]] = _amounts[i];
+        }
+    }
+
+    /* ========== PUBLIC FUNCTIONS ========== */
+
+    function claim() external override {
+        _claim(msg.sender);
+    }
+
+    function claimFor(address _beneficiary) public override {
+        _claim(_beneficiary);
+    }
+
+    function claimBatch(address[] calldata _beneficiary) external override {
+        for (uint256 i = 0; i < _beneficiary.length; i++) {
+            _claim(_beneficiary[i]);
+        }
+    }
+
+    /* ========== INTERNAL FUNCTIONS ========== */
+
+    function _claim(address _beneficiary) internal {
+        require(!claimed[_beneficiary], "Airdrop: already claimed");
+
+        uint256 _amount = claims[_beneficiary];
+        require(_amount > 0 && _amount <= address(this).balance, "Airdrop: no claimable amount");
+
+        claimed[_beneficiary] = true;
+
+        (bool success, ) = _beneficiary.call{value: _amount}("");
+        require(success, "Transfer failed.");
+
+        emit Claimed(_beneficiary, _amount);
+    }
+}

--- a/contracts/contracts/system_contracts/allocation/IAirdrop.sol
+++ b/contracts/contracts/system_contracts/allocation/IAirdrop.sol
@@ -1,0 +1,46 @@
+// Copyright 2024 The kaia Authors
+// This file is part of the kaia library.
+//
+// The kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.25;
+
+interface IAirdrop {
+    /* ========== EVENT ========== */
+
+    event Claimed(address indexed beneficiary, uint256 amount);
+
+    /* ========== VIEWS ========== */
+
+    function KAIA_UNIT() external view returns (uint256);
+
+    function TOTAL_AIRDROP_AMOUNT() external view returns (uint256);
+
+    function claims(address) external view returns (uint256);
+
+    function claimed(address) external view returns (bool);
+
+    /* ========== MUTATIVE FUNCTIONS ========== */
+
+    function addClaim(address _beneficiary, uint256 _amount) external;
+
+    function addBatchClaims(address[] calldata _beneficiaries, uint256[] calldata _amounts) external;
+
+    function claim() external;
+
+    function claimFor(address _beneficiary) external;
+
+    function claimBatch(address[] calldata _beneficiaries) external;
+}

--- a/contracts/contracts/system_contracts/allocation/ILockup.sol
+++ b/contracts/contracts/system_contracts/allocation/ILockup.sol
@@ -1,0 +1,119 @@
+// Copyright 2024 The kaia Authors
+// This file is part of the kaia library.
+//
+// The kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.25;
+
+interface ILockup {
+    /* ========== DATA STRUCTURE ========== */
+
+    enum AcquisitionStatus {
+        UNDEFINED,
+        PROPOSED,
+        CONFIRMED,
+        WITHDRAWN,
+        REJECTED
+    }
+
+    struct Acquisition {
+        uint256 acReqId;
+        uint256 amount;
+        AcquisitionStatus status;
+    }
+
+    struct DelegatedTransfer {
+        uint256 delegatedTransferId;
+        uint256 amount;
+        address to;
+        AcquisitionStatus status; // Reuse the AcquisitionStatus enum
+    }
+
+    /* ========== EVENTS ========== */
+
+    event RefreshedDelegated(uint256 totalDelegatedAmount);
+
+    event ProposeAcquisition(uint256 acReqId, uint256 amount);
+
+    event RequestDelegatedTransfer(uint256 delegatedTransferId, uint256 amount, address to);
+
+    event WithdrawAcquisition(uint256 acReqId);
+
+    event WithdrawDelegatedTransfer(uint256 delegatedTransferId);
+
+    event WithdrawStakingAmounts(address pdKaia, uint256 shares);
+
+    event ClaimStakingAmounts(address pdKaia, uint256 requestId);
+
+    event ConfirmAcquisition(uint256 acReqId);
+
+    event RejectAcquisition(uint256 acReqId);
+
+    event ConfirmDelegatedTransfer(uint256 delegatedTransferId);
+
+    event RejectDelegatedTransfer(uint256 delegatedTransferId);
+
+    /* ========== VIEWS ========== */
+
+    function ADMIN_ROLE() external view returns (bytes32);
+
+    function SECRETARY_ROLE() external view returns (bytes32);
+
+    function nextAcReqId() external view returns (uint256);
+
+    function nextDelegatedTransferId() external view returns (uint256);
+
+    function getAllAcquisitions() external view returns (Acquisition[] memory);
+
+    function getAllDelegatedTransfers() external view returns (DelegatedTransfer[] memory);
+
+    function getAcquisition(uint256 acReqId) external view returns (Acquisition memory);
+
+    function getDelegatedTransfer(uint256 delegatedTransferId) external view returns (DelegatedTransfer memory);
+
+    function getAcquisitionAtStatus(AcquisitionStatus status) external view returns (Acquisition[] memory);
+
+    function getDelegatedTransferAtStatus(AcquisitionStatus status) external view returns (DelegatedTransfer[] memory);
+
+    /* ========== MUTATIVE FUNCTIONS ========== */
+
+    receive() external payable;
+
+    function transferAdmin(address newAdmin) external;
+
+    function transferSecretary(address newSecretary) external;
+
+    function refreshDelegated() external;
+
+    function proposeAcquisition(uint256 amount) external;
+
+    function requestDelegatedTransfer(uint256 amount, address to) external;
+
+    function withdrawAcquisition(uint256 acReqId) external;
+
+    function withdrawDelegatedTransfer(uint256 delegatedTransferId) external;
+
+    function withdrawStakingAmounts(address pdKaia, uint256 shares) external;
+
+    function claimStakingAmounts(address pdKaia, uint256 requestId) external;
+
+    function confirmAcquisition(uint256 acReqId) external;
+
+    function rejectAcquisition(uint256 acReqId) external;
+
+    function confirmDelegatedTransfer(uint256 delegatedTransferId) external;
+
+    function rejectDelegatedTransfer(uint256 delegatedTransferId) external;
+}

--- a/contracts/contracts/system_contracts/allocation/Lockup.sol
+++ b/contracts/contracts/system_contracts/allocation/Lockup.sol
@@ -1,0 +1,326 @@
+// Copyright 2024 The kaia Authors
+// This file is part of the kaia library.
+//
+// The kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.25;
+
+import "./ILockup.sol";
+import "../consensus/PublicDelegation/IPublicDelegation.sol";
+import "openzeppelin-contracts-5.0/access/extensions/AccessControlEnumerable.sol";
+
+contract Lockup is AccessControlEnumerable, ILockup {
+    /* ========== CONSTANTS ========== */
+
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+
+    bytes32 public constant SECRETARY_ROLE = keccak256("SECRETARY_ROLE");
+
+    /* ========== STATE VARIABLES ========== */
+
+    // Acquisition request list
+    Acquisition[] private _acquisitions;
+
+    // Delegated transfer request list
+    // Note that the `DelegatedTransfer` is used when stake the lockup amount, not the `Acquisition`.
+    // If the `DelegatedTransfer.to` is not the staking related contract, it won't be confirmed by the secretary.
+    DelegatedTransfer[] private _delegatedTransfers;
+
+    uint256 public totalDelegatedAmount;
+
+    bool public isInitialized;
+
+    /* ========== MODIFIERS ========== */
+
+    modifier notNull(address _address) {
+        _checkNull(_address);
+        _;
+    }
+
+    modifier beforeInit() {
+        _checkNotInit();
+        _;
+    }
+
+    modifier afterInit() {
+        _checkInit();
+        _;
+    }
+
+    /* ========== CONSTRUCTOR ========== */
+
+    constructor(address _admin, address _secretary) notNull(_admin) notNull(_secretary) {
+        _grantRole(ADMIN_ROLE, _admin);
+        _grantRole(SECRETARY_ROLE, _secretary);
+    }
+
+    // Since the KAIA will directly set to the contract, the admin needs to manually refresh the delegated amount.
+    function refreshDelegated() external override onlyRole(ADMIN_ROLE) beforeInit {
+        require(address(this).balance > 0, "Lockup: no claimable amount");
+
+        totalDelegatedAmount = address(this).balance;
+
+        isInitialized = true;
+
+        emit RefreshedDelegated(totalDelegatedAmount);
+    }
+
+    /* ========== ROLE MANAGEMENT FUNCTIONS ========== */
+
+    function transferAdmin(address _newAdmin) external override onlyRole(ADMIN_ROLE) notNull(_newAdmin) {
+        _grantRole(ADMIN_ROLE, _newAdmin);
+        _revokeRole(ADMIN_ROLE, msg.sender);
+    }
+
+    function transferSecretary(
+        address _newSecretary
+    ) external override onlyRole(SECRETARY_ROLE) notNull(_newSecretary) {
+        _grantRole(SECRETARY_ROLE, _newSecretary);
+        _revokeRole(SECRETARY_ROLE, msg.sender);
+    }
+
+    /* ========== ADMIN REQUEST FUNCTIONS ========== */
+
+    function proposeAcquisition(uint256 _amount) external override onlyRole(ADMIN_ROLE) afterInit {
+        require(_amount > 0 && _amount <= address(this).balance - _totalPendingAmount(), "Lockup: invalid amount");
+
+        uint256 _acReqId = nextAcReqId();
+
+        _acquisitions.push(Acquisition(_acquisitions.length, _amount, AcquisitionStatus.PROPOSED));
+
+        emit ProposeAcquisition(_acReqId, _amount);
+    }
+
+    function requestDelegatedTransfer(
+        uint256 _amount,
+        address _to
+    ) external override onlyRole(ADMIN_ROLE) afterInit notNull(_to) {
+        require(_amount > 0 && _amount <= address(this).balance - _totalPendingAmount(), "Lockup: invalid amount");
+
+        uint256 _delegatedTransferId = nextDelegatedTransferId();
+
+        _delegatedTransfers.push(
+            DelegatedTransfer(_delegatedTransfers.length, _amount, _to, AcquisitionStatus.PROPOSED)
+        );
+
+        emit RequestDelegatedTransfer(_delegatedTransferId, _amount, _to);
+    }
+
+    /* ========== ADMIN WITHDRAW FUNCTIONS ========== */
+
+    function withdrawAcquisition(uint256 _acReqId) external override onlyRole(ADMIN_ROLE) afterInit {
+        require(_acquisitions[_acReqId].status == AcquisitionStatus.CONFIRMED, "Lockup: invalid status");
+
+        _acquisitions[_acReqId].status = AcquisitionStatus.WITHDRAWN;
+
+        (bool success, ) = msg.sender.call{value: _acquisitions[_acReqId].amount}("");
+        require(success, "Lockup: transfer failed");
+
+        emit WithdrawAcquisition(_acReqId);
+    }
+
+    function withdrawDelegatedTransfer(uint256 _delegatedTransferId) external override onlyRole(ADMIN_ROLE) afterInit {
+        require(
+            _delegatedTransfers[_delegatedTransferId].status == AcquisitionStatus.CONFIRMED,
+            "Lockup: invalid status"
+        );
+
+        _delegatedTransfers[_delegatedTransferId].status = AcquisitionStatus.WITHDRAWN;
+
+        (bool success, ) = _delegatedTransfers[_delegatedTransferId].to.call{
+            value: _delegatedTransfers[_delegatedTransferId].amount
+        }("");
+        require(success, "Lockup: transfer failed");
+
+        emit WithdrawDelegatedTransfer(_delegatedTransferId);
+    }
+
+    /* ========== ADMIN PUBLIC DELEGATION INTERACTIONS ========== */
+
+    function withdrawStakingAmounts(address _pdKaia, uint256 _shares) external override onlyRole(ADMIN_ROLE) afterInit {
+        IPublicDelegation pdKaia = IPublicDelegation(payable(_pdKaia));
+        require(_shares > 0 && pdKaia.maxRedeem(address(this)) >= _shares, "Lockup: invalid shares");
+
+        pdKaia.redeem(address(this), _shares);
+
+        emit WithdrawStakingAmounts(_pdKaia, _shares);
+    }
+
+    function claimStakingAmounts(address _pdKaia, uint256 _requestId) external override onlyRole(ADMIN_ROLE) afterInit {
+        IPublicDelegation pdKaia = IPublicDelegation(payable(_pdKaia));
+        require(pdKaia.requestIdToOwner(_requestId) == address(this), "Lockup: invalid request owner");
+
+        pdKaia.claim(_requestId);
+
+        emit ClaimStakingAmounts(_pdKaia, _requestId);
+    }
+
+    /* ========== SECRETARY FUNCTIONS ========== */
+
+    function confirmAcquisition(uint256 _acReqId) external override onlyRole(SECRETARY_ROLE) afterInit {
+        require(_acquisitions[_acReqId].status == AcquisitionStatus.PROPOSED, "Lockup: invalid status");
+
+        _acquisitions[_acReqId].status = AcquisitionStatus.CONFIRMED;
+
+        emit ConfirmAcquisition(_acReqId);
+    }
+
+    function rejectAcquisition(uint256 _acReqId) external override onlyRole(SECRETARY_ROLE) afterInit {
+        require(_acquisitions[_acReqId].status == AcquisitionStatus.PROPOSED, "Lockup: invalid status");
+
+        _acquisitions[_acReqId].status = AcquisitionStatus.REJECTED;
+
+        emit RejectAcquisition(_acReqId);
+    }
+
+    function confirmDelegatedTransfer(
+        uint256 _delegatedTransferId
+    ) external override onlyRole(SECRETARY_ROLE) afterInit {
+        require(
+            _delegatedTransfers[_delegatedTransferId].status == AcquisitionStatus.PROPOSED,
+            "Lockup: invalid status"
+        );
+
+        _delegatedTransfers[_delegatedTransferId].status = AcquisitionStatus.CONFIRMED;
+
+        emit ConfirmDelegatedTransfer(_delegatedTransferId);
+    }
+
+    function rejectDelegatedTransfer(
+        uint256 _delegatedTransferId
+    ) external override onlyRole(SECRETARY_ROLE) afterInit {
+        require(
+            _delegatedTransfers[_delegatedTransferId].status == AcquisitionStatus.PROPOSED,
+            "Lockup: invalid status"
+        );
+
+        _delegatedTransfers[_delegatedTransferId].status = AcquisitionStatus.REJECTED;
+
+        emit RejectDelegatedTransfer(_delegatedTransferId);
+    }
+
+    /* ========== PUBLIC FUNCTIONS ========== */
+
+    // `receive` is used when depositing the KAIA that withdrew for staking, which is `DelegatedTransfer`.
+    receive() external payable override {}
+
+    /* ========== INTERNAL UTILS ========== */
+
+    function _checkNull(address _address) private pure {
+        require(_address != address(0), "Address is null.");
+    }
+
+    function _checkInit() private view {
+        require(isInitialized, "Contract is not initialized.");
+    }
+
+    function _checkNotInit() private view {
+        require(!isInitialized, "Contract has been initialized.");
+    }
+
+    function _totalPendingAmount() private view returns (uint256 amount) {
+        return _pendingAcquisitionAmount() + _pendingDelegatedTransferAmount();
+    }
+
+    function _pendingAcquisitionAmount() private view returns (uint256 amount) {
+        for (uint256 i = 0; i < _acquisitions.length; i++) {
+            if (
+                _acquisitions[i].status == AcquisitionStatus.PROPOSED ||
+                _acquisitions[i].status == AcquisitionStatus.CONFIRMED
+            ) {
+                amount += _acquisitions[i].amount;
+            }
+        }
+
+        return amount;
+    }
+
+    function _pendingDelegatedTransferAmount() private view returns (uint256 amount) {
+        for (uint256 i = 0; i < _delegatedTransfers.length; i++) {
+            if (
+                _delegatedTransfers[i].status == AcquisitionStatus.PROPOSED ||
+                _delegatedTransfers[i].status == AcquisitionStatus.CONFIRMED
+            ) {
+                amount += _delegatedTransfers[i].amount;
+            }
+        }
+
+        return amount;
+    }
+
+    /* ========== GETTERS ========== */
+
+    function nextAcReqId() public view override returns (uint256) {
+        return _acquisitions.length;
+    }
+
+    function nextDelegatedTransferId() public view override returns (uint256) {
+        return _delegatedTransfers.length;
+    }
+
+    function getAllAcquisitions() external view override returns (Acquisition[] memory) {
+        return _acquisitions;
+    }
+
+    function getAllDelegatedTransfers() external view override returns (DelegatedTransfer[] memory) {
+        return _delegatedTransfers;
+    }
+
+    function getAcquisition(uint256 _acReqId) external view override returns (Acquisition memory) {
+        return _acquisitions[_acReqId];
+    }
+
+    function getDelegatedTransfer(
+        uint256 _delegatedTransferId
+    ) external view override returns (DelegatedTransfer memory) {
+        return _delegatedTransfers[_delegatedTransferId];
+    }
+
+    function getAcquisitionAtStatus(
+        AcquisitionStatus _status
+    ) external view override returns (Acquisition[] memory acquisitions) {
+        acquisitions = new Acquisition[](_acquisitions.length);
+        uint256 count = 0;
+
+        for (uint256 i = 0; i < _acquisitions.length; i++) {
+            if (_acquisitions[i].status == _status) {
+                acquisitions[count] = _acquisitions[i];
+                count++;
+            }
+        }
+
+        assembly {
+            mstore(acquisitions, count)
+        }
+    }
+
+    function getDelegatedTransferAtStatus(
+        AcquisitionStatus _status
+    ) external view override returns (DelegatedTransfer[] memory delegatedTransfers) {
+        delegatedTransfers = new DelegatedTransfer[](_delegatedTransfers.length);
+        uint256 count = 0;
+
+        for (uint256 i = 0; i < _delegatedTransfers.length; i++) {
+            if (_delegatedTransfers[i].status == _status) {
+                delegatedTransfers[count] = _delegatedTransfers[i];
+                count++;
+            }
+        }
+
+        assembly {
+            mstore(delegatedTransfers, count)
+        }
+    }
+}

--- a/contracts/test/Allocation/airdrop.test.ts
+++ b/contracts/test/Allocation/airdrop.test.ts
@@ -1,0 +1,169 @@
+import {
+  loadFixture,
+  setBalance,
+} from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+
+import { airdropTestFixture } from "../common/fixtures";
+
+type UnPromisify<T> = T extends Promise<infer U> ? U : T;
+
+describe("Airdrop", function () {
+  let fixture: UnPromisify<ReturnType<typeof airdropTestFixture>>;
+  beforeEach(async function () {
+    fixture = await loadFixture(airdropTestFixture);
+    const { airdrop, totalAirdropAmount } = fixture;
+
+    await setBalance(airdrop.address, totalAirdropAmount);
+  });
+  describe("Check constants", function () {
+    it("#totalAirdropAmount", async function () {
+      const { airdrop } = fixture;
+
+      expect(await airdrop.KAIA_UNIT()).to.equal(
+        hre.ethers.utils.parseEther("1")
+      );
+      expect(await airdrop.TOTAL_AIRDROP_AMOUNT()).to.equal(
+        hre.ethers.utils.parseEther("80000000")
+      );
+    });
+  });
+  describe("Set airdrop list", function () {
+    it("#addClaim", async function () {
+      const { airdrop, claimInfo } = fixture;
+
+      await airdrop.addClaim(claimInfo[0].claimer, claimInfo[0].amount);
+
+      expect(await airdrop.claims(claimInfo[0].claimer)).to.equal(
+        claimInfo[0].amount
+      );
+    });
+    it("#addClaim/addBatchClaims: only owner can add claim", async function () {
+      const { airdrop, notClaimer, claimInfo } = fixture;
+
+      await expect(
+        airdrop
+          .connect(notClaimer)
+          .addClaim(claimInfo[0].claimer, claimInfo[0].amount)
+      ).to.be.revertedWithCustomError(airdrop, "OwnableUnauthorizedAccount");
+
+      await expect(
+        airdrop
+          .connect(notClaimer)
+          .addBatchClaims([claimInfo[0].claimer], [claimInfo[0].amount])
+      ).to.be.revertedWithCustomError(airdrop, "OwnableUnauthorizedAccount");
+    });
+    it("#addBatchClaims", async function () {
+      const { airdrop, claimInfo } = fixture;
+
+      for (const claim of claimInfo) {
+        await airdrop.addClaim(claim.claimer, claim.amount);
+      }
+
+      for (const claim of claimInfo) {
+        expect(await airdrop.claims(claim.claimer)).to.equal(claim.amount);
+      }
+    });
+  });
+  describe("Claim airdrop", function () {
+    this.beforeEach(async function () {
+      const { airdrop, claimInfo } = fixture;
+
+      for (const claim of claimInfo) {
+        await airdrop.addClaim(claim.claimer, claim.amount);
+      }
+    });
+    it("#claim/claimFor: can't claim if not in the list", async function () {
+      const { airdrop, notClaimer, claimers } = fixture;
+
+      await expect(airdrop.connect(notClaimer).claim()).to.be.revertedWith(
+        "Airdrop: no claimable amount"
+      );
+
+      await expect(
+        airdrop.connect(claimers[0]).claimFor(notClaimer.address)
+      ).to.be.revertedWith("Airdrop: no claimable amount");
+    });
+    it("#claim: successfully get airdrop", async function () {
+      const { airdrop, claimers, claimInfo } = fixture;
+
+      const beforeBalance = await hre.ethers.provider.getBalance(
+        claimers[0].address
+      );
+
+      await expect(airdrop.connect(claimers[0]).claim())
+        .to.emit(airdrop, "Claimed")
+        .withArgs(claimers[0].address, claimInfo[0].amount);
+
+      const afterBalance = await hre.ethers.provider.getBalance(
+        claimers[0].address
+      );
+      // 0.0001 is a transaction fee
+      expect(afterBalance.sub(beforeBalance)).to.be.closeTo(
+        claimInfo[0].amount,
+        hre.ethers.utils.parseEther("0.0001")
+      );
+    });
+    it("#claimFor: successfully get airdrop", async function () {
+      const { airdrop, notClaimer, claimers, claimInfo } = fixture;
+
+      const beforeBalance = await hre.ethers.provider.getBalance(
+        claimers[0].address
+      );
+
+      await expect(airdrop.connect(notClaimer).claimFor(claimers[0].address))
+        .to.emit(airdrop, "Claimed")
+        .withArgs(claimers[0].address, claimInfo[0].amount);
+
+      const afterBalance = await hre.ethers.provider.getBalance(
+        claimers[0].address
+      );
+      expect(afterBalance.sub(beforeBalance)).to.equal(claimInfo[0].amount);
+    });
+    it("#claim/claimFor: can't get twice", async function () {
+      const { airdrop, notClaimer, claimers, claimInfo } = fixture;
+
+      await expect(airdrop.connect(claimers[0]).claim())
+        .to.emit(airdrop, "Claimed")
+        .withArgs(claimers[0].address, claimInfo[0].amount);
+
+      await expect(airdrop.connect(claimers[0]).claim()).to.be.revertedWith(
+        "Airdrop: already claimed"
+      );
+
+      await expect(
+        airdrop.connect(notClaimer).claimFor(claimers[0].address)
+      ).to.be.revertedWith("Airdrop: already claimed");
+    });
+    it("#claimBatch: successfully get airdrop", async function () {
+      const { airdrop, notClaimer, claimers, claimInfo } = fixture;
+
+      const beforeBalances = await Promise.all(
+        claimers.map((claimer) =>
+          hre.ethers.provider.getBalance(claimer.address)
+        )
+      );
+
+      await airdrop
+        .connect(notClaimer)
+        .claimBatch(claimers.map((claimer) => claimer.address));
+
+      //   const tx = await airdrop.connect(notClaimer).claimBatch(claimers.map((claimer) => claimer.address));
+      //   console.log(
+      //     "Gas used for claimBatch is",
+      //     (await tx.wait()).gasUsed.toString() + " when # of claimers is " + claimers.length,
+      //   );
+
+      const afterBalances = await Promise.all(
+        claimers.map((claimer) =>
+          hre.ethers.provider.getBalance(claimer.address)
+        )
+      );
+      for (let i = 0; i < claimers.length; i++) {
+        expect(afterBalances[i].sub(beforeBalances[i])).to.equal(
+          claimInfo[i].amount
+        );
+      }
+    });
+  });
+});

--- a/contracts/test/Allocation/lockup.test.ts
+++ b/contracts/test/Allocation/lockup.test.ts
@@ -1,0 +1,566 @@
+import {
+  loadFixture,
+  setBalance,
+} from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+
+import { LockupTestFixture } from "../common/fixtures";
+import {
+  PublicDelegation,
+  PublicDelegation__factory,
+} from "../../typechain-types";
+import { FakeContract, smock } from "@defi-wonderland/smock";
+
+const ADMIN_ROLE = hre.ethers.utils.keccak256(
+  hre.ethers.utils.toUtf8Bytes("ADMIN_ROLE")
+);
+const SECRETARY_ROLE = hre.ethers.utils.keccak256(
+  hre.ethers.utils.toUtf8Bytes("SECRETARY_ROLE")
+);
+
+enum AcquisitionStatus {
+  UNDEFINED,
+  PROPOSED,
+  CONFIRMED,
+  WITHDRAWN,
+  REJECTED,
+}
+
+type UnPromisify<T> = T extends Promise<infer U> ? U : T;
+describe("Airdrop", function () {
+  let fixture: UnPromisify<ReturnType<typeof LockupTestFixture>>;
+  beforeEach(async function () {
+    fixture = await loadFixture(LockupTestFixture);
+    const { lockup, totalDelegatedAmount } = fixture;
+
+    await setBalance(lockup.address, totalDelegatedAmount);
+  });
+  describe("Setup", function () {
+    it("Initial role setup", async function () {
+      const { lockup, deployer, admin } = fixture;
+
+      expect(await lockup.ADMIN_ROLE()).to.equal(ADMIN_ROLE);
+      expect(await lockup.SECRETARY_ROLE()).to.equal(SECRETARY_ROLE);
+
+      expect(await lockup.hasRole(ADMIN_ROLE, admin.address)).to.be.true;
+      expect(await lockup.hasRole(SECRETARY_ROLE, deployer.address)).to.be.true;
+    });
+    it("Role transfer", async function () {
+      const { lockup, deployer, admin, user } = fixture;
+
+      await lockup.connect(admin).transferAdmin(user.address);
+      await lockup.connect(deployer).transferSecretary(user.address);
+
+      expect(await lockup.hasRole(ADMIN_ROLE, user.address)).to.be.true;
+      expect(await lockup.hasRole(SECRETARY_ROLE, user.address)).to.be.true;
+    });
+    it("#refreshDelegated: refresh delegated amount", async function () {
+      const { lockup, admin, totalDelegatedAmount } = fixture;
+
+      await lockup.connect(admin).refreshDelegated();
+
+      expect(await lockup.totalDelegatedAmount()).to.equal(
+        totalDelegatedAmount
+      );
+      expect(await lockup.isInitialized()).to.be.true;
+    });
+  });
+  describe("only role check", function () {
+    it("check all functions", async function () {
+      const { lockup, user } = fixture;
+
+      await expect(
+        lockup.connect(user).transferAdmin(user.address)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).transferSecretary(user.address)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).refreshDelegated()
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).proposeAcquisition(1)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).requestDelegatedTransfer(1, user.address)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).withdrawAcquisition(0)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).withdrawDelegatedTransfer(0)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).withdrawStakingAmounts(user.address, 1)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).claimStakingAmounts(user.address, 0)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).confirmAcquisition(0)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).rejectAcquisition(0)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).confirmDelegatedTransfer(0)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+      await expect(
+        lockup.connect(user).rejectDelegatedTransfer(0)
+      ).to.be.revertedWithCustomError(
+        lockup,
+        "AccessControlUnauthorizedAccount"
+      );
+    });
+  });
+  describe("Acquisition", function () {
+    this.beforeEach(async function () {
+      const { lockup, admin } = fixture;
+
+      await lockup.connect(admin).refreshDelegated();
+    });
+    describe("Propose Acquisition", function () {
+      it("#proposeAcquisition: successfully propose acqusition request", async function () {
+        const { lockup, admin } = fixture;
+
+        await expect(lockup.connect(admin).proposeAcquisition(1000))
+          .to.emit(lockup, "ProposeAcquisition")
+          .withArgs(0, 1000);
+
+        const acquisition = await lockup.getAcquisition(0);
+        expect(acquisition.amount).to.equal(1000);
+        expect(acquisition.status).to.equal(AcquisitionStatus.PROPOSED);
+        expect(await lockup.nextAcReqId()).to.equal(1);
+      });
+      it("#proposeAcquisition: failed to propose acqusition request with 0 amount", async function () {
+        const { lockup, admin } = fixture;
+
+        await expect(
+          lockup.connect(admin).proposeAcquisition(0)
+        ).to.be.revertedWith("Lockup: invalid amount");
+      });
+      it("#proposeAcquisition: failed to propose acquisition request more than total delegated amount", async function () {
+        const { lockup, admin, totalDelegatedAmount } = fixture;
+
+        await expect(
+          lockup.connect(admin).proposeAcquisition(totalDelegatedAmount + 1n)
+        ).to.be.revertedWith("Lockup: invalid amount");
+
+        // or there's pending acquisition
+        await lockup.connect(admin).proposeAcquisition(totalDelegatedAmount);
+
+        await expect(
+          lockup.connect(admin).proposeAcquisition(1)
+        ).to.be.revertedWith("Lockup: invalid amount");
+      });
+    });
+    describe("Confirm/Reject Acquisition", function () {
+      this.beforeEach(async function () {
+        const { lockup, admin } = fixture;
+
+        await lockup.connect(admin).proposeAcquisition(1000);
+      });
+      it("#confirmAcquisition: successfully confirm acquisition request", async function () {
+        const { lockup, deployer } = fixture;
+
+        await expect(lockup.connect(deployer).confirmAcquisition(0))
+          .to.emit(lockup, "ConfirmAcquisition")
+          .withArgs(0);
+
+        const acquisition = await lockup.getAcquisition(0);
+        expect(acquisition.status).to.equal(AcquisitionStatus.CONFIRMED);
+      });
+      it("#confirmAcquisition: failed to confirm acquisition request not proposed status", async function () {
+        const { lockup, deployer } = fixture;
+
+        await expect(lockup.connect(deployer).confirmAcquisition(0))
+          .to.emit(lockup, "ConfirmAcquisition")
+          .withArgs(0);
+        // Already confirmed
+        await expect(
+          lockup.connect(deployer).confirmAcquisition(0)
+        ).to.be.revertedWith("Lockup: invalid status");
+      });
+      it("#rejectAcquisition: successfully reject acquisition request", async function () {
+        const { lockup, deployer } = fixture;
+
+        await expect(lockup.connect(deployer).rejectAcquisition(0))
+          .to.emit(lockup, "RejectAcquisition")
+          .withArgs(0);
+
+        const acquisition = await lockup.getAcquisition(0);
+        expect(acquisition.status).to.equal(AcquisitionStatus.REJECTED);
+      });
+      it("#rejectAcquisition: failed to reject acquisition request not proposed status", async function () {
+        const { lockup, deployer } = fixture;
+
+        await expect(lockup.connect(deployer).confirmAcquisition(0))
+          .to.emit(lockup, "ConfirmAcquisition")
+          .withArgs(0);
+        // Already confirmed
+        await expect(
+          lockup.connect(deployer).rejectAcquisition(0)
+        ).to.be.revertedWith("Lockup: invalid status");
+      });
+    });
+    describe("#withdrawAcquisition", function () {
+      const requestAmount = hre.ethers.utils.parseEther("1000");
+      this.beforeEach(async function () {
+        const { lockup, admin } = fixture;
+
+        await lockup.connect(admin).proposeAcquisition(requestAmount);
+      });
+      it("successfully withdraw acquisition request", async function () {
+        const { lockup, deployer, admin } = fixture;
+
+        const beforeBalance = await hre.ethers.provider.getBalance(
+          admin.address
+        );
+
+        await lockup.connect(deployer).confirmAcquisition(0);
+        await expect(lockup.connect(admin).withdrawAcquisition(0))
+          .to.emit(lockup, "WithdrawAcquisition")
+          .withArgs(0);
+
+        const afterBalance = await hre.ethers.provider.getBalance(
+          admin.address
+        );
+        // 0.0001 is a transaction fee
+        expect(afterBalance).to.be.closeTo(
+          beforeBalance.add(requestAmount),
+          hre.ethers.utils.parseEther("0.0001")
+        );
+        const acquisition = await lockup.getAcquisition(0);
+        expect(acquisition.status).to.equal(AcquisitionStatus.WITHDRAWN);
+      });
+      it("failed to withdraw acquisition request not confirmed status", async function () {
+        const { lockup, deployer, admin } = fixture;
+
+        await expect(
+          lockup.connect(admin).withdrawAcquisition(0)
+        ).to.be.revertedWith("Lockup: invalid status");
+
+        await lockup.connect(deployer).confirmAcquisition(0);
+        await expect(lockup.connect(admin).withdrawAcquisition(0))
+          .to.emit(lockup, "WithdrawAcquisition")
+          .withArgs(0);
+
+        await expect(
+          lockup.connect(admin).withdrawAcquisition(0)
+        ).to.be.revertedWith("Lockup: invalid status");
+      });
+    });
+  });
+  describe("Delegated Transfer", function () {
+    this.beforeEach(async function () {
+      const { lockup, admin } = fixture;
+
+      await lockup.connect(admin).refreshDelegated();
+    });
+    describe("Request Delegated Transfer", function () {
+      it("#requestDelegatedTransfer: successfully request delegated transfer", async function () {
+        const { lockup, admin, user } = fixture;
+
+        await expect(
+          lockup.connect(admin).requestDelegatedTransfer(1000, user.address)
+        )
+          .to.emit(lockup, "RequestDelegatedTransfer")
+          .withArgs(0, 1000, user.address);
+
+        const transfer = await lockup.getDelegatedTransfer(0);
+        expect(transfer.amount).to.equal(1000);
+        expect(transfer.to).to.equal(user.address);
+        expect(transfer.status).to.equal(AcquisitionStatus.PROPOSED);
+        expect(await lockup.nextDelegatedTransferId()).to.equal(1);
+      });
+      it("#requestDelegatedTransfer: failed to request delegated transfer with 0 amount", async function () {
+        const { lockup, admin, user } = fixture;
+
+        await expect(
+          lockup.connect(admin).requestDelegatedTransfer(0, user.address)
+        ).to.be.revertedWith("Lockup: invalid amount");
+      });
+      it("#requestDelegatedTransfer: failed to request delegated transfer more than total delegated amount", async function () {
+        const { lockup, admin, user, totalDelegatedAmount } = fixture;
+
+        await expect(
+          lockup
+            .connect(admin)
+            .requestDelegatedTransfer(totalDelegatedAmount + 1n, user.address)
+        ).to.be.revertedWith("Lockup: invalid amount");
+
+        // or there's pending transfer
+        await lockup
+          .connect(admin)
+          .requestDelegatedTransfer(totalDelegatedAmount, user.address);
+
+        await expect(
+          lockup.connect(admin).requestDelegatedTransfer(1, user.address)
+        ).to.be.revertedWith("Lockup: invalid amount");
+      });
+    });
+    describe("Confirm/Reject Delegated Transfer", function () {
+      this.beforeEach(async function () {
+        const { lockup, admin, user } = fixture;
+
+        await lockup
+          .connect(admin)
+          .requestDelegatedTransfer(1000, user.address);
+      });
+      it("#confirmDelegatedTransfer: successfully confirm delegated transfer", async function () {
+        const { lockup, deployer } = fixture;
+
+        await expect(lockup.connect(deployer).confirmDelegatedTransfer(0))
+          .to.emit(lockup, "ConfirmDelegatedTransfer")
+          .withArgs(0);
+
+        const transfer = await lockup.getDelegatedTransfer(0);
+        expect(transfer.status).to.equal(AcquisitionStatus.CONFIRMED);
+      });
+      it("#confirmDelegatedTransfer: failed to confirm delegated transfer not proposed status", async function () {
+        const { lockup, deployer } = fixture;
+
+        await expect(lockup.connect(deployer).confirmDelegatedTransfer(0))
+          .to.emit(lockup, "ConfirmDelegatedTransfer")
+          .withArgs(0);
+        // Already confirmed
+        await expect(
+          lockup.connect(deployer).confirmDelegatedTransfer(0)
+        ).to.be.revertedWith("Lockup: invalid status");
+      });
+      it("#rejectDelegatedTransfer: successfully reject delegated transfer", async function () {
+        const { lockup, deployer } = fixture;
+
+        await expect(lockup.connect(deployer).rejectDelegatedTransfer(0))
+          .to.emit(lockup, "RejectDelegatedTransfer")
+          .withArgs(0);
+
+        const transfer = await lockup.getDelegatedTransfer(0);
+        expect(transfer.status).to.equal(AcquisitionStatus.REJECTED);
+      });
+      it("#rejectDelegatedTransfer: failed to reject delegated transfer not proposed status", async function () {
+        const { lockup, deployer } = fixture;
+
+        await expect(lockup.connect(deployer).confirmDelegatedTransfer(0))
+          .to.emit(lockup, "ConfirmDelegatedTransfer")
+          .withArgs(0);
+        // Already confirmed
+        await expect(
+          lockup.connect(deployer).rejectDelegatedTransfer(0)
+        ).to.be.revertedWith("Lockup: invalid status");
+      });
+    });
+    describe("#withdrawDelegatedTransfer", function () {
+      const requestAmount = hre.ethers.utils.parseEther("1000");
+      this.beforeEach(async function () {
+        const { lockup, admin, user } = fixture;
+
+        await lockup
+          .connect(admin)
+          .requestDelegatedTransfer(requestAmount, user.address);
+      });
+      it("successfully withdraw delegated transfer", async function () {
+        const { lockup, deployer, admin, user } = fixture;
+
+        const beforeBalance = await hre.ethers.provider.getBalance(
+          user.address
+        );
+
+        await lockup.connect(deployer).confirmDelegatedTransfer(0);
+        await expect(lockup.connect(admin).withdrawDelegatedTransfer(0))
+          .to.emit(lockup, "WithdrawDelegatedTransfer")
+          .withArgs(0);
+
+        const afterBalance = await hre.ethers.provider.getBalance(user.address);
+        expect(afterBalance).to.be.equal(beforeBalance.add(requestAmount));
+
+        const transfer = await lockup.getDelegatedTransfer(0);
+        expect(transfer.status).to.equal(AcquisitionStatus.WITHDRAWN);
+      });
+      it("failed to withdraw delegated transfer not confirmed status", async function () {
+        const { lockup, deployer, admin } = fixture;
+
+        await expect(
+          lockup.connect(admin).withdrawDelegatedTransfer(0)
+        ).to.be.revertedWith("Lockup: invalid status");
+
+        await lockup.connect(deployer).confirmDelegatedTransfer(0);
+        await expect(lockup.connect(admin).withdrawDelegatedTransfer(0))
+          .to.emit(lockup, "WithdrawDelegatedTransfer")
+          .withArgs(0);
+
+        await expect(
+          lockup.connect(admin).withdrawDelegatedTransfer(0)
+        ).to.be.revertedWith("Lockup: invalid status");
+      });
+    });
+  });
+  describe("Interact with public delegation", function () {
+    let mockPD: FakeContract<PublicDelegation>;
+    this.beforeEach(async function () {
+      const { lockup, admin } = fixture;
+
+      await lockup.connect(admin).refreshDelegated();
+
+      mockPD = await smock.fake<PublicDelegation>(
+        PublicDelegation__factory.abi
+      );
+      mockPD.maxRedeem.returns(1000);
+
+      mockPD.requestIdToOwner.returns(lockup.address);
+    });
+    it("#withdrawStakingAmounts: successfully withdraw staking amounts", async function () {
+      const { lockup, admin } = fixture;
+
+      await expect(
+        lockup.connect(admin).withdrawStakingAmounts(mockPD.address, 1000)
+      )
+        .to.emit(lockup, "WithdrawStakingAmounts")
+        .withArgs(mockPD.address, 1000);
+    });
+    it("#withdrawStakingAmounts: failed to withdraw more than max redeemable shares", async function () {
+      const { lockup, admin } = fixture;
+
+      await expect(
+        lockup.connect(admin).withdrawStakingAmounts(mockPD.address, 10_000)
+      ).to.be.revertedWith("Lockup: invalid shares");
+    });
+    it("#claimStakingAmounts: successfully claim staking amounts", async function () {
+      const { lockup, admin } = fixture;
+
+      await expect(lockup.connect(admin).claimStakingAmounts(mockPD.address, 0))
+        .to.emit(lockup, "ClaimStakingAmounts")
+        .withArgs(mockPD.address, 0);
+    });
+    it("#claimStakingAmounts: failed to claim staking of not owned public delegation", async function () {
+      const { lockup, admin, user } = fixture;
+
+      mockPD.requestIdToOwner.returns(user.address); // Not owned
+
+      await expect(
+        lockup.connect(admin).claimStakingAmounts(mockPD.address, 0)
+      ).to.be.revertedWith("Lockup: invalid request owner");
+    });
+  });
+  describe("Check view functions", function () {
+    let acList: number[];
+    let dtList: { amount: number; to: string }[];
+    this.beforeEach(async function () {
+      const { lockup, admin } = fixture;
+
+      await lockup.connect(admin).refreshDelegated();
+
+      acList = [1000, 2000, 3000];
+      dtList = [
+        { amount: 1000, to: admin.address },
+        { amount: 2000, to: admin.address },
+        { amount: 3000, to: admin.address },
+      ];
+
+      for (const amount of acList) {
+        await lockup.connect(admin).proposeAcquisition(amount);
+      }
+      for (const { amount, to } of dtList) {
+        await lockup.connect(admin).requestDelegatedTransfer(amount, to);
+      }
+    });
+    it("#getAllAcquisitions", async function () {
+      const { lockup } = fixture;
+
+      const ret = await lockup.getAllAcquisitions();
+      expect(ret.length).to.equal(acList.length);
+      for (let i = 0; i < acList.length; i++) {
+        expect(ret[i].acReqId).to.equal(i);
+        expect(ret[i].amount).to.equal(acList[i]);
+      }
+    });
+    it("#getAllDelegatedTransfers", async function () {
+      const { lockup } = fixture;
+
+      const ret = await lockup.getAllDelegatedTransfers();
+      expect(ret.length).to.equal(dtList.length);
+      for (let i = 0; i < dtList.length; i++) {
+        expect(ret[i].delegatedTransferId).to.equal(i);
+        expect(ret[i].amount).to.equal(dtList[i].amount);
+        expect(ret[i].to).to.equal(dtList[i].to);
+      }
+    });
+    it("#getAcquisitionAtStatus: 1 propose, 2 confirm", async function () {
+      const { lockup, deployer } = fixture;
+
+      await lockup.connect(deployer).confirmAcquisition(0);
+      await lockup.connect(deployer).confirmAcquisition(1);
+
+      const ret = await lockup.getAcquisitionAtStatus(
+        AcquisitionStatus.CONFIRMED
+      );
+      expect(ret.length).to.equal(2);
+      expect(ret[0].acReqId).to.equal(0);
+      expect(ret[1].acReqId).to.equal(1);
+
+      const ret2 = await lockup.getAcquisitionAtStatus(
+        AcquisitionStatus.PROPOSED
+      );
+      expect(ret2.length).to.equal(1);
+      expect(ret2[0].acReqId).to.equal(2);
+    });
+    it("#getDelegatedTransferAtStatus: 1 propose, 2 withdrawn", async function () {
+      const { lockup, deployer, admin } = fixture;
+
+      await lockup.connect(deployer).confirmDelegatedTransfer(0);
+      await lockup.connect(deployer).confirmDelegatedTransfer(1);
+
+      await lockup.connect(admin).withdrawDelegatedTransfer(0);
+      await lockup.connect(admin).withdrawDelegatedTransfer(1);
+
+      const ret = await lockup.getDelegatedTransferAtStatus(
+        AcquisitionStatus.WITHDRAWN
+      );
+      expect(ret.length).to.equal(2);
+      expect(ret[0].delegatedTransferId).to.equal(0);
+      expect(ret[1].delegatedTransferId).to.equal(1);
+
+      const ret2 = await lockup.getDelegatedTransferAtStatus(
+        AcquisitionStatus.PROPOSED
+      );
+      expect(ret2.length).to.equal(1);
+      expect(ret2[0].delegatedTransferId).to.equal(2);
+    });
+  });
+});

--- a/contracts/test/common/fixtures.ts
+++ b/contracts/test/common/fixtures.ts
@@ -6,6 +6,8 @@ import {
   StakingTrackerMockReceiver__factory,
   PublicDelegationFactory__factory,
   MultiCallContract__factory,
+  Airdrop__factory,
+  Lockup__factory,
 } from "../../typechain-types";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { deployAddressBook, nowTime, toPeb } from "./helper";
@@ -572,5 +574,51 @@ export async function multiCallTestFixture() {
     AB,
     multiCall,
     deployer,
+  };
+}
+
+export async function airdropTestFixture() {
+  const [deployer, notClaimer, ...claimers] = await ethers.getSigners();
+
+  const claimInfo = [];
+
+  let totalAirdropAmount = 0n;
+
+  for (let i = 0; i < claimers.length; i++) {
+    claimInfo.push({
+      claimer: claimers[i].address,
+      amount: toPeb(100n),
+    });
+    totalAirdropAmount += BigInt(toPeb(100n));
+  }
+
+  const airdrop = await new Airdrop__factory(deployer).deploy();
+
+  return {
+    airdrop,
+    deployer,
+    notClaimer,
+    claimers,
+    claimInfo,
+    totalAirdropAmount,
+  };
+}
+
+export async function LockupTestFixture() {
+  const [deployer, admin, user] = await ethers.getSigners();
+
+  const lockup = await new Lockup__factory(deployer).deploy(
+    admin.address,
+    deployer.address
+  );
+
+  const totalDelegatedAmount = BigInt(toPeb(1_000n));
+
+  return {
+    lockup,
+    deployer, // secretary
+    admin,
+    user,
+    totalDelegatedAmount,
   };
 }


### PR DESCRIPTION
## Proposed changes

This PR suggests:
1. Airdrop.sol: It is a simple airdrop contract. The target airdrop receivers will be registered by owner, and anyone can claim if they're qualified to receive the airdrop.
2. Lockup.sol: It is a lockup contract. The `ADMIN` can propose acquisition request or delegated transfer request.
    - Acquisition: Be ready to unlock the lockup amount.
    - Delegated Transfer: Not acquisition, but used when withdrawing the locked amount to staking contract (CnStakingContract).
        - It needs to be re-locked to the contract after withdrawing the KAIA from staking contract.

Note that the KAIA for both contracts will be injected directly, not via normal `transfer`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
