### PR TITLE
rpc: Fix StartWSEndpoint whitelist

### DIFF
--- a/networks/rpc/endpoints.go
+++ b/networks/rpc/endpoints.go
@@ -72,6 +72,7 @@ func StartWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []
 		if module == "klay" {
 			module = "kaia"
 		}
+		whitelist[module] = true
 	}
 	// Register all the APIs exposed by the services
 	handler := NewServer()


### PR DESCRIPTION
## Proposed changes

- Make websocket namespace whitelist (i.e. `--wsapi` flag) work again by fixing StartWSEndpoint to be analogous to StartHTTPEndpoint.
- Should fix the failing nightly-rpc

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
