### PR TITLE
[KAIABridge] Added next provision sequence query

### DIFF
--- a/contracts/contracts/system_contracts/kaiabridge/IBridge.sol
+++ b/contracts/contracts/system_contracts/kaiabridge/IBridge.sol
@@ -298,6 +298,7 @@ abstract contract IBridge {
     uint256 public minLockableKAIA;
     uint256 public maxLockableKAIA;
     uint64 public seq;
+    uint64 public nextProvisionSeq;
     uint256 public maxTryTransfer;
     bool public addrValidationOn;
     uint256 public TRANSFERLOCK;

--- a/contracts/contracts/system_contracts/kaiabridge/IOperator.sol
+++ b/contracts/contracts/system_contracts/kaiabridge/IOperator.sol
@@ -236,6 +236,7 @@ abstract contract IOperator {
     mapping (uint64 => EnumerableSet.UintSet) seq2TxID; // <sequence number, all provision transaction ID set>
     mapping (address => uint64) public unsubmittedNextSeq; // <operator address, next unsubmitted sequence number>
     mapping (address => uint64) public greatestSubmittedSeq; // Gratest submitted seq per operator
+    mapping (address => uint64) public nextProvisionSeq; // next sequence to be submitted per operator
     EnumerableSet.UintSet revokedProvisionSeqs; // revoked provision sequence list
     mapping (uint256 => uint64) public submission2TxID; // <unique user input number, tx ID>
 

--- a/contracts/contracts/system_contracts/kaiabridge/Operator.sol
+++ b/contracts/contracts/system_contracts/kaiabridge/Operator.sol
@@ -189,6 +189,7 @@ contract Operator is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeable,
         if (provision.seq != 0) {
             EnumerableSetUint64.setAdd(seq2TxID[provision.seq], txID);
             updateGreatestSubmittedSeq(provision.seq);
+            updateNextSeq(provision.seq);
             emit IBridge.Provision(IBridge.ProvisionIndividualEvent({
                 seq: provision.seq,
                 sender: provision.sender,
@@ -281,6 +282,14 @@ contract Operator is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeable,
     function updateGreatestSubmittedSeq(uint64 seq) internal operatorExists(msg.sender) {
         if (greatestSubmittedSeq[msg.sender] < seq) {
             greatestSubmittedSeq[msg.sender] = seq;
+        }
+    }
+
+    /// @dev Update next sequence per operator
+    /// @param seq ProvisionData sequence number
+    function updateNextSeq(uint64 seq) internal operatorExists(msg.sender) {
+        if (seq > 0 && nextProvisionSeq[msg.sender] == seq - 1) {
+            nextProvisionSeq[msg.sender] = seq;
         }
     }
 

--- a/contracts/contracts/testing/kaiabridge/Operator.sol
+++ b/contracts/contracts/testing/kaiabridge/Operator.sol
@@ -188,6 +188,7 @@ contract NewOperator is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeab
         if (provision.seq != 0) {
             EnumerableSetUint64.setAdd(seq2TxID[provision.seq], txID);
             updateGreatestSubmittedSeq(provision.seq);
+            updateNextSeq(provision.seq);
             emit IBridge.Provision(IBridge.ProvisionIndividualEvent({
                 seq: provision.seq,
                 sender: provision.sender,
@@ -280,6 +281,14 @@ contract NewOperator is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeab
     function updateGreatestSubmittedSeq(uint64 seq) internal operatorExists(msg.sender) {
         if (greatestSubmittedSeq[msg.sender] < seq) {
             greatestSubmittedSeq[msg.sender] = seq;
+        }
+    }
+
+    /// @dev Update next sequence per operator
+    /// @param seq ProvisionData sequence number
+    function updateNextSeq(uint64 seq) internal operatorExists(msg.sender) {
+        if (seq > 0 && nextProvisionSeq[msg.sender] == seq - 1) {
+            nextProvisionSeq[msg.sender] = seq;
         }
     }
 

--- a/contracts/test/KAIABridge/bridge.ts
+++ b/contracts/test/KAIABridge/bridge.ts
@@ -1287,4 +1287,31 @@ describe("[Bridge Test]", function () {
     expect(isOp3Submitted).to.be.equal(true);
     expect(isOp4Submitted).to.be.equal(true);
   });
+
+  it("#Query the operator and bridge next provision sequence", async function () {
+    expect(await bridge.nextProvisionSeq()).to.be.equal(0)
+    expect(await operator.nextProvisionSeq(operator1.address)).to.be.equal(0)
+
+    let provision = [1, sender, receiver, amount];
+    let rawTxData = (await bridge.provision.populateTransaction(provision)).data;
+    await operator.connect(operator1).submitTransaction(bridge.target, rawTxData, 0);
+    await operator.connect(operator2).confirmTransaction(txID);
+    await operator.connect(operator3).confirmTransaction(txID);
+
+    expect(await bridge.nextProvisionSeq()).to.be.equal(1)
+    expect(await operator.nextProvisionSeq(operator1.address)).to.be.equal(1)
+    expect(await operator.nextProvisionSeq(operator2.address)).to.be.equal(1)
+    expect(await operator.nextProvisionSeq(operator3.address)).to.be.equal(1)
+    expect(await operator.nextProvisionSeq(operator4.address)).to.be.equal(0)
+
+    provision = [2, sender, receiver, amount];
+    rawTxData = (await bridge.provision.populateTransaction(provision)).data;
+    await operator.connect(operator1).submitTransaction(bridge.target, rawTxData, 0);
+
+    expect(await bridge.nextProvisionSeq()).to.be.equal(1)
+    expect(await operator.nextProvisionSeq(operator1.address)).to.be.equal(2)
+    expect(await operator.nextProvisionSeq(operator2.address)).to.be.equal(1)
+    expect(await operator.nextProvisionSeq(operator3.address)).to.be.equal(1)
+    expect(await operator.nextProvisionSeq(operator4.address)).to.be.equal(0)
+  });
 });


### PR DESCRIPTION
## Proposed changes

- Bridge: Bridge updates the subsequent provision sequence number when a provision is confirmed
- Operator: Each operator updates the subsequent provision sequence number when an individual provision is submitted

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
