### PR TITLE
pass chainConfig for calculating effectiveGasPrice

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -139,7 +139,7 @@ func (b *BlockchainContractBackend) callContract(call kaia.CallMsg, block *types
 	msg := types.NewMessage(call.From, call.To, 0, call.Value, call.Gas, call.GasPrice, call.Data,
 		false, intrinsicGas, accessList)
 
-	txContext := blockchain.NewEVMTxContext(msg, block.Header())
+	txContext := blockchain.NewEVMTxContext(msg, block.Header(), b.bc.Config())
 	blockContext := blockchain.NewEVMBlockContext(block.Header(), b.bc, nil)
 
 	// EVM demands the sender to have enough KAIA balance (gasPrice * gasLimit) in buyGas()

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -468,7 +468,7 @@ func (b *SimulatedBackend) callContract(_ context.Context, call kaia.CallMsg, bl
 	}
 	msg := types.NewMessage(call.From, call.To, nonce, call.Value, call.Gas, call.GasPrice, call.Data, true, intrinsicGas, accessList)
 
-	txContext := blockchain.NewEVMTxContext(msg, block.Header())
+	txContext := blockchain.NewEVMTxContext(msg, block.Header(), b.config)
 	blockContext := blockchain.NewEVMBlockContext(block.Header(), b.blockchain, nil)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -842,7 +842,7 @@ func TestEthereumAPI_GetTransactionByBlockNumberAndIndex(t *testing.T) {
 
 	// Mock Backend functions.
 	mockBackend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil).Times(txs.Len())
-
+	mockBackend.EXPECT().ChainConfig().Return(dummyChainConfigForEthereumAPITest).AnyTimes()
 	// Get transaction by block number and index for each transaction types.
 	for i := 0; i < txs.Len(); i++ {
 		ethTx := api.GetTransactionByBlockNumberAndIndex(context.Background(), rpc.BlockNumber(block.NumberU64()), hexutil.Uint(i))
@@ -859,6 +859,7 @@ func TestEthereumAPI_GetTransactionByBlockHashAndIndex(t *testing.T) {
 
 	// Mock Backend functions.
 	mockBackend.EXPECT().BlockByHash(gomock.Any(), gomock.Any()).Return(block, nil).Times(txs.Len())
+	mockBackend.EXPECT().ChainConfig().Return(dummyChainConfigForEthereumAPITest).AnyTimes()
 
 	// Get transaction by block hash and index for each transaction types.
 	for i := 0; i < txs.Len(); i++ {
@@ -883,6 +884,7 @@ func TestEthereumAPI_GetTransactionByHash(t *testing.T) {
 	// Mock Backend functions.
 	mockBackend.EXPECT().ChainDB().Return(mockDBManager).Times(txs.Len())
 	mockBackend.EXPECT().BlockByHash(gomock.Any(), block.Hash()).Return(block, nil).Times(txs.Len())
+	mockBackend.EXPECT().ChainConfig().Return(dummyChainConfigForEthereumAPITest).AnyTimes()
 
 	// Get transaction by hash for each transaction types.
 	for i := 0; i < txs.Len(); i++ {
@@ -909,6 +911,7 @@ func TestEthereumAPI_GetTransactionByHashFromPool(t *testing.T) {
 
 	// Mock Backend functions.
 	mockBackend.EXPECT().ChainDB().Return(mockDBManager).Times(txs.Len())
+	mockBackend.EXPECT().ChainConfig().Return(dummyChainConfigForEthereumAPITest).AnyTimes()
 	mockBackend.EXPECT().GetPoolTransaction(gomock.Any()).DoAndReturn(
 		func(hash common.Hash) *types.Transaction {
 			return txHashMap[hash]
@@ -934,7 +937,7 @@ func TestEthereumAPI_PendingTransactions(t *testing.T) {
 
 	mockAccountManager := mock_accounts.NewMockAccountManager(mockCtrl)
 	mockBackend.EXPECT().AccountManager().Return(mockAccountManager)
-
+	mockBackend.EXPECT().ChainConfig().Return(dummyChainConfigForEthereumAPITest).AnyTimes()
 	mockBackend.EXPECT().GetPoolTransactions().Return(txs, nil)
 
 	wallets := make([]accounts.Wallet, 1)
@@ -968,6 +971,7 @@ func TestEthereumAPI_GetTransactionReceipt(t *testing.T) {
 	).Times(txs.Len())
 	mockBackend.EXPECT().GetBlockReceipts(gomock.Any(), gomock.Any()).Return(receipts).Times(txs.Len())
 	mockBackend.EXPECT().HeaderByHash(gomock.Any(), block.Hash()).Return(block.Header(), nil).Times(txs.Len())
+	mockBackend.EXPECT().ChainConfig().Return(dummyChainConfigForEthereumAPITest).AnyTimes()
 
 	// Get receipt for each transaction types.
 	for i := 0; i < txs.Len(); i++ {
@@ -976,7 +980,7 @@ func TestEthereumAPI_GetTransactionReceipt(t *testing.T) {
 			t.Fatal(err)
 		}
 		txIdx := uint64(i)
-		checkEthTransactionReceiptFormat(t, block, receipts, receipt, RpcOutputReceipt(block.Header(), txs[i], block.Hash(), block.NumberU64(), txIdx, receiptMap[txs[i].Hash()]), txIdx)
+		checkEthTransactionReceiptFormat(t, block, receipts, receipt, RpcOutputReceipt(block.Header(), txs[i], block.Hash(), block.NumberU64(), txIdx, receiptMap[txs[i].Hash()], params.TestChainConfig), txIdx)
 	}
 
 	mockCtrl.Finish()
@@ -2482,7 +2486,7 @@ func testEstimateGas(t *testing.T, mockBackend *mock_api.MockBackend, fnEstimate
 	getEVM := func(_ context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmConfig vm.Config) (*vm.EVM, func() error, error) {
 		// Taken from node/cn/api_backend.go
 		vmError := func() error { return nil }
-		txContext := blockchain.NewEVMTxContext(msg, header)
+		txContext := blockchain.NewEVMTxContext(msg, header, chainConfig)
 		blockContext := blockchain.NewEVMBlockContext(header, chain, nil)
 		return vm.NewEVM(blockContext, txContext, state, chainConfig, &vmConfig), vmError, nil
 	}

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -33,6 +33,7 @@ import (
 	"github.com/klaytn/klaytn/common/hexutil"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/networks/rpc"
+	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 )
 
@@ -71,7 +72,7 @@ func (s *PublicTransactionPoolAPI) GetBlockTransactionCountByHash(ctx context.Co
 func (s *PublicTransactionPoolAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) (map[string]interface{}, error) {
 	block, err := s.b.BlockByNumber(ctx, blockNr)
 	if block != nil && err == nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index)), nil
+		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig()), nil
 	}
 	return nil, err
 }
@@ -80,7 +81,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionByBlockNumberAndIndex(ctx conte
 func (s *PublicTransactionPoolAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) (map[string]interface{}, error) {
 	block, err := s.b.BlockByHash(ctx, blockHash)
 	if block != nil && err == nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index)), nil
+		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig()), nil
 	}
 	return nil, err
 }
@@ -132,11 +133,11 @@ func (s *PublicTransactionPoolAPI) GetTransactionBySenderTxHash(ctx context.Cont
 func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) map[string]interface{} {
 	// Try to return an already finalized transaction
 	if tx, blockHash, blockNumber, index := s.b.ChainDB().ReadTxAndLookupInfo(hash); tx != nil {
-		return newRPCTransaction(nil, tx, blockHash, blockNumber, index)
+		return newRPCTransaction(nil, tx, blockHash, blockNumber, index, s.b.ChainConfig())
 	}
 	// No finalized transaction, try to retrieve it from the pool
 	if tx := s.b.GetPoolTransaction(hash); tx != nil {
-		return newRPCPendingTransaction(tx)
+		return newRPCPendingTransaction(tx, s.b.ChainConfig())
 	}
 	// Transaction unknown, return as such
 	return nil
@@ -202,12 +203,12 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 
 // RpcOutputReceipt converts a receipt to the RPC output with the associated information regarding to the
 // block in which the receipt is included, the transaction that outputs the receipt, and the receipt itself.
-func RpcOutputReceipt(header *types.Header, tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, receipt *types.Receipt) map[string]interface{} {
+func RpcOutputReceipt(header *types.Header, tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, receipt *types.Receipt, config *params.ChainConfig) map[string]interface{} {
 	if tx == nil || receipt == nil {
 		return nil
 	}
 
-	fields := newRPCTransaction(nil, tx, blockHash, blockNumber, index)
+	fields := newRPCTransaction(nil, tx, blockHash, blockNumber, index, config)
 
 	if receipt.Status != types.ReceiptStatusSuccessful {
 		fields["status"] = hexutil.Uint(types.ReceiptStatusFailed)
@@ -219,7 +220,7 @@ func RpcOutputReceipt(header *types.Header, tx *types.Transaction, blockHash com
 	fields["logsBloom"] = receipt.Bloom
 	fields["gasUsed"] = hexutil.Uint64(receipt.GasUsed)
 
-	fields["effectiveGasPrice"] = hexutil.Uint64(tx.EffectiveGasPrice(header).Uint64())
+	fields["effectiveGasPrice"] = hexutil.Uint64(tx.EffectiveGasPrice(header, config).Uint64())
 
 	if receipt.Logs == nil {
 		fields["logs"] = [][]*types.Log{}
@@ -267,7 +268,7 @@ func (s *PublicTransactionPoolAPI) getTransactionReceipt(ctx context.Context, tx
 	// No error handling is required here.
 	// Header is checked in the following RpcOutputReceipt function
 	header, _ := s.b.HeaderByHash(ctx, blockHash)
-	return RpcOutputReceipt(header, tx, blockHash, blockNumber, index, receipt), nil
+	return RpcOutputReceipt(header, tx, blockHash, blockNumber, index, receipt, s.b.ChainConfig()), nil
 }
 
 // sign is a helper function that signs a transaction with the private key of the given address.
@@ -493,7 +494,7 @@ func (s *PublicTransactionPoolAPI) PendingTransactions() ([]map[string]interface
 	for _, tx := range pending {
 		from := getFrom(tx)
 		if _, exists := accounts[from]; exists {
-			transactions = append(transactions, newRPCPendingTransaction(tx))
+			transactions = append(transactions, newRPCPendingTransaction(tx, s.b.ChainConfig()))
 		}
 	}
 	return transactions, nil

--- a/api/api_public_tx_pool.go
+++ b/api/api_public_tx_pool.go
@@ -22,6 +22,7 @@ package api
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common/hexutil"
@@ -49,7 +50,7 @@ func (s *PublicTxPoolAPI) Content() map[string]map[string]map[string]map[string]
 	for account, txs := range pending {
 		dump := make(map[string]map[string]interface{})
 		for _, tx := range txs {
-			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx)
+			dump[strconv.FormatUint(tx.Nonce(), 10)] = newRPCPendingTransaction(tx, s.b.ChainConfig())
 		}
 		content["pending"][account.Hex()] = dump
 	}
@@ -57,7 +58,7 @@ func (s *PublicTxPoolAPI) Content() map[string]map[string]map[string]map[string]
 	for account, txs := range queue {
 		dump := make(map[string]map[string]interface{})
 		for _, tx := range txs {
-			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx)
+			dump[strconv.FormatUint(tx.Nonce(), 10)] = newRPCPendingTransaction(tx, s.b.ChainConfig())
 		}
 		content["queued"][account.Hex()] = dump
 	}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2750,7 +2750,7 @@ func (bc *BlockChain) ApplyTransaction(chainConfig *params.ChainConfig, author *
 	}
 	// Create a new context to be used in the EVM environment
 	blockContext := NewEVMBlockContext(header, bc, author)
-	txContext := NewEVMTxContext(msg, header)
+	txContext := NewEVMTxContext(msg, header, chainConfig)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(blockContext, txContext, statedb, chainConfig, vmConfig)

--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -90,15 +90,10 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 }
 
 // NewEVMTxContext creates a new transaction context for a single transaction.
-func NewEVMTxContext(msg Message, header *types.Header) vm.TxContext {
-	effectiveGasPrice := msg.GasPrice()
-	if header.BaseFee != nil {
-		effectiveGasPrice = header.BaseFee
-	}
-
+func NewEVMTxContext(msg Message, header *types.Header, config *params.ChainConfig) vm.TxContext {
 	return vm.TxContext{
 		Origin:   msg.ValidatedSender(),
-		GasPrice: new(big.Int).Set(effectiveGasPrice),
+		GasPrice: new(big.Int).Set(msg.EffectiveGasPrice(header, config)),
 	}
 }
 

--- a/blockchain/state_prefetcher.go
+++ b/blockchain/state_prefetcher.go
@@ -101,7 +101,7 @@ func precacheTransaction(config *params.ChainConfig, bc ChainContext, author *co
 	}
 	// Create the EVM and execute the transaction
 	blockContext := NewEVMBlockContext(header, bc, author)
-	txContext := NewEVMTxContext(msg, header)
+	txContext := NewEVMTxContext(msg, header, config)
 	vm := vm.NewEVM(blockContext, txContext, statedb, config, &cfg)
 
 	_, err = ApplyMessage(vm, msg)

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -98,7 +98,7 @@ type Message interface {
 	GasTipCap() *big.Int
 	GasFeeCap() *big.Int
 	EffectiveGasTip(baseFee *big.Int) *big.Int
-	EffectiveGasPrice(header *types.Header) *big.Int
+	EffectiveGasPrice(header *types.Header, config *params.ChainConfig) *big.Int
 
 	Gas() uint64
 	Value() *big.Int
@@ -381,7 +381,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 			txFee := getBurnAmountMagma(new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), effectiveGasPrice))
 			st.state.AddBalance(st.evm.Context.Rewardbase, txFee)
 		} else {
-			effectiveGasPrice := msg.EffectiveGasPrice(nil)
+			effectiveGasPrice := msg.EffectiveGasPrice(nil, st.evm.ChainConfig())
 			st.state.AddBalance(st.evm.Context.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), effectiveGasPrice))
 		}
 	}

--- a/blockchain/system/multicall.go
+++ b/blockchain/system/multicall.go
@@ -64,7 +64,7 @@ func (caller *ContractCallerForMultiCall) CallContract(ctx context.Context, call
 		call.Value, gasLimit, gasPrice, call.Data, false, intrinsicGas, nil)
 
 	blockContext := blockchain.NewEVMBlockContext(caller.header, caller.chain, nil)
-	txContext := blockchain.NewEVMTxContext(msg, caller.header)
+	txContext := blockchain.NewEVMTxContext(msg, caller.header, caller.chain.Config())
 	txContext.GasPrice = gasPrice                                                                // set gasPrice again if baseFee is assigned
 	evm := vm.NewEVM(blockContext, txContext, caller.state, caller.chain.Config(), &vm.Config{}) // no additional vm config required
 

--- a/blockchain/system/rebalance.go
+++ b/blockchain/system/rebalance.go
@@ -123,7 +123,7 @@ func (caller *Kip103ContractCaller) CallContract(ctx context.Context, call kaia.
 		call.Value, gasLimit, gasPrice, call.Data, false, intrinsicGas, nil)
 
 	blockContext := blockchain.NewEVMBlockContext(caller.header, caller.chain, nil)
-	txContext := blockchain.NewEVMTxContext(msg, caller.header)
+	txContext := blockchain.NewEVMTxContext(msg, caller.header, caller.chain.Config())
 	txContext.GasPrice = gasPrice                                                                // set gasPrice again if baseFee is assigned
 	evm := vm.NewEVM(blockContext, txContext, caller.state, caller.chain.Config(), &vm.Config{}) // no additional vm config required
 

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -39,6 +39,7 @@ import (
 	"github.com/klaytn/klaytn/common/math"
 	"github.com/klaytn/klaytn/crypto"
 	"github.com/klaytn/klaytn/kerrors"
+	"github.com/klaytn/klaytn/params"
 	"github.com/klaytn/klaytn/rlp"
 )
 
@@ -308,16 +309,14 @@ func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) *big.Int {
 	return tx.GasPrice()
 }
 
-func (tx *Transaction) EffectiveGasPrice(header *Header) *big.Int {
-	if header != nil && header.BaseFee != nil {
-		return header.BaseFee
+func (tx *Transaction) EffectiveGasPrice(header *Header, config *params.ChainConfig) *big.Int {
+	if header == nil || header.BaseFee == nil {
+		return tx.GasPrice()
 	}
-	// Only enters if Magma is not enabled. If Magma is enabled, it will return BaseFee in the above if statement.
-	if tx.Type() == TxTypeEthereumDynamicFee {
-		te := tx.GetTxInternalData().(TxInternalDataBaseFee)
-		return te.GetGasFeeCap()
+	if config.Rules(header.Number).IsKaia {
+		// TODO-kaia: add kaia hard-fork
 	}
-	return tx.GasPrice()
+	return new(big.Int).Set(header.BaseFee)
 }
 
 func (tx *Transaction) AccessList() AccessList {

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -347,30 +347,30 @@ func TestEffectiveGasPrice(t *testing.T) {
 
 	header := new(Header)
 
-	have := legacyTx.EffectiveGasPrice(header)
+	have := legacyTx.EffectiveGasPrice(header, params.TestChainConfig)
 	want := gasPrice
 	assert.Equal(t, want, have)
 
-	have = dynamicTx.EffectiveGasPrice(header)
+	have = dynamicTx.EffectiveGasPrice(header, params.TestChainConfig)
 	te := dynamicTx.GetTxInternalData().(TxInternalDataBaseFee)
 	want = te.GetGasFeeCap()
 	assert.Equal(t, want, have)
 
 	header.BaseFee = big.NewInt(2000)
-	have = legacyTx.EffectiveGasPrice(header)
+	have = legacyTx.EffectiveGasPrice(header, params.TestChainConfig)
 	want = header.BaseFee
 	assert.Equal(t, want, have)
 
-	have = dynamicTx.EffectiveGasPrice(header)
+	have = dynamicTx.EffectiveGasPrice(header, params.TestChainConfig)
 	want = header.BaseFee
 	assert.Equal(t, want, have)
 
 	header.BaseFee = big.NewInt(0)
-	have = legacyTx.EffectiveGasPrice(header)
+	have = legacyTx.EffectiveGasPrice(header, params.TestChainConfig)
 	want = header.BaseFee
 	assert.Equal(t, want, have)
 
-	have = dynamicTx.EffectiveGasPrice(header)
+	have = dynamicTx.EffectiveGasPrice(header, params.TestChainConfig)
 	want = header.BaseFee
 	assert.Equal(t, want, have)
 }

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -312,7 +312,7 @@ func (api *APIExtension) makeRPCBlockOutput(b *types.Block,
 	if bc, ok := api.chain.(*blockchain.BlockChain); ok {
 		td = bc.GetTd(hash, b.NumberU64())
 	}
-	r, err := kaiaApi.RpcOutputBlock(b, td, false, false, api.chain.Config().Rules(b.Header().Number))
+	r, err := kaiaApi.RpcOutputBlock(b, td, false, false, api.chain.Config())
 	if err != nil {
 		logger.Error("failed to RpcOutputBlock", "err", err)
 		return nil
@@ -323,10 +323,10 @@ func (api *APIExtension) makeRPCBlockOutput(b *types.Block,
 	rpcTransactions := make([]map[string]interface{}, numTxs)
 	for i, tx := range transactions {
 		if len(receipts) == len(transactions) {
-			rpcTransactions[i] = kaiaApi.RpcOutputReceipt(head, tx, hash, head.Number.Uint64(), uint64(i), receipts[i])
+			rpcTransactions[i] = kaiaApi.RpcOutputReceipt(head, tx, hash, head.Number.Uint64(), uint64(i), receipts[i], api.chain.Config())
 		} else {
 			// fill the transaction output if receipt is not found
-			rpcTransactions[i] = kaiaApi.NewRPCTransaction(b, tx, hash, head.Number.Uint64(), uint64(i))
+			rpcTransactions[i] = kaiaApi.NewRPCTransaction(b, tx, hash, head.Number.Uint64(), uint64(i), api.chain.Config())
 		}
 	}
 

--- a/datasync/chaindatafetcher/kafka/utils.go
+++ b/datasync/chaindatafetcher/kafka/utils.go
@@ -67,14 +67,14 @@ func makeBlockGroupOutput(blockchain *blockchain.BlockChain, block *types.Block,
 	hash := head.Hash()
 
 	td := blockchain.GetTd(hash, block.NumberU64())
-	r, _ := kaiaApi.RpcOutputBlock(block, td, false, false, blockchain.Config().Rules(block.Header().Number))
+	r, _ := kaiaApi.RpcOutputBlock(block, td, false, false, blockchain.Config())
 
 	// make transactions
 	transactions := block.Transactions()
 	numTxs := len(transactions)
 	rpcTransactions := make([]map[string]interface{}, numTxs)
 	for i, tx := range transactions {
-		rpcTransactions[i] = kaiaApi.RpcOutputReceipt(head, tx, hash, head.Number.Uint64(), uint64(i), receipts[i])
+		rpcTransactions[i] = kaiaApi.RpcOutputReceipt(head, tx, hash, head.Number.Uint64(), uint64(i), receipts[i], blockchain.Config())
 	}
 
 	r["committee"] = cInfo.Committee

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -238,7 +238,7 @@ func (b *CNAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 func (b *CNAPIBackend) GetEVM(ctx context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error) {
 	vmError := func() error { return nil }
 
-	txContext := blockchain.NewEVMTxContext(msg, header)
+	txContext := blockchain.NewEVMTxContext(msg, header, b.ChainConfig())
 	blockContext := blockchain.NewEVMBlockContext(header, b.cn.BlockChain(), nil)
 
 	return vm.NewEVM(blockContext, txContext, state, b.cn.chainConfig, &vmCfg), vmError, nil

--- a/node/cn/state_accessor.go
+++ b/node/cn/state_accessor.go
@@ -184,7 +184,7 @@ func (cn *CN) stateAtTransaction(block *types.Block, txIndex int, reexec uint64)
 			return nil, vm.BlockContext{}, vm.TxContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 
-		txContext := blockchain.NewEVMTxContext(msg, block.Header())
+		txContext := blockchain.NewEVMTxContext(msg, block.Header(), cn.chainConfig)
 		blockContext := blockchain.NewEVMBlockContext(block.Header(), cn.blockchain, nil)
 		if idx == txIndex {
 			return msg, blockContext, txContext, statedb, nil

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -316,7 +316,7 @@ func (api *CommonAPI) traceChain(start, end *types.Block, config *TraceConfig, n
 						break
 					}
 
-					txCtx := blockchain.NewEVMTxContext(msg, task.block.Header())
+					txCtx := blockchain.NewEVMTxContext(msg, task.block.Header(), api.backend.ChainConfig())
 					blockCtx := blockchain.NewEVMBlockContext(task.block.Header(), newChainContext(localctx, api.backend), nil)
 
 					res, err := api.traceTx(localctx, msg, blockCtx, txCtx, task.statedb, config)
@@ -629,7 +629,7 @@ func (api *CommonAPI) traceBlock(ctx context.Context, block *types.Block, config
 					continue
 				}
 
-				txCtx := blockchain.NewEVMTxContext(msg, block.Header())
+				txCtx := blockchain.NewEVMTxContext(msg, block.Header(), api.backend.ChainConfig())
 				blockCtx := blockchain.NewEVMBlockContext(block.Header(), newChainContext(ctx, api.backend), nil)
 				res, err := api.traceTx(ctx, msg, blockCtx, txCtx, task.statedb, config)
 				if err != nil {
@@ -654,7 +654,7 @@ func (api *CommonAPI) traceBlock(ctx context.Context, block *types.Block, config
 			break
 		}
 
-		txCtx := blockchain.NewEVMTxContext(msg, block.Header())
+		txCtx := blockchain.NewEVMTxContext(msg, block.Header(), api.backend.ChainConfig())
 		blockCtx := blockchain.NewEVMBlockContext(block.Header(), newChainContext(ctx, api.backend), nil)
 		vmenv := vm.NewEVM(blockCtx, txCtx, statedb, api.backend.ChainConfig(), &vm.Config{})
 		if _, err = blockchain.ApplyMessage(vmenv, msg); err != nil {
@@ -726,7 +726,7 @@ func (api *CommonAPI) standardTraceBlockToFile(ctx context.Context, block *types
 		}
 
 		var (
-			txCtx    = blockchain.NewEVMTxContext(msg, block.Header())
+			txCtx    = blockchain.NewEVMTxContext(msg, block.Header(), api.backend.ChainConfig())
 			blockCtx = blockchain.NewEVMBlockContext(block.Header(), newChainContext(ctx, api.backend), nil)
 
 			vmConf vm.Config
@@ -876,7 +876,7 @@ func (api *CommonAPI) TraceCall(ctx context.Context, args kaiaapi.CallArgs, bloc
 	// Add gas fee to sender for estimating gasLimit/computing cost or calling a function by insufficient balance sender.
 	statedb.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), basefee))
 
-	txCtx := blockchain.NewEVMTxContext(msg, block.Header())
+	txCtx := blockchain.NewEVMTxContext(msg, block.Header(), api.backend.ChainConfig())
 	blockCtx := blockchain.NewEVMBlockContext(block.Header(), newChainContext(ctx, api.backend), nil)
 
 	return api.traceTx(ctx, msg, blockCtx, txCtx, statedb, config)

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -168,7 +168,7 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 	signer := types.MakeSigner(b.chainConfig, block.Number())
 	for idx, tx := range block.Transactions() {
 		msg, _ := tx.AsMessageWithAccountKeyPicker(signer, statedb, block.NumberU64())
-		txContext := blockchain.NewEVMTxContext(msg, block.Header())
+		txContext := blockchain.NewEVMTxContext(msg, block.Header(), b.chainConfig)
 		blockContext := blockchain.NewEVMBlockContext(block.Header(), b.chain, nil)
 		if idx == txIndex {
 			return msg, blockContext, txContext, statedb, nil

--- a/tests/smartcontract_execution_test.go
+++ b/tests/smartcontract_execution_test.go
@@ -107,7 +107,7 @@ func callContract(bcdata *BCData, tx *types.Transaction) ([]byte, error) {
 		return nil, err
 	}
 
-	txContext := blockchain.NewEVMTxContext(msg, header)
+	txContext := blockchain.NewEVMTxContext(msg, header, bcdata.bc.Config())
 	blockContext := blockchain.NewEVMBlockContext(header, bcdata.bc, nil)
 	vmenv := vm.NewEVM(blockContext, txContext, statedb, bcdata.bc.Config(), &vm.Config{})
 

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -164,7 +164,7 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 	if err != nil {
 		return nil, err
 	}
-	txContext := blockchain.NewEVMTxContext(msg, block.Header())
+	txContext := blockchain.NewEVMTxContext(msg, block.Header(), config)
 	blockContext := blockchain.NewEVMBlockContext(block.Header(), nil, &t.json.Env.Coinbase)
 	blockContext.GetHash = vmTestBlockHash
 	evm := vm.NewEVM(blockContext, txContext, statedb, config, &vmconfig)


### PR DESCRIPTION
## Proposed changes

- This PR passes chainConfig through newEVMTxContext and newRPCTransaction (newEthRPCTransaction) to calculate the effectiveGasPrice.
- This chainConfig pass PR is a part of kip-162 implementation, but take it on seperate PR due to its amount.
- For the reference, adding an effectiveGasPrice field at Receipt and Transaction(Message) is discussed before to replace this PR, but concluded there's not much need for it even though this way degrades the readability. Actually, effectiveGasPrice field will not be used for consensus purpose and TransactionArgs refactoring also cannot optimize the change.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
