### PR TITLE
[KAIABridge] Getter refined and execution revert removed

### DIFF
--- a/contracts/contracts/system_contracts/kaiabridge/Bridge.sol
+++ b/contracts/contracts/system_contracts/kaiabridge/Bridge.sol
@@ -424,9 +424,30 @@ contract KAIABridge is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeabl
         return EnumerableSetUint64.getAll(claimCandidates);
     }
 
+    // @dev See {IBridge-getClaimCandidates}
+    function getClaimCandidatesSize() public override view returns (uint256) {
+        return EnumerableSetUint64.setLength(claimCandidates);
+    }
+
+    // @dev See {IBridge-getClaimCandidatesRangePure}
+    function getClaimCandidatesRangePure(uint64 range) public override view returns (uint64[] memory) {
+        return EnumerableSetUint64.getRange(claimCandidates, range);
+    }
+
     // @dev See {IBridge-getClaimCandidatesRange}
     function getClaimCandidatesRange(uint64 range) public override view returns (uint64[] memory) {
-        return EnumerableSetUint64.getRange(claimCandidates, range);
+        uint64[] memory seqs = EnumerableSetUint64.getRange(claimCandidates, range);
+        uint64[] memory candidates = new uint64[](range);
+        uint256 cnt = 0;
+        for (uint i=0; i<seqs.length; i++) {
+            if (isPassedTimeLockDuration(seqs[i])) {
+                candidates[cnt++] = seqs[i];
+            }
+        }
+        assembly {
+            mstore(candidates, cnt)
+        }
+        return candidates;
     }
 
     // @dev See {IBridge-getClaimFailures}

--- a/contracts/contracts/system_contracts/kaiabridge/Guardian.sol
+++ b/contracts/contracts/system_contracts/kaiabridge/Guardian.sol
@@ -159,8 +159,11 @@ contract Guardian is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeable,
         override
         guardianExists(msg.sender)
         confirmed(txID, msg.sender)
-        notExecuted(txID)
     {
+        // if transaction was already executed, silently return without revert
+        if (transactions[txID].executed) {
+            return;
+        }
         if (isConfirmed(txID)) {
             Transaction storage targetTx = transactions[txID];
             if (predefinedExecute(targetTx.to, targetTx.data)) {

--- a/contracts/contracts/system_contracts/kaiabridge/IBridge.sol
+++ b/contracts/contracts/system_contracts/kaiabridge/IBridge.sol
@@ -263,6 +263,12 @@ abstract contract IBridge {
     /// @dev Return `claimCandidates` set
     function getClaimCandidates() external virtual view returns (uint64[] memory);
 
+    /// @dev Return `claimCandidates` set size
+    function getClaimCandidatesSize() external virtual view returns (uint256);
+
+    /// @dev Return `claimCandidates` set with the given range
+    function getClaimCandidatesRangePure(uint64 range) external virtual view returns (uint64[] memory);
+
     /// @dev Return `claimCandidates` set with the given range
     /// @param range Range of set
     function getClaimCandidatesRange(uint64 range) external virtual view returns (uint64[] memory);

--- a/contracts/contracts/system_contracts/kaiabridge/Judge.sol
+++ b/contracts/contracts/system_contracts/kaiabridge/Judge.sol
@@ -173,8 +173,11 @@ contract Judge is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeable, IE
         override
         judgeExists(msg.sender)
         confirmed(txID, msg.sender)
-        notExecuted(txID)
     {
+        // if transaction was already executed, silently return without revert
+        if (transactions[txID].executed) {
+            return;
+        }
         if (isConfirmed(txID)) {
             Transaction storage targetTx = transactions[txID];
             if (predefinedExecute(targetTx.to, targetTx.data)) {

--- a/contracts/contracts/system_contracts/kaiabridge/Operator.sol
+++ b/contracts/contracts/system_contracts/kaiabridge/Operator.sol
@@ -223,8 +223,11 @@ contract Operator is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeable,
         override
         operatorExists(msg.sender)
         confirmed(txID, msg.sender)
-        notExecuted(txID)
     {
+        // if transaction was already executed, silently return without revert
+        if (transactions[txID].executed) {
+            return;
+        }
         if (isConfirmed(txID)) {
             Transaction storage targetTx = transactions[txID];
             if (predefinedExecute(targetTx.to, targetTx.data)) {

--- a/contracts/contracts/testing/kaiabridge/Bridge.sol
+++ b/contracts/contracts/testing/kaiabridge/Bridge.sol
@@ -421,9 +421,30 @@ contract NewKAIABridge is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrade
         return EnumerableSetUint64.getAll(claimCandidates);
     }
 
+    // @dev See {IBridge-getClaimCandidates}
+    function getClaimCandidatesSize() public override view returns (uint256) {
+        return EnumerableSetUint64.setLength(claimCandidates);
+    }
+
+    // @dev See {IBridge-getClaimCandidatesRangePure}
+    function getClaimCandidatesRangePure(uint64 range) public override view returns (uint64[] memory) {
+        return EnumerableSetUint64.getRange(claimCandidates, range);
+    }
+
     // @dev See {IBridge-getClaimCandidatesRange}
     function getClaimCandidatesRange(uint64 range) public override view returns (uint64[] memory) {
-        return EnumerableSetUint64.getRange(claimCandidates, range);
+        uint64[] memory seqs = EnumerableSetUint64.getRange(claimCandidates, range);
+        uint64[] memory candidates = new uint64[](range);
+        uint256 cnt = 0;
+        for (uint i=0; i<seqs.length; i++) {
+            if (isPassedTimeLockDuration(seqs[i])) {
+                candidates[cnt++] = seqs[i];
+            }
+        }
+        assembly {
+            mstore(candidates, cnt)
+        }
+        return candidates;
     }
 
     // @dev See {IBridge-getClaimFailures}

--- a/contracts/contracts/testing/kaiabridge/Guardian.sol
+++ b/contracts/contracts/testing/kaiabridge/Guardian.sol
@@ -159,8 +159,11 @@ contract NewGuardian is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeab
         override
         guardianExists(msg.sender)
         confirmed(txID, msg.sender)
-        notExecuted(txID)
     {
+        // if transaction was already executed, silently return without revert
+        if (transactions[txID].executed) {
+            return;
+        }
         if (isConfirmed(txID)) {
             Transaction storage targetTx = transactions[txID];
             if (predefinedExecute(targetTx.to, targetTx.data)) {

--- a/contracts/contracts/testing/kaiabridge/Judge.sol
+++ b/contracts/contracts/testing/kaiabridge/Judge.sol
@@ -173,8 +173,11 @@ contract NewJudge is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeable,
         override
         judgeExists(msg.sender)
         confirmed(txID, msg.sender)
-        notExecuted(txID)
     {
+        // if transaction was already executed, silently return without revert
+        if (transactions[txID].executed) {
+            return;
+        }
         if (isConfirmed(txID)) {
             Transaction storage targetTx = transactions[txID];
             if (predefinedExecute(targetTx.to, targetTx.data)) {

--- a/contracts/contracts/testing/kaiabridge/Operator.sol
+++ b/contracts/contracts/testing/kaiabridge/Operator.sol
@@ -222,8 +222,11 @@ contract NewOperator is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeab
         override
         operatorExists(msg.sender)
         confirmed(txID, msg.sender)
-        notExecuted(txID)
     {
+        // if transaction was already executed, silently return without revert
+        if (transactions[txID].executed) {
+            return;
+        }
         if (isConfirmed(txID)) {
             Transaction storage targetTx = transactions[txID];
             if (predefinedExecute(targetTx.to, targetTx.data)) {

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -19,7 +19,7 @@ const config: HardhatUserConfig = {
       },
       {
         version: "0.8.24",
-        settings: { optimizer: { enabled: true, runs: 10000 }, viaIR: true },
+        settings: { optimizer: { enabled: true, runs: 1000 }, viaIR: true },
       },
       {
         version: "0.8.25",


### PR DESCRIPTION
## Proposed changes

1. Add claim candidates getter with TimeLock filter
  - getClaimCandidatesRangePure(range): Return all claim candidates sequences numbers less than `range`
  - getClaimCandidatesRange(range): Return all claim candidates sequence numbers less than `range` and the timelock has passed
2. Do not revert when confirming an already-executed multisig transaction (i.e. replace `notExecuted` with `if (executed) return`)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
