### PR TITLE
reward: Robust getTotalSupply API under partial information

### DIFF
--- a/api/api_public_klay.go
+++ b/api/api_public_klay.go
@@ -103,22 +103,35 @@ func (s *PublicKaiaAPI) FeeHistory(ctx context.Context, blockCount DecimalOrHex,
 }
 
 type TotalSupplyResult struct {
-	TotalSupply *hexutil.Big `json:"totalSupply"` // The total supply of the native token. i.e. Minted - Burnt.
-	TotalMinted *hexutil.Big `json:"totalMinted"` // Total minted amount.
-	TotalBurnt  *hexutil.Big `json:"totalBurnt"`  // Total burnt amount. Sum of all burnt amounts below.
-	BurntFee    *hexutil.Big `json:"burntFee"`    // from tx fee burn. ReadAccReward(num).BurntFee.
-	ZeroBurn    *hexutil.Big `json:"zeroBurn"`    // balance of 0x0 (zero) address.
-	DeadBurn    *hexutil.Big `json:"deadBurn"`    // balance of 0xdead (dead) address.
-	Kip103Burn  *hexutil.Big `json:"kip103Burn"`  // by KIP103 fork. Read from its memo.
-	Kip160Burn  *hexutil.Big `json:"kip160Burn"`  // by KIP160 fork. Read from its memo.
+	Number      *hexutil.Big `json:"number"`          // Block number in which the total supply was calculated.
+	Error       *string      `json:"error,omitempty"` // Errors that occurred while fetching the components, thus failed to deliver the total supply.
+	TotalSupply *hexutil.Big `json:"totalSupply"`     // The total supply of the native token. i.e. Minted - Burnt.
+	TotalMinted *hexutil.Big `json:"totalMinted"`     // Total minted amount.
+	TotalBurnt  *hexutil.Big `json:"totalBurnt"`      // Total burnt amount. Sum of all burnt amounts below.
+	BurntFee    *hexutil.Big `json:"burntFee"`        // from tx fee burn. ReadAccReward(num).BurntFee.
+	ZeroBurn    *hexutil.Big `json:"zeroBurn"`        // balance of 0x0 (zero) address.
+	DeadBurn    *hexutil.Big `json:"deadBurn"`        // balance of 0xdead (dead) address.
+	Kip103Burn  *hexutil.Big `json:"kip103Burn"`      // by KIP103 fork. Read from its memo.
+	Kip160Burn  *hexutil.Big `json:"kip160Burn"`      // by KIP160 fork. Read from its memo.
 }
 
 func (s *PublicKaiaAPI) GetTotalSupply(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*TotalSupplyResult, error) {
-	ts, err := s.b.GetTotalSupply(ctx, blockNrOrHash)
+	block, err := s.b.BlockByNumberOrHash(ctx, blockNrOrHash)
 	if err != nil {
 		return nil, err
 	}
-	return &TotalSupplyResult{
+
+	// Case 1. Failed to fetch essential components. The API fails.
+	ts, err := s.b.GetTotalSupply(ctx, blockNrOrHash)
+	if ts == nil {
+		return nil, err
+	}
+
+	// Case 2. Failed to fetch some components. The API delivers the partial result with the 'error' field set.
+	// Case 3. Succeeded to fetch all components. The API delivers the full result.
+	res := &TotalSupplyResult{
+		Number:      (*hexutil.Big)(block.Number()),
+		Error:       nil,
 		TotalSupply: (*hexutil.Big)(ts.TotalSupply),
 		TotalMinted: (*hexutil.Big)(ts.TotalMinted),
 		TotalBurnt:  (*hexutil.Big)(ts.TotalBurnt),
@@ -127,7 +140,12 @@ func (s *PublicKaiaAPI) GetTotalSupply(ctx context.Context, blockNrOrHash rpc.Bl
 		DeadBurn:    (*hexutil.Big)(ts.DeadBurn),
 		Kip103Burn:  (*hexutil.Big)(ts.Kip103Burn),
 		Kip160Burn:  (*hexutil.Big)(ts.Kip160Burn),
-	}, nil
+	}
+	if err != nil {
+		errStr := err.Error()
+		res.Error = &errStr
+	}
+	return res, nil
 }
 
 // Syncing returns false in case the node is currently not syncing with the network. It can be up to date or has not

--- a/reward/supply_manager.go
+++ b/reward/supply_manager.go
@@ -280,11 +280,12 @@ func (sm *supplyManager) catchup() {
 	if lastNum > 0 && sm.db.ReadAccReward(lastNum) == nil {
 		logger.Error("Last accumulated reward not found. Restarting supply catchup", "last", lastNum, "head", headNum)
 		sm.db.WriteLastAccRewardBlockNumber(0) // soft reset to genesis
+		lastNum = 0
 	}
 
 	// Store genesis supply if not exists
-	// ReadLastAccRewardBlockNumber is 0 when either (a) the database is empty or (b) was soft reset to 0.
-	if sm.db.ReadLastAccRewardBlockNumber() == 0 {
+	// lastNum is 0 when either (a) the database was empty or (b) was soft reset to 0.
+	if lastNum == 0 {
 		genesisTotalSupply, err := sm.totalSupplyFromState(0)
 		if err != nil {
 			logger.Error("totalSupplyFromState failed", "number", 0, "err", err)

--- a/reward/supply_manager.go
+++ b/reward/supply_manager.go
@@ -19,11 +19,13 @@ package reward
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 	"sync/atomic"
 
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/accounts/abi/bind/backends"
 	"github.com/klaytn/klaytn/blockchain"
 	"github.com/klaytn/klaytn/common"
@@ -43,6 +45,14 @@ var (
 	errNoBlock           = errors.New("block not found")
 	errNoRebalanceMemo   = errors.New("rebalance memo not yet stored")
 )
+
+func errNoCanonicalBurn(err error) error {
+	return fmt.Errorf("cannot determine canonical (0x0, 0xdead) burn amount: %v", err)
+}
+
+func errNoRebalanceBurn(err error) error {
+	return fmt.Errorf("cannot determine rebalance (kip103, kip160) burn amount: %v", err)
+}
 
 // SupplyManager tracks the total supply of native tokens.
 // Note that SupplyManager only deals with the block rewards.
@@ -125,18 +135,97 @@ func (sm *supplyManager) GetAccReward(num uint64) (*database.AccReward, error) {
 		return accReward.(*database.AccReward), nil
 	}
 
-	if accReward := sm.db.ReadAccReward(num); accReward != nil {
-		sm.accRewardCache.Add(num, accReward.Copy())
-		return accReward, nil
+	lastNum := sm.db.ReadLastAccRewardBlockNumber()
+	if lastNum < num { // soft deleted
+		return nil, errNoAccReward
 	}
 
-	return nil, errNoAccReward
+	accReward := sm.db.ReadAccReward(num)
+	if accReward == nil {
+		return nil, errNoAccReward
+	}
+
+	sm.accRewardCache.Add(num, accReward.Copy())
+	return accReward, nil
+}
+
+func (sm *supplyManager) GetCanonicalBurn(num uint64) (zero *big.Int, dead *big.Int, err error) {
+	header := sm.chain.GetHeaderByNumber(num)
+	if header == nil {
+		return nil, nil, errNoCanonicalBurn(errNoBlock)
+	}
+	state, err := sm.chain.StateAt(header.Root)
+	if err != nil {
+		return nil, nil, errNoCanonicalBurn(err)
+	}
+	return state.GetBalance(zeroBurnAddress), state.GetBalance(deadBurnAddress), nil
+}
+
+// GetRebalanceBurn attempts to read the burnt amount from the rebalance memo.
+// 1. Rebalance is not configured or the fork block is not reached: return 0.
+// 2. Found the memo: return the burnt amount.
+// 3. Rebalance is configured but the memo is not found: return nil.
+// - 3a. the rebalance is misconfigured so that system.RebalanceTreasury did not change the state.
+// - 3b. the memo is not yet submitted to the contract.
+// 4. Something else went wrong: return nil.
+//
+// The case 3a returning 0 would be more accurate representation of the rebalance burn amount,
+// but 3a is indistinguishable from 3b or 4. Therefore it returns nil and an error for safety.
+// If we actually create case 3a by accident (i.e. rebalance skipped at the fork block), fix this function to return 0.
+func (sm *supplyManager) GetRebalanceBurn(num uint64, forkNum *big.Int, addr common.Address) (*big.Int, error) {
+	bigNum := new(big.Int).SetUint64(num)
+
+	if forkNum == nil || forkNum.Cmp(bigNum) > 0 {
+		// 1. rebalance is not configured or the rebalance forkNum has not passed (at the given block number).
+		return big.NewInt(0), nil
+	}
+
+	if burnt, ok := sm.memoCache.Get(addr); ok {
+		// 2. memo is in cache.
+		return burnt.(*big.Int), nil
+	}
+
+	// Load the state at latest block, not the rebalance fork block.
+	// The memo is manually stored in the contract after-the-fact by calling the finalizeContract function.
+	// Therefore it's safest to read from the latest state.
+	backend := backends.NewBlockchainContractBackend(sm.chain, nil, nil)
+	caller, err := rebalance.NewTreasuryRebalanceV2Caller(addr, backend)
+	if err != nil {
+		// 4. contract call failed.
+		return nil, errNoRebalanceBurn(err)
+	}
+	memo, err := caller.Memo(&bind.CallOpts{BlockNumber: nil}) // call at the latest block
+	if err != nil {
+		// 3a. the contract reverted or the contract is not there.
+		// 4. contract call failed for other unknown reasons.
+		return nil, errNoRebalanceBurn(err)
+	}
+	if memo == "" {
+		// 3a. the contract is intact but the rebalance did not happen due to e.g. insufficient funds.
+		// 3b. the memo is not yet submitted to the contract.
+		// Return nil to prevent totalSupply calculation, therefore prevents misinformation.
+		return nil, errNoRebalanceBurn(errNoRebalanceMemo)
+	}
+
+	result := struct { // See system.rebalanceResult struct
+		Burnt *big.Int `json:"burnt"`
+	}{}
+	if err := json.Unmarshal([]byte(memo), &result); err != nil {
+		// 4. memo is malformed
+		return nil, errNoRebalanceBurn(err)
+	}
+
+	// 2. found the memo
+	sm.memoCache.Add(addr, result.Burnt)
+	return result.Burnt, nil
 }
 
 func (sm *supplyManager) GetTotalSupply(num uint64) (*TotalSupply, error) {
-	ts := &TotalSupply{}
+	errs := make([]error, 0)
+	ts := new(TotalSupply)
 
 	// Read accumulated rewards (minted, burntFee)
+	// This is an essential component, so failure to read it immediately aborts the function.
 	accReward, err := sm.GetAccReward(num)
 	if err != nil {
 		return nil, err
@@ -145,48 +234,37 @@ func (sm *supplyManager) GetTotalSupply(num uint64) (*TotalSupply, error) {
 	ts.BurntFee = accReward.BurntFee
 
 	// Read canonical burn address balances
-	header := sm.chain.GetHeaderByNumber(num)
-	if header == nil {
-		return nil, errNoBlock
-	}
-	state, err := sm.chain.StateAt(header.Root)
+	// Leave them nil if the historic state isn't available.
+	ts.ZeroBurn, ts.DeadBurn, err = sm.GetCanonicalBurn(num)
 	if err != nil {
-		return nil, err
+		errs = append(errs, err)
 	}
-	ts.ZeroBurn = state.GetBalance(zeroBurnAddress)
-	ts.DeadBurn = state.GetBalance(deadBurnAddress)
 
 	// Read KIP103 and KIP160 burns
-	bigNum := new(big.Int).SetUint64(num)
+	// 1. Leave them zero if the rebalance is not configured or the fork block is not reached.
+	// 2. Leave them nil if the rebalance should have been executed but rebalance memo isn't available yet.
 	config := sm.chain.Config()
-
-	ts.Kip103Burn = big.NewInt(0)
-	if config.Kip103CompatibleBlock != nil && config.Kip103CompatibleBlock.Cmp(bigNum) <= 0 {
-		burn, err := sm.readRebalanceMemo(config.Kip103ContractAddress)
-		if err != nil {
-			return nil, err
-		}
-		ts.Kip103Burn = burn
+	ts.Kip103Burn, err = sm.GetRebalanceBurn(num, config.Kip103CompatibleBlock, config.Kip103ContractAddress)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	ts.Kip160Burn, err = sm.GetRebalanceBurn(num, config.Kip160CompatibleBlock, config.Kip160ContractAddress)
+	if err != nil {
+		errs = append(errs, err)
 	}
 
-	ts.Kip160Burn = big.NewInt(0)
-	if config.Kip160CompatibleBlock != nil && config.Kip160CompatibleBlock.Cmp(bigNum) <= 0 {
-		burn, err := sm.readRebalanceMemo(config.Kip160ContractAddress)
-		if err != nil {
-			return nil, err
-		}
-		ts.Kip160Burn = burn
+	// TotalBurnt and TotalSupply is only calculated if all components are available.
+	if ts.BurntFee != nil && ts.ZeroBurn != nil && ts.DeadBurn != nil && ts.Kip103Burn != nil && ts.Kip160Burn != nil {
+		ts.TotalBurnt = new(big.Int)
+		ts.TotalBurnt.Add(ts.TotalBurnt, ts.BurntFee)
+		ts.TotalBurnt.Add(ts.TotalBurnt, ts.ZeroBurn)
+		ts.TotalBurnt.Add(ts.TotalBurnt, ts.DeadBurn)
+		ts.TotalBurnt.Add(ts.TotalBurnt, ts.Kip103Burn)
+		ts.TotalBurnt.Add(ts.TotalBurnt, ts.Kip160Burn)
+		ts.TotalSupply = new(big.Int).Sub(ts.TotalMinted, ts.TotalBurnt)
 	}
 
-	ts.TotalBurnt = new(big.Int)
-	ts.TotalBurnt.Add(ts.TotalBurnt, ts.BurntFee)
-	ts.TotalBurnt.Add(ts.TotalBurnt, ts.ZeroBurn)
-	ts.TotalBurnt.Add(ts.TotalBurnt, ts.DeadBurn)
-	ts.TotalBurnt.Add(ts.TotalBurnt, ts.Kip103Burn)
-	ts.TotalBurnt.Add(ts.TotalBurnt, ts.Kip160Burn)
-
-	ts.TotalSupply = new(big.Int).Sub(ts.TotalMinted, ts.TotalBurnt)
-	return ts, nil
+	return ts, errors.Join(errs...)
 }
 
 func (sm *supplyManager) readRebalanceMemo(addr common.Address) (*big.Int, error) {
@@ -232,12 +310,13 @@ func (sm *supplyManager) catchup() {
 		lastNum = sm.db.ReadLastAccRewardBlockNumber()
 	)
 
-	if sm.db.ReadAccReward(lastNum) == nil {
-		logger.Error("Last accumulated reward not found. Restarting supply catchup")
+	if lastNum > 0 && sm.db.ReadAccReward(lastNum) == nil {
+		logger.Error("Last accumulated reward not found. Restarting supply catchup", "last", lastNum, "head", headNum)
 		sm.db.WriteLastAccRewardBlockNumber(0) // soft reset to genesis
 	}
 
 	// Store genesis supply if not exists
+	// ReadLastAccRewardBlockNumber is 0 when either (a) the database is empty or (b) was soft reset to 0.
 	if sm.db.ReadLastAccRewardBlockNumber() == 0 {
 		genesisTotalSupply, err := sm.totalSupplyFromState(0)
 		if err != nil {

--- a/reward/supply_manager.go
+++ b/reward/supply_manager.go
@@ -175,7 +175,7 @@ func (sm *supplyManager) GetCanonicalBurn(num uint64) (zero *big.Int, dead *big.
 func (sm *supplyManager) GetRebalanceBurn(num uint64, forkNum *big.Int, addr common.Address) (*big.Int, error) {
 	bigNum := new(big.Int).SetUint64(num)
 
-	if forkNum == nil || forkNum.Cmp(bigNum) > 0 {
+	if forkNum == nil || forkNum.Sign() == 0 || (addr == common.Address{}) || forkNum.Cmp(bigNum) > 0 {
 		// 1. rebalance is not configured or the rebalance forkNum has not passed (at the given block number).
 		return big.NewInt(0), nil
 	}


### PR DESCRIPTION
## Proposed changes

- Harden the `kaia_getTotalSupply` API added in https://github.com/klaytn/klaytn/pull/2148.
- TotalSupply API _partially_ works even when some information isn't available.
- When the state trie isn't available at the given block (e.g. pruning node), do not return `zeroBurn, deadBurn, totalBurnt, totalSupply`. Not returning totalSupply to prevent misinformation.
	```js
	> kaia.getTotalSupply(128)
	{
	  burntFee: "0x0",
	  deadBurn: null,
	  error: "cannot determine canonical (0x0, 0xdead) burn amount: missing trie node d158d63e7624b0a16f45d61c231301e0d1d5b39114e1941daf5abab9c2eb0884 (path )",
	  kip103Burn: "0x0",
	  kip160Burn: "0x0",
	  number: "0x80",
	  totalBurnt: null,
	  totalMinted: "0x204fcea0db2b93eaf0000000",
	  totalSupply: null,
	  zeroBurn: null
	}
	```
- When the TreasuryRebalance (KIP-103 or KIP-160) has been executed but the `memo` is not stored via the `finalizeContract()` function, do not return `kip103Burn and/or kip160Burn, totalBurnt, totalSupply`. Not returning totalSupply to prevent misinformation.
	```js
	> klay.getTotalSupply(1)
	{
	  burntFee: "0x0",
	  deadBurn: "0x0",
	  error: "cannot determine rebalance (kip103, kip160) burn amount: no contract code at given address\ncannot determine rebalance (kip103, kip160) burn amount: no contract code at given address",
	  kip103Burn: null,
	  kip160Burn: null,
	  number: "0x1",
	  totalBurnt: null,
	  totalMinted: "0x446c3b15f9926687d2c40534fdb564000000000000",
	  totalSupply: null,
	  zeroBurn: "0x0"
	}
	```
  - But don't worry. Regardless of the requested block, the API reads the memo from the latest block. Once the `memo` is stored at some point, the previous block's total supply also shows up correctly.

- In all cases, the API additionally prints the block number
	```js
	{
	  burntFee: "0x29ec817ffd11a9cd3a4b3",
	  deadBurn: "0x40c166a428511ad626d306",
	  kip103Burn: "0x111d0449fb2a238eca3b1720",
	  kip160Burn: "0x0",
	  number: "0x93295ce",
	  totalBurnt: "0x11606478b75245c43d358ed9",
	  totalMinted: "0x249a79581de10f4cd3000000",
	  totalSupply: "0x133a14df668ec98895ca7127",
	  zeroBurn: "0x0"
	}
	```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

https://github.com/klaytn/klaytn/issues/1617

## Further comments
