### PR TITLE
Revert "Handle staking info since kaia fork in downloader."

### DIFF
--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -396,18 +396,7 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 	if !atomic.CompareAndSwapInt32(&d.synchronising, 0, 1) {
 		return errBusy
 	}
-	defer func() {
-		atomic.StoreInt32(&d.synchronising, 0)
-		// Staking info for kaia block has been temporarily stored in DB for post-download VerifyHeader.
-		// Now that the download and sync are complete, remove staking info for kaia block from DB
-		// to save space. They might stay in the cache though.
-		for _, blockNum := range d.queue.stakingInfoStoredBlocks {
-			if d.blockchain.Config().IsKaiaForkEnabled(big.NewInt(int64(blockNum) + 1)) {
-				reward.DeleteStakingInfoFromDB(blockNum)
-			}
-		}
-		d.queue.stakingInfoStoredBlocks = []uint64{} // Reset stored blocks
-	}()
+	defer atomic.StoreInt32(&d.synchronising, 0)
 
 	// Post a user notification of the sync (only once per session)
 	if atomic.CompareAndSwapInt32(&d.notified, 0, 1) {
@@ -1899,7 +1888,6 @@ func (d *Downloader) commitFastSyncData(results []*fetchResult, stateSync *state
 				logger.Error("Inserting downloaded staking info is failed", "err", err)
 				return fmt.Errorf("failed to insert the downloaded staking information: %v", err)
 			} else {
-				d.queue.stakingInfoStoredBlocks = append(d.queue.stakingInfoStoredBlocks, result.StakingInfo.BlockNum)
 				logger.Info("Imported new staking information", "number", result.StakingInfo.BlockNum)
 			}
 		}
@@ -1919,7 +1907,6 @@ func (d *Downloader) commitPivotBlock(result *fetchResult) error {
 			logger.Error("Inserting downloaded staking info is failed on pivot block", "err", err, "pivot", block.Number())
 			return fmt.Errorf("failed to insert the downloaded staking information on pivot block (%v) : %v", block.Number(), err)
 		} else {
-			d.queue.stakingInfoStoredBlocks = append(d.queue.stakingInfoStoredBlocks, result.StakingInfo.BlockNum)
 			logger.Info("Imported new staking information on pivot block", "number", result.StakingInfo.BlockNum, "pivot", block.Number())
 		}
 	}

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -58,7 +58,6 @@ var (
 	lock                      sync.Mutex
 	setter                    *govSetter
 	testStakingUpdateInterval = uint64(4)
-	kaiaCompatibleBlock       *big.Int
 )
 
 // govSetter sets governance items for testing purpose
@@ -359,9 +358,7 @@ func (dl *downloadTester) CurrentBlock() *types.Block {
 
 // Config retrieves the chain configuration of the tester.
 func (dl *downloadTester) Config() *params.ChainConfig {
-	config := params.TestChainConfig
-	config.KaiaCompatibleBlock = kaiaCompatibleBlock
-	return config
+	return params.TestChainConfig
 }
 
 // CurrentFastBlock retrieves the current head fast-sync block from the canonical chain.
@@ -775,12 +772,7 @@ func assertOwnForkedChain(t *testing.T, tester *downloadTester, common int, leng
 		receipts += length - common - fsMinFullBlocks
 		stakingInfos += length - common - fsMinFullBlocks
 	}
-	stakingInfos = stakingInfos / int(testStakingUpdateInterval) // assuming that staking information update interval is 4 or 1 (kaia fork)
-	if testStakingUpdateInterval == 1 {
-		// Since staking information is a previous block on kaia fork, it needs to be subtracted by 1
-		// [common = 1, 2, 3, 4, 5] => We need staking information at [1, 2, 3, 4], not [1, 2, 3, 4, 5]
-		stakingInfos = stakingInfos - 1
-	}
+	stakingInfos = stakingInfos / int(testStakingUpdateInterval) // assuming that staking information update interval is 4
 	switch tester.downloader.getMode() {
 	case FullSync:
 		receipts, stakingInfos = 1, 0
@@ -1008,11 +1000,6 @@ func TestBoundedForkedSync64Light(t *testing.T) { testBoundedForkedSync(t, 64, L
 func TestBoundedForkedSync65Full(t *testing.T)  { testBoundedForkedSync(t, 65, FullSync) }
 func TestBoundedForkedSync65Fast(t *testing.T)  { testBoundedForkedSync(t, 65, FastSync) }
 
-// The staking info after kaia should be deleted after finishing the sync process.
-func TestBoundedForkedSync65FastOnKaia(t *testing.T) {
-	testBoundedForkedSync65FastOnKaia(t, 65, FastSync)
-}
-
 func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
 
@@ -1035,37 +1022,6 @@ func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	// Synchronise with the second peer and ensure that the fork is rejected to being too old
 	if err := tester.sync("rewriter", nil, mode); err != errInvalidAncestor {
 		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidAncestor)
-	}
-}
-
-func testBoundedForkedSync65FastOnKaia(t *testing.T, protocol int, mode SyncMode) {
-	originalStakingUpdateInterval := testStakingUpdateInterval
-	kaiaCompatibleBlock = big.NewInt(0)
-	testStakingUpdateInterval = 1
-	tester := newTester()
-	defer func() {
-		tester.terminate()
-		kaiaCompatibleBlock = nil
-		testStakingUpdateInterval = originalStakingUpdateInterval
-	}()
-
-	// Create a long enough forked chain
-	common, fork := 13, int(MaxForkAncestry+17)
-	hashesA, _, headersA, _, blocksA, _, receiptsA, _, stakingInfoA, _ := tester.makeChainFork(common+fork, fork, tester.genesis, nil, true)
-
-	tester.newPeer("original", protocol, hashesA, headersA, blocksA, receiptsA, stakingInfoA)
-
-	// Synchronise with the peer and make sure all blocks were retrieved
-	if err := tester.sync("original", nil, mode); err != nil {
-		t.Fatalf("failed to synchronise blocks: %v", err)
-	}
-	assertOwnChain(t, tester, common+fork+1)
-
-	for _, stakingInfo := range tester.ownStakingInfo {
-		has, _ := reward.HasStakingInfoFromDB(stakingInfo.BlockNum)
-		if has {
-			t.Fatalf("staking info should be deleted after sync process")
-		}
 	}
 }
 

--- a/datasync/downloader/queue.go
+++ b/datasync/downloader/queue.go
@@ -89,7 +89,7 @@ func newFetchResult(header *types.Header, mode SyncMode, proposerPolicy uint64, 
 	if (fastSync || snapSync) && !header.EmptyReceipts() {
 		item.pending |= (1 << receiptType)
 	}
-	if (fastSync || snapSync) && proposerPolicy == uint64(istanbul.WeightedRandom) && (params.IsStakingUpdateInterval(header.Number.Uint64()) || isKaiaFork) {
+	if (fastSync || snapSync) && proposerPolicy == uint64(istanbul.WeightedRandom) && (params.IsStakingUpdateInterval(header.Number.Uint64()) && !isKaiaFork) {
 		item.pending |= (1 << stakingInfoType)
 	}
 	return item
@@ -155,8 +155,6 @@ type queue struct {
 	stakingInfoTaskQueue *prque.Prque                  // [kaia/65] Priority queue of the headers to fetch the staking infos for
 	stakingInfoPendPool  map[string]*fetchRequest      // [kaia/65] Currently pending staking info retrieval operations
 
-	stakingInfoStoredBlocks []uint64 // Block numbers for which staking info is stored in the DB
-
 	resultCache *resultStore       // Downloaded but not yet delivered fetch results
 	resultSize  common.StorageSize // Approximate size of a block (exponential moving average)
 
@@ -210,8 +208,6 @@ func (q *queue) Reset(blockCacheLimit int, thresholdInitialSize int) {
 	q.stakingInfoTaskPool = make(map[common.Hash]*types.Header)
 	q.stakingInfoTaskQueue.Reset()
 	q.stakingInfoPendPool = make(map[string]*fetchRequest)
-
-	q.stakingInfoStoredBlocks = []uint64{}
 
 	q.resultCache = newResultStore(blockCacheLimit)
 	q.resultCache.SetThrottleThreshold(uint64(thresholdInitialSize))
@@ -382,14 +378,12 @@ func (q *queue) Schedule(headers []*types.Header, from uint64) []*types.Header {
 			}
 		}
 
-		if (q.mode == FastSync || q.mode == SnapSync) && q.proposerPolicy == uint64(istanbul.WeightedRandom) {
-			if params.IsStakingUpdateInterval(header.Number.Uint64()) || q.IsKaiaFork(header.Number) {
-				if _, ok := q.stakingInfoTaskPool[hash]; ok {
-					logger.Trace("Header already scheduled for staking info fetch", "number", header.Number, "hash", hash)
-				} else {
-					q.stakingInfoTaskPool[hash] = header
-					q.stakingInfoTaskQueue.Push(header, -int64(header.Number.Uint64()))
-				}
+		if (q.mode == FastSync || q.mode == SnapSync) && q.proposerPolicy == uint64(istanbul.WeightedRandom) && (params.IsStakingUpdateInterval(header.Number.Uint64()) && !q.IsKaiaFork(header.Number)) {
+			if _, ok := q.stakingInfoTaskPool[hash]; ok {
+				logger.Trace("Header already scheduled for staking info fetch", "number", header.Number, "hash", hash)
+			} else {
+				q.stakingInfoTaskPool[hash] = header
+				q.stakingInfoTaskQueue.Push(header, -int64(header.Number.Uint64()))
 			}
 		}
 		inserts = append(inserts, header)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -177,6 +177,10 @@ func senderTxHashIndexer(db database.DBManager, chainEvent <-chan blockchain.Cha
 }
 
 func checkSyncMode(config *Config) error {
+	// TODO-Kaia: allow snap sync after resolving the staking info sync issue
+	if config.SyncMode == downloader.SnapSync {
+		return errors.New("snap sync is temporarily disabled")
+	}
 	if !config.SyncMode.IsValid() {
 		return fmt.Errorf("invalid sync mode %d", config.SyncMode)
 	}

--- a/reward/staking_info_db.go
+++ b/reward/staking_info_db.go
@@ -27,7 +27,6 @@ type stakingInfoDB interface {
 	HasStakingInfo(blockNum uint64) (bool, error)
 	ReadStakingInfo(blockNum uint64) ([]byte, error)
 	WriteStakingInfo(blockNum uint64, stakingInfo []byte) error
-	DeleteStakingInfo(blockNum uint64)
 }
 
 // HasStakingInfoFromDB returns existence of staking information from miscdb.
@@ -70,14 +69,5 @@ func AddStakingInfoToDB(stakingInfo *StakingInfo) error {
 		return err
 	}
 
-	return nil
-}
-
-func DeleteStakingInfoFromDB(blockNum uint64) error {
-	if stakingManager.stakingInfoDB == nil {
-		return ErrStakingDBNotSet
-	}
-
-	stakingManager.stakingInfoDB.DeleteStakingInfo(blockNum)
 	return nil
 }

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -141,17 +141,7 @@ func GetStakingInfo(blockNum uint64) *StakingInfo {
 		if blockNum > 0 {
 			stakingBlockNumber--
 		}
-		if stakingInfo = GetStakingInfoForKaiaBlock(stakingBlockNumber); stakingInfo == nil {
-			// Get staking info from DB if it exists.
-			// The staking info stored in DB is for downloader to verify the header.
-			// After downloader verifies all headers, the staking info in DB will be removed.
-			if stakingInfo, err := getStakingInfoFromDB(stakingBlockNumber); stakingInfo != nil && err == nil {
-				// Fill in Gini coeff before adding to cache.
-				if err := fillMissingGiniCoefficient(stakingInfo, stakingBlockNumber); err != nil {
-					logger.Warn("Cannot fill in gini coefficient", "staking block number", stakingBlockNumber, "err", err)
-				}
-			}
-		}
+		stakingInfo = GetStakingInfoForKaiaBlock(stakingBlockNumber)
 	} else {
 		stakingBlockNumber = params.CalcStakingBlockNumber(blockNum)
 		stakingInfo = GetStakingInfoOnStakingBlock(stakingBlockNumber)

--- a/reward/staking_manager_test.go
+++ b/reward/staking_manager_test.go
@@ -162,25 +162,6 @@ func TestStakingManager_GetFromDB(t *testing.T) {
 	checkGetStakingInfo(t)
 }
 
-// Check that StakingInfo are deleted from database
-func TestStakingManager_DeleteFromDB(t *testing.T) {
-	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
-	resetStakingManagerForTest(t)
-
-	for _, testdata := range stakingManagerTestData {
-		AddStakingInfoToDB(testdata)
-	}
-
-	for _, testdata := range stakingManagerTestData {
-		DeleteStakingInfoFromDB(testdata.BlockNum)
-	}
-
-	for _, testdata := range stakingManagerTestData {
-		res, _ := getStakingInfoFromDB(testdata.BlockNum)
-		assert.Nil(t, res)
-	}
-}
-
 // Even if Gini was -1 in the cache, GetStakingInfo returns valid Gini
 func TestStakingManager_FillGiniFromCache(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)


### PR DESCRIPTION
Reverts klaytn/klaytn#2160

Initially, I mis-interpreted the testing results so I merged it. Sorry for the confusion.

During several snap sync tests, it was found that #2160 can't solve the block header verification issue correctly. The block header initially comes to `processHeaders`, which inserts the header into the header chain first. Then, the contents for fetched headers will be scheduled by `Schedule`, which includes staking info. So, the staking info needs to be fetched with headers and ready before `insertHeaderChain`. But the current implementation fetches staking info after `insertHeaderChain`, which means it does nothing. (It worked before kaia fork since it required staking info before staking update interval)

Additionally, it seems that `randao` also breaks snap sync since it requires state at a block to retrieve the BLS registry. https://github.com/klaytn/klaytn/blob/dev/consensus/istanbul/backend/randao.go#L63

To sum up, I concluded it would be better to consider all the cases carefully to fix the snap sync. If you have suggestions, please let me know. Thanks.