### PR TITLE
Add cypress, baobab flags as aliases

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1219,7 +1219,7 @@ var (
 	MainnetFlag = &cli.BoolFlag{
 		Name:     "mainnet",
 		Usage:    "Pre-configured Kaia Mainnet network",
-		Aliases:  []string{"p2p.cypress", "p2p.mainnet"},                     // TODO: remove cypress
+		Aliases:  []string{"p2p.cypress", "p2p.mainnet", "cypress"},          // TODO: remove cypress
 		EnvVars:  []string{"KLAYTN_CYPRESS", "KAIA_CYPRESS", "KAIA_MAINNET"}, // TODO: remove cypress
 		Category: "NETWORK",
 	}
@@ -1227,7 +1227,7 @@ var (
 	TestnetFlag = &cli.BoolFlag{
 		Name:     "testnet",
 		Usage:    "Pre-configured Kaia Testnet network",
-		Aliases:  []string{"p2p.baobab", "p2p.testnet"},                    // TODO: remove baobab
+		Aliases:  []string{"p2p.baobab", "p2p.testnet", "baobab"},          // TODO: remove baobab
 		EnvVars:  []string{"KLAYTN_BAOBAB", "KAIA_BAOBAB", "KAIA_TESTNET"}, // TODO: remove baobab
 		Category: "NETWORK",
 	}


### PR DESCRIPTION
## Proposed changes

Add back `--cypress`, `--baobab` flags for `ken` for backward compatibility

## Types of changes

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
